### PR TITLE
Add Vue error handler function to send JS errors to Rollbar

### DIFF
--- a/app/javascript/vendor/customized_vue.js
+++ b/app/javascript/vendor/customized_vue.js
@@ -28,6 +28,18 @@ Vue.prototype.$routes = window.Routes;
 
 Vue.config.productionTip = false;
 
+Vue.config.errorHandler = (error, vm, info) => {
+  const { env } = window.davidrunger;
+  if (env === 'production') {
+    if (window.Rollbar && window.Rollbar.error) window.Rollbar.error(error, { info });
+  } else if (env === 'development' || env === 'test') {
+    // log the error; test is configured such that this will actually raise an error and fail tests
+    console.error(error); // eslint-disable-line no-console
+  } else {
+    throw new Error(`Env "${env}" is not an expected environment!`);
+  }
+};
+
 Vue.use(Vuex);
 
 Vue.use(Button);

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -5,7 +5,7 @@
     %title #{@title.present? ? "#{@title} - " : ''} David Runger
     = csrf_meta_tags
     %script{type: "text/javascript"}
-      window.davidrunger = {env: '<%= Rails.env %>'};
+      window.davidrunger = {env: '#{Rails.env}'};
       window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript((@bootstrap_data || {}).to_json))}")
 
     - if Rails.env.development?

--- a/spec/javascript/mocha_runner.html
+++ b/spec/javascript/mocha_runner.html
@@ -10,6 +10,7 @@
   <script>mocha.setup('bdd')</script>
   <script src="http://localhost:8080/packs-test/spec_index.js"></script>
   <script>
+    window.davidrunger = { env: 'test' };
     mocha.checkLeaks();
     mocha.run();
   </script>


### PR DESCRIPTION
This will also fail tests when errors occur during test, I think, which previously/currently does not happen, disturbingly.

In `development` we will stick with the default behavior of logging the error to the console.