### PR TITLE
Assume only 1 error argument in spec_helper.js console.error

### DIFF
--- a/spec/javascript/spec_helper.js
+++ b/spec/javascript/spec_helper.js
@@ -29,9 +29,9 @@ expect.extend({
 
 const originalConsoleError = console.error; // eslint-disable-line no-console
 beforeEach(() => {
-  console.error = (...args) => { // eslint-disable-line no-console
-    originalConsoleError(args);
-    throw new Error(JSON.stringify(args));
+  console.error = (error) => { // eslint-disable-line no-console
+    originalConsoleError(error);
+    throw new Error(JSON.stringify(error));
   };
 });
 afterEach(() => {


### PR DESCRIPTION
This will make it easier to see the error in Chrome, without having to click down into an array, which usually consists of only a single element, anyway.