### PR TITLE
Refresh home page waypoints when images are loaded

### DIFF
--- a/app/javascript/components/performant_image.vue
+++ b/app/javascript/components/performant_image.vue
@@ -6,6 +6,7 @@
       :class='imageClass'
       :style='imageStyle'
       :alt='alt'
+      @load='emitGlobalLoadEvent'
     )
 </template>
 
@@ -13,6 +14,7 @@
 import whenDomReady from 'when-dom-ready';
 
 import checkWebpSupport from 'lib/check_webp_support';
+import { emit } from 'lib/event_bus';
 
 export default {
   mounted() {
@@ -56,6 +58,12 @@ export default {
       type: Boolean,
       required: false,
       default: false,
+    },
+  },
+
+  methods: {
+    emitGlobalLoadEvent() {
+      emit('performant-image:image-loaded');
     },
   },
 };

--- a/app/javascript/home/scripts/position_listener.js
+++ b/app/javascript/home/scripts/position_listener.js
@@ -3,6 +3,8 @@ import Gator from 'gator';
 import 'waypoints/lib/noframework.waypoints'; // adds `Waypoint` to window
 import 'waypoints/lib/shortcuts/inview'; // adds `Inview` to `Waypoint`
 
+import { on } from 'lib/event_bus';
+
 let forcedActiveNavIdSetAt;
 let forcedActiveNavId;
 
@@ -66,6 +68,16 @@ function getScrollHooks() {
   return [].slice.apply(document.querySelectorAll('[data-section] .js-scroll-hook'));
 }
 
+// Image loading can alter page layout (increasing height), so refresh waypoints when that happens.
+function initImageLoadedRefreshing() {
+  const throttledRefreshAll = _.throttle(refreshAll, 1000, { leading: false });
+  on('performant-image:image-loaded', throttledRefreshAll);
+}
+
+function refreshAll() {
+  window.requestAnimationFrame(() => window.Waypoint.refreshAll());
+}
+
 // The explicitness of being able to call this as `positionListener.init()` is nice here
 // eslint-disable-next-line import/prefer-default-export
 export function init() {
@@ -103,4 +115,5 @@ export function init() {
   });
 
   initNavlinkClickHandling();
+  initImageLoadedRefreshing();
 }

--- a/app/javascript/lib/event_bus.js
+++ b/app/javascript/lib/event_bus.js
@@ -1,0 +1,11 @@
+// Currently, this is just a thin wrapper around addEventListener/dispatchEvent, for conciseness.
+// This can be expanded in the future to include a payload, too.
+// This would require using CustomEvent rather than Event, and possibly a polyfill for IE.
+
+export function on(eventName, callback) {
+  window.addEventListener(eventName, callback);
+}
+
+export function emit(eventName) {
+  window.dispatchEvent(new Event(eventName));
+}


### PR DESCRIPTION
Image loading can alter page layout (increasing height), so refresh waypoints when that happens.