### PR TITLE
Use only built-in fonts in home splash view

### DIFF
--- a/app/assets/stylesheets/utils/text.scss
+++ b/app/assets/stylesheets/utils/text.scss
@@ -8,6 +8,10 @@ i {
   font-family: monospace;
 }
 
+.sans-serif {
+  font-family: sans-serif;
+}
+
 ////////////////////////////
 // weights
 .bold {

--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -7,11 +7,11 @@ div
     #headline-container.flex-grow-1(data-section='')
       #headline-name.monospace.font-size-1.font-blue-light.pb-5.mb-5.border-bottom.border-gray.pb-2
         span David Runger
-      #headline-subtitle.font-size-3.light Full stack web developer
+      #headline-subtitle.sans-serif.font-size-3.light Full stack web developer
     header#header.fixed-top.flex-grow-1.flex.bg-black.width-100.relative
       .font-size-4.js-link.js-scroll-top.m-l-3
         a.monospace.font-blue-light(href='#home') David Runger
-      nav#nav.flex.justify-around.absolute.m-r-4
+      nav#nav.sans-serif.flex.justify-around.absolute.m-r-4
         a.nav-link(href='#about')
           span.ptb-1 About
         a.nav-link(href='#skills')


### PR DESCRIPTION
Previously, some of the fonts in the home splash view were using a webfont (Karla, sourced via Google), and others were using a built-in font (monospace). As a result, the monospace text was rendering sooner, because the Karla text had to wait for the webfont to load before it could render. This was an unpleasing visual effect.

This change should make it so that:
1. All text in the splash view renders at the same time
2. The perceived load time will be faster