### PR TITLE
Don't load all element-ui CSS

### DIFF
--- a/app/javascript/packs/styles.js
+++ b/app/javascript/packs/styles.js
@@ -2,4 +2,3 @@
 // here, we'll just ignore the issue rather than solving it more systemically.
 // eslint-disable-next-line import/no-unresolved,import/no-extraneous-dependencies
 import 'css/styles.scss';
-import 'element-ui/lib/theme-chalk/index.css';


### PR DESCRIPTION
This brings the styles.css file from 233kB down to 46kb! It seems that the styles needed for individual components get loaded via the JavaScript imports of those components, so importing the entire global stylesheet was not only importing more than we actually need, but also actually importing totally redundant CSS, too. :(

The good news is, it's fixed now! :D :tada: