### PR TITLE
Move logged-in header to sidebar

### DIFF
--- a/app/javascript/groceries/components/logged_in_header.vue
+++ b/app/javascript/groceries/components/logged_in_header.vue
@@ -1,16 +1,11 @@
 <template lang="pug">
-.right-align.bg-lighten-4.pr2
-  el-dropdown(
-    :hide-timeout=50
-    :show-timeout=0
-    placement='bottom-end'
-  )
-    .user-email {{ bootstrap.current_user.email }} #[el-icon(name='arrow-down')]
-    el-dropdown-menu(slot='dropdown')
-      a(:href="$routes.edit_user_path(bootstrap.current_user)")
-        el-dropdown-item Edit Account
-      a.js-link(@click='signOut()')
-        el-dropdown-item(divided :command='signOut') Sign Out
+el-menu.center
+  el-submenu(index='1')
+    template(slot='title') {{ bootstrap.current_user.email }}
+    a(:href="$routes.edit_user_path(bootstrap.current_user)")
+      el-menu-item(index='1-1') Account Settings
+    a.js-link(@click='signOut()')
+      el-menu-item(index='1-2') Sign Out
 </template>
 
 <script>
@@ -29,5 +24,23 @@ export default {
 <style lang='scss' scoped>
 .user-email {
   line-height: 30px;
+}
+
+.el-menu {
+  background-color: #e1eeff;
+  border: none;
+}
+
+/deep/ .el-submenu.is-opened .el-submenu__title {
+  background-color: #d1e7ff;
+}
+
+/deep/ .el-menu,
+/deep/ .el-submenu__title i {
+  color: #111;
+}
+
+/deep/ .el-menu--inline {
+  background-color: rgba(255, 255, 255, 0.9);
 }
 </style>

--- a/app/javascript/groceries/components/sidebar.vue
+++ b/app/javascript/groceries/components/sidebar.vue
@@ -1,37 +1,45 @@
 <template lang='pug'>
-aside.border-right.border-gray.p2
-  vue-form.add-store.flex(@submit.prevent='createStore' :state='formstate')
-    validate.flex-1.mr1
-      el-input(
-        type='text'
-        v-model='newStoreName'
-        name='newStoreName'
-        required
-        placeholder='Add a store'
+aside.border-right.border-gray
+  LoggedInHeader.mb2
+  .p2
+    vue-form.add-store.flex(@submit.prevent='createStore' :state='formstate')
+      validate.flex-1.mr1
+        el-input(
+          type='text'
+          v-model='newStoreName'
+          name='newStoreName'
+          required
+          placeholder='Add a store'
+          size='medium'
+        )
+      el-input.flex-0(
+        value='Add'
+        type='submit'
+        :disabled='postingStore || formstate.$invalid'
         size='medium'
       )
-    el-input.flex-0(
-      value='Add'
-      type='submit'
-      :disabled='postingStore || formstate.$invalid'
-      size='medium'
-    )
-  ul.stores-list
-    li.js-link.stores-list__item.h3.my2.py1.px2(
-      v-for='store in sortedStores'
-      :class='{selected: store === currentStore}'
-      @click='$store.dispatch("selectStore", { store })'
-    )
-      Drop(@drop='dropItem(store, ...arguments)')
-        a.store-name {{store.name}}
-        a.js-link.right(@click.stop="$store.dispatch('deleteStore', { store })") &times;
+    ul.stores-list
+      li.js-link.stores-list__item.h3.my2.py1.px2(
+        v-for='store in sortedStores'
+        :class='{selected: store === currentStore}'
+        @click='$store.dispatch("selectStore", { store })'
+      )
+        Drop(@drop='dropItem(store, ...arguments)')
+          a.store-name {{store.name}}
+          a.js-link.right(@click.stop="$store.dispatch('deleteStore', { store })") &times;
 </template>
 
 <script>
 import { mapGetters, mapState } from 'vuex';
 import _ from 'lodash';
 
+import LoggedInHeader from './logged_in_header.vue';
+
 export default {
+  components: {
+    LoggedInHeader,
+  },
+
   computed: {
     ...mapGetters([
       'currentStore',

--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -3,19 +3,16 @@
     div#page.flex.vh-100
       Sidebar
       main.flex-1.bg-cover.overflow-auto
-        LoggedInHeader
         Store(v-if='currentStore' :store='currentStore')
 </template>
 
 <script>
 import { mapGetters } from 'vuex';
-import LoggedInHeader from './components/logged_in_header.vue';
 import Sidebar from './components/sidebar.vue';
 import Store from './components/store.vue';
 
 export default {
   components: {
-    LoggedInHeader,
     Sidebar,
     Store,
   },

--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -1,19 +1,22 @@
 import axios from 'axios';
 // don't (explicitly) load  element-ui button.css, because it's included in dropdown.css
+import 'element-ui/lib/theme-chalk/base.css';
+import 'element-ui/lib/theme-chalk/button.css';
 import 'element-ui/lib/theme-chalk/card.css';
-import 'element-ui/lib/theme-chalk/dropdown.css';
-import 'element-ui/lib/theme-chalk/dropdown-menu.css';
 import 'element-ui/lib/theme-chalk/dropdown-item.css';
 import 'element-ui/lib/theme-chalk/icon.css';
 import 'element-ui/lib/theme-chalk/input.css';
+import 'element-ui/lib/theme-chalk/menu.css';
+import 'element-ui/lib/theme-chalk/menu-item.css';
+import 'element-ui/lib/theme-chalk/submenu.css';
 import {
   Button,
   Card,
-  Dropdown,
-  DropdownMenu,
-  DropdownItem,
   Icon,
   Input,
+  Menu,
+  MenuItem,
+  Submenu,
 } from 'element-ui';
 import Vue from 'vue';
 import { Drag, Drop } from 'vue-drag-drop';
@@ -55,11 +58,11 @@ Vue.use(VueForm);
 
 Vue.use(Button);
 Vue.use(Card);
-Vue.use(Dropdown);
-Vue.use(DropdownMenu);
-Vue.use(DropdownItem);
 Vue.use(Icon);
 Vue.use(Input);
+Vue.use(Menu);
+Vue.use(MenuItem);
+Vue.use(Submenu);
 
 Vue.component('Modal', Modal);
 Vue.component('Drag', Drag);

--- a/spec/javascript/groceries/components/sidebar.spec.js
+++ b/spec/javascript/groceries/components/sidebar.spec.js
@@ -22,9 +22,12 @@ describe('Sidebar', function () { // eslint-disable-line func-names
   beforeEach(() => {
     item = { id: 48, name: 'bananas', needed: 0 };
     groceryStore = { id: 23, name: 'Costco', items: [item] };
-    bootstrap = { stores: [groceryStore] };
+    bootstrap = {
+      stores: [groceryStore],
+      current_user: { id: 1, email: 'davidjrunger@gmail.com' },
+    };
     vuexStore = groceryVuexStoreFactory(bootstrap);
-    wrapper = mount(Sidebar, { localVue, store: vuexStore });
+    wrapper = mount(Sidebar, { localVue, store: vuexStore, mocks: { bootstrap } });
   });
 
   it('is a Vue instance', () => {


### PR DESCRIPTION
It's kind of a long story why I even started down this road in the first place. Suffice it to say, though, that I think that this is better. The left-hand panel is more the "controls" of the app (choosing a store, and now also configuring user settings & logging out); it didn't make as much sense to have the logged-in header mixed in among the main panel of the grocery store and items.

## Before

![](http://take.ms/O3Hlz)

## After

**Unexpanded:**
![](http://take.ms/Pjunz)

**Expanded:**
![](http://take.ms/7u9L3)