### PR TITLE
Load app-specific CSS in the <head>, not <body>

### DIFF
--- a/app/views/groceries/show.haml
+++ b/app/views/groceries/show.haml
@@ -1,6 +1,7 @@
 -# load CSS, except in development, where CSS will be loaded by style-loader, via JavaScript
-- unless Rails.env.development?
-  %link{rel: "stylesheet", href: asset_pack_path('groceries_initializer.css')}
+- content_for(:extra_css) do
+  - unless Rails.env.development?
+    %link{rel: "stylesheet", href: asset_pack_path('groceries_initializer.css')}
 
 - content_for(:extra_javascript) do
   = javascript_pack_tag('groceries_initializer')

--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -1,6 +1,7 @@
 -# load CSS, except in development, where CSS will be loaded by style-loader, via JavaScript
-- unless Rails.env.development?
-  %link{rel: "stylesheet", href: asset_pack_path('home_app.css')}
+- content_for(:extra_css) do
+  - unless Rails.env.development?
+    %link{rel: "stylesheet", href: asset_pack_path('home_app.css')}
 
 - content_for(:extra_javascript) do
   = javascript_pack_tag('home_app')

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -14,6 +14,7 @@
     - else
       %link{rel: "stylesheet", href: asset_pack_path('styles.css')}
       %link{rel: "stylesheet", href: asset_pack_path('commons.css')}
+    = content_for(:extra_css)
     = content_for(:extra_javascript)
     %link{rel: 'stylesheet', href: '//fonts.googleapis.com/css?family=Karla:400,700'}
     %link{rel: 'stylesheet', href: '//cdn.rawgit.com/konpa/devicon/df6431e323547add1b4cf45992913f15286456d3/devicon.min.css'}


### PR DESCRIPTION
I'm not sure that I have any particular motivation for this, other than the fact that this will move us back to rendering completely empty <body>'s, which I kind of like for a Single Page App. This _might_ also help to avoid FOUC by putting CSS loading blocking prior to JavaScript in the head?, but I honestly have no idea.