### PR TITLE
Get stylelint working again

### DIFF
--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,0 +1,4 @@
+personal/
+public/assets/
+public/packs/
+tmp/

--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -448,18 +448,18 @@ i[class^=devicon-] {
         color: white;
       }
 
-      &:not(.active) span {
-        border-bottom-color: rgba($white-dark, 0);
+      span {
+        border-bottom-width: 2px;
+        border-bottom-style: solid;
+        transition: border-bottom-color 1s ease-out;
       }
 
       &.active span {
         border-bottom-color: rgba($white-dark, 0.8);
       }
 
-      span {
-        border-bottom-width: 2px;
-        border-bottom-style: solid;
-        transition: border-bottom-color 1s ease-out;
+      &:not(.active) span {
+        border-bottom-color: rgba($white-dark, 0);
       }
     }
   }

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,6 +1,8 @@
 const webpack = require('webpack');
 const fs = require('fs');
 const merge = require('webpack-merge');
+const StyleLintPlugin = require('stylelint-webpack-plugin');
+
 const environment = require('./environment');
 const shared = require('./shared');
 
@@ -60,7 +62,11 @@ environment.loaders.append('style', {
 const developmentConfig = merge(environment.toWebpackConfig(), shared, {
   mode: 'development',
   devtool: 'inline-cheap-module-source-map',
-  plugins: [],
+  plugins: [
+    new StyleLintPlugin({
+      files: ['**/*.vue', '**/*.css', '**/*.scss'],
+    }),
+  ],
 });
 
 fs.writeFileSync(

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "stylelint": "^9.2.0",
     "stylelint-config-standard": "^18.2.0",
     "stylelint-scss": "^3.0.0",
+    "stylelint-webpack-plugin": "^0.10.4",
     "vue-test-utils": "^1.0.0-beta.11",
     "webpack-dev-server": "^3.1.3",
     "webpack-node-externals": "^1.7.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7211,6 +7211,10 @@ quick-lru@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-1.1.0.tgz#4360b17c61136ad38078397ff11416e186dcfbb8"
 
+ramda@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.25.0.tgz#8fdf68231cffa90bc2f9460390a0cb74a29b29a9"
+
 randomatic@^1.1.3:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/randomatic/-/randomatic-1.1.7.tgz#c7abe9cc8b87c0baa876b19fde83fd464797e38c"
@@ -8453,6 +8457,15 @@ stylelint-scss@^3.0.0:
     postcss-resolve-nested-selector "^0.1.1"
     postcss-selector-parser "^3.1.1"
     postcss-value-parser "^3.3.0"
+
+stylelint-webpack-plugin@^0.10.4:
+  version "0.10.4"
+  resolved "https://registry.yarnpkg.com/stylelint-webpack-plugin/-/stylelint-webpack-plugin-0.10.4.tgz#08d52666bcdc1e9808ebcdabfde555b15a839a34"
+  dependencies:
+    arrify "^1.0.1"
+    micromatch "^3.1.8"
+    object-assign "^4.1.0"
+    ramda "^0.25.0"
 
 stylelint@^9.2.0:
   version "9.2.0"


### PR DESCRIPTION
I had removed `stylelint-webpack-plugin` in 65366db / #436 because it was not yet compatibile with Webpack 4. But now it is! :tada: