### PR TITLE
Redirect to Groceries app after sign in

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -2,9 +2,8 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   skip_before_action :authenticate_user!, only: [:google_oauth2]
 
   def google_oauth2
-    # You need to implement the method below in your model (e.g. app/models/user.rb)
-    user = User.from_omniauth!(request.env["omniauth.auth"])
-    sign_in user
-    redirect_to session.delete('user_redirect_to') || root_path
+    user = User.from_omniauth!(request.env['omniauth.auth'])
+    sign_in(user)
+    redirect_to(session.delete('user_redirect_to') || groceries_path)
   end
 end


### PR DESCRIPTION
Since the Home page isn't authenticated, but the Groceries app is, it's much more likely that someone is signing in to view the groceries app rather than the home app -- so that's where we'll send 'em! :)

Also, conform to RuboCop and delete an old comment provided by Devise.