### PR TITLE
Enable Layout/ClassStructure Rubocop rule

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,15 @@
 AllCops:
   EnabledByDefault: true
   TargetRubyVersion: 2.4
+Layout/ClassStructure:
+  ExpectedOrder:
+      - module_inclusion
+      - constants
+      - public_class_methods
+      - initializer
+      - public_methods
+      - protected_methods
+      - private_methods
 Layout/DotPosition:
   EnforcedStyle: trailing
 Layout/IndentArray:


### PR DESCRIPTION
[This cop][0] is newly [added in Rubocop 0.52.0][1], but not enabled by default. I think it's a good cop, so I'm enabling it. :)

[0]: https://rubocop.readthedocs.io/en/latest/cops_layout/#layoutclassstructure
[1]: https://github.com/bbatsov/rubocop/releases/tag/v0.52.0