### PR TITLE
Remove duplicated CSS rules (from WebP changes)

### DIFF
--- a/app/assets/stylesheets/components/parallax.scss
+++ b/app/assets/stylesheets/components/parallax.scss
@@ -48,16 +48,12 @@
 html.webp {
   .parallax-inner--macbook-1 {
     &::before {
-      @extend %parallax-pseudo;
-
       background-image: url('~img/macbook-1.webp');
     }
   }
 
   .parallax-inner--macbook-2 {
     &::before {
-      @extend %parallax-pseudo;
-
       background-image: url('~img/macbook-2.webp');
     }
   }


### PR DESCRIPTION
We only need to override the `background-image` rule in browsers that suppoert WebP; we don't need to re-specify `@extend %parallax-pseudo;`, as that is already specified in the non-WebP version of the selector.