### PR TITLE
Delete obsolete new_home route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,5 @@
 Rails.application.routes.draw do
   root to: 'home#index'
-  get 'new_home', to: 'home#new_home'
 
   devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   devise_scope :user do


### PR DESCRIPTION
What was formerly routed to via `/new_home` now is routed to via `/`. `/new_home` now 404's since its controller has already been deleted.