### PR TITLE
DRY extra autoload_paths and eager_load_paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,7 +37,10 @@ module DavidRunger
 
     config.middleware.insert_after(Rack::MethodOverride, RequestUuid)
 
-    config.autoload_paths << Rails.root.join('lib')
-    config.eager_load_paths << Rails.root.join('lib')
+    extra_load_paths = [
+      Rails.root.join('lib'),
+    ]
+    config.autoload_paths.concat(extra_load_paths)
+    config.eager_load_paths.concat(extra_load_paths)
   end
 end


### PR DESCRIPTION
This should help to avoid the class of bug that was fixed, for example, in [#13][1] (`NameError: uninitialized constant Api::TextMessagesController::NexmoClient`).

[1]: https://github.com/davidrunger/david_runger/pull/13