### PR TITLE
Use CSS source maps in test

### DIFF
--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -23,9 +23,27 @@ environment.loaders.set('style', {
   test: /\.(scss|sass|css)$/,
   use: extractCSS.extract({
     use: [
-      { loader: 'css-loader', options: { minimize: false } },
-      'postcss-loader',
-      { loader: 'sass-loader', options: { sourceMap: true } },
+      {
+        loader: 'css-loader',
+        options: {
+          hmr: true,
+          minimize: false,
+          sourceMap: true,
+          convertToAbsoluteUrls: true,
+        },
+      },
+      {
+        loader: 'postcss-loader',
+        options: {
+          sourceMap: true,
+        },
+      },
+      {
+        loader: 'sass-loader',
+        options: {
+          sourceMap: true,
+        },
+      },
     ],
   }),
 });


### PR DESCRIPTION
I'm not sure whether having CSS source maps in test will really ultimately be useful, but my main motivation here is actually just to silence these warnings from postcss in test:

```
WARNING in ./node_modules/mocha/mocha.css
(Emitted value instead of an instance of Error)
 ⚠️  PostCSS Loader
Previous source map found, but options.sourceMap isn't set.
In this case the loader will discard the source map entirely for performance reasons.
See https://github.com/postcss/postcss-loader#sourcemap for more information.
 @ ./spec/javascript/packs/mocha.js 3:0-26
 @ multi (webpack)-dev-server/c
```