### PR TITLE
Don't log New Relic pings to StatsD

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  before_action :count_request
+  before_action :count_request, unless: -> { DavidRunger::LogSkip.should_skip?(params: params) }
   before_action :authenticate_user
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized

--- a/config/initializers/request_logging.rb
+++ b/config/initializers/request_logging.rb
@@ -36,7 +36,7 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
 
   params = stashed_data['params']
 
-  next if params['new_relic_ping'].present? && ENV['LOG_NEW_RELIC_PINGS'].blank?
+  next if DavidRunger::LogSkip.should_skip?(params: params)
 
   user_id = stashed_data['user_id']
   requested_at = stashed_data['requested_at']

--- a/config/initializers/status_code_logging.rb
+++ b/config/initializers/status_code_logging.rb
@@ -1,5 +1,8 @@
 ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*args|
   payload = args.extract_options!
+  params = payload[:params]
+  next if DavidRunger::LogSkip.should_skip?(params: params)
+
   # Devise annoyingly sets payload[:status] to 401 in some cases even when an exception has occurred
   status_code = payload[:exception].present? ? 500 : payload[:status]
   # round down to the nearest hundred, e.g. 404 => 400

--- a/lib/david_runger/log_skip.rb
+++ b/lib/david_runger/log_skip.rb
@@ -1,0 +1,5 @@
+module DavidRunger::LogSkip
+  def self.should_skip?(params: {})
+    params['new_relic_ping'].present? && ENV['LOG_NEW_RELIC_PINGS'].blank?
+  end
+end


### PR DESCRIPTION
Skip StatsD counts if this is just a New Relic monitoring ping. Extract a `DavidRunger::LogSkip` module to globally encapsulate this logic.