### PR TITLE
Load all <script> tags with defer

### DIFF
--- a/app/views/groceries/show.haml
+++ b/app/views/groceries/show.haml
@@ -4,4 +4,4 @@
     %link{rel: "stylesheet", href: asset_pack_path('groceries_initializer.css')}
 
 - content_for(:extra_javascript) do
-  = javascript_pack_tag('groceries_initializer')
+  = javascript_pack_tag('groceries_initializer', defer: true)

--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -6,4 +6,4 @@
   %link{rel: 'stylesheet', href: '//cdn.rawgit.com/konpa/devicon/df6431e323547add1b4cf45992913f15286456d3/devicon.min.css'}
 
 - content_for(:extra_javascript) do
-  = javascript_pack_tag('home_app')
+  = javascript_pack_tag('home_app', defer: true)

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -12,9 +12,9 @@
       window.davidrunger = {env: '#{Rails.env}'};
       window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript((@bootstrap_data || {}).to_json))}")
 
-    = javascript_pack_tag('commons')
+    = javascript_pack_tag('commons', defer: true)
     - if Rails.env.development? && !ENV['PRODUCTION_ASSET_CONFIG'].present?
-      = javascript_pack_tag('styles')
+      = javascript_pack_tag('styles', defer: true)
     - else
       %link{rel: "stylesheet", href: asset_pack_path('styles.css')}
       %link{rel: "stylesheet", href: asset_pack_path('commons.css')}


### PR DESCRIPTION
In practical terms, I don't think that this will atually matter hardly at all (and this seems to be confirmed by my testing with Chrome dev tools w/ Network throttled to "Fast 3G" and CPU throttled to "6x slowdown"). Loading/parsing JavaScript with `defer` basically means, as far as I can tell, that HTML parsing is blocked for as long as it would be otherwise. However, since everything at davidrunger.com is basically rendered via JavaScript, there is hardly any HTML to parse in the first place. But who knows, maybe there will be in the future (e.g. if I setup prerendering or server-side rendering). And it just seems like a good practice as a general rule. So I'm doing it.

Reference: http://www.growingwiththeweb.com/2014/02/async-vs-defer-attributes.html