### PR TITLE
Configure StatsD to post to Hosted Graphite

### DIFF
--- a/statsd-config.js
+++ b/statsd-config.js
@@ -1,3 +1,10 @@
+// Example w/ explanations of these and other available settings:
+// https://github.com/etsy/statsd/blob/master/exampleConfig.js
+
 {
-  dumpMessages: true
+  graphite: {
+    globalPrefix: process.env.HOSTEDGRAPHITE_APIKEY,
+    legacyNamespace: false, // required for globalPrefix to be applied
+  },
+  graphiteHost: process.env.HOSTEDGRAPHITE_HOST,
 }


### PR DESCRIPTION
I've provisioned the Hosted Graphite Heroku addon. If works when I hook it up locally. Hopefully it will work on production, too. :)

![](http://take.ms/F6ydb)