### PR TITLE
Make store component of grocery list overflow-scroll

### DIFF
--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -2,7 +2,7 @@
   div#groceries-app.sans-serif
     div#page.flex.vh-100
       Sidebar
-      main.flex-1.bg-cover
+      main.flex-1.bg-cover.overflow-scroll
         LoggedInHeader
         Store(v-if='currentStore' :store='currentStore')
 </template>


### PR DESCRIPTION
This prevents an awkard visual effect when the item list is longer than the screen height.