### PR TITLE
Setup `sudo: false` in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+sudo: false
 cache:
   bundler: true
   directories:


### PR DESCRIPTION
Supposedly this helps with bundler cacheing?
https://bibwild.wordpress.com/2015/04/08/simple-config-for-faster-travis-ruby-builds/