### PR TITLE
Focus item name input when triggering editing

### DIFF
--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -4,14 +4,14 @@
       span.increment.h2.js-link.olive(@click='setNeeded(item, item.needed + 1)' title='Increment') +
       span.decrement.h2.pl1.pr1.js-link.red(@click='setNeeded(item, item.needed - 1)' title='Decrement') &ndash;
       input(
-        v-if='editingName'
+        v-show='editingName'
         type='text'
-        autofocus
         v-model='item.name'
         @blur='stopEditingAndUpdateItemName()'
         @keydown.enter='stopEditingAndUpdateItemName()'
+        ref='item-name-input'
       )
-      span(v-else @dblclick='editingName = true') {{item.name}}
+      span(v-show='!editingName' @dblclick='editItemName') {{item.name}}
       | &nbsp;
       span ({{item.needed}})
       .delete.h2.pl1.pr1.js-link.right.red(
@@ -31,6 +31,12 @@ export default {
   },
 
   methods: {
+    editItemName() {
+      this.editingName = true;
+      // wait a tick for input to render, then focus it
+      setTimeout(() => { this.$refs['item-name-input'].focus(); });
+    },
+
     isJustAdded(item) {
       return !!item.createdAt && item.createdAt > ((new Date()).valueOf() - 1000);
     },

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "stylelint": "^8.2.0",
     "stylelint-config-standard": "^17.0.0",
     "stylelint-scss": "^2.1.0",
-    "vue-test-utils": "^1.0.0-beta.2",
+    "vue-test-utils": "vuejs/vue-test-utils#dev",
     "webpack-dev-server": "^2.9.7",
     "webpack-node-externals": "^1.6.0"
   }

--- a/spec/javascript/groceries/components/item.spec.js
+++ b/spec/javascript/groceries/components/item.spec.js
@@ -49,8 +49,8 @@ describe('Item', function () { // eslint-disable-line func-names, prefer-arrow-c
     expect(util.findAll(wrapper, 'span:text(bananas)')).toExist();
   });
 
-  it('doesnt initially contain a text input', () => {
-    expect(wrapper.contains('input[type="text"]')).toBeFalsy();
+  it('doesnt initially show a text input', () => {
+    expect(wrapper.find('input[type=text]').attributes().style).toMatch(/display: none/);
   });
 
   describe('editing the item name', () => {
@@ -88,8 +88,8 @@ describe('Item', function () { // eslint-disable-line func-names, prefer-arrow-c
           xhr.restore();
         });
 
-        it('removes the text input', () => {
-          expect(wrapper.contains('input')).toBe(false);
+        it('hides the text input', () => {
+          expect(wrapper.find('input[type=text]').attributes().style).toMatch(/display: none/);
         });
 
         it('updates the item text shown on the client', () => {
@@ -115,7 +115,7 @@ describe('Item', function () { // eslint-disable-line func-names, prefer-arrow-c
       });
 
       it('doesnt convert to a text input', () => {
-        expect(wrapper.contains('input[type="text"]')).toBeFalsy();
+        expect(wrapper.find('input[type=text]').attributes().style).toMatch(/display: none/);
       });
     });
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7535,9 +7535,9 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
-vue-test-utils@^1.0.0-beta.2:
-  version "1.0.0-beta.2"
-  resolved "https://registry.yarnpkg.com/vue-test-utils/-/vue-test-utils-1.0.0-beta.2.tgz#821733022ebc07ea93cefc53aedeea736ca85526"
+vue-test-utils@vuejs/vue-test-utils#dev:
+  version "1.0.0-beta.8"
+  resolved "https://codeload.github.com/vuejs/vue-test-utils/tar.gz/e4151b00ed72da134b8e6f38239824c87c715ce3"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
Previously, I was using `autofocus` for this, but the problem is that Chrome only seems to respect `autofocus` once; subsequent double- clicking of other inputs (or even the same input, IIRC) would result in an unfocused input.

This PR moves us to managing focus manually so that the input will _always_ be focused when editing is triggered.