### PR TITLE
Modify migration to not enable pg_stat_statements on Heroku

### DIFF
--- a/db/migrate/20171223054515_enable_pg_stat_statements_extension.rb
+++ b/db/migrate/20171223054515_enable_pg_stat_statements_extension.rb
@@ -1,9 +1,9 @@
 class EnablePgStatStatementsExtension < ActiveRecord::Migration[5.1]
   def up
-    ApplicationRecord.connection.execute('CREATE EXTENSION pg_stat_statements;')
+    ApplicationRecord.connection.execute('CREATE EXTENSION IF NOT EXISTS pg_stat_statements;')
   end
 
   def down
-    ApplicationRecord.connection.execute('DROP EXTENSION pg_stat_statements;')
+    ApplicationRecord.connection.execute('DROP EXTENSION IF EXISTS pg_stat_statements;')
   end
 end


### PR DESCRIPTION
I know it's not a good idea to modify migrations retroactively, but this migration can't run successfully as-is on Heroku (and is thus blocking deploys) because the `pg_stat_statements` extension is already enabled on Heroku. Adding `IF NOT EXISTS` should prevent this migration from causing an error when run on Heroku.