### PR TITLE
Move webpack-cli from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "vuex": "^3.0.1",
     "waypoints": "^4.0.1",
     "webpack": "^4.0.1",
+    "webpack-cli": "^2.0.9",
     "webpack-merge": "^4.1.2",
     "when-dom-ready": "^1.2.12"
   },
@@ -86,7 +87,6 @@
     "stylelint-config-standard": "^18.1.0",
     "stylelint-scss": "^2.4.0",
     "vue-test-utils": "^1.0.0-beta.11",
-    "webpack-cli": "^2.0.9",
     "webpack-dev-server": "^3.0.0",
     "webpack-node-externals": "^1.6.0"
   }


### PR DESCRIPTION
We need it on Heroku to compile assets. Currently asset compilation (and, by extension, deploys) are failing on Heroku/production.

It's not totally my fault. At least, _I think_ that wherever I read about `webpack-cli` the suggestion was to add the `-D` flag to `yarn add`. I can't be blamed for mindlessly following instructions from the Internet, can I? :-p