### PR TITLE
Allow drag-and-drop of Grocery items from one store to another

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -26,6 +26,6 @@ class Api::ItemsController < ApplicationController
   private
 
   def item_params
-  	params.require(:item).permit(:name, :needed)
+    params.require(:item).permit(:name, :needed, :store_id)
   end
 end

--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -17,6 +17,8 @@
           li.stores-list__item(
             v-for='store in sortedStores'
             :class='{selected: store === $store.state.currentStore}'
+            @drop="drop(store.id)"
+            @dragover="allowDrop()"
           )
             a.js-link.store-name(@click='$store.commit("selectStore", store.id)') {{store.name}}
             button.js-link.delete(@click='deleteStore(store)') ×
@@ -52,6 +54,23 @@ export default {
   },
 
   methods: {
+    allowDrop() {
+      const { event } = window;
+      event.preventDefault();
+    },
+
+    drop(storeId) {
+      const { event } = window;
+      event.preventDefault();
+      const itemId = Number(event.dataTransfer.getData('itemId'));
+      const oldStoreId = Number(event.dataTransfer.getData('storeId'));
+      this.$store.dispatch('moveItem', {
+        itemId,
+        newStoreId: storeId,
+        oldStoreId,
+      });
+    },
+
     deleteStore(store) {
       this.$http.delete(`api/stores/${store.id}`);
       this.$store.commit('deleteStore', store.id);

--- a/app/javascript/groceries/item.vue
+++ b/app/javascript/groceries/item.vue
@@ -1,5 +1,11 @@
 <template lang='pug'>
-  li(:class='{unneeded: item.needed <= 0, "just-added": isJustAdded(item)}')
+  li(
+    :class='{unneeded: item.needed <= 0, "just-added": isJustAdded(item)}'
+    draggable="true"
+    @dragstart="drag()"
+    :data-id='item.id'
+    :data-store-id='item.store_id'
+  )
     input(
       v-if='editingName'
       type='text'
@@ -30,6 +36,12 @@ export default {
   methods: {
     deleteItem(item) {
       this.$store.dispatch('deleteItem', item.id);
+    },
+
+    drag() {
+      const { event } = window;
+      const itemId = event.target.getAttribute('data-id');
+      event.dataTransfer.setData('itemId', itemId);
     },
 
     isJustAdded(item) {

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -17,6 +17,13 @@ const mutations = {
     state.stores = state.stores.filter(store => store.id !== id);
   },
 
+  moveItem(state, { itemId, newStoreId }) {
+    const item = _.remove(state.currentStore.items, { id: itemId })[0];
+    state.currentStore.items = state.currentStore.items.slice(); // use #slice to register? whatevs.
+    const newStore = _.find(state.stores, { id: newStoreId });
+    newStore.items.push(item);
+  },
+
   selectStore(state, id) {
     state.currentStore = _.find(state.stores, { id });
   },
@@ -26,6 +33,11 @@ const actions = {
   deleteItem({ commit }, id) {
     axios.delete(`api/items/${id}`);
     commit('deleteItem', id);
+  },
+
+  moveItem({ commit }, { itemId, newStoreId }) {
+    commit('moveItem', { itemId, newStoreId });
+    axios.patch(`/api/items/${itemId}`, { item: { store_id: newStoreId } });
   },
 
   updateItem(_context, { id, attributes }) {

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -1,3 +1,3 @@
 class ItemSerializer < ActiveModel::Serializer
-  attributes :id, :name, :needed
+  attributes :id, :name, :needed, :store_id
 end


### PR DESCRIPTION
Uses (more-or-less) the native HTML5 drag and drop API, via view event handlers and then passing the update via Vuex.

For the moment, I think that this probably was the right decision vs using some plugin library. I don't think I needed a lot more than the native drag-and-drop API, plus I got to learn it (or, at least, part of it), which I haven't used before.

Tests are still missing, though. But that's because I'm trying to ship this before I go to the store! :-p :)