### PR TITLE
Remove newline from within pug template inline tag

### DIFF
--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -245,8 +245,8 @@ div.font-nunito
           of styling can be done in the markup itself.
         li.
           The official #[b #[a(href='https://vue-test-utils.vuejs.org/en/') vue-test-utils]] library
-          facilitates Vue component unit testing. Tests are run using #[b Mocha], #[b headless
-          Chrome], and "regular" (non-headless) Chrome.
+          facilitates Vue component unit testing. Tests are run using #[b Mocha],
+          #[b headless Chrome], and "regular" (non-headless) Chrome.
         li.
           #[b Continuous integration (CI)] via Travis, which also provides
           #[b continuous deployment (CD)] via #[b Heroku] (which hosts the app)

--- a/bin/setup-mocha-tests
+++ b/bin/setup-mocha-tests
@@ -22,5 +22,5 @@ const specIndexPath = join(__dirname, '..', 'spec', 'javascript', 'packs', 'spec
 fs.writeFileSync(specIndexPath, `${indexFileContents}\n`);
 
 console.log('NOTE: For the tests to work, you must first run');
-console.log('NODE_ENV=test bin/webpack-dev-server');
+console.log('RAILS_ENV=test NODE_ENV=test bin/webpack-dev-server');
 console.log('(maybe in another tab).');

--- a/spec/javascript/home/home.spec.js
+++ b/spec/javascript/home/home.spec.js
@@ -1,0 +1,22 @@
+import 'spec_helper';
+import { createLocalVue, mount } from '@vue/test-utils';
+import Home from 'home/home.vue';
+
+describe('Home', function () { // eslint-disable-line func-names, prefer-arrow-callback
+  const localVue = createLocalVue();
+
+  let home;
+
+  beforeEach(() => {
+    home = mount(Home, { localVue });
+  });
+
+  it('is a Vue instance', () => {
+    expect(home.isVueInstance()).toBeTruthy();
+  });
+
+  it('renders a basic headline', () => {
+    expect(home.text()).toContain('David Runger');
+    expect(home.text()).toContain('Full stack web developer');
+  });
+});


### PR DESCRIPTION
Apparently having a newline within an inline element tag this is not allowed / breaks compilation of the template.

Fortunately this problem occurred during deploy rather than on production.

However, this was not caught by tests in CI, and should have been. This PR also adds a basic test for the Home Vue component that should catch this sort of issue in CI in the future.