### PR TITLE
Pass options object for all Vuex mutations/actions

### DIFF
--- a/app/javascript/components/modal.vue
+++ b/app/javascript/components/modal.vue
@@ -16,12 +16,12 @@ export default {
     closeModal(e) {
       // make sure we don't close the modal when clicks within the modal propagate up
       if (e.target === this.$refs.mask) {
-        this.$store.commit('setShowModal', false);
+        this.$store.commit('setShowModal', { value: false });
       }
     },
 
     handleKeydown(e) {
-      if (e.which === keycode('escape')) this.$store.commit('setShowModal', false);
+      if (e.which === keycode('escape')) this.$store.commit('setShowModal', { value: false });
     },
   },
 

--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -15,7 +15,7 @@
       | &nbsp;
       span ({{item.needed}})
       .delete.h2.pl1.pr1.js-link.right.red(
-        @click="$store.dispatch('deleteItem', item)"
+        @click="$store.dispatch('deleteItem', { item })"
         title='Delete item'
       ) ×
 </template>

--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -36,7 +36,7 @@ export default {
     },
 
     setNeeded(item, needed) {
-      this.$store.commit('setCollectingDebounces', true);
+      this.$store.commit('setCollectingDebounces', { value: true });
       item.needed = needed;
       this.debouncedPatchItem(item.id, item.needed);
     },
@@ -62,7 +62,7 @@ export default {
       this.$store.commit('incrementPendingRequests');
       // set collectingDebounces to false _after_ incrementing pendingRequests so that
       // debouncingOrWaitingOnNetwork stays consistently true
-      this.$store.commit('setCollectingDebounces', false);
+      this.$store.commit('setCollectingDebounces', { value: false });
     }, 500),
   },
 

--- a/app/javascript/groceries/components/sidebar.vue
+++ b/app/javascript/groceries/components/sidebar.vue
@@ -18,7 +18,7 @@ aside.border-right.border-gray.p2
     li.js-link.stores-list__item.h3.my2.py1.px2(
       v-for='store in sortedStores'
       :class='{selected: store === currentStore}'
-      @click='$store.dispatch("selectStore", store.id)'
+      @click='$store.dispatch("selectStore", { store })'
     )
       drop(@drop='dropItem(store, ...arguments)')
         a.store-name {{store.name}}

--- a/app/javascript/groceries/components/sidebar.vue
+++ b/app/javascript/groceries/components/sidebar.vue
@@ -20,7 +20,7 @@ aside.border-right.border-gray.p2
       :class='{selected: store === currentStore}'
       @click='$store.dispatch("selectStore", store.id)'
     )
-      drop(@drop='dropItem(store.id, ...arguments)')
+      drop(@drop='dropItem(store, ...arguments)')
         a.store-name {{store.name}}
         a.js-link.right(@click.stop="$store.dispatch('deleteStore', { store })") &times;
 </template>
