### PR TITLE
Pass storeId argument to deleteItem mutation

### DIFF
--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -14,7 +14,10 @@
       span(v-else @dblclick='editingName = true') {{item.name}}
       | &nbsp;
       span ({{item.needed}})
-      .delete.h2.pl1.pr1.js-link.right.red(@click='deleteItem(item)' title='Delete item') ×
+      .delete.h2.pl1.pr1.js-link.right.red(
+        @click="$store.dispatch('deleteItem', item.id)"
+        title='Delete item'
+      ) ×
 </template>
 
 <script>
@@ -28,10 +31,6 @@ export default {
   },
 
   methods: {
-    deleteItem(item) {
-      this.$store.dispatch('deleteItem', item.id);
-    },
-
     isJustAdded(item) {
       return !!item.createdAt && item.createdAt > ((new Date()).valueOf() - 1000);
     },

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -105,11 +105,6 @@ export default {
       });
     },
 
-    deleteItem(item) {
-      this.$http.delete(this.$routes.api_item_path(item.id));
-      this.store.items = this.store.items.filter(otherItem => otherItem.id !== item.id);
-    },
-
     handleTripCheckinModalSubmit() {
       this.$store.dispatch('zeroItems', this.itemsToZero.slice());
       this.itemsToZero = [];

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -9,9 +9,11 @@ if (csrfMetaTag) {
   axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
 }
 
-const mutations = {
-  deleteItem(state, id) {
-    state.currentStore.items = state.currentStore.items.filter(item => item.id !== id);
+// export for testing
+export const mutations = {
+  deleteItem(state, { itemId, storeId }) {
+    const store = _.find(state.stores, { id: storeId });
+    store.items = store.items.filter(item => item.id !== itemId);
   },
 
   deleteStore(state, id) {
@@ -43,9 +45,12 @@ const mutations = {
 };
 
 const actions = {
-  deleteItem({ commit }, id) {
+  deleteItem({ commit, getters }, id) {
     axios.delete(Routes.api_item_path(id));
-    commit('deleteItem', id);
+    commit('deleteItem', {
+      itemId: id,
+      storeId: getters.currentStore.id,
+    });
   },
 
   moveItem({ commit }, { itemId, newStoreId }) {
@@ -86,7 +91,8 @@ const getters = {
   },
 };
 
-function initialState(bootstrap) {
+// export for testing
+export function initialState(bootstrap) {
   return Object.assign({},
     bootstrap,
     {

--- a/spec/javascript/groceries/store.spec.js
+++ b/spec/javascript/groceries/store.spec.js
@@ -1,0 +1,32 @@
+/* eslint-env mocha */
+
+import 'spec_helper';
+import { initialState, mutations } from 'groceries/store';
+
+describe('Grocery Vuex store', function () { // eslint-disable-line func-names
+  const suite = this;
+  suite.timeout(120000); // make timeout 2 minutes to allow time to play around in `debugger`
+
+  const item = { id: 48, name: 'bananas', needed: 0 };
+  const groceryStore = { id: 1, name: 'Costco', items: [item] };
+  const bootstrap = { stores: [groceryStore] };
+
+  let state;
+
+  beforeEach(() => {
+    state = initialState(bootstrap);
+  });
+
+  describe('#deleteItem', () => {
+    it("removes the item from the currentStore's items", () => {
+      expect(state.stores[0].items).toContain(item);
+
+      mutations.deleteItem(state, {
+        itemId: item.id,
+        storeId: groceryStore.id,
+      });
+
+      expect(state.stores[0].items).not.toContain(item);
+    });
+  });
+});


### PR DESCRIPTION
Mutations [don't have access to getters][1], and since `currentStore` is now a `getter` rather than an attribute of the `state`, this `deleteItem` mutation wasn't working anymore. This fixes it.

[1]: https://github.com/vuejs/vuex/issues/684

I've also deleted an old version of the `deleteItem` method that wasn't being used anymore.