### PR TITLE
Fix element-ui CSS on production

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -4,16 +4,17 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const environment = require('./environment');
 const shared = require('./shared');
 
-const extractCSS = new ExtractTextPlugin('[name]-[contenthash].css');
+const cssExtractOptions = ExtractTextPlugin.extract({
+  use: [
+    { loader: 'css-loader', options: { minimize: true, sourceMap: false } },
+    { loader: 'postcss-loader', options: { sourceMap: false } },
+    { loader: 'sass-loader', options: { sourceMap: false } },
+  ],
+})
+
 environment.loaders.set('style', {
   test: /\.(scss|sass|css)$/,
-  use: extractCSS.extract({
-    use: [
-      { loader: 'css-loader', options: { minimize: true, sourceMap: false } },
-      { loader: 'postcss-loader', options: { sourceMap: false } },
-      { loader: 'sass-loader', options: { sourceMap: false } },
-    ],
-  }),
+  use: cssExtractOptions,
 });
 
 const environmentConfig = environment.toWebpackConfig();
@@ -36,13 +37,7 @@ const productionConfig = merge(environmentConfig, shared, {
         loader: 'vue-loader',
         options: {
           cssSourceMap: false,
-          extractCSS: ExtractTextPlugin.extract({
-            use: [
-              { loader: 'css-loader', options: { minimize: true, sourceMap: false } },
-              { loader: 'postcss-loader', options: { sourceMap: false } },
-              { loader: 'sass-loader', options: { sourceMap: false } },
-            ],
-          }),
+          extractCSS: cssExtractOptions,
           loaders: {
             js: 'babel-loader',
             file: 'file-loader',
@@ -53,11 +48,14 @@ const productionConfig = merge(environmentConfig, shared, {
   },
   plugins: [
     new webpack.NoEmitOnErrorsPlugin(),
-    extractCSS,
     new webpack.optimize.CommonsChunkPlugin({
       name: 'commons',
       filename: 'commons-[hash].js',
       minChunks: 2,
+    }),
+    new ExtractTextPlugin({
+      filename: '[name]-[contenthash].css',
+      allChunks: true,
     }),
     new webpack.SourceMapDevToolPlugin({
       test: /\.(js|vue)/,


### PR DESCRIPTION
Man, keeping this CSS configuration working is tough.

I think that the main change in this PR is adding the `allChunks: true` option to the `ExtractTextPlugin` configuration.

Per the docs:

> `allChunks`: Extract from all additional chunks too (by default it extracts only from the initial chunk(s))

> When using `CommonsChunkPlugin` and there are extracted chunks (from `ExtractTextPlugin.extract`) in the commons chunk, `allChunks` **must** be set to `true`

This was working previously without the `allChunks` option, but something (or some combination of things) in the package upgrades that I've done recently seems to have broken it. But now with this PR it's working again. (The "brokenness" is that actually 2 `commons-<hash>.css` bundles were being built on production. One contained the element-ui CSS; the other didn't -- and the one that did _not_ contain the element- ui CSS is the one that was being served on production.)

This _might_ (total speculation) solve the problem of the fact that _I think_ (at least, according to dareboost.com) that I might have been loading the element-ui CSS rules twice?