### PR TITLE
Count every request with StatsD

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
+  before_action :count_request
   before_action :authenticate_user
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
@@ -31,6 +32,10 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(_resource_or_scope)
     login_path
+  end
+
+  def count_request
+    StatsD.increment('requests')
   end
 
   def filtered_params


### PR DESCRIPTION
My site has low enough activity that my Grafana dashboards aren't very interesting. Adding a metric that counts every request should at least be a somewhat active metric (especially between my New Relic Synthetics monitoring pings, bot crawls, my own usage of the app, etc).