### PR TITLE
Source Devise from Ruby Gems (rather than GitHub)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 gem 'active_model_serializers'
 gem 'administrate', '~> 0.8.1'
 gem 'browser'
-gem 'devise', github: 'plataformatec/devise'
+gem 'devise'
 gem 'dotenv-rails', require: 'dotenv/rails-now'
 gem 'foreman', require: false
 gem 'hamlit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,17 +7,6 @@ GIT
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
 
-GIT
-  remote: https://github.com/plataformatec/devise.git
-  revision: 4f2e9158336a3e82fcfd803f2a74f4830fcc364d
-  specs:
-    devise (4.3.0)
-      bcrypt (~> 3.0)
-      orm_adapter (~> 0.1)
-      railties (>= 4.1.0, < 5.2)
-      responders
-      warden (~> 1.2.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -104,6 +93,12 @@ GEM
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
     debug_inspector (0.0.3)
+    devise (4.3.0)
+      bcrypt (~> 3.0)
+      orm_adapter (~> 0.1)
+      railties (>= 4.1.0, < 5.2)
+      responders
+      warden (~> 1.2.3)
     diff-lcs (1.3)
     domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
@@ -386,7 +381,7 @@ DEPENDENCIES
   better_errors
   binding_of_caller
   browser
-  devise!
+  devise
   dotenv-rails
   factory_bot_rails
   faker


### PR DESCRIPTION
I originally had sourced `devise` via GitHub rather than Ruby Gems because the released version(s) of Devise did not yet support Rails 5.1. However, a released version of Devise now does support Rails 5.1 (🎉 ), so this PR changes the `devise` source from GitHub to Ruby Gems.