### PR TITLE
Fix and improve CSS webpacking

### DIFF
--- a/app/views/groceries/show.haml
+++ b/app/views/groceries/show.haml
@@ -1,2 +1,6 @@
+-# load CSS, except in development, where CSS will be loaded by style-loader, via JavaScript
+- unless Rails.env.development?
+  %link{rel: "stylesheet", href: asset_pack_path('groceries_initializer.css')}
+
 - content_for(:extra_javascript) do
   = javascript_pack_tag('groceries_initializer')

--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -1,2 +1,6 @@
+-# load CSS, except in development, where CSS will be loaded by style-loader, via JavaScript
+- unless Rails.env.development?
+  %link{rel: "stylesheet", href: asset_pack_path('home_app.css')}
+
 - content_for(:extra_javascript) do
   = javascript_pack_tag('home_app')

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -8,10 +8,12 @@
       window.davidrunger = {env: '#{Rails.env}'};
       window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript((@bootstrap_data || {}).to_json))}")
 
+    = javascript_pack_tag('commons')
     - if Rails.env.development?
       = javascript_pack_tag('styles')
     - else
       %link{rel: "stylesheet", href: asset_pack_path('styles.css')}
+      %link{rel: "stylesheet", href: asset_pack_path('commons.css')}
     = content_for(:extra_javascript)
     %link{rel: 'stylesheet', href: '//fonts.googleapis.com/css?family=Karla:400,700'}
     %link{rel: 'stylesheet', href: '//cdn.rawgit.com/konpa/devicon/df6431e323547add1b4cf45992913f15286456d3/devicon.min.css'}

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -4,6 +4,19 @@ const StyleLintPlugin = require('stylelint-webpack-plugin');
 const environment = require('./environment');
 const shared = require('./shared');
 
+environment.loaders.set('vue', {
+  test: /.vue$/,
+  loader: 'vue-loader',
+  options: {
+    loaders: {
+      js: 'babel-loader',
+      file: 'file-loader',
+      scss: 'vue-style-loader!css-loader!postcss-loader!sass-loader',
+      sass: 'vue-style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax',
+    },
+  },
+});
+
 environment.loaders.set('style', {
   test: /\.(scss|sass|css)$/,
   use: [
@@ -31,6 +44,11 @@ const developmentConfig = merge(environment.toWebpackConfig(), shared, {
   devtool: 'inline-cheap-module-source-map',
   plugins: [
     new StyleLintPlugin(),
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'commons',
+      filename: 'commons-[hash].js',
+      minChunks: 2,
+    }),
   ],
 });
 

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,16 +1,5 @@
 const { environment } = require('@rails/webpacker');
 
-environment.loaders.set('vue', {
-  test: /.vue$/,
-  loader: 'vue-loader',
-  options: {
-    loaders: {
-      js: 'babel-loader',
-      file: 'file-loader',
-      scss: 'vue-style-loader!css-loader!postcss-loader!sass-loader',
-      sass: 'vue-style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax',
-    },
-  },
-});
+environment.loaders.set('vue', {});
 
 module.exports = environment;

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -27,9 +27,23 @@ const productionConfig = merge(environment.toWebpackConfig(), shared, {
       return path.replace(/^\/app\/node_modules/, '/vendor/node_modules');
     },
   },
+  rules: [
+    {
+      test: /\.vue$/,
+      loader: 'vue-loader',
+      options: {
+        extractCSS: true,
+      },
+    },
+  ],
   plugins: [
     new webpack.NoEmitOnErrorsPlugin(),
     extractCSS,
+    new webpack.optimize.CommonsChunkPlugin({
+      name: 'commons',
+      filename: 'commons-[hash].js',
+      minChunks: 2,
+    }),
   ],
 });
 

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -5,6 +5,19 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const environment = require('./environment');
 const shared = require('./shared');
 
+environment.loaders.set('vue', {
+  test: /.vue$/,
+  loader: 'vue-loader',
+  options: {
+    loaders: {
+      js: 'babel-loader',
+      file: 'file-loader',
+      scss: 'vue-style-loader!css-loader!postcss-loader!sass-loader',
+      sass: 'vue-style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax',
+    },
+  },
+});
+
 const extractCSS = new ExtractTextPlugin('[name].css');
 environment.loaders.set('style', {
   test: /\.(scss|sass|css)$/,


### PR DESCRIPTION
The main thing that I wanted to do was to serve 3 CSS files per "app":
1. My global styles (`styles.css`). Basic style rules & utilities.
2. Common Vue component styles (particularly `element-ui` CSS).
3. App-specific styles (defined in the `<style>` sections of `.vue` files).

(1) and (2) will be hopefully somewhat stable over time, and will also be shared between apps. This means that they can be cached over time and between apps. The only thing that will vary for each app is (3), which comes out to be a pretty small CSS file for each app (since I don't write a lot of style rules in `.vue` files, since the BassCSS utilities can do most of the styling, anyway.).