### PR TITLE
Specify SHA in webpack git URL in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "vue-template-compiler": "^2.3.0",
     "vuex": "^3.0.1",
     "waypoints": "^4.0.1",
-    "webpack": "https://github.com/webpack/webpack.git",
+    "webpack": "https://github.com/webpack/webpack.git#ae2ae4e",
     "webpack-cli": "^2.0.9",
     "webpack-merge": "^4.1.2",
     "when-dom-ready": "^1.2.12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9130,7 +9130,7 @@ webpack@^4.0.0:
     watchpack "^1.4.0"
     webpack-sources "^1.0.1"
 
-"webpack@https://github.com/webpack/webpack.git":
+"webpack@https://github.com/webpack/webpack.git#ae2ae4e":
   version "4.1.0"
   resolved "https://github.com/webpack/webpack.git#ae2ae4e50401671e0a7b36bb0f35f44a831c5af3"
   dependencies:


### PR DESCRIPTION
This is my latest attempt to fix whatever this problem is that's causing Travis CI to not want to install my npm packages successfully (via yarn). It seems to have something to do with Travis cacheing? I dunno. Let's see what happens.