### PR TITLE
Switch from FactoryGirl to FactoryBot

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'webpacker'
 
 group :development, :test do
   gem 'awesome_print'
-  gem 'factory_girl_rails'
+  gem 'factory_bot_rails'
   gem 'faker'
   gem 'fixture_builder'
   gem 'pry'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,10 +118,10 @@ GEM
       railties (>= 3.2, < 5.2)
     erubi (1.7.0)
     execjs (2.7.0)
-    factory_girl (4.9.0)
+    factory_bot (4.8.2)
       activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
+    factory_bot_rails (4.8.2)
+      factory_bot (~> 4.8.2)
       railties (>= 3.0.0)
     faker (1.7.3)
       i18n (~> 0.5)
@@ -390,7 +390,7 @@ DEPENDENCIES
   browser
   devise!
   dotenv-rails
-  factory_girl_rails
+  factory_bot_rails
   faker
   fixture_builder
   foreman

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -25,7 +25,7 @@
 #  index_requests_on_user_id       (user_id)
 #
 
-FactoryGirl.define do
+FactoryBot.define do
   bot_user_agent = <<-BOT.squish
     Generic Browser 0 Other mobile=false raw=Mozilla/5.0 (compatible; Googlebot/2.1;
     +http://www.google.com/bot.html)

--- a/spec/factories/sms_records.rb
+++ b/spec/factories/sms_records.rb
@@ -15,7 +15,7 @@
 #  index_sms_records_on_user_id  (user_id)
 #
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :sms_record do
     error nil
     sequence(:nexmo_id) { |n| n.to_s.rjust(8, '0') }

--- a/spec/factories/stores.rb
+++ b/spec/factories/stores.rb
@@ -15,7 +15,7 @@
 #  index_stores_on_user_id     (user_id)
 #
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :store do
     name { Faker::Company.name }
     association :user

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,7 +15,7 @@
 #  index_users_on_email  (email) UNIQUE
 #
 
-FactoryGirl.define do
+FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     last_activity_at { 2.months.ago }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 ENV['RAILS_ENV'] ||= 'test'
 require 'pry'
-require 'factory_girl_rails'
+require 'factory_bot_rails'
 require 'webmock'
 require 'webmock/rspec'
 require File.expand_path('../../config/environment', __FILE__)
@@ -60,7 +60,7 @@ RSpec.configure do |config|
   config.global_fixtures = :all
   config.use_transactional_fixtures
 
-  config.include(FactoryGirl::Syntax::Methods)
+  config.include(FactoryBot::Syntax::Methods)
   config.include(Devise::Test::ControllerHelpers, type: :controller)
 
   config.after(:each, type: :controller) do

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -1,4 +1,4 @@
-include FactoryGirl::Syntax::Methods
+include FactoryBot::Syntax::Methods
 
 FixtureBuilder.configure do |fbuilder|
   # rebuild fixtures automatically when these files change:


### PR DESCRIPTION
thoughtbot renamed the gem because its gendered name made some people uncomfortable. ([Discussion here][1].) Updating from factory_girl to factory_bot fixes the deprection warning requesting/suggesting said change.

[1]: https://github.com/thoughtbot/factory_bot/issues/921

I followed the [upgrade guide here][2].

[2]: https://github.com/thoughtbot/factory_bot/blob/v4.9.0/UPGRADE_FROM_FACTORY_GIRL.md