### PR TITLE
Set sans-serif font for log app via body class

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -2,6 +2,7 @@ class LogsController < ApplicationController
   def index
     @title = 'Log'
     @description = 'Log your weight and exercise history'
+    @body_class = 'sans-serif'
     bootstrap(
       current_user: current_user.as_json,
       exercises: ActiveModel::Serializer::CollectionSerializer.new(current_user.exercises),

--- a/app/javascript/log/log.vue
+++ b/app/javascript/log/log.vue
@@ -15,9 +15,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-div {
-  font-family: sans-serif;
-}
-</style>

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -19,7 +19,7 @@
     = content_for(:extra_css)
     = content_for(:extra_javascript)
 
-  %body
+  %body{class: @body_class}
     - if notice.present?
       %p.notice= notice
     - if alert.present?


### PR DESCRIPTION
If an element is added as a direct child of the `body` (for example, this will happen when using the ElementUI select component), then that element would previously not have `sans-serif` font (which was only being applied to the log app component element and its children).