### PR TITLE
Reload log app after entering any new data

### DIFF
--- a/app/javascript/log/components/resistance_section.vue
+++ b/app/javascript/log/components/resistance_section.vue
@@ -67,6 +67,7 @@ export default {
       };
       this.$http.post(this.$routes.api_exercises_path(), payload).then(() => {
         this.newExercise = {};
+        window.location.reload();
       });
     },
 
@@ -81,6 +82,7 @@ export default {
       };
       this.$http.post(this.$routes.api_exercise_count_logs_path(), payload).then(() => {
         this.newResistanceLog = {};
+        window.location.reload();
       });
     },
   },

--- a/app/javascript/log/components/weight_section.vue
+++ b/app/javascript/log/components/weight_section.vue
@@ -69,6 +69,7 @@ export default {
       };
       this.$http.post(this.$routes.api_weight_logs_path(), payload).then(() => {
         this.newWeightLogWeight = '';
+        window.location.reload();
       });
     },
   },


### PR DESCRIPTION
This change makes it such that the user does not need to manually reload the page in order to see any data that they have entered. This is a temporary measure until I make an effort to add the new data directly to the Vuex store at the same time that we POST the data to the server; then, it will of course not be necessary to refresh the page, as the updated Vuex state will be rendered immediately.