### PR TITLE
Revert "Bump administrate from a34ee1 to 666188"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,9 +20,9 @@ GIT
 
 GIT
   remote: https://github.com/thoughtbot/administrate.git
-  revision: 6661889711edd688c8768e48602fa4a25b82d7bf
+  revision: a34ee154d9b7af1a6fe29ce14671f6c66398210c
   specs:
-    administrate (0.8.1)
+    administrate (0.7.0)
       actionpack (>= 4.2, < 5.2)
       actionview (>= 4.2, < 5.2)
       activerecord (>= 4.2, < 5.2)
@@ -86,7 +86,7 @@ GEM
       rake (>= 10.4, < 12.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.2.3)
+    autoprefixer-rails (7.1.1)
       execjs
     awesome_print (1.7.0)
     bcrypt (3.1.11)
@@ -168,18 +168,18 @@ GEM
       sprockets-rails
     jsonapi-renderer (0.1.2)
     jwt (1.5.6)
-    kaminari (1.1.1)
+    kaminari (1.0.1)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.1.1)
-      kaminari-activerecord (= 1.1.1)
-      kaminari-core (= 1.1.1)
-    kaminari-actionview (1.1.1)
+      kaminari-actionview (= 1.0.1)
+      kaminari-activerecord (= 1.0.1)
+      kaminari-core (= 1.0.1)
+    kaminari-actionview (1.0.1)
       actionview
-      kaminari-core (= 1.1.1)
-    kaminari-activerecord (1.1.1)
+      kaminari-core (= 1.0.1)
+    kaminari-activerecord (1.0.1)
       activerecord
-      kaminari-core (= 1.1.1)
-    kaminari-core (1.1.1)
+      kaminari-core (= 1.0.1)
+    kaminari-core (1.0.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -325,18 +325,14 @@ GEM
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
-    sass (3.5.4)
-      sass-listen (~> 4.0.0)
-    sass-listen (4.0.0)
-      rb-fsevent (~> 0.9, >= 0.9.4)
-      rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
+    sass (3.4.24)
+    sass-rails (5.0.6)
       railties (>= 4.0.0, < 6)
       sass (~> 3.1)
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selectize-rails (0.12.4.1)
+    selectize-rails (0.12.4)
     shellany (0.0.1)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)


### PR DESCRIPTION
Reverts davidrunger/david_runger#175

This seems to be crashing the app on production (`uninitialized constant Administrate::Punditize::Pundit`), although it works locally. :-/

Gonna revert while I investigate.

I don't get a ton of value out of administrate, anyway ... thinking about dropping it completely.

```
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | /app/vendor/bundle/ruby/2.4.0/bundler/gems/administrate-6661889711ed/app/controllers/concerns/administrate/punditize.rb:4:in `<module:Punditize>': uninitialized constant Administrate::Punditize::Pundit (NameError) 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/bundler/gems/administrate-6661889711ed/app/controllers/concerns/administrate/punditize.rb:2:in `<module:Administrate>' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/bundler/gems/administrate-6661889711ed/app/controllers/concerns/administrate/punditize.rb:1:in `<top (required)>' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.1/lib/active_support/dependencies/interlock.rb:12:in `block in loading' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.1/lib/active_support/concurrency/share_lock.rb:149:in `exclusive' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/activesupport-5.1.1/lib/active_support/dependencies/interlock.rb:11:in `loading' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/engine.rb:476:in `block (2 levels) in eager_load!' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/engine.rb:475:in `each' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/engine.rb:475:in `block in eager_load!' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/engine.rb:473:in `each' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/engine.rb:473:in `eager_load!' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/engine.rb:354:in `eager_load!' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/application/finisher.rb:67:in `each' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/application/finisher.rb:67:in `block in <module:Finisher>' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/initializable.rb:30:in `instance_exec' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/initializable.rb:30:in `run' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/initializable.rb:59:in `block in run_initializers' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/ruby-2.4.2/lib/ruby/2.4.0/tsort.rb:228:in `block in tsort_each' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/ruby-2.4.2/lib/ruby/2.4.0/tsort.rb:350:in `block (2 levels) in each_strongly_connected_component' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/ruby-2.4.2/lib/ruby/2.4.0/tsort.rb:431:in `each_strongly_connected_component_from' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/ruby-2.4.2/lib/ruby/2.4.0/tsort.rb:349:in `block in each_strongly_connected_component' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/ruby-2.4.2/lib/ruby/2.4.0/tsort.rb:347:in `each' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/ruby-2.4.2/lib/ruby/2.4.0/tsort.rb:347:in `call' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/ruby-2.4.2/lib/ruby/2.4.0/tsort.rb:347:in `each_strongly_connected_component' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/ruby-2.4.2/lib/ruby/2.4.0/tsort.rb:226:in `tsort_each' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/ruby-2.4.2/lib/ruby/2.4.0/tsort.rb:205:in `tsort_each' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/initializable.rb:58:in `run_initializers' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/application.rb:353:in `initialize!' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/config/environment.rb:5:in `<top (required)>' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from config.ru:3:in `require_relative' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from config.ru:3:in `block in <main>' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:55:in `instance_eval' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:55:in `initialize' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from config.ru:in `new' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from config.ru:in `<main>' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:49:in `eval' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:49:in `new_from_string' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/builder.rb:40:in `parse_file' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/server.rb:319:in `build_app_and_options_from_config' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/server.rb:219:in `app' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/commands/server/server_command.rb:24:in `app' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/server.rb:354:in `wrapped_app' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/rack-2.0.3/lib/rack/server.rb:283:in `start' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/commands/server/server_command.rb:44:in `start' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/commands/server/server_command.rb:131:in `block in perform' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/commands/server/server_command.rb:126:in `tap' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/commands/server/server_command.rb:126:in `perform' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/thor-0.20.0/lib/thor/command.rb:27:in `run' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/thor-0.20.0/lib/thor/invocation.rb:126:in `invoke_command' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/thor-0.20.0/lib/thor.rb:387:in `dispatch' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/command/base.rb:63:in `perform' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/command.rb:44:in `invoke' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from /app/vendor/bundle/ruby/2.4.0/gems/railties-5.1.1/lib/rails/commands.rb:16:in `<top (required)>' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from bin/rails:9:in `require' 
Dec 22 06:06:20 davidrunger app/web.1: 14:06:19 web.1    | 	from bin/rails:9:in `<main>' 
```