### PR TITLE
Install statsd from davidrunger fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "sass-loader": "^6.0.5",
     "script-loader": "^0.7.2",
     "smooth-scroll": "^12.1.5",
-    "statsd": "https://github.com/etsy/statsd.git",
+    "statsd": "https://github.com/davidrunger/statsd.git",
     "style-loader": "^0.20.3",
     "vue": "^2.5.16",
     "vue-drag-drop": "^0.2.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,12 +1917,6 @@ combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-1.3.1.tgz#02443e02db96f4b32b674225451abb6e9510000e"
-  dependencies:
-    keypress "0.1.x"
-
 commander@2.11.0:
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.11.0.tgz#157152fd1e7a6c8d98a5b715cf376df928004563"
@@ -4648,10 +4642,6 @@ keycode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/keycode/-/keycode-2.2.0.tgz#3d0af56dc7b8b8e5cba8d0a97f107204eec22b04"
 
-keypress@0.1.x:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.1.0.tgz#4a3188d4291b66b4f65edb99f806aa9ae293592a"
-
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -5361,12 +5351,6 @@ mocha@^5.0.5:
     mkdirp "0.5.1"
     supports-color "4.4.0"
 
-modern-syslog@1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/modern-syslog/-/modern-syslog-1.1.2.tgz#f1fa58899f3f452d788f1573401212a4ef898de5"
-  dependencies:
-    nan "^2.0.5"
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -5414,7 +5398,7 @@ mutexify@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mutexify/-/mutexify-1.0.1.tgz#9880206795d89e75efc1bcb4b4f52ebbd796e5e7"
 
-nan@^2.0.5, nan@^2.10.0, nan@^2.3.0, nan@^2.3.2:
+nan@^2.10.0, nan@^2.3.0, nan@^2.3.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -7780,10 +7764,6 @@ send@0.16.2:
     range-parser "~1.2.0"
     statuses "~1.4.0"
 
-sequence@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/sequence/-/sequence-2.2.1.tgz#7f5617895d44351c0a047e764467690490a16b03"
-
 serialize-javascript@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/serialize-javascript/-/serialize-javascript-1.4.0.tgz#7c958514db6ac2443a8abc062dc9f7886a7f6005"
@@ -8154,15 +8134,13 @@ static-extend@^0.1.1:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-"statsd@https://github.com/etsy/statsd.git":
-  version "0.8.0"
-  resolved "https://github.com/etsy/statsd.git#8d5363cb109cc6363661a1d5813e0b96787c4411"
+"statsd@https://github.com/davidrunger/statsd.git":
+  version "0.10.0"
+  resolved "https://github.com/davidrunger/statsd.git#d9d8419467e56734e3d2ea3e701586090a01ab31"
   dependencies:
     generic-pool "2.2.0"
   optionalDependencies:
     hashring "3.2.0"
-    modern-syslog "1.1.2"
-    winser "=0.1.6"
 
 "statuses@>= 1.3.1 < 2", statuses@~1.4.0:
   version "1.4.0"
@@ -9312,13 +9290,6 @@ wide-align@^1.1.0:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-
-winser@=0.1.6:
-  version "0.1.6"
-  resolved "https://registry.yarnpkg.com/winser/-/winser-0.1.6.tgz#08663dc32878a12bbce162d840da5097b48466c9"
-  dependencies:
-    commander "1.3.1"
-    sequence "2.2.1"
 
 with@^5.0.0:
   version "5.1.1"


### PR DESCRIPTION
My [`davidrunger/statsd` fork][1] drops the optional `winser` dependency of `statsd`. Motivation: `winser` depends on `sequence` which references the `ender` engine which raises a warning in `yarn check`.

`modern-syslog` was also causing a warning of `warning Optional dependency "statsd#modern-syslog" not installed` (which is weird, because it was still listed in my `yarn.lock`, but whatever), so I've dropped that, too.

[1]: https://github.com/davidrunger/statsd