### PR TITLE
Install webpack from master for SourceMapDevToolPlugin fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "vue-template-compiler": "^2.3.0",
     "vuex": "^3.0.1",
     "waypoints": "^4.0.1",
-    "webpack": "^4.0.1",
+    "webpack": "https://github.com/webpack/webpack",
     "webpack-cli": "^2.0.9",
     "webpack-merge": "^4.1.2",
     "when-dom-ready": "^1.2.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,7 +1619,7 @@ chokidar@^1.6.1, chokidar@^1.7.0:
   optionalDependencies:
     fsevents "^1.0.0"
 
-chokidar@^2.0.0:
+chokidar@^2.0.0, chokidar@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.0.2.tgz#4dc65139eeb2714977735b6a35d06e97b494dfd7"
   dependencies:
@@ -9009,6 +9009,14 @@ watchpack@^1.4.0:
     chokidar "^1.7.0"
     graceful-fs "^4.1.2"
 
+watchpack@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.5.0.tgz#231e783af830a22f8966f65c4c4bacc814072eed"
+  dependencies:
+    chokidar "^2.0.2"
+    graceful-fs "^4.1.2"
+    neo-async "^2.5.0"
+
 waypoints@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/waypoints/-/waypoints-4.0.1.tgz#09979a0573810b29627cba4366a284a062ec69c8"
@@ -9167,7 +9175,7 @@ webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.0.0, webpack@^4.0.1:
+webpack@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.0.1.tgz#768d708beeca4c5f77f6c2d38a240fb6ff50ba5d"
   dependencies:
@@ -9189,6 +9197,30 @@ webpack@^4.0.0, webpack@^4.0.1:
     tapable "^1.0.0"
     uglifyjs-webpack-plugin "^1.1.1"
     watchpack "^1.4.0"
+    webpack-sources "^1.0.1"
+
+"webpack@https://github.com/webpack/webpack":
+  version "4.1.0"
+  resolved "https://github.com/webpack/webpack#6970103b7907be08d5cd37dd03d7687bcc609233"
+  dependencies:
+    acorn "^5.0.0"
+    acorn-dynamic-import "^3.0.0"
+    ajv "^6.1.0"
+    ajv-keywords "^3.1.0"
+    chrome-trace-event "^0.1.1"
+    enhanced-resolve "^4.0.0"
+    eslint-scope "^3.7.1"
+    loader-runner "^2.3.0"
+    loader-utils "^1.1.0"
+    memory-fs "~0.4.1"
+    micromatch "^3.1.8"
+    mkdirp "~0.5.0"
+    neo-async "^2.5.0"
+    node-libs-browser "^2.0.0"
+    schema-utils "^0.4.2"
+    tapable "^1.0.0"
+    uglifyjs-webpack-plugin "^1.1.1"
+    watchpack "^1.5.0"
     webpack-sources "^1.0.1"
 
 websocket-driver@>=0.5.1:


### PR DESCRIPTION
Fixes https://rollbar.com/davidjrunger/davidrunger/items/68/

`SourceMapDevToolPlugin` was not producing source maps in production as described in this issue: https://github.com/webpack/webpack/issues/6614

This is fixed on `webpack` `master` by this just-merged fix: https://github.com/webpack/webpack/pull/6627

Therefore, this PR installs webpack from `master` so that source maps will work on production again. :)