### PR TITLE
Remove unused white-space CSS rule

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -14,7 +14,6 @@ $fa-font-path: "~font-awesome/fonts";
 @import "utils/font_size";
 @import "utils/font_weight";
 @import "utils/height";
-@import "utils/whitespace";
 @import "utils/width";
 
 html,

--- a/app/assets/stylesheets/utils/whitespace.scss
+++ b/app/assets/stylesheets/utils/whitespace.scss
@@ -1,3 +1,0 @@
-.nowrap {
-  white-space: nowrap;
-}


### PR DESCRIPTION
This used to be used, but no more.