### PR TITLE
Bump node from 8.9.3 to 10.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@ before_install:
   - gem update --system
   - gem install bundler -v 1.16.1
   - . $HOME/.nvm/nvm.sh
-  - nvm install 8.9.3
-  - nvm use 8.9.3
+  - nvm install 10.0.0
+  - nvm use 10.0.0
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.5.1
   - export PATH="$HOME/.yarn/bin:$PATH"
 script:
   - "[ \"$(ruby --version | cut -c1-11)\" == 'ruby 2.5.1p' ]"
-  - "[ \"$(node --version)\" == 'v8.9.3' ]"
+  - "[ \"$(node --version)\" == 'v10.0.0' ]"
   - "[ \"$(yarn --version)\" == '1.5.1' ]"
   - yarn install
   - bundle exec rails db:create

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test-chrome": "bin/setup-mocha-tests && open -a 'Google Chrome' http://localhost:8080/packs-test/mocha_runner.html"
   },
   "engines": {
-    "node": "8.9.3",
+    "node": "10.0.0",
     "yarn": "1.5.1"
   },
   "browserslist": [


### PR DESCRIPTION
Fortunately Heroku supports node 10.x, and it should also work on Travis since we use `nvm` on Travis.