@@ -52,14 +52,8 @@ export default {
   },
 
   methods: {
-    dropItem(storeId, itemData) {
-      const itemId = itemData.id;
-      const oldStoreId = itemData.store_id;
-      this.$store.dispatch('moveItem', {
-        itemId,
-        newStoreId: storeId,
-        oldStoreId,
-      });
+    dropItem(store, item) {
+      this.$store.dispatch('moveItem', { item, newStore: store });
     },
 
     createStore(event) {

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -42,7 +42,7 @@ div.mt1.mb2.ml3.mr2
           plain
         ) Set checked items to 0 needed
         el-button(
-          @click="$store.commit('setShowModal', false)"
+          @click="$store.commit('setShowModal', { value: false })"
           type='text'
         ) Cancel
 </template>
@@ -108,12 +108,12 @@ export default {
     handleTripCheckinModalSubmit() {
       this.$store.dispatch('zeroItems', this.itemsToZero.slice());
       this.itemsToZero = [];
-      this.$store.commit('setShowModal', false);
+      this.$store.commit('setShowModal', { value: false });
     },
 
     initializeTripCheckinModal() {
       this.itemsToZero = this.neededItems;
-      this.$store.commit('setShowModal', true);
+      this.$store.commit('setShowModal', { value: true });
     },
 
     // we need `function` for correct `this`

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -106,7 +106,7 @@ export default {
     },
 
     handleTripCheckinModalSubmit() {
-      this.$store.dispatch('zeroItems', this.itemsToZero.slice());
+      this.$store.dispatch('zeroItems', { items: this.itemsToZero.slice() });
       this.itemsToZero = [];
       this.$store.commit('setShowModal', { value: false });
     },

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -32,11 +32,11 @@ export const mutations = {
     newStore.items.push(item);
   },
 
-  setCollectingDebounces(state, value) {
+  setCollectingDebounces(state, { value }) {
     state.collectingDebounces = value;
   },
 
-  setShowModal(state, value) {
+  setShowModal(state, { value }) {
     state.showModal = value;
   },
 };

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -57,10 +57,9 @@ const actions = {
     axios.patch(Routes.api_item_path(item.id), { item: { store_id: newStore.id } });
   },
 
-  selectStore({ state }, id) {
-    const store = _.find(state.stores, { id });
+  selectStore(_context, { store }) {
     Vue.set(store, 'viewed_at', (new Date()).toISOString());
-    axios.patch(Routes.api_store_path(id), { store: _.pick(store, ['viewed_at']) });
+    axios.patch(Routes.api_store_path(store.id), { store: _.pick(store, ['viewed_at']) });
   },
 
   updateItem(_context, { id, attributes }) {

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -27,10 +27,8 @@ export const mutations = {
     state.pendingRequests += 1;
   },
 
-  moveItem(state, { itemId, newStoreId }) {
-    const item = _.remove(state.currentStore.items, { id: itemId })[0];
-    state.currentStore.items = state.currentStore.items.slice(); // use #slice to register? whatevs.
-    const newStore = _.find(state.stores, { id: newStoreId });
+  moveItem(state, { item, newStore, oldStore }) {
+    oldStore.items = _.reject(oldStore.items, { id: item.id });
     newStore.items.push(item);
   },
 
@@ -57,9 +55,9 @@ const actions = {
     commit('deleteStore', { store });
   },
 
-  moveItem({ commit }, { itemId, newStoreId }) {
-    commit('moveItem', { itemId, newStoreId });
-    axios.patch(Routes.api_item_path(itemId), { item: { store_id: newStoreId } });
+  moveItem({ commit, getters }, { item, newStore }) {
+    commit('moveItem', { item, newStore, oldStore: getters.currentStore });
+    axios.patch(Routes.api_item_path(item.id), { item: { store_id: newStore.id } });
   },
 
   selectStore({ state }, id) {

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -42,12 +42,9 @@ export const mutations = {
 };
 
 const actions = {
-  deleteItem({ commit, getters }, item) {
+  deleteItem({ commit, getters }, { item }) {
     axios.delete(Routes.api_item_path(item.id));
-    commit('deleteItem', {
-      item,
-      store: getters.currentStore,
-    });
+    commit('deleteItem', { item, store: getters.currentStore });
   },
 
   deleteStore({ commit }, { store }) {

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -66,12 +66,10 @@ const actions = {
     axios.patch(Routes.api_item_path(id), { item: attributes });
   },
 
-  zeroItems(context, items) {
+  zeroItems(_context, { items }) {
     items.forEach((item) => {
       item.needed = 0;
-      axios.patch(Routes.api_item_path(item.id), {
-        item: { needed: 0 },
-      });
+      axios.patch(Routes.api_item_path(item.id), { item: { needed: 0 } });
     });
   },
 };


### PR DESCRIPTION
Also, use right objects (i.e. `store`, `item`) in these options arguments, rather than reducing down to integers (`storeId`, `itemId`) and then re-looking-up the desired object in the store. It's much easier to just pass the objects around directly. If we can (and we can!), why not? :)