### PR TITLE
Update node (8.7.0 => 8.9.3)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ Style/MethodCallWithArgsParentheses:
     - include
     - not_to
     - p
+    - print
     - puts
     - render
     - require

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,11 @@ env:
   - RAILS_ENV=test NODE_ENV=test SECRET_KEY_BASE=0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b
 before_install:
   - . $HOME/.nvm/nvm.sh
-  - nvm install v8.7.0
-  - nvm use v8.7.0
+  - nvm install 8.9.3
+  - nvm use 8.9.3
   - export PATH="$HOME/.yarn/bin:$PATH"
 script:
+  - "[ \"$(node --version)\" == 'v8.9.3' ]"
   - "[ \"$(yarn --version)\" == '1.3.2' ]"
   - yarn install
   - bin/rails db:create

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -34,8 +34,6 @@ namespace :spec do
 
   desc 'Run JavaScript specs'
   task js: :environment do
-    run_logged_system_command('node --version')
-    run_logged_system_command('webpack --version')
     run_logged_system_command('bin/setup-mocha-tests >/dev/null 2>&1')
     print "\n"
     dev_server = Rails.root.join('bin', 'webpack-dev-server')

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "test-chrome": "bin/setup-mocha-tests && open -a 'Google Chrome' http://localhost:8080/packs-test/mocha_runner.html"
   },
   "engines": {
+    "node": "8.9.3",
     "yarn": "1.3.2"
   },
   "browserslist": [


### PR DESCRIPTION
Also, remove logging of `node --version` (and `webpack --version` while we're at it) since `node` version should be locked/assured via the other changes in this PR (and `webpack` version should be locked/assured via `yarn.lock`).