### PR TITLE
Convert store viewed_at dates to iso8601 when parsing from bootstrap

### DIFF
--- a/app/javascript/groceries/components/sidebar.vue
+++ b/app/javascript/groceries/components/sidebar.vue
@@ -74,7 +74,7 @@ export default {
         this.newStoreName = '';
         this.$store.state.postingStore = false;
         const newStore = response.data;
-        newStore.viewed_at = Date(newStore.viewed_at);
+        newStore.viewed_at = (new Date(newStore.viewed_at)).toISOString();
         this.stores.unshift(newStore);
       });
     },


### PR DESCRIPTION
This fixes a bug wherein, after creating a new store, it was impossible to select a pre-existing store, because the timestamp formats were different, and the newly created store(s) always had a "greater" viewed_at, even after updating the viewed_at of the clicked/selected store.