### PR TITLE
Remove rails-erb-loader as an explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "postcss-smart-import": "^0.7.4",
     "precss": "^1.4.0",
     "pug": "^2.0.0-rc.1",
-    "rails-erb-loader": "^5.0.1",
     "resolve-url-loader": "^2.0.2",
     "rollbar-browser": "^1.9.4",
     "sass-loader": "^6.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5884,7 +5884,7 @@ querystringify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-1.0.0.tgz#6286242112c5b712fa654e526652bf6a13ff05cb"
 
-rails-erb-loader@^5.0.1, rails-erb-loader@^5.2.1:
+rails-erb-loader@^5.2.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/rails-erb-loader/-/rails-erb-loader-5.2.1.tgz#399b7781b88c129bc621a8256329ed2f855398e9"
   dependencies:


### PR DESCRIPTION
Since I'm not actually compiling any `.erb` files with webpack, I might as well have my `package.json` reflect that. `rails-erb-loader` was originally added to my `package.json` by Rails when I first initalized the Rails app.

(It's till an implicit dependency for the app via `webpacker`, though.)