### PR TITLE
Set `table-layout: auto` rather than `initial`

### DIFF
--- a/app/javascript/log/components/resistance_section.vue
+++ b/app/javascript/log/components/resistance_section.vue
@@ -118,7 +118,7 @@ export default {
 
 <style>
 .el-table__body {
-  table-layout: initial;
+  table-layout: auto;
 }
 
 .el-table__empty-block {


### PR DESCRIPTION
The CSS property `initial` only started getting supported [on IE12][1], and we don't need `initial` here, since we know that what we really want is `auto`.

[1]: https://www.w3schools.com/cssref/css_initial.asp