### PR TITLE
Don't attempt to log requests without a request_uuid

### DIFF
--- a/config/initializers/request_logging.rb
+++ b/config/initializers/request_logging.rb
@@ -10,9 +10,14 @@ end
 ActiveSupport::Notifications.subscribe('process_action.action_controller') do |_name, _started, _finished, _unique_id, payload|
   params = payload[:params]
   request_uuid = params['request_uuid']
-  stashed_json = request_uuid && $redis.get(request_uuid)
+
+  next unless request_uuid.present?
+
+  stashed_json = $redis.get(request_uuid)
   stashed_data = stashed_json.present? ? JSON.parse(stashed_json) : {}
+
   next if stashed_data['admin'] == true
+
   user_agent = stashed_data['user_agent']
   request_attributes = {
     user_id: stashed_data['user_id'],


### PR DESCRIPTION
Fixes https://rollbar.com/davidjrunger/davidrunger/items/16/

... maybe. :-p :)

I think that maybe when the request gets redirected by an `http` => `https` upgrade, there is no `request_uuid`? That would at least explain https://rollbar.com/davidjrunger/davidrunger/items/16/, I think.

Also, fix Rubocop violations in request_logging.rb.