### PR TITLE
Bump yarn from 1.3.2 to 1.5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ before_install:
   - . $HOME/.nvm/nvm.sh
   - nvm install 8.9.3
   - nvm use 8.9.3
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 script:
   - "[ \"$(node --version)\" == 'v8.9.3' ]"
-  - "[ \"$(yarn --version)\" == '1.3.2' ]"
+  - "[ \"$(yarn --version)\" == '1.5.1' ]"
   - yarn install
   - bundle exec rails db:create
   - bundle exec rails db:schema:load

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "engines": {
     "node": "8.9.3",
-    "yarn": "1.3.2"
+    "yarn": "1.5.1"
   },
   "browserslist": [
     ">10%"


### PR DESCRIPTION
I had initially done this version bump as part of a larger effort to remove warnings in `yarn check`. It does not appear to have been successful in that, but hey, we might as will update `yarn`. (1.3.2 is now about 4.5 months old, [released Nov 2, 2017](https://github.com/yarnpkg/yarn/releases/tag/v1.3.2)).

One downside here is that we now have to manually download and install yarn on Travis (which has 1.3.2 by default), so CI builds will be a bit slower, but I feel like it's worth it to have the peace of mind of 4.5 extra months worth of yarn bug fixes.