### PR TITLE
Allow running webpack with test config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,8 @@
 
 if (process.env.NODE_ENV === 'production') {
   module.exports = require('./config/webpack/production.js');
+} else if (process.env.NODE_ENV === 'test') {
+  module.exports = require('./config/webpack/test.js');
 } else {
   module.exports = require('./config/webpack/development.js');
 }


### PR DESCRIPTION
(We are not "metaprogramming" the `require` statement because eslint says that `require` statements should use string literals.)