### PR TITLE
Specify node-sass as ^4.7.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "keycode": "^2.2.0",
     "lodash": "^4.17.5",
     "node-pre-gyp": "^0.9.0",
-    "node-sass": "^4.8.1",
+    "node-sass": "^4.7.2",
     "path-complete-extname": "^1.0.0",
     "postcss-loader": "^2.1.3",
     "precss": "^3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5398,7 +5398,7 @@ mutexify@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mutexify/-/mutexify-1.0.1.tgz#9880206795d89e75efc1bcb4b4f52ebbd796e5e7"
 
-nan@^2.10.0, nan@^2.3.0, nan@^2.3.2:
+nan@^2.3.0, nan@^2.3.2:
   version "2.10.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.10.0.tgz#96d0cd610ebd58d4b4de9cc0c6828cda99c7548f"
 
@@ -5555,30 +5555,6 @@ node-sass@^4.7.2:
     meow "^3.7.0"
     mkdirp "^0.5.1"
     nan "^2.3.2"
-    node-gyp "^3.3.1"
-    npmlog "^4.0.0"
-    request "~2.79.0"
-    sass-graph "^2.2.4"
-    stdout-stream "^1.4.0"
-    "true-case-path" "^1.0.2"
-
-node-sass@^4.8.1:
-  version "4.8.3"
-  resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.8.3.tgz#d077cc20a08ac06f661ca44fb6f19cd2ed41debb"
-  dependencies:
-    async-foreach "^0.1.3"
-    chalk "^1.1.1"
-    cross-spawn "^3.0.0"
-    gaze "^1.0.0"
-    get-stdin "^4.0.1"
-    glob "^7.0.3"
-    in-publish "^2.0.0"
-    lodash.assign "^4.2.0"
-    lodash.clonedeep "^4.3.2"
-    lodash.mergewith "^4.6.0"
-    meow "^3.7.0"
-    mkdirp "^0.5.1"
-    nan "^2.10.0"
     node-gyp "^3.3.1"
     npmlog "^4.0.0"
     request "~2.79.0"


### PR DESCRIPTION
`@rails/webpacker` specifies node-sass in this way (`^4.7.2`). Since this cannot bump to >= 4.8.0, having `node-sass` `^4.8.1` in my own `package.json` produces a warning of `warning "@rails/webpacker#node- sass@^4.7.2" could be deduped from "4.8.3" to "node-sass@4.8.3"` in `yarn check`.

My OCD tells me it's worthwhile to lock `node-sass` at an earlier version in order to avoid this problem. I guess it'll also make `yarn install` a little faster to only have to install one version of `node- sass`?