### PR TITLE
Specify props w/ object syntax for all components

### DIFF
--- a/app/javascript/components/modal.vue
+++ b/app/javascript/components/modal.vue
@@ -33,10 +33,16 @@ export default {
     window.addEventListener('keydown', this.handleKeydown);
   },
 
-  props: [
-    'width',
-    'maxWidth',
-  ],
+  props: {
+    width: {
+      type: String,
+      required: true,
+    },
+    maxWidth: {
+      type: String,
+      required: true,
+    },
+  },
 };
 </script>
 

--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
   li.my1.p1(:class='{unneeded: item.needed <= 0, "appear-vertically": isJustAdded(item)}')
-    drag(:transferData='item')
+    Drag(:transferData='item')
       span.increment.h2.js-link.olive(@click='setNeeded(item, item.needed + 1)' title='Increment') +
       span.decrement.h2.pl1.pr1.js-link.red(@click='setNeeded(item, item.needed - 1)' title='Decrement') &ndash;
       input(
@@ -72,9 +72,12 @@ export default {
     }, 500),
   },
 
-  props: [
-    'item',
-  ],
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+  },
 };
 </script>
 

--- a/app/javascript/groceries/components/logged_in_header.vue
+++ b/app/javascript/groceries/components/logged_in_header.vue
@@ -21,6 +21,8 @@ export default {
         then(() => { window.location.assign(this.$routes.login_path()); });
     },
   },
+
+  props: {},
 };
 </script>
 

--- a/app/javascript/groceries/components/sidebar.vue
+++ b/app/javascript/groceries/components/sidebar.vue
@@ -22,7 +22,7 @@ aside.border-right.border-gray.p2
       :class='{selected: store === currentStore}'
       @click='$store.dispatch("selectStore", { store })'
     )
-      drop(@drop='dropItem(store, ...arguments)')
+      Drop(@drop='dropItem(store, ...arguments)')
         a.store-name {{store.name}}
         a.js-link.right(@click.stop="$store.dispatch('deleteStore', { store })") &times;
 </template>
@@ -77,6 +77,8 @@ export default {
       });
     },
   },
+
+  props: {},
 };
 </script>
 

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -30,7 +30,7 @@ div.mt1.mb2.ml3.mr2
   ul.items-list.mt0.mb0
     Item(v-for='item in sortedItems' :item="item" :key="item.id")
 
-  modal(v-if="showModal" width='85%', maxWidth='400px')
+  Modal(v-if="showModal" width='85%', maxWidth='400px')
     slot
       h3.bold.fonst-size-2.mb2.
         What did you get?
@@ -152,9 +152,12 @@ export default {
     },
   },
 
-  props: [
-    'store',
-  ],
+  props: {
+    store: {
+      type: Object,
+      required: true,
+    },
+  },
 };
 </script>
 

--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -25,6 +25,8 @@ export default {
       'currentStore',
     ]),
   },
+
+  props: {},
 };
 </script>
 

--- a/app/javascript/home/components/home_section.vue
+++ b/app/javascript/home/components/home_section.vue
@@ -10,8 +10,14 @@
 <script>
 export default {
   props: {
-    section: {},
-    title: {},
+    section: {
+      type: String,
+      required: false,
+    },
+    title: {
+      type: String,
+      required: false,
+    },
   },
 };
 </script>

--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -365,6 +365,8 @@ export default {
     positionListener.init();
     new SmoothScroll('a[href*="#"]');
   },
+
+  props: {},
 };
 </script>
 

--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -20,7 +20,7 @@ import { Drag, Drop } from 'vue-drag-drop';
 import VueForm from 'vue-form';
 import Vuex from 'vuex';
 
-import modal from 'components/modal.vue';
+import Modal from 'components/modal.vue';
 import 'shared/common';
 
 const csrfMetaTag = document.querySelector('meta[name="csrf-token"]');
@@ -60,9 +60,9 @@ Vue.use(DropdownItem);
 Vue.use(Icon);
 Vue.use(Input);
 
-Vue.component('modal', modal);
-Vue.component('drag', Drag);
-Vue.component('drop', Drop);
+Vue.component('Modal', Modal);
+Vue.component('Drag', Drag);
+Vue.component('Drop', Drop);
 
 export default Vue;
 


### PR DESCRIPTION
... or, specifically, at least all components that have a `<script>` part; it didn't seem quite worthwhile to create a `<script>` tag for presentational components just to specify an empty `props` list.

Also, capitalize components (so they are easier to distinguish visually and can be autocompleted, per the [style guide][1]).

[1]: https://vuejs.org/v2/style-guide/#Component-name-casing-in-templates-strongly-recommended