### PR TITLE
Fix webpack deprecation error by listening to done event correctly

### DIFF
--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -63,7 +63,7 @@ const testConfig = merge(environment.toWebpackConfig(), shared, {
     }),
     // from https://github.com/webpack/webpack/issues/708#issuecomment-70869174
     function () {
-      this.plugin('done', stats => {
+      this.hooks.done.tap('RungerTestEnvErrorLogger', stats => {
         if (stats.compilation.errors && stats.compilation.errors.length && process.env.TRAVIS) {
           console.error(stats.compilation.errors);
           process.exit(1);


### PR DESCRIPTION
Previously we were using a deprecated API that was generating a log warning of `DeprecationWarning: Tapable.plugin is deprecated. Use new API on `.hooks` instead` (in the `test` env).