### PR TITLE
Strip prefixes needed only by <10% share browsers

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -17,6 +17,7 @@ environment.loaders.set('style', {
         convertToAbsoluteUrls: true,
       },
     },
+    'postcss-loader',
     {
       loader: 'sass-loader',
       options: {

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -10,6 +10,7 @@ environment.loaders.set('style', {
   use: extractCSS.extract({
     use: [
       { loader: 'css-loader', options: { minimize: true } },
+      'postcss-loader',
       { loader: 'sass-loader', options: { sourceMap: false } },
     ],
   }),

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -11,6 +11,7 @@ environment.loaders.set('style', {
   use: extractCSS.extract({
     use: [
       { loader: 'css-loader', options: { minimize: false } },
+      'postcss-loader',
       { loader: 'sass-loader', options: { sourceMap: true } },
     ],
   }),

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "test": "bin/setup-mocha-tests && mocha-headless-chrome -f http://localhost:8080/packs-test/mocha_runner.html",
     "test-chrome": "bin/setup-mocha-tests && open -a 'Google Chrome' http://localhost:8080/packs-test/mocha_runner.html"
   },
+  "browserslist": [
+    ">10%"
+  ],
   "dependencies": {
     "@rails/webpacker": "^3.0.2",
     "autoprefixer": "^7.1.1",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,7 @@
+const autoprefixer = require('autoprefixer');
+
+module.exports = {
+  plugins: [
+    autoprefixer,
+  ],
+};


### PR DESCRIPTION
This is accomplished via postcss & autoprefixer.

The win is not super huge...
```
BEFORE
groceries_initializer-264bec0feeba61abdcc5a6a95259d638.css    37.1 kB
             home_app-264bec0feeba61abdcc5a6a95259d638.css    37.1 kB
               styles-60d798e4cba257c4a19dd75225b3c5a1.css    45.9 kB
```

```
AFTER
groceries_initializer-e51d0279d9a434ada2bd9eefee1e4fc5.css      34 kB       0  [emitted]         groceries_initializer
             home_app-e51d0279d9a434ada2bd9eefee1e4fc5.css      34 kB       1  [emitted]         home_app
               styles-d59aec3b6d4c58f5f9dadf47bed8cba1.css    43.5 kB       2  [emitted]         styles
```

... but hey, I like optimizing stuff. :)