### PR TITLE
Specify use of webpack file-loader for webp images

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -21,6 +21,10 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /\.webp$/,
+        loader: 'file-loader',
+      },
+      {
         test: /\/rails_assets\/.*\.js$/,
         loader: 'script-loader',
       },


### PR DESCRIPTION
It seems that #344 / e4a463d (which bumped the @rails/webpacker JavaScript package from 3.2.0 to 3.2.1, along with a number of dependency version bumps, as well) causes `.webp` images to no longer be loaded successfully via webpack (at least, given our configuration settings at the time). (As a result, all CD deployment attempts since the merge of that PR have failed because of this error occurring during the precompilation step of the deploy process, unbeknownst to me.)

I'm unclear what has changed to cause this. Presumably some webpacker dependency dropped what was previously built- in support for `.webp` images? I wonder if this should be taken as a sign that the web community is voting against `.webp` as an image format that we want to support; hmm...

Anyway, explicitly Specifying `file-loader` as the loader for `.webp` images fixes the problem; webpack compiles successfully again.