### PR TITLE
Specify eslint mocha env override for spec files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,6 +10,14 @@ module.exports = {
     _: false,
     Routes: false,
   },
+  overrides: [
+    {
+      files: ['spec/javascript/**/*.js'],
+      env: {
+        mocha: true,
+      },
+    },
+  ],
   plugins: ['vue'],
   rules: {
     'arrow-parens': 'off',

--- a/spec/javascript/groceries/components/item.spec.js
+++ b/spec/javascript/groceries/components/item.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env mocha */
-
 import 'spec_helper';
 import { mount, createLocalVue } from 'vue-test-utils';
 import sinon from 'sinon';

--- a/spec/javascript/groceries/components/sidebar.spec.js
+++ b/spec/javascript/groceries/components/sidebar.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env mocha */
-
 import 'spec_helper';
 import { mount, createLocalVue } from 'vue-test-utils';
 import sinon from 'sinon';

--- a/spec/javascript/groceries/store.spec.js
+++ b/spec/javascript/groceries/store.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env mocha */
-
 import 'spec_helper';
 import { initialState, mutations } from 'groceries/store';
 

--- a/spec/javascript/spec_helper.js
+++ b/spec/javascript/spec_helper.js
@@ -1,4 +1,3 @@
-/* eslint-env mocha */
 import Vue from 'shared/customized_vue';
 import _ from 'lodash';
 


### PR DESCRIPTION
This way, we no longer have to say `/* eslint-env mocha */` at the top of every spec file! :smile: :tada: :sparkles: