### PR TITLE
Load PerformantImages right away after DOM is ready

### DIFF
--- a/app/javascript/components/performant_image.vue
+++ b/app/javascript/components/performant_image.vue
@@ -27,12 +27,7 @@ export default {
     this.webpImageUrl = webpSource ? webpSource.data.attrs.src : null;
 
     checkWebpSupport().then(webpIsSupported => { this.canUseWebp = webpIsSupported; });
-    whenDomReady().then(() => {
-      // An additional timeout seems to be required in order pass the Chrome Lighthouse "Audit"
-      setTimeout(() => {
-        this.mayRenderLazyImages = true;
-      }, 3000);
-    });
+    whenDomReady().then(() => this.mayRenderLazyImages = true);
   },
 
   data() {


### PR DESCRIPTION
This commit removes a 3-second timeout that I had only added to satisfy Chrome's Lighthouse audit. I think that we will get basically the same performance benefits (which I don't actually think are all too significant, anyway, though) without waiting for those 3 seconds, with the upside that if the user starts scrolling down quickly, the image won't suddenly load later.