### PR TITLE
Remove text-align CSS rules

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -13,7 +13,6 @@ $fa-font-path: "~font-awesome/fonts";
 @import "utils/font_family";
 @import "utils/font_size";
 @import "utils/font_weight";
-@import "utils/text_align";
 @import "utils/viewport";
 @import "utils/visibility";
 @import "utils/whitespace";

--- a/app/assets/stylesheets/utils/text_align.scss
+++ b/app/assets/stylesheets/utils/text_align.scss
@@ -1,3 +1,0 @@
-.text-center {
-  text-align: center;
-}

--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -45,7 +45,7 @@ div
           #[a(href='http://www.appacademy.io') App Academy], a high school math teacher, a public
           bus driver, and a long haul truck driver.
 
-      .pr-6.text-center.flex-1.flex.items-center
+      .pr-6.flex-1.flex.items-center
         img.about-image(src='~img/david.jpg' alt='A picture of me')
 
   HomeSection(section='skills', title='Skills / Technologies', color-palette='Purples')


### PR DESCRIPTION
I was only using it in one place, and it wasn't even needed there (and basscss also has text-align rules, for when we do need 'em.)