### PR TITLE
Enable force_ssl globally in production

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
 class ApplicationController < ActionController::Base
   class StashRequestError < StandardError; end
 
-  force_ssl subdomain: 'www', unless: -> { Rails.env.development? || Rails.env.test? }
   protect_from_forgery with: :exception
   before_action :store_request_data_in_redis
   before_action :authenticate_user!

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -40,7 +40,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   config.log_level = :info
 


### PR DESCRIPTION
This should not only force secure https connections, but it should also set cookies to `secure`, which we don't currently have via the controller `force_ssl` call (being deleted in this PR in preference of `production.rb` config setting).

Reference: http://www.eq8.eu/blogs/14-config-force_ssl-is-different-than-controller-force_ssl