### PR TITLE
Set store viewed_at to iso8601 string

### DIFF
--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -64,7 +64,7 @@ const actions = {
 
   selectStore({ state }, id) {
     const store = _.find(state.stores, { id });
-    Vue.set(store, 'viewed_at', Date());
+    Vue.set(store, 'viewed_at', (new Date()).toISOString());
     axios.patch(Routes.api_store_path(id), { store: _.pick(store, ['viewed_at']) });
   },
 


### PR DESCRIPTION
This contains milliseconds for more accurate sorting. I think also that maybe the previous method would have sorted based on day of the week? Whatever; I'm pretty positive that using iso8601 will be better here.