### PR TITLE
Use no-sandbox option when running headless Chrome on Travis

### DIFF
--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -48,6 +48,6 @@ namespace :spec do
       end
     end
 
-    run_logged_system_command('yarn run test')
+    run_logged_system_command("yarn run test#{ENV.key?('TRAVIS') ? '-no-sandbox' : ''}")
   end
 end

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "scripts": {
     "test": "mocha-headless-chrome -f http://localhost:8080/packs-test/mocha_runner.html",
+    "test-no-sandbox": "mocha-headless-chrome -f http://localhost:8080/packs-test/mocha_runner.html -a no-sandbox -a disable-setuid-sandbox",
     "test-chrome": "bin/setup-mocha-tests && open -a 'Google Chrome' http://localhost:8080/packs-test/mocha_runner.html"
   },
   "engines": {


### PR DESCRIPTION
Sad, but it begins to seem that this might be necessary, possibly caused by the Ubuntu image upgrade [described here][1], particularly the Chrome update.

[1]: https://docs.travis-ci.com/user/build-environment-updates/2017-12-12/