### PR TITLE
Redirect to admin after login if original request was for admin

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -4,30 +4,33 @@
 #
 # If you want to add pagination or other controller-level concerns,
 # you're free to overwrite the RESTful controller actions.
-module Admin
-  class ApplicationController < Administrate::ApplicationController
-    before_action :store_request_data_in_redis
-    before_action :authenticate_admin
+class Admin::ApplicationController < Administrate::ApplicationController
+  before_action :store_request_data_in_redis
+  before_action :authenticate_admin
 
-    def authenticate_admin
-      unless current_user&.admin?
-        sign_out_all_scopes
-        redirect_to(login_path)
-      end
+  def authenticate_admin
+    return if current_user&.admin?
+
+    if current_user
+      redirect_to(root_path)
+    else
+      flash[:alert] = 'You must sign in first.'
+      session['user_redirect_to'] = request.path
+      redirect_to(login_path)
     end
+  end
 
-    # Override this value to specify the number of elements to display at a time
-    # on index pages. Defaults to 20.
-    # def records_per_page
-    #   params[:per_page] || 20
-    # end
+  # Override this value to specify the number of elements to display at a time
+  # on index pages. Defaults to 20.
+  # def records_per_page
+  #   params[:per_page] || 20
+  # end
 
-    def store_request_data_in_redis
-      $redis.setex(
-        params['request_uuid'],
-        ::ApplicationController::REQUEST_DATA_TTL,
-        {admin: true}.to_json
-      )
-    end
+  def store_request_data_in_redis
+    $redis.setex(
+      params['request_uuid'],
+      ::ApplicationController::REQUEST_DATA_TTL,
+      {admin: true}.to_json,
+    )
   end
 end


### PR DESCRIPTION
The `sign_out_all_scopes` call was obliterating the whole `session` or something? At least, for some reason, `session['user_redirect_to']` was `nil` when we got to the `Users::OmniauthCallbacksController#google_oauth2` action, and this change seems to fix that.