### PR TITLE
Pause before rendering Vue app in development to prevent FOUC

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,6 +21,7 @@ module.exports = {
     'no-else-return': 'off',
     'no-new': 'off',
     'no-param-reassign': 'off',
+    'no-underscore-dangle': 'off',
     'no-use-before-define': ['error', { functions: false }],
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     'object-curly-newline': ['error', {

--- a/app/javascript/packs/groceries_initializer.js
+++ b/app/javascript/packs/groceries_initializer.js
@@ -1,11 +1,5 @@
-import Vue from 'vendor/customized_vue';
+import { renderApp } from 'vendor/customized_vue';
 import Groceries from 'groceries/groceries.vue';
 import { groceryVuexStoreFactory } from 'groceries/store';
 
-document.addEventListener('DOMContentLoaded', () => {
-  document.body.appendChild(document.createElement('replaced-container'));
-  new Vue({
-    render: (h) => h(Groceries),
-    store: groceryVuexStoreFactory(window.davidrunger.bootstrap),
-  }).$mount('replaced-container');
-});
+renderApp(Groceries, { store: groceryVuexStoreFactory(window.davidrunger.bootstrap) });

--- a/app/javascript/packs/home_app.js
+++ b/app/javascript/packs/home_app.js
@@ -1,9 +1,4 @@
-import Vue from 'vendor/customized_vue';
+import { renderApp } from 'vendor/customized_vue';
 import Home from '../home/home.vue';
 
-document.addEventListener('DOMContentLoaded', () => {
-  document.body.appendChild(document.createElement('replaced-container'));
-  new Vue({
-    render: (h) => h(Home),
-  }).$mount('replaced-container');
-});
+renderApp(Home);

--- a/app/javascript/packs/template_show_app.js
+++ b/app/javascript/packs/template_show_app.js
@@ -1,9 +1,4 @@
-import Vue from 'vendor/customized_vue';
+import { renderApp } from 'vendor/customized_vue';
 import TempateShowApp from '../templates/template_show_app.vue';
 
-document.addEventListener('DOMContentLoaded', () => {
-  document.body.appendChild(document.createElement('replaced-container'));
-  new Vue({
-    render: (h) => h(TempateShowApp),
-  }).$mount('replaced-container');
-});
+renderApp(TempateShowApp);

--- a/app/javascript/vendor/customized_vue.js
+++ b/app/javascript/vendor/customized_vue.js
@@ -26,3 +26,19 @@ Vue.component('drag', Drag);
 Vue.component('drop', Drop);
 
 export default Vue;
+
+export function renderApp(vueApp, options = {}) {
+  const _renderApp = () => {
+    document.body.appendChild(document.createElement('replaced-container'));
+    new Vue({ render: h => h(vueApp), ...options }).$mount('replaced-container');
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    // to prevent FOUC in development, pause briefly (to parse CSS source maps) before rendering
+    if (window.davidrunger.env === 'development') {
+      setTimeout(_renderApp, 150);
+    } else {
+      _renderApp();
+    }
+  });
+}


### PR DESCRIPTION
Previously, we were experiencing a FOUC (flash of unstyled content) in development because it was taking Chrome a while to parse the CSS source maps that were recently added in f5efc5c / #35. At least, the FOUC seems to be fixed if I disable CSS source maps, so I'm _assuming_ that's the problem.

To facilitate this, I've extracted a `renderApp` function into our `app/javascript/vendor/customized_vue.js`, which is a nice DRYing of the code. :)