### PR TITLE
Remove unused visibility CSS rule

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -14,7 +14,6 @@ $fa-font-path: "~font-awesome/fonts";
 @import "utils/font_size";
 @import "utils/font_weight";
 @import "utils/height";
-@import "utils/visibility";
 @import "utils/whitespace";
 @import "utils/width";
 

--- a/app/assets/stylesheets/utils/visibility.scss
+++ b/app/assets/stylesheets/utils/visibility.scss
@@ -1,3 +1,0 @@
-.visibility-hidden {
-  visibility: hidden;
-}


### PR DESCRIPTION
I was previously using this, not not anymore. (Maybe basscss covers this, anyway (not that it matters with respect to this removal)).