### PR TITLE
Only attempt to cache Ruby gems (not node_modules) on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: ruby
 cache:
   directories:
-    - $HOME/.rvm/gems/ruby-2.4.1/gems/
-    - node_modules
+    - /home/travis/.rvm/gems/ruby-2.4.2/gems/
 rvm:
   - "2.4.2"
 services:
@@ -29,7 +28,7 @@ script:
 notifications:
   email:
     on_success: never
-    on_success: never
+    on_failure: always
 deploy:
   provider: heroku
   api_key:

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -39,7 +39,6 @@ namespace :spec do
     run_logged_system_command('node --version')
     run_logged_system_command('yarn --version')
     run_logged_system_command('webpack --version')
-    run_logged_system_command('yarn install')
     run_logged_system_command('bin/setup-mocha-tests')
     run_logged_system_command(
       "NODE_ENV=test #{Rails.root.join('bin/webpack-dev-server')}",


### PR DESCRIPTION
Also:
* be explicit about always sending emails on failed builds
* don't double-`yarn install` (both in travis and in `spec:js` rake task)