### PR TITLE
Import plain CSS files via JavaScript (not via Sass @import)

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1,10 +1,3 @@
-@import "vendor/reset";
-@import '~basscss/css/basscss';
-@import '~basscss-background-colors/css/background-colors';
-@import '~basscss-background-images/css/background-images';
-@import '~basscss-border-colors/css/border-colors';
-@import '~basscss-colors/css/colors';
-@import '~basscss-lighten/css/lighten';
 @import "variables";
 @import "animations/appear_vertically";
 @import "components/spinner";

--- a/app/javascript/packs/styles.js
+++ b/app/javascript/packs/styles.js
@@ -1,4 +1,10 @@
-// `eslint-plugin-import` doesnt know about our `css/` alias. Since we only use the `css/`` alias
-// here, we'll just ignore the issue rather than solving it more systemically.
-// eslint-disable-next-line import/no-unresolved,import/no-extraneous-dependencies
+// node-sass doesn't support `@import`ing plain CSS files, so import plain CSS files here
+import 'css/vendor/reset.css';
+import 'basscss/css/basscss.css';
+import 'basscss-background-colors/css/background-colors.css';
+import 'basscss-background-images/css/background-images.css';
+import 'basscss-border-colors/css/border-colors.css';
+import 'basscss-colors/css/colors.css';
+import 'basscss-lighten/css/lighten.css';
+
 import 'css/styles.scss';


### PR DESCRIPTION
LibSass/`node-sass` have deprecated plain CSS `@imports` in Sass files, so import plain CSS files via JavaScript instead.

See:
https://github.com/sass/libsass/releases/tag/3.5.3
https://github.com/sass/node-sass/releases/tag/v4.9.0