### PR TITLE
Don't assume that stashed data exists for request logging

### DIFF
--- a/config/initializers/request_logging.rb
+++ b/config/initializers/request_logging.rb
@@ -3,10 +3,34 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
   params = payload[:params]
   request_uuid = params['request_uuid']
 
-  next if request_uuid.blank?
+  if request_uuid.blank?
+    Rails.logger.warn(<<-LOG.squish)
+      Request UUID for request logging was blank.
+      request_uuid=#{request_uuid.inspect}
+    LOG
+    Rollbar.warn(
+      Request::CreateRequestError.new('Request UUID for request logging was blank'),
+      request_uuid: request_uuid,
+    )
+    next
+  end
 
   stashed_json = $redis.get(request_uuid)
-  stashed_data = stashed_json.present? ? JSON.parse(stashed_json) : {}
+  if stashed_json.blank?
+    Rails.logger.warn(<<-LOG.squish)
+      Stashed JSON for request logging was blank.
+      stashed_json=#{stashed_json.inspect}
+      request_uuid=#{request_uuid.inspect}
+    LOG
+    Rollbar.warn(
+      Request::CreateRequestError.new('Stashed JSON for request logging was blank'),
+      stashed_json: stashed_json,
+      request_uuid: request_uuid,
+    )
+    next
+  end
+
+  stashed_data = JSON.parse(stashed_json)
 
   next if stashed_data['admin'] == true
 


### PR DESCRIPTION
... since evidently, sometimes it doesn't. Hopefully the Rollbar logging I've added might give insight into why this happens?

Fixes https://rollbar.com/davidjrunger/davidrunger/items/49