### PR TITLE
Don't declare User#items association before #stores

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -21,10 +21,10 @@ class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: [:google_oauth2]
 
   has_many :exercises, dependent: :destroy
-  has_many :items, through: :stores
   has_many :requests, dependent: :destroy
   has_many :sms_records, dependent: :destroy
   has_many :stores, dependent: :destroy
+  has_many :items, through: :stores # must come after has_many :stores declaration
   has_many :weight_logs, dependent: :destroy
 
   def self.from_omniauth!(access_token)

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,0 +1,22 @@
+# == Schema Information
+#
+# Table name: items
+#
+#  created_at :datetime         not null
+#  id         :integer          not null, primary key
+#  name       :string           not null
+#  needed     :integer          default(1), not null
+#  store_id   :integer          not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_items_on_store_id  (store_id)
+#
+
+FactoryBot.define do
+  factory :item do
+    name 'milk'
+    needed 1
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,10 +1,20 @@
 require 'spec_helper'
 
 RSpec.describe User do
-  subject(:user) { create(:user) }
+  subject(:user) { users(:user) }
 
   it { should have_many(:sms_records) }
+  it { should have_many(:items) }
   it { should have_many(:weight_logs) }
+
+  describe '#items' do
+    subject(:items) { user.items }
+
+    it 'returns a relation that allows a specific item to be found by `id`' do
+      item_id = user.items.first!.id
+      expect(user.items.find(item_id)).to eq(Item.find(item_id))
+    end
+  end
 
   describe '#may_send_sms?' do
     subject(:may_send_sms?) { user.may_send_sms? }

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -12,7 +12,8 @@ FixtureBuilder.configure do |fbuilder|
 
   fbuilder.factory do
     user = name(:user, create(:user)).first
-    create(:store, user: user)
+    store = name(:store, create(:store, user: user)).first
+    create(:item, store: store)
     name(:weight_log, create(:weight_log, user: user))
     chin_ups = name(:chin_ups, create(:exercise, user: user)).first
     name(:chin_ups_count_log, create(:exercise_count_log, exercise: chin_ups))


### PR DESCRIPTION
Fixes https://rollbar.com/davidjrunger/davidrunger/items/84/
Fixes https://rollbar.com/davidjrunger/davidrunger/items/69/

```
ActiveRecord::HasManyThroughOrderError: Cannot have a has_many :through association 'User#items' which goes through 'User#stores' before the through association is defined.
```