### PR TITLE
Make Request::recent scope ignore daylight savings time change

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -36,7 +36,7 @@ class Request < ApplicationRecord
 
   scope :human, -> { where(bot: false) }
   scope :recent, (lambda do |time_period = 1.day|
-    where('requests.requested_at > ?', time_period.ago)
+    where('requests.requested_at > ?', Time.current - time_period.to_i) # use #to_i bc of DST stuff
   end)
   scope :ordered, ->() { order('requests.requested_at') }
 end


### PR DESCRIPTION
When I ask for `Request.recent(2.days)`, I think that I really want `Request`s created within the last 48 hours, not just since the same time of day two calendar days ago. This change updates the application code to reflect that desire.

The real motivation for getting involved with this code/specs is that there is currently a failure on `master` related to daylight savings time; this change fixes that failure.