### PR TITLE
Disable log submit buttons while data is being posted

### DIFF
--- a/app/javascript/log/components/resistance_section.vue
+++ b/app/javascript/log/components/resistance_section.vue
@@ -26,7 +26,11 @@ div
             name='newResistanceLog.count'
             required
           )
-        el-input.flex-0(type='submit' value='Log' :disabled='resistanceLogFormstate.$invalid')
+        el-input.flex-0(
+          type='submit'
+          value='Log'
+          :disabled='postingResistanceLog || resistanceLogFormstate.$invalid'
+        )
       .h3.mt3.mb1 Today's Exercise
       div {{JSON.stringify(bootstrap.exercise_counts_today || 'No exercises have been done today')}}
       .h3.mt3.mb1 Add a new exercise
@@ -39,7 +43,11 @@ div
             name='newExercise.name'
             required
           )
-        el-input.flex-0(type='submit' value='Submit' :disabled='newExerciseFormstate.$invalid')
+        el-input.flex-0(
+          type='submit'
+          value='Submit'
+          :disabled='postingExercise || newExerciseFormstate.$invalid'
+        )
 </template>
 
 <script>
@@ -52,6 +60,8 @@ export default {
         exerciseId: null,
         count: null,
       },
+      postingExercise: false,
+      postingResistanceLog: false,
       resistanceLogFormstate: {},
     };
   },
@@ -59,6 +69,8 @@ export default {
   methods: {
     postNewExercise() {
       if (this.newExerciseFormstate.$invalid) return;
+
+      this.postingExercise = true;
 
       const payload = {
         exercise: {
@@ -73,6 +85,8 @@ export default {
 
     postResistanceLog() {
       if (this.resistanceLogFormstate.$invalid) return;
+
+      this.postingResistanceLog = true;
 
       const payload = {
         exercise_count_log: {

--- a/app/javascript/log/components/weight_section.vue
+++ b/app/javascript/log/components/weight_section.vue
@@ -12,7 +12,11 @@ div
             name='newWeightLogWeight'
             required
           )
-        el-button.flex-0(:disabled='formstate.$invalid') Add
+        el-input.flex-0(
+          type='submit'
+          value='Add'
+          :disabled='postingWeightLog || formstate.$invalid'
+        )
   weight-chart(:data='weightChartMetadata')
 </template>
 
@@ -55,12 +59,15 @@ export default {
     return {
       formstate: {},
       newWeightLogWeight: '',
+      postingWeightLog: false,
     };
   },
 
   methods: {
     postWeightLog() {
       if (this.formstate.$invalid) return;
+
+      this.postingWeightLog = true;
 
       const payload = {
         weight_log: {


### PR DESCRIPTION
This should prevent accidentally double-submitting any values by hitting enter multiple times in relatively rapid succession or by clicking a submit button multiple times in relatively rapid succession.