### PR TITLE
Source webpacker from Rubygems and npm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,7 +31,7 @@ gem 'rollbar'
 gem 'rubocop', require: false
 gem 'sass-rails', '~> 5.0'
 gem 'statsd-instrument'
-gem 'webpacker', github: 'rails/webpacker'
+gem 'webpacker', '>= 4.0.0.pre.pre.2'
 
 group :development, :test do
   gem 'awesome_print'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,15 +15,6 @@ GIT
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
 
-GIT
-  remote: https://github.com/rails/webpacker.git
-  revision: 90373c21b1987bed4f8e040bccb7e5e33cac9a71
-  specs:
-    webpacker (4.0.0.pre.pre.2)
-      activesupport (>= 4.2)
-      rack-proxy (>= 0.6.1)
-      railties (>= 4.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -387,6 +378,10 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
+    webpacker (4.0.0.pre.pre.2)
+      activesupport (>= 4.2)
+      rack-proxy (>= 0.6.1)
+      railties (>= 4.2)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -438,7 +433,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.2)!
   statsd-instrument
   webmock
-  webpacker!
+  webpacker (>= 4.0.0.pre.pre.2)
 
 RUBY VERSION
    ruby 2.4.2p198

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "facebook/jscodeshift#247/head**/nomnom": "gerhobbelt/nomnom#master"
   },
   "dependencies": {
-    "@rails/webpacker": "https://github.com/rails/webpacker.git",
+    "@rails/webpacker": "^4.0.0-pre.2",
     "autoprefixer": "^8.4.1",
     "axios": "^0.18.0",
     "babel-core": "^6.26.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -104,11 +104,11 @@
     call-me-maybe "^1.0.1"
     glob-to-regexp "^0.3.0"
 
-"@rails/webpacker@https://github.com/rails/webpacker.git":
+"@rails/webpacker@^4.0.0-pre.2":
   version "4.0.0-pre.2"
-  resolved "https://github.com/rails/webpacker.git#90373c21b1987bed4f8e040bccb7e5e33cac9a71"
+  resolved "https://registry.yarnpkg.com/@rails/webpacker/-/webpacker-4.0.0-pre.2.tgz#66be9b5eac9e5f54030de4dde93820a626e70657"
   dependencies:
-    babel-core "^6.26.3"
+    babel-core "^6.26.0"
     babel-loader "^7.1.3"
     babel-plugin-syntax-dynamic-import "^6.18.0"
     babel-plugin-transform-class-properties "^6.24.1"
@@ -122,17 +122,17 @@
     glob "^7.1.2"
     js-yaml "^3.11.0"
     mini-css-extract-plugin "^0.4.0"
-    node-sass "^4.9.0"
+    node-sass "^4.8.3"
     path-complete-extname "^1.0.0"
     postcss-cssnext "^3.1.0"
     postcss-import "^11.1.0"
-    postcss-loader "^2.1.4"
-    sass-loader "^7.0.1"
-    style-loader "^0.21.0"
-    uglifyjs-webpack-plugin "^1.2.5"
-    webpack "^4.6.0"
+    postcss-loader "^2.1.3"
+    sass-loader "^6.0.7"
+    style-loader "^0.20.3"
+    uglifyjs-webpack-plugin "^1.2.4"
+    webpack "^4.4.1"
     webpack-assets-manifest "^3.0.1"
-    webpack-cli "^2.0.15"
+    webpack-cli "^2.0.13"
 
 "@sindresorhus/is@^0.7.0":
   version "0.7.0"
@@ -5675,7 +5675,7 @@ node-pre-gyp@^0.9.0:
     semver "^5.3.0"
     tar "^4"
 
-node-sass@^4.9.0:
+node-sass@^4.8.3, node-sass@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.9.0.tgz#d1b8aa855d98ed684d6848db929a20771cc2ae52"
   dependencies:
@@ -6589,7 +6589,7 @@ postcss-load-plugins@^2.3.0:
     cosmiconfig "^2.1.1"
     object-assign "^4.1.0"
 
-postcss-loader@^2.1.4, postcss-loader@^2.1.5:
+postcss-loader@^2.1.3, postcss-loader@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/postcss-loader/-/postcss-loader-2.1.5.tgz#3c6336ee641c8f95138172533ae461a83595e788"
   dependencies:
@@ -7899,6 +7899,16 @@ sass-graph@^2.2.4:
     scss-tokenizer "^0.2.3"
     yargs "^7.0.0"
 
+sass-loader@^6.0.7:
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-6.0.7.tgz#dd2fdb3e7eeff4a53f35ba6ac408715488353d00"
+  dependencies:
+    clone-deep "^2.0.1"
+    loader-utils "^1.0.1"
+    lodash.tail "^4.1.1"
+    neo-async "^2.5.0"
+    pify "^3.0.0"
+
 sass-loader@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.0.1.tgz#fd937259ccba3a9cfe0d5f8a98746d48adfcc261"
@@ -8484,6 +8494,13 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+style-loader@^0.20.3:
+  version "0.20.3"
+  resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.20.3.tgz#ebef06b89dec491bcb1fdb3452e913a6fd1c10c4"
+  dependencies:
+    loader-utils "^1.1.0"
+    schema-utils "^0.4.5"
+
 style-loader@^0.21.0:
   version "0.21.0"
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.21.0.tgz#68c52e5eb2afc9ca92b6274be277ee59aea3a852"
@@ -8879,7 +8896,7 @@ uglify-to-browserify@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz#6e0924d6bda6b5afe349e39a6d632850a0f882b7"
 
-uglifyjs-webpack-plugin@^1.2.4, uglifyjs-webpack-plugin@^1.2.5:
+uglifyjs-webpack-plugin@^1.2.4:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.5.tgz#2ef8387c8f1a903ec5e44fa36f9f3cbdcea67641"
   dependencies:
@@ -9276,7 +9293,7 @@ webpack-assets-manifest@^3.0.1:
     schema-utils "^0.4.5"
     tapable "^1.0.0"
 
-webpack-cli@^2.0.15, webpack-cli@^2.1.3:
+webpack-cli@^2.0.13, webpack-cli@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-2.1.3.tgz#65d166851abaa56067ef3f716b02a97ba6bbe84d"
   dependencies:
@@ -9378,7 +9395,7 @@ webpack-sources@^1.0, webpack-sources@^1.0.1, webpack-sources@^1.1.0:
     source-list-map "^2.0.0"
     source-map "~0.6.1"
 
-webpack@^4.6.0, webpack@^4.7.0:
+webpack@^4.4.1, webpack@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.7.0.tgz#a04f68dab86d5545fd0277d07ffc44e4078154c9"
   dependencies:


### PR DESCRIPTION
We'll source the `webpacker` gem at version `4.0.0.pre.pre.2` via Rubygems and the `@rails/webpacker` JavaScript package via npm rather than sourcing either from `rails/webpacker` `master` on GitHub, because it's good to get packages via official channels.

Version 4 of webpacker has support for version 4 of webpack.