### PR TITLE
Use `style` loader, not new webpacker `css`/`sass` loaders

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -26,8 +26,8 @@ environment.loaders.set('vue', {
   },
 });
 
-environment.loaders.set('sass', {
-  test: /\.(scss|sass)$/,
+environment.loaders.set('style', {
+  test: /\.(scss|sass|css)$/,
   use: [
     {
       loader: 'style-loader',

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,5 +1,8 @@
 const { environment } = require('@rails/webpacker');
 
+// the following loaders are manually configured in environment-specific configs
 environment.loaders.set('vue', {});
+environment.loaders.set('css', {}); // configured as `style` in environment-specific configs
+environment.loaders.set('sass', {}); // configured as `style` in environment-specific configs
 
 module.exports = environment;


### PR DESCRIPTION
I initially only updated the development environment with this change from `style` => `css` & `sass` ... but thinking about it more, I think it makes sense to just have a single `style` loader, as it was originally. Therefore, this PR reverts the change to development and nullifies the webpacker `css` and `sass` loaders, so I will continue using the `style` loader in all environments.