### PR TITLE
Delete unused/redundant/old Groceries#signOut method

### DIFF
--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -25,13 +25,6 @@ export default {
       'currentStore',
     ]),
   },
-
-  methods: {
-    signOut() {
-      this.$http.delete(this.$routes.destroy_user_session_path({ format: 'json' })).
-        then(() => { window.location.assign(this.$routes.login_path()); });
-    },
-  },
 };
 </script>
 


### PR DESCRIPTION
This method was copied to `app/javascript/groceries/components/logged_in_header.vue`. The original method in `app/javascript/groceries/groceries.vue` should have been deleted at that time. Better late than never! :-p