### PR TITLE
Attempt to run StatsD on Heroku web dyno

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
+statsd-config.js
 /node_modules
 /public/packs
 /app/javascript/rails_assets

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ gem 'rest-client'
 gem 'rollbar'
 gem 'rubocop'
 gem 'sass-rails', '~> 5.0'
+gem 'statsd-instrument'
 gem 'webpacker'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -352,6 +352,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    statsd-instrument (2.1.4)
     temple (0.8.0)
     thor (0.20.0)
     thread_safe (0.3.6)
@@ -418,6 +419,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
+  statsd-instrument
   webmock
   webpacker
 
@@ -425,4 +427,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.15.4
+   1.16.0

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: foreman start -f Procfile.multi

--- a/Procfile.multi
+++ b/Procfile.multi
@@ -1,0 +1,2 @@
+web: bin/rails server -p $PORT -e $RAILS_ENV
+statsd: node_modules/.bin/statsd statsd-config.js

--- a/app/controllers/api/stores_controller.rb
+++ b/app/controllers/api/stores_controller.rb
@@ -2,8 +2,10 @@ class Api::StoresController < ApplicationController
   def create
     @store = current_user.stores.build(store_params.merge(viewed_at: Time.current))
     if @store.save
+      StatsD.increment('stores.create.success')
       render json: @store
     else
+      StatsD.increment('stores.create.failure')
       render json: {errors: @store.errors.to_h}, status: 422
     end
   end

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -18,4 +18,5 @@
 class Store < ApplicationRecord
   belongs_to :user
   has_many :items, dependent: :destroy
+  validates :name, presence: true
 end

--- a/config/initializers/statsd.rb
+++ b/config/initializers/statsd.rb
@@ -1,0 +1,1 @@
+StatsD.backend = StatsD::Instrument::Backends::UDPBackend.new('localhost:8125', :statsd)

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "sass-loader": "^6.0.5",
     "script-loader": "^0.7.2",
     "smooth-scroll": "^12.1.5",
+    "statsd": "https://github.com/etsy/statsd.git",
     "style-loader": "^0.18.1",
     "stylelint-webpack-plugin": "^0.9.0",
     "vue": "^2.3.0",

--- a/statsd-config.js
+++ b/statsd-config.js
@@ -1,0 +1,3 @@
+{
+  dumpMessages: true
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1533,6 +1533,12 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-1.3.1.tgz#02443e02db96f4b32b674225451abb6e9510000e"
+  dependencies:
+    keypress "0.1.x"
+
 commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
@@ -1591,6 +1597,10 @@ concat-stream@1.6.0, concat-stream@^1.6.0:
 connect-history-api-fallback@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/connect-history-api-fallback/-/connect-history-api-fallback-1.4.0.tgz#3db24f973f4b923b0e82f619ce0df02411ca623d"
+
+connection-parse@0.0.x:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/connection-parse/-/connection-parse-0.0.7.tgz#18e7318aab06a699267372b10c5226d25a1c9a69"
 
 console-browserify@^1.1.0:
   version "1.1.0"
@@ -2888,6 +2898,10 @@ gaze@^1.0.0:
   dependencies:
     globule "^1.0.0"
 
+generic-pool@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/generic-pool/-/generic-pool-2.2.0.tgz#8b465c1a7588ea9dd2bb133bda0bb66bfef8a63e"
+
 get-caller-file@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-1.0.2.tgz#f702e63127e7e231c160a80c1554acb70d5047e5"
@@ -3068,6 +3082,13 @@ hash.js@^1.0.0, hash.js@^1.0.3:
   dependencies:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.0"
+
+hashring@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/hashring/-/hashring-3.2.0.tgz#fda4efde8aa22cdb97fb1d2a65e88401e1c144ce"
+  dependencies:
+    connection-parse "0.0.x"
+    simple-lru-cache "0.0.x"
 
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
@@ -3808,6 +3829,10 @@ keycode@^2.1.9:
   version "2.1.9"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.1.9.tgz#964a23c54e4889405b4861a5c9f0480d45141dfa"
 
+keypress@0.1.x:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.1.0.tgz#4a3188d4291b66b4f65edb99f806aa9ae293592a"
+
 killable@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.0.tgz#da8b84bd47de5395878f95d64d02f2449fe05e6b"
@@ -4337,6 +4362,12 @@ mocha@^4.0.1:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
+modern-syslog@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/modern-syslog/-/modern-syslog-1.1.2.tgz#f1fa58899f3f452d788f1573401212a4ef898de5"
+  dependencies:
+    nan "^2.0.5"
+
 mri@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.0.tgz#5c0a3f29c8ccffbbb1ec941dcec09d71fa32f36a"
@@ -4363,6 +4394,10 @@ multicast-dns@^6.0.1:
 mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
+
+nan@^2.0.5:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.8.0.tgz#ed715f3fe9de02b57a5e6252d90a96675e1f085a"
 
 nan@^2.3.0, nan@^2.3.2:
   version "2.7.0"
@@ -6381,6 +6416,10 @@ send@0.16.1:
     range-parser "~1.2.0"
     statuses "~1.3.1"
 
+sequence@2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/sequence/-/sequence-2.2.1.tgz#7f5617895d44351c0a047e764467690490a16b03"
+
 serve-index@^1.7.2:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/serve-index/-/serve-index-1.9.1.tgz#d3768d69b1e7d82e5ce050fff5b453bea12a9239"
@@ -6451,6 +6490,10 @@ shebang-regex@^1.0.0:
 signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
+
+simple-lru-cache@0.0.x:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/simple-lru-cache/-/simple-lru-cache-0.0.2.tgz#d59cc3a193c1a5d0320f84ee732f6e4713e511dd"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"
@@ -6632,6 +6675,16 @@ sshpk@^1.7.0:
 state-toggle@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.0.tgz#d20f9a616bb4f0c3b98b91922d25b640aa2bc425"
+
+"statsd@https://github.com/etsy/statsd.git":
+  version "0.8.0"
+  resolved "https://github.com/etsy/statsd.git#8d5363cb109cc6363661a1d5813e0b96787c4411"
+  dependencies:
+    generic-pool "2.2.0"
+  optionalDependencies:
+    hashring "3.2.0"
+    modern-syslog "1.1.2"
+    winser "=0.1.6"
 
 "statuses@>= 1.3.1 < 2", statuses@~1.3.1:
   version "1.3.1"
@@ -7514,6 +7567,13 @@ window-size@0.1.0:
 window-size@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.2.0.tgz#b4315bb4214a3d7058ebeee892e13fa24d98b075"
+
+winser@=0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/winser/-/winser-0.1.6.tgz#08663dc32878a12bbce162d840da5097b48466c9"
+  dependencies:
+    commander "1.3.1"
+    sequence "2.2.1"
 
 with@^5.0.0:
   version "5.1.1"


### PR DESCRIPTION
This is an experiment. We'll see if it works. If it works, then I can work next on actually piping the StatsD output to a service that I can use to view/process that data.

**Commits:**

1. Add StatsD daemon JavaScript library. Installed from GitHub since this fix hasn't been released yet https://github.com/etsy/statsd/pull/593.
2. Add temp testing StatsD deamon configuration
3. Add Shopify's StatsD Ruby library
4. Configure StatsD client
5. Add Procfile & Procfile.multi to run multiple Heroku processes. Huge shoutout to [James Aylett](https://tartarus.org/james/diary/2013/04/18/running-statsd-on-heroku) for this hack/idea! Why aren't more people doing this? Well, maybe we should see if it works first. :-p
6. Use StatsD to track success/failure of Grocery store creation