### PR TITLE
Don't build CSS source maps in production

### DIFF
--- a/app/views/groceries/show.haml
+++ b/app/views/groceries/show.haml
@@ -1,6 +1,6 @@
 -# load CSS, except in development, where CSS will be loaded by style-loader, via JavaScript
 - content_for(:extra_css) do
-  - unless Rails.env.development?
+  - unless Rails.env.development? && ENV['PRODUCTION_ASSET_CONFIG'].blank?
     %link{rel: "stylesheet", href: asset_pack_path('groceries_initializer.css')}
 
 - content_for(:extra_javascript) do

--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -1,6 +1,6 @@
 -# load CSS, except in development, where CSS will be loaded by style-loader, via JavaScript
 - content_for(:extra_css) do
-  - unless Rails.env.development?
+  - unless Rails.env.development? && ENV['PRODUCTION_ASSET_CONFIG'].blank?
     %link{rel: "stylesheet", href: asset_pack_path('home_app.css')}
 
 - content_for(:extra_javascript) do

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -9,7 +9,7 @@
       window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript((@bootstrap_data || {}).to_json))}")
 
     = javascript_pack_tag('commons')
-    - if Rails.env.development?
+    - if Rails.env.development? && !ENV['PRODUCTION_ASSET_CONFIG'].present?
       = javascript_pack_tag('styles')
     - else
       %link{rel: "stylesheet", href: asset_pack_path('styles.css')}


### PR DESCRIPTION
Also, check a new ENV variable, `PRODUCTION_ASSET_CONFIG`, so that I can easily test production webpack config settings while running in development mode, simply by running `PRODUCTION_ASSET_CONFIG=true rails s`.