### PR TITLE
Revert "Add route to verify to Google that I own davidrunger.com"

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,8 +27,4 @@ Rails.application.routes.draw do
 
     root to: 'users#index'
   end
-
-  get 'google83c07e1014ea4a70', to: ->(env) {
-    [200, {}, ['google-site-verification: google83c07e1014ea4a70.html']]
-  }
 end


### PR DESCRIPTION
Reverts davidrunger/david_runger#118

Google did its verification, so we don't need this route lying around anymore.