### PR TITLE
Source vue-test-utils from npm (not GitHub)

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "stylelint": "^8.4.0",
     "stylelint-config-standard": "^18.0.0",
     "stylelint-scss": "^2.2.0",
-    "vue-test-utils": "vuejs/vue-test-utils#dev",
+    "vue-test-utils": "^1.0.0-beta.9",
     "webpack-dev-server": "^2.9.7",
     "webpack-node-externals": "^1.6.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7782,9 +7782,9 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
-vue-test-utils@vuejs/vue-test-utils#dev:
+vue-test-utils@^1.0.0-beta.9:
   version "1.0.0-beta.9"
-  resolved "https://codeload.github.com/vuejs/vue-test-utils/tar.gz/1482c2b8dd77c62733958fa4ca20ca1e0e90ca49"
+  resolved "https://registry.yarnpkg.com/vue-test-utils/-/vue-test-utils-1.0.0-beta.9.tgz#bb67c01e2386f85c3ffbceae460b6e785eb7f81a"
   dependencies:
     lodash "^4.17.4"
 


### PR DESCRIPTION
Due to [a bug in `vue-test-utils`][1], I switched to source `vue-test- utils` via GitHub. The fix is now released from npm, so source from there instead, now.

[1]: https://github.com/vuejs/vue-test-utils/issues/263