### PR TITLE
Remove babel-preset-es2015 per deprecation warning

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,5 @@
 {
   "presets": [
-    "es2015",
     ["env", {
       "modules": false,
       "targets": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "babel-plugin-transform-vue-jsx": "^3.7.0",
     "babel-polyfill": "^6.23.0",
     "babel-preset-env": "^1.6.1",
-    "babel-preset-es2015": "^6.24.1",
     "basscss": "^8.0.4",
     "basscss-background-colors": "^2.1.0",
     "basscss-background-images": "^0.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1102,7 +1102,7 @@ babel-preset-env@^1.6.1:
     invariant "^2.2.2"
     semver "^5.3.0"
 
-babel-preset-es2015@^6.24.1, babel-preset-es2015@^6.9.0:
+babel-preset-es2015@^6.9.0:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz#d44050d6bc2c9feea702aaf38d727a0210538939"
   dependencies:


### PR DESCRIPTION
> Thanks for using Babel: we recommend using babel-preset-env now: please read babeljs.io/env to update!

https://babeljs.io/env