### PR TITLE
Don't save Requests for New Relic pings

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -26,14 +26,17 @@
 #
 
 class Request < ApplicationRecord
+  # error class for Rollbar logging
+  class CreateRequestError < StandardError ; end
+
   belongs_to :user, optional: true
 
   validates :url, :handler, :method, :format, :ip, :requested_at, presence: true
   validates :bot, inclusion: [true, false]
 
   scope :human, -> { where(bot: false) }
-  scope :recent, ->(time_period = 1.day) do
+  scope :recent, (lambda do |time_period = 1.day|
     where('requests.requested_at > ?', time_period.ago)
-  end
+  end)
   scope :ordered, ->() { order('requests.requested_at') }
 end

--- a/config/initializers/request_logging.rb
+++ b/config/initializers/request_logging.rb
@@ -1,12 +1,3 @@
-module RequestLogging
-  class CreateRequestError < StandardError ; end
-
-  IGNORED_USER_AGENTS = %w[
-    NewRelicPinger
-  ].map(&:freeze).freeze
-  IGNORED_USER_AGENTS_REGEX = Regexp.new(IGNORED_USER_AGENTS.join('|'))
-end
-
 ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*args|
   payload = args.extract_options!
   params = payload[:params]
@@ -19,7 +10,10 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
 
   next if stashed_data['admin'] == true
 
-  user_agent = stashed_data['user_agent']
+  params = stashed_data['params']
+
+  next if params['new_relic_ping'].present? && ENV['LOG_NEW_RELIC_PINGS'].blank?
+
   request_attributes = {
     user_id: stashed_data['user_id'],
     url: stashed_data['url'],
@@ -27,37 +21,30 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
     method: stashed_data['method'],
     status: payload[:status],
     handler: stashed_data['handler'],
-    params: stashed_data['params'],
+    params: params,
     referer: stashed_data['referer'],
     view: payload[:view_runtime],
     db: payload[:db_runtime],
     ip: stashed_data['ip'],
-    user_agent: user_agent,
+    user_agent: stashed_data['user_agent'],
     bot: stashed_data['bot'],
     requested_at: stashed_data['requested_at'],
   }
 
-  if user_agent.match?(RequestLogging::IGNORED_USER_AGENTS_REGEX)
-    Rails.logger.info(<<-LOG.squish)
-      Skipping creation of a Request because user_agent #{user_agent} is in IGNORED_USER_AGENTS.
-      Request attributes were #{request_attributes}
+  request = Request.new(request_attributes)
+  saved_successfully = request.save
+  if !saved_successfully
+    Rails.logger.error(<<-LOG.squish)
+      Failed to create a Request,
+      errors=#{request.errors.to_h},
+      stashed_json=#{stashed_json.inspect},
+      request_attributes=#{request_attributes.inspect}
     LOG
-  else
-    request = Request.new(request_attributes)
-    saved_successfully = request.save
-    if !saved_successfully
-      Rails.logger.warn(<<-LOG.squish)
-        Failed to create a Request,
-        errors=#{request.errors.to_h},
-        stashed_json=#{stashed_json.inspect},
-        request_attributes=#{request_attributes.inspect}
-      LOG
-      Rollbar.warning(
-        RequestLogging::CreateRequestError.new('Failed to save a Request'),
-        stashed_json: stashed_json,
-        request_attributes: request_attributes,
-        errors: request.errors.to_h,
-      )
-    end
+    Rollbar.error(
+      Request::CreateRequestError.new('Failed to save a Request'),
+      stashed_json: stashed_json,
+      request_attributes: request_attributes,
+      errors: request.errors.to_h,
+    )
   end
 end


### PR DESCRIPTION
I've setup New Relic Synthetics pinging. The New Relic Synthetics agent appears to be Chrome 36 (no longer NewRelicPinger), so we are currently logging these requests.

It's kind of interesting to see the requests from all over the USA, but it's misleading/confusing, since I mostly mean for requests to gather ideally just requests from humans, or at least bots that I don't already know about and expect regularly (such as the New Relic Synthetics requests).

I've added an ENV var check, in case I do want to look at the New Relic requests every once in a while. I'll be able to easily toggle the ENV var on and off.