### PR TITLE
Nest rules under module in production webpack config

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -27,15 +27,17 @@ const productionConfig = merge(environment.toWebpackConfig(), shared, {
       return path.replace(/^\/app\/node_modules/, '/vendor/node_modules');
     },
   },
-  rules: [
-    {
-      test: /\.vue$/,
-      loader: 'vue-loader',
-      options: {
-        extractCSS: true,
+  module: {
+    rules: [
+      {
+        test: /\.vue$/,
+        loader: 'vue-loader',
+        options: {
+          extractCSS: true,
+        },
       },
-    },
-  ],
+    ],
+  },
   plugins: [
     new webpack.NoEmitOnErrorsPlugin(),
     extractCSS,


### PR DESCRIPTION
Because of this mis-configuration, production deploys are failing to compile:

```
Invalid configuration object. Webpack has been initialised using a
configuration object that does not match the API schema.
- configuration has an unknown property 'rules'.
```