### PR TITLE
Rescue encoding errors when saving requests to redis

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -60,6 +60,8 @@ class ApplicationController < ActionController::Base
     }
     begin
       $redis.setex(params['request_uuid'], REQUEST_DATA_TTL, request_data.to_json)
+    rescue Encoding::UndefinedConversionError => e
+      Rollbar.info(e)
     rescue
       # wrap the original exception in StashRequestError by raising and immediately rescuing
       begin


### PR DESCRIPTION
These seem to come from bots (or maybe just one bot), presumably making some really dumb requests. No need to clutter Rollbar with this junk.

Fixes https://rollbar.com/davidjrunger/davidrunger/items/15