### PR TITLE
Remove references to application.js/common.js in test config

### DIFF
--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -17,9 +17,6 @@ environment.loaders.set('style', {
 });
 
 const testConfig = merge(environment.toWebpackConfig(), shared, {
-  entry: {
-    application: resolve(__dirname, '../../app/javascript/shared/common.js'),
-  },
   devtool: 'inline-cheap-module-source-map',
   module: {
     rules: [

--- a/spec/javascript/mocha_runner.html
+++ b/spec/javascript/mocha_runner.html
@@ -3,7 +3,6 @@
   <meta charset="utf-8">
   <title>Mocha Tests</title>
   <link href="http://localhost:8080/packs-test/mocha.css" rel="stylesheet" />
-  <script src="http://localhost:8080/packs-test/application.js"></script>
 </head>
 <body>
   <div id="mocha"></div>


### PR DESCRIPTION
`application.js` was deleted in #46 / bca1408 .

`shared/common.js` is now loaded in `app/javascript/vendor/customized_vue.js`, so there's no longer a need to manually load it in tests as the entry point of the test webpack config.

I didn't notice either of these necessary/good changes in time to include them in #48 / 1b5fc15 because that was a hotfix for a production error that I wanted to get out right away.