### PR TITLE
Log errors via Rails.logger (in additionl to Rollbar)

### DIFF
--- a/app/controllers/concerns/request_recordable.rb
+++ b/app/controllers/concerns/request_recordable.rb
@@ -12,6 +12,7 @@ module RequestRecordable
   def store_request_data_in_redis
     $redis.setex(params['request_uuid'], REQUEST_DATA_TTL, request_data.to_json)
   rescue Encoding::UndefinedConversionError => error
+    Rails.logger.info("Error storing request data in Redis, error=#{error.inspect}")
     Rollbar.info(error)
   rescue
     # wrap the original exception in StashRequestError by raising and immediately rescuing

--- a/app/form_objects/sms_message.rb
+++ b/app/form_objects/sms_message.rb
@@ -44,6 +44,10 @@ class SmsMessage
     if SmsRecord.create_records_from_httparty_response(response: nexmo_response, user: @user)
       true
     else
+      Rails.logger.error(<<~LOG.squish)
+        Failed to create SmsRecord(s),
+        user=#{@user&.id}, message_type=#{@message_type}, message_params=#{@message_params}
+      LOG
       Rollbar.error(
         SaveSmsRecordError.new,
         user: @user&.id,

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -100,7 +100,8 @@ module SourceMapHelper
 
       begin
         post_to_rollbar!(source_url: source_url, source_map_path: full_local_map_path)
-      rescue
+      rescue => error
+        Rails.logger.error("Error posting source maps to Rollbar, error=#{error.inspect}")
         # wrap the original exception by raising and immediately rescuing
         begin
           raise(SourceMapUploadError, 'Failed to upload a source map')

--- a/lib/tasks/requests.rake
+++ b/lib/tasks/requests.rake
@@ -21,6 +21,7 @@ namespace :requests do
         body: ip_addresses_to_lookup.map { |ip| {query: ip} }.to_json,
       ).parsed_response
     rescue Net::OpenTimeout, Errno::ECONNRESET => e # log connection issues as info, not error
+      Rails.logger.info("Error fetching IP data, error=#{e.inspect}")
       Rollbar.info(e)
     end
 


### PR DESCRIPTION
Rollbar is not going to be 100% reliable, so it's good to have `Rails.logger` logging available as a backup. Plus, logs are to capture what happens in the app; errors are notable happenings. Also, it might be easier in some cases to search logs than to search Rollbar. Finally, I believe that I have indefinite logs retention on my DigitalOcean droplet, whereas I don't think that Rollbar retains errors indefinitely.