### PR TITLE
Add pghero_space_stats to list of truncated tables

### DIFF
--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -6,7 +6,7 @@ module DavidRunger::TruncateTables
   SQL
 
   def self.max_allowed_rows
-    Integer(ENV['MAX_TABLE_ROWS']) || 2_500
+    Integer(ENV['MAX_TABLE_ROWS']) || 2_000
   end
 
   def self.print_row_counts
@@ -47,7 +47,7 @@ module DavidRunger::TruncateTables
 end
 
 namespace :db do
-  desc 'Delete all but the most recent rows in the `requests` table'
+  desc 'Delete all but the most recent rows in our larger tables'
   task truncate_tables: :environment do
     puts "About to truncate database tables; max is #{DavidRunger::TruncateTables.max_allowed_rows}"
 
@@ -57,6 +57,7 @@ namespace :db do
 
     DavidRunger::TruncateTables.truncate(table: 'requests', timestamp: 'requested_at')
     DavidRunger::TruncateTables.truncate(table: 'pghero_query_stats', timestamp: 'captured_at')
+    DavidRunger::TruncateTables.truncate(table: 'pghero_space_stats', timestamp: 'captured_at')
 
     puts 'Done truncating tables'
   end


### PR DESCRIPTION
I've gotten a warning from Heroku about approaching my 10,000-row limit on the free postgres plan that I'm on.

Currently I'm at 7,236 rows, which obviously still has some wiggle room, but I'd like to get ahead of this issue.

Accordingly, I'm also reducuing the MAX_TABLE_ROWS environment variable and fallback value to 2,000.