### PR TITLE
Check that window.davidrunger is defined for devtools predicate

### DIFF
--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -30,7 +30,7 @@ Vue.prototype.bootstrap = window.davidrunger && window.davidrunger.bootstrap;
 Vue.prototype.$routes = window.Routes;
 
 Vue.config.productionTip = false;
-Vue.config.devtools = (window.davidrunger.env === 'development');
+Vue.config.devtools = (window.davidrunger && (window.davidrunger.env === 'development'));
 
 Vue.config.errorHandler = (error, _vm, info) => {
   if (window.Rollbar && window.Rollbar.error) {


### PR DESCRIPTION
`window.davidrunger` is _not_ defined for tests, so this was breaking JavaScript test runs (`Error: TypeError: Cannot read property 'env' of undefined`).