### PR TITLE
Remove created_at indices from stores & items tables

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -12,8 +12,7 @@
 #
 # Indexes
 #
-#  index_items_on_created_at  (created_at)
-#  index_items_on_store_id    (store_id)
+#  index_items_on_store_id  (store_id)
 #
 
 class Item < ApplicationRecord

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -11,8 +11,7 @@
 #
 # Indexes
 #
-#  index_stores_on_created_at  (created_at)
-#  index_stores_on_user_id     (user_id)
+#  index_stores_on_user_id  (user_id)
 #
 
 class Store < ApplicationRecord

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -12,8 +12,7 @@
 #
 # Indexes
 #
-#  index_items_on_created_at  (created_at)
-#  index_items_on_store_id    (store_id)
+#  index_items_on_store_id  (store_id)
 #
 
 class ItemSerializer < ActiveModel::Serializer

--- a/app/serializers/store_serializer.rb
+++ b/app/serializers/store_serializer.rb
@@ -11,8 +11,7 @@
 #
 # Indexes
 #
-#  index_stores_on_created_at  (created_at)
-#  index_stores_on_user_id     (user_id)
+#  index_stores_on_user_id  (user_id)
 #
 
 class StoreSerializer < ActiveModel::Serializer

--- a/db/migrate/20171223060403_remove_created_at_indices_for_stores_and_items.rb
+++ b/db/migrate/20171223060403_remove_created_at_indices_for_stores_and_items.rb
@@ -1,0 +1,6 @@
+class RemoveCreatedAtIndicesForStoresAndItems < ActiveRecord::Migration[5.1]
+  def change
+    remove_index :items, :created_at
+    remove_index :stores, :created_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171223054515) do
+ActiveRecord::Schema.define(version: 20171223060403) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,7 +23,6 @@ ActiveRecord::Schema.define(version: 20171223054515) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "archived", default: false, null: false
-    t.index ["created_at"], name: "index_items_on_created_at"
     t.index ["store_id"], name: "index_items_on_store_id"
   end
 
@@ -83,7 +82,6 @@ ActiveRecord::Schema.define(version: 20171223054515) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "viewed_at"
-    t.index ["created_at"], name: "index_stores_on_created_at"
     t.index ["user_id"], name: "index_stores_on_user_id"
   end
 

--- a/spec/factories/stores.rb
+++ b/spec/factories/stores.rb
@@ -11,8 +11,7 @@
 #
 # Indexes
 #
-#  index_stores_on_created_at  (created_at)
-#  index_stores_on_user_id     (user_id)
+#  index_stores_on_user_id  (user_id)
 #
 
 FactoryBot.define do


### PR DESCRIPTION
Sorting of stores in the Groceries app is alphabetical. I don't think that we ever sort by `created_at` or otherwise make use of the indexes that are being deleted in this PR. So we'll remove them for better write performance! :smile: :tada: