### PR TITLE
Re-enable Vue devtools in development

### DIFF
--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -30,7 +30,7 @@ Vue.prototype.bootstrap = window.davidrunger && window.davidrunger.bootstrap;
 Vue.prototype.$routes = window.Routes;
 
 Vue.config.productionTip = false;
-Vue.config.devtools = false;
+Vue.config.devtools = (window.davidrunger.env === 'development');
 
 Vue.config.errorHandler = (error, _vm, info) => {
   if (window.Rollbar && window.Rollbar.error) {


### PR DESCRIPTION
I recently set `Vue.config.devtools = false` because doing so suppressed a warning/notice about devtools in the output when running my JavaScript tests. I thought that I was just disabling that notice, but it turns out that setting that to `false` also actually turns of the devtools functionality. So this re-enables the devtools in `development`.