### PR TITLE
Convert modal css to basscss; use flexbox

### DIFF
--- a/app/javascript/components/modal.vue
+++ b/app/javascript/components/modal.vue
@@ -1,43 +1,21 @@
 <template lang='pug'>
   transition(name='modal')
-    div.modal-mask
-      div.modal-wrapper
-        div.modal-container
-          div.modal-body
-            slot
+    div.modal-mask.fixed.flex.items-center.justify-center.col-12.top-0.left-0.vh-100.z1
+      div.modal-container.p3.bg-white.rounded
+        slot
 </template>
 
 <style lang='scss' scoped>
 .modal-mask {
-  position: fixed;
-  z-index: 9998;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
-  display: table;
   transition: opacity 0.3s ease;
-}
-
-.modal-wrapper {
-  display: table-cell;
-  vertical-align: middle;
 }
 
 .modal-container {
   width: 300px;
-  margin: 0 auto;
-  padding: 20px 30px;
-  background-color: #fff;
-  border-radius: 2px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33);
   transition: all 0.3s ease;
   font-family: Helvetica, Arial, sans-serif;
-}
-
-.modal-body {
-  margin: 20px 0;
 }
 
 .modal-enter {
@@ -50,7 +28,6 @@
 
 .modal-enter .modal-container,
 .modal-leave-active .modal-container {
-  -webkit-transform: scale(1.1);
   transform: scale(1.1);
 }
 </style>


### PR DESCRIPTION
I'd say that one's opinion on this diff largely informs one's opinion on utility CSS. I don't feel super strongly one way or another, but I think it's a bit of a win. If nothing else, vertical space does matter, and this diff deletes 23 lines of code.