### PR TITLE
Import routes in `customized_vue.js` (not individual packs)

### DIFF
--- a/app/javascript/packs/groceries_initializer.js
+++ b/app/javascript/packs/groceries_initializer.js
@@ -1,6 +1,5 @@
 import { renderApp } from 'vendor/customized_vue';
 import Groceries from 'groceries/groceries.vue';
 import { groceryVuexStoreFactory } from 'groceries/store';
-import 'shared/common';
 
 renderApp(Groceries, { store: groceryVuexStoreFactory(window.davidrunger.bootstrap) });

--- a/app/javascript/packs/home_app.js
+++ b/app/javascript/packs/home_app.js
@@ -1,5 +1,4 @@
 import { renderApp } from 'vendor/customized_vue';
 import Home from 'home/home.vue';
-import 'shared/common';
 
 renderApp(Home);

--- a/app/javascript/packs/template_show_app.js
+++ b/app/javascript/packs/template_show_app.js
@@ -1,5 +1,4 @@
 import { renderApp } from 'vendor/customized_vue';
 import TempateShowApp from 'templates/template_show_app.vue';
-import 'shared/common';
 
 renderApp(TempateShowApp);

--- a/app/javascript/vendor/customized_vue.js
+++ b/app/javascript/vendor/customized_vue.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex';
 import axios from 'axios';
 import { Drag, Drop } from 'vue-drag-drop';
 import modal from 'components/modal.vue';
+import 'shared/common';
 
 const csrfMetaTag = document.querySelector('meta[name="csrf-token"]');
 if (csrfMetaTag) {


### PR DESCRIPTION
This fixes an error in production.

The problem is that $routes was undefined on bootstrap instances because `Routes` hadn't been loaded yet at the time that `customized_vue.js` was loaded.

This PR fixes that bug, and DRYs up the code a bit, too.