### PR TITLE
Correct Devise setting status 401 even when exception has occurred

### DIFF
--- a/config/initializers/status_code_logging.rb
+++ b/config/initializers/status_code_logging.rb
@@ -1,6 +1,7 @@
 ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*args|
   payload = args.extract_options!
-  status_code = payload[:status]
+  # Devise annoyingly sets payload[:status] to 401 in some cases even when an exception has occurred
+  status_code = payload[:exception].present? ? 500 : payload[:status]
   # round down to the nearest hundred, e.g. 404 => 400
   status_code_class = (status_code / 100) * 100
   StatsD.increment("response.#{status_code_class}")

--- a/lib/david_runger/log_builder.rb
+++ b/lib/david_runger/log_builder.rb
@@ -8,8 +8,9 @@ class DavidRunger::LogBuilder
 
   def extra_logged_data
     {
-      params: params_log,
       exception: exception_log,
+      params: params_log,
+      status: status_code_log,
       user_id: user_id_log,
     }.compact
   end
@@ -20,9 +21,11 @@ class DavidRunger::LogBuilder
     @event.payload
   end
 
-  def exception_log
-    exception = payload[:exception]
+  def exception
+    payload[:exception]
+  end
 
+  def exception_log
     if exception.present?
       exception_class, exception_message = exception
       "#{exception_class}[#{exception_message}]"
@@ -31,6 +34,11 @@ class DavidRunger::LogBuilder
 
   def params_log
     payload[:params].except(*OMITTED_PARAMS)
+  end
+
+  def status_code_log
+    # Devise annoyingly sets payload[:status] to 401 sometimes even when an exception has occurred
+    exception.present? ? 500 : payload[:status]
   end
 
   def user_id_log


### PR DESCRIPTION
... in both `status_code_logging.rb` (for StatsD) and `log_builder.rb` (for request-summarizing log output)