### PR TITLE
Add Google site ownership verification

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,4 +31,9 @@ Rails.application.routes.draw do
   authenticate :user, -> (user) { user.admin? } do
     mount PgHero::Engine, at: 'pghero'
   end
+
+  # Google periodically re-verifies this route, so we need to leave it here indefinitely
+  get 'google83c07e1014ea4a70', to: ->(env) {
+    [200, {}, ['google-site-verification: google83c07e1014ea4a70.html']]
+  }
 end


### PR DESCRIPTION
I originally added this in #118 / 5d8176f and then removed it in #120 / e314aa3, thinking that it was no longer necessary. However, it turns out that Google periodically re-verifies this route and content, so we actually need to leave it here indefinitely.