### PR TITLE
Don't load element-ui button CSS twice

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,12 +15,6 @@
     "syntax-dynamic-import",
     "transform-object-rest-spread",
     ["transform-class-properties", { "spec": true }],
-    ["component", [
-      {
-        "libraryName": "element-ui",
-        "styleLibraryName": "theme-chalk"
-      }
-    ]]
   ],
 
   "env": {

--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -1,4 +1,11 @@
 import axios from 'axios';
+// don't (explicitly) load  element-ui button.css, because it's included in dropdown.css
+import 'element-ui/lib/theme-chalk/card.css';
+import 'element-ui/lib/theme-chalk/dropdown.css';
+import 'element-ui/lib/theme-chalk/dropdown-menu.css';
+import 'element-ui/lib/theme-chalk/dropdown-item.css';
+import 'element-ui/lib/theme-chalk/icon.css';
+import 'element-ui/lib/theme-chalk/input.css';
 import {
   Button,
   Card,

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "axios": "^0.17.1",
     "babel-core": "^6.24.1",
     "babel-loader": "^7.1.2",
-    "babel-plugin-component": "^1.0.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,21 +10,6 @@
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/helper-module-imports@7.0.0-beta.35":
-  version "7.0.0-beta.35"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.35.tgz#308e350e731752cdb4d0f058df1d704925c64e0a"
-  dependencies:
-    "@babel/types" "7.0.0-beta.35"
-    lodash "^4.2.0"
-
-"@babel/types@7.0.0-beta.35":
-  version "7.0.0-beta.35"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.35.tgz#cf933a9a9a38484ca724b335b88d83726d5ab960"
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^2.0.0"
-
 "@rails/webpacker@^3.0.2":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-3.2.0.tgz#e9e98a4da4a3e09441c71d2cbd66461659971055"
@@ -561,12 +546,6 @@ babel-plugin-check-es2015-constants@^6.22.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz#35157b101426fd2ffd3da3f75c7d1e91835bbf8a"
   dependencies:
     babel-runtime "^6.22.0"
-
-babel-plugin-component@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-component/-/babel-plugin-component-1.0.0.tgz#9229448673c66c9b0ca643abecb6ea4b4d0671f8"
-  dependencies:
-    "@babel/helper-module-imports" "7.0.0-beta.35"
 
 babel-plugin-syntax-async-functions@^6.8.0:
   version "6.13.0"
@@ -4290,7 +4269,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0, lodash@~4.17.4:
+"lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0, lodash@~4.17.4:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -7407,10 +7386,6 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
-
-to-fast-properties@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 token-stream@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
It turns out that the element-ui `Button` element CSS seems to be included in the `dropdown.css`. I'm not sure if this is intentional or not, but anyway it has the effect that the `button` CSS gets loaded twice if imported once via `Button`/`button.css` and then a second time through `Dropdown`/`dropdown.css`. So this PR switches from using the `babel-plugin-component` plugin to instead explicitly import the CSS that I want (thus giving me the option to _not_ import the `button.css`, since it's also included in `dropdown.css`).