### PR TITLE
Use element-ui icons instead of Font Awesome

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1,7 +1,4 @@
-$fa-font-path: "~font-awesome/fonts";
-
 @import "vendor/reset";
-@import "../../../node_modules/font-awesome/scss/font-awesome";
 @import '~basscss/css/basscss';
 @import '~basscss-background-colors/css/background-colors';
 @import '~basscss-background-images/css/background-images';

--- a/app/javascript/groceries/components/logged_in_header.vue
+++ b/app/javascript/groceries/components/logged_in_header.vue
@@ -5,7 +5,7 @@
     :show-timeout=0
     placement='bottom-end'
   )
-    .user-email {{ bootstrap.current_user.email }} #[i.fa.fa-angle-down]
+    .user-email {{ bootstrap.current_user.email }} #[el-icon(name='arrow-down')]
     el-dropdown-menu(slot='dropdown')
       a(:href="$routes.edit_user_path(bootstrap.current_user)")
         el-dropdown-item Edit Account

--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -23,7 +23,7 @@ div
         a.nav-link(href='#contact')
           span.ptb-1 Contact
     a.down-arrow-container.center.circle.mb3(href='#about')
-      i.fa.fa-angle-double-down(aria-hidden='true')
+      el-icon(name='arrow-down')
 
   .parallax-outer
     .parallax-inner.parallax-inner--macbook-1
@@ -473,7 +473,7 @@ i[class^=devicon-] {
   color: $black-light;
   background: $gray-light;
   font-size: 30px;
-  padding: 2px 0 0 2px; // nudges the font-awesome icon into the right place
+  padding: 2px 0 0 2px; // nudges the arrow icon into the right place
 }
 
 .skills table {

--- a/app/javascript/vendor/customized_vue.js
+++ b/app/javascript/vendor/customized_vue.js
@@ -6,6 +6,7 @@ import {
   Dropdown,
   DropdownMenu,
   DropdownItem,
+  Icon,
   Input,
 } from 'element-ui';
 import axios from 'axios';
@@ -44,6 +45,7 @@ Vue.use(Card);
 Vue.use(Dropdown);
 Vue.use(DropdownMenu);
 Vue.use(DropdownItem);
+Vue.use(Icon);
 Vue.use(Input);
 
 Vue.component('modal', modal);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "eslint-plugin-vue": "^2.1.0",
     "extract-text-webpack-plugin": "^2.1.0",
     "file-loader": "^0.11.1",
-    "font-awesome": "^4.7.0",
     "gator": "^1.2.4",
     "glob": "^7.1.2",
     "js-yaml": "^3.8.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2730,10 +2730,6 @@ follow-redirects@^1.2.3:
   dependencies:
     debug "^2.6.9"
 
-font-awesome@^4.7.0:
-  version "4.7.0"
-  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
-
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"


### PR DESCRIPTION
The primary motivation here is to shrink our page weight. Font Awesome icons define lots of CSS rules, which we were only using two of, and also have a significantly larger font file than the element-ui font icons.

This gets styles.css from 44.9kB on the production build to just 12.7kB! And the font file is 6.0kB instead of 75.4kB! Pretty good!