### PR TITLE
Install administrate from RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ git_source(:github) do |repo_name|
 end
 
 gem 'active_model_serializers'
-gem 'administrate', github: 'thoughtbot/administrate' # installed from `master` for Rails 5.1 compat
+gem 'administrate', '~> 0.8.1'
 gem 'browser'
 gem 'devise', github: 'plataformatec/devise'
 gem 'dotenv-rails', require: 'dotenv/rails-now'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,22 +18,6 @@ GIT
       responders
       warden (~> 1.2.3)
 
-GIT
-  remote: https://github.com/thoughtbot/administrate.git
-  revision: a34ee154d9b7af1a6fe29ce14671f6c66398210c
-  specs:
-    administrate (0.7.0)
-      actionpack (>= 4.2, < 5.2)
-      actionview (>= 4.2, < 5.2)
-      activerecord (>= 4.2, < 5.2)
-      autoprefixer-rails (>= 6.0)
-      datetime_picker_rails (~> 0.0.7)
-      jquery-rails (>= 4.0)
-      kaminari (>= 1.0)
-      momentjs-rails (~> 2.8)
-      sass-rails (~> 5.0)
-      selectize-rails (~> 0.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -81,12 +65,23 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    administrate (0.8.1)
+      actionpack (>= 4.2, < 5.2)
+      actionview (>= 4.2, < 5.2)
+      activerecord (>= 4.2, < 5.2)
+      autoprefixer-rails (>= 6.0)
+      datetime_picker_rails (~> 0.0.7)
+      jquery-rails (>= 4.0)
+      kaminari (>= 1.0)
+      momentjs-rails (~> 2.8)
+      sass-rails (~> 5.0)
+      selectize-rails (~> 0.6)
     annotate (2.7.1)
       activerecord (>= 3.2, < 6.0)
       rake (>= 10.4, < 12.0)
     arel (8.0.0)
     ast (2.3.0)
-    autoprefixer-rails (7.1.1)
+    autoprefixer-rails (7.2.3)
       execjs
     awesome_print (1.7.0)
     bcrypt (3.1.11)
@@ -168,18 +163,18 @@ GEM
       sprockets-rails
     jsonapi-renderer (0.1.2)
     jwt (1.5.6)
-    kaminari (1.0.1)
+    kaminari (1.1.1)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.0.1)
-      kaminari-activerecord (= 1.0.1)
-      kaminari-core (= 1.0.1)
-    kaminari-actionview (1.0.1)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
       actionview
-      kaminari-core (= 1.0.1)
-    kaminari-activerecord (1.0.1)
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
       activerecord
-      kaminari-core (= 1.0.1)
-    kaminari-core (1.0.1)
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -332,7 +327,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    selectize-rails (0.12.4)
+    selectize-rails (0.12.4.1)
     shellany (0.0.1)
     shoulda-matchers (3.1.2)
       activesupport (>= 4.0.0)
@@ -380,7 +375,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers
-  administrate!
+  administrate (~> 0.8.1)
   annotate
   awesome_print
   better_errors


### PR DESCRIPTION
There is a breaking change on administrate `master` (see [revert PR][1]) that appears not to be on RubyGems. This should be in general more stable going forward, anyway.

[1]: https://github.com/davidrunger/david_runger/pull/184

The reason that I had been on `master` originally is because there wasn't a gem release that supported Rails 5.1, but now there is, so there's no longer a good reason to stay on master.