### PR TITLE
Add Foreman to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'administrate', github: 'thoughtbot/administrate' # installed from `master` 
 gem 'browser'
 gem 'devise', github: 'plataformatec/devise'
 gem 'dotenv-rails', require: 'dotenv/rails-now'
+gem 'foreman', require: false
 gem 'hamlit'
 gem 'httparty'
 gem 'jbuilder', '~> 2.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -131,6 +131,9 @@ GEM
     fixture_builder (0.5.0)
       activerecord (>= 2)
       activesupport (>= 2)
+    foreman (0.63.0)
+      dotenv (>= 0.7)
+      thor (>= 0.13.6)
     formatador (0.2.5)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -393,6 +396,7 @@ DEPENDENCIES
   factory_girl_rails
   faker
   fixture_builder
+  foreman
   guard-espect!
   hamlit
   httparty

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: foreman start -f Procfile.multi
+web: bundle exec foreman start -f Procfile.multi


### PR DESCRIPTION
The app failed to boot when we deployed #162 with error:
```
Dec 16 23:28:59 davidrunger app/web.1: bash: foreman: command not found
```

I had avoided adding `foreman` to the Gemfile, since the Foreman docs say explicitly not to add it. However, hopefully `require: false` makes this not a problem?

I figured that Heroku might make the `foreman` command available, since I had thought that's what it uses to run the `Procfile`, but apparently one or both of these things is not true.