### PR TITLE
Configure StatsD for DigitalOcean-hosted graphite instance

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -35,7 +35,8 @@ class ApplicationController < ActionController::Base
   end
 
   def count_request
-    StatsD.increment('requests')
+    StatsD.increment("requests_by_action.#{params['controller']}-#{params['action']}")
+    StatsD.increment("requests_by_user.#{current_user&.id || 0}")
   end
 
   def filtered_params

--- a/statsd-config.js
+++ b/statsd-config.js
@@ -12,8 +12,11 @@
 
 {
   graphite: {
-    globalPrefix: process.env.HOSTEDGRAPHITE_APIKEY,
+    globalPrefix: process.env.GRAPHITE_SECRET,
     legacyNamespace: false, // required for globalPrefix to be applied
   },
-  graphiteHost: process.env.HOSTEDGRAPHITE_HOST,
+  deleteCounters: true,
+  deleteTimers: true,
+  graphitePort: 2023, // using non-default (which would be 2003) bc. sending to aggregator instead
+  graphiteHost: process.env.GRAPHITE_HOST,
 }


### PR DESCRIPTION
I've just setup a DigitalOcean droplet with graphite & grafana that I'm going to be using for metrics/monitoring.

Also, send per-user & per-action request count details to StatsD. (Before we were just sending a count of all requests, without any details. Might as well include the details. We can aggregate via graphite into a total count if we really want to, but we probably don't want to, as the per-user and per-action counts are just as informative and more interesting/informative.)