### PR TITLE
Remove unused Api::ItemsController#index action & route

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -1,10 +1,4 @@
 class Api::ItemsController < ApplicationController
-  def index
-    store = current_user.stores.find(params[:store_id])
-    @items = store.items.not_archived.order('items.created_at DESC')
-    render :index
-  end
-
   def create
     store = current_user.stores.find(params[:store_id])
     @item = store.items.create!(item_params)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: {format: :json} do
     resources :stores, only: %i[create update destroy] do
-      resources :items, only: %i[index create]
+      resources :items, only: %i[create]
     end
     resources :items, only: %i[update destroy]
     resources :text_messages, only: %i[create]


### PR DESCRIPTION
I actually came across this unused route while exploring PgHero. (The deleted controller action had an `order(:created_at)` that might have justified an index on `items.created_at` -- but further investigation revealed that this controller action is not used at all, in the first place.)