### PR TITLE
Update yarn (1.2.1 => 1.3.2)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,9 @@ before_install:
   - . $HOME/.nvm/nvm.sh
   - nvm install v8.7.0
   - nvm use v8.7.0
-  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.2.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 script:
+  - "[ \"$(yarn --version)\" == '1.3.2' ]"
   - yarn install
   - bin/rails db:create
   - bin/rails db:schema:load

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -35,7 +35,6 @@ namespace :spec do
   desc 'Run JavaScript specs'
   task js: :environment do
     run_logged_system_command('node --version')
-    run_logged_system_command('yarn --version')
     run_logged_system_command('webpack --version')
     run_logged_system_command('bin/setup-mocha-tests >/dev/null 2>&1')
     print "\n"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
     "test": "mocha-headless-chrome -f http://localhost:8080/packs-test/mocha_runner.html",
     "test-chrome": "bin/setup-mocha-tests && open -a 'Google Chrome' http://localhost:8080/packs-test/mocha_runner.html"
   },
+  "engines": {
+    "yarn": "1.3.2"
+  },
   "browserslist": [
     ">10%"
   ],


### PR DESCRIPTION
This involves:
1. Add a yarn specification to `engines` in `package.json`
2. Update a Travis `before_install` command to verify that we're using `1.3.2` on Travis

I've also removed the `yarn --version` check when running JavaScript specs, since we've already verified that `yarn` is (or, at least, should be...) on the correct version, so this log statement unnecessarily clutters the test output.