### PR TITLE
Rename application.scss to styles.scss

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1,18 +1,3 @@
-/*
- * This is a manifest file that'll be compiled into application.css, which will include all the files
- * listed below.
- *
- * Any CSS and SCSS file within this directory, lib/assets/stylesheets, or any plugin's
- * vendor/assets/stylesheets directory can be referenced here using a relative path.
- *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
- *
- *= require_self
- */
-
 $fa-font-path: "~font-awesome/fonts";
 
 @import "vendor/reset";

--- a/app/javascript/packs/styles.js
+++ b/app/javascript/packs/styles.js
@@ -1,4 +1,4 @@
 // `eslint-plugin-import` doesnt know about our `css/` alias. Since we only use the `css/`` alias
 // here, we'll just ignore the issue rather than solving it more systemically.
 // eslint-disable-next-line import/no-unresolved,import/no-extraneous-dependencies
-import 'css/application.scss';
+import 'css/styles.scss';

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -18,6 +18,7 @@ environment.loaders.set('style', {
 const productionConfig = merge(environment.toWebpackConfig(), shared, {
   plugins: [
     new webpack.NoEmitOnErrorsPlugin(),
+    extractCSS,
   ],
 });
 


### PR DESCRIPTION
This is so that Rails won't attempt to precompile this asset on production (which precompilation is currently failing because Rails doesn't have awareness of `node_modules` CSS as referenced via `~`).

fixes https://rollbar.com/davidjrunger/davidrunger/items/27/