### PR TITLE
Enable database connection reaping

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -20,6 +20,7 @@ default: &default
   # For details on connection pooling, see Rails configuration guide
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  reaping_frequency: 60
 
 development:
   <<: *default


### PR DESCRIPTION
This is a neat feature that is built into Rails, but which is not currently enabled by default (although I believe that it _will_ be enabled by default in Rails 5.2, which is currently at beta2). I believe that the reason that this feature isn't enabled by default is because it doesn't play well with MySQL. Fortunately, we're on PostgreSQL! :smile: