### PR TITLE
Remove file option from vue-loader config that does nothing

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -11,7 +11,6 @@ environment.loaders.set('vue', {
   options: {
     loaders: {
       js: 'babel-loader',
-      file: 'file-loader',
       scss:
         'vue-style-loader?sourceMap' +
         '!css-loader?sourceMap' +

--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -10,7 +10,7 @@ const cssExtractOptions = ExtractTextPlugin.extract({
     { loader: 'postcss-loader', options: { sourceMap: false } },
     { loader: 'sass-loader', options: { sourceMap: false } },
   ],
-})
+});
 
 environment.loaders.set('style', {
   test: /\.(scss|sass|css)$/,
@@ -40,7 +40,6 @@ const productionConfig = merge(environmentConfig, shared, {
           extractCSS: cssExtractOptions,
           loaders: {
             js: 'babel-loader',
-            file: 'file-loader',
           },
         },
       },

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -11,7 +11,6 @@ environment.loaders.set('vue', {
   options: {
     loaders: {
       js: 'babel-loader',
-      file: 'file-loader',
       scss: 'vue-style-loader!css-loader!postcss-loader!sass-loader',
       sass: 'vue-style-loader!css-loader!postcss-loader!sass-loader?indentedSyntax',
     },


### PR DESCRIPTION
I'm not sure if this used to do anything before, but it certainly doesn't seem to be doing anything now (nor is it mentioned in the [vue- loader docs][1]... although nor is `sass` or `scss` mentioned there, but those options _do_ seem to have an effect, although I believe that's because they are the `lang` attribute of many/all of my `<style>` tags, which cannot be said of `file`). To prove this, I replaced `file-loader` with `runger- loader` and `bin/webpack-dev-server` compiled just fine. Also, images still loaded in the app.

[1]: https://vue-loader.vuejs.org/en/options.html#loaders