### PR TITLE
Use when-dom-ready lib to check for DOM readiness

### DIFF
--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -19,6 +19,7 @@ import Vue from 'vue';
 import { Drag, Drop } from 'vue-drag-drop';
 import VueForm from 'vue-form';
 import Vuex from 'vuex';
+import whenDomReady from 'when-dom-ready';
 
 import Modal from 'components/modal.vue';
 import 'shared/common';
@@ -72,7 +73,7 @@ export function renderApp(vueApp, options = {}) {
     new Vue({ render: h => h(vueApp), ...options }).$mount('replaced-container');
   };
 
-  document.addEventListener('DOMContentLoaded', () => {
+  whenDomReady(() => {
     // to prevent FOUC in development, pause briefly (to parse CSS source maps) before rendering
     if (window.davidrunger.env === 'development') {
       setTimeout(_renderApp, 150);

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "waypoints": "^4.0.1",
     "webpack": "^3.10.0",
     "webpack-manifest-plugin": "^1.1.0",
-    "webpack-merge": "^4.1.1"
+    "webpack-merge": "^4.1.1",
+    "when-dom-ready": "^1.2.12"
   },
   "devDependencies": {
     "expect": "^22.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7915,6 +7915,10 @@ whatwg-url@^6.3.0:
     tr46 "^1.0.0"
     webidl-conversions "^4.0.1"
 
+when-dom-ready@^1.2.12:
+  version "1.2.12"
+  resolved "https://registry.yarnpkg.com/when-dom-ready/-/when-dom-ready-1.2.12.tgz#99f46f02ef65dbb2bb2f4b58c44588234e724c98"
+
 whet.extend@~0.9.9:
   version "0.9.9"
   resolved "https://registry.yarnpkg.com/whet.extend/-/whet.extend-0.9.9.tgz#f877d5bf648c97e5aa542fadc16d6a259b9c11a1"


### PR DESCRIPTION
Previously, I was checking for the `DOMContentLoaded` event, but this is not ideal because if that event has _already_ fired, then the callback will not be triggered, whereas with `when-dom-ready`, [it's claimed][1] that

> The Promise will resolve instantly if the DOM is already ready.

[1]: https://github.com/lukechilds/when-dom-ready#when-dom-ready

(Based on looking at the code and doing a simple experiment/check, it appears that this will apply to the "callback" way to use `when-dom-ready`, in addition to the "Promise-based" usage that is mentioned in the docs.)

Thanks, `when-dom-ready`! :smile: :+1:

An additional part of my motivation is that I'm also going to need a DOM-ready listener function for another upcoming PR (in order to lazy- load below-the-fold images only after the DOM has loaded / become interactive).