### PR TITLE
Don't set `columns: false` in production SourceMapDevToolPlugin

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -63,10 +63,6 @@ const productionConfig = merge(environmentConfig, shared, {
       test: /\.(js|vue)/,
       filename: '[file].map[query]',
       append: false,
-      module: true,
-      columns: false,
-      lineToLine: false,
-      noSources: false,
     }),
   ],
 });

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -48,8 +48,9 @@ module SourceMapHelper
   class SourceMapUploadError < StandardError ; end
 
   JS_FILES = (
-    Dir['app/javascript/packs/**/*.js'].map { |path| path.match(%r{/([^/]+).js})[1] } -
-      %w[styles] # Don't need CSS source maps. Also, styles are built into a CSS file on production.
+    Dir['app/javascript/packs/**/*.js'].map { |path| path.match(%r{/([^/]+).js})[1] } +
+      %w[commons] -
+      %w[styles] # Don't need CSS source maps. Also, styles are built into a CSS file on prod
   ).freeze
   ROLLBAR_SOURCE_MAP_URI = 'https://api.rollbar.com/api/1/sourcemap/'.freeze
   APP_URL_BASE = 'http://davidrunger.com'.freeze


### PR DESCRIPTION
Apparently having `columns: false` causes the generated source maps to not have a `names` property, which Rollbar requires.

Also, start posting source maps for the newly added common bundle (`commons.js`) to Rollar.