### PR TITLE
Disable some Rubocop rules that I disagree with

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -90,7 +90,13 @@ Style/NumericPredicate:
   Enabled: false
 Style/RescueStandardError:
   Enabled: false
+Style/ReturnNil:
+  Enabled: false
+Style/Semicolon:
+  Enabled: false
 Style/SignalException:
+  Enabled: false
+Style/TernaryParentheses:
   Enabled: false
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma


### PR DESCRIPTION
1. `Style/ReturnNil`: Sometimes we are `return`ing just because we don't want the rest of the method to execute. In this case, just `return`. Sometimes, though, we are `return`ing `nil` because we expect that `nil` to be used within the method caller. In this case, I prefer `return nil` for "explicitness".
2. `Style/Semicolon`: I like to use semicolons in order to make some statements one-liners, e.g. declaring a custom error class (if it's just an empty class, i.e. if we are only declaring the class name and which class it inherits from).
3. `Style/TernaryParentheses`: I think this can structure the code in a less noisy / more readily parseable way.