### PR TITLE
Exit with code 1 if a system command exits with a non-zero code

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   class StashRequestError < StandardError; end
 
-  force_ssl subdomain: 'www', unless: -> { Rails.env.development? }
+  force_ssl subdomain: 'www', unless: -> { Rails.env.development? || Rails.env.test? }
   protect_from_forgery with: :exception
   before_action :store_request_data_in_redis
   before_action :authenticate_user!

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -9,8 +9,7 @@ def run_logged_system_command(command, background: false)
       puts '... success.'
       true
     else
-      puts '... failed.'
-      false
+      abort("System command `#{command}` exited with a non-zero status.")
     end
   end
 end
@@ -48,6 +47,6 @@ namespace :spec do
       break if webpack_dev_server_running?
     end
 
-    exit(1) unless run_logged_system_command('yarn run test')
+    run_logged_system_command('yarn run test')
   end
 end


### PR DESCRIPTION
This is so that tests will actually fail CI, which they aren't doing currently.

Also, don't force SSL in test environment (to get tests passing again).