### PR TITLE
Post graphite events to port 8000

### DIFF
--- a/bin/publish-graphite-release
+++ b/bin/publish-graphite-release
@@ -1,4 +1,4 @@
 short_sha=`cat SOURCE_VERSION | cut -c1-7`
-curl -X POST "$GRAPHITE_HTTP_USERNAME:$GRAPHITE_HTTP_PASSWORD@$GRAPHITE_HOST/events/" \
+curl -X POST "$GRAPHITE_HTTP_USERNAME:$GRAPHITE_HTTP_PASSWORD@$GRAPHITE_HOST:8000/events/" \
   -H "Content-Type: application/json" \
   -d "{ \"what\": \"Deploy $short_sha\", \"tags\": \"deploy\", \"when\": `date +%s` }"


### PR DESCRIPTION
I have my graphite server listening on port 8000 nowadays ... I guess that I had it listening on port 80 before? Well, not anymore! (I am using port 8000 rather than port 80 because I don't know that my graphite server is really what I want to have as my "default" served by my DigitalOcean droplet.)