### PR TITLE
Tell Travis that we are on Postgres 9.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 services:
   - postgresql
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
 env:
   - RAILS_ENV=test NODE_ENV=test SECRET_KEY_BASE=0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b
 before_install:


### PR DESCRIPTION
Heroku has already been on Postgres 9.6, and as of tonight I am, too, and so Travis should be as well.