### PR TITLE
Add quick-logging functionality to log app

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,7 @@ module.exports = {
     'no-new': 'off',
     'no-param-reassign': 'off',
     'no-underscore-dangle': 'off',
+    'no-unreachable': ((env.NODE_ENV === 'production') ? 'error' : 'warn'),
     'no-use-before-define': ['error', { functions: false }],
     'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
     'object-curly-newline': ['error', {

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -7,6 +7,7 @@ class LogsController < ApplicationController
       current_user: current_user.as_json,
       exercise_counts_today: ExerciseCountsTodaySerializer.new(current_user),
       exercises: ActiveModel::Serializer::CollectionSerializer.new(current_user.exercises),
+      latest_sets: LatestSetsSerializer.new(current_user),
       weight_logs: ActiveModel::Serializer::CollectionSerializer.new(current_user.weight_logs),
     )
     render :index

--- a/app/javascript/log/components/resistance_section.vue
+++ b/app/javascript/log/components/resistance_section.vue
@@ -4,7 +4,10 @@ div
   .flex.justify-center.mb1
     div(style='max-width: 600px')
       .h3.my1 Log a set
-      vue-form.flex.px1(@submit.prevent='postResistanceLog' :state='resistanceLogFormstate')
+      vue-form.flex.px1.mb1(
+        @submit.prevent='submitResistanceLogForm'
+        :state='resistanceLogFormstate'
+      )
         validate.flex-1.mr1
           el-select(
             v-model='newResistanceLog.exerciseId'
@@ -31,6 +34,12 @@ div
           value='Log'
           :disabled='postingResistanceLog || resistanceLogFormstate.$invalid'
         )
+      .mb1(v-for='set in bootstrap.latest_sets')
+        el-button.flex-0(
+          @click='postResistanceLog({ exerciseId: set.exercise_id, count: set.count })'
+          :disabled='postingResistanceLog'
+          size='small'
+        ) {{set.exercise_name}} &times; {{set.count}}
       .h3.mt3.mb1 Today's Exercise
       el-table.flex.justify-center(
         :data='bootstrap.exercise_counts_today'
@@ -96,21 +105,31 @@ export default {
       });
     },
 
-    postResistanceLog() {
-      if (this.resistanceLogFormstate.$invalid) return;
+    postResistanceLog(resistanceLogData) {
+      if (this.postingResistanceLog) return;
 
       this.postingResistanceLog = true;
 
       const payload = {
         exercise_count_log: {
-          exercise_id: this.newResistanceLog.exerciseId,
-          count: this.newResistanceLog.count,
+          exercise_id: resistanceLogData.exerciseId,
+          count: resistanceLogData.count,
         },
       };
       this.$http.post(this.$routes.api_exercise_count_logs_path(), payload).then(() => {
-        this.newResistanceLog = {};
         window.location.reload();
       });
+    },
+
+    submitResistanceLogForm() {
+      if (this.resistanceLogFormstate.$invalid) return;
+
+      this.postResistanceLog({
+        exerciseId: this.newResistanceLog.exerciseId,
+        count: this.newResistanceLog.count,
+      });
+
+      this.newResistanceLog = {};
     },
   },
 };

--- a/app/serializers/latest_sets_serializer.rb
+++ b/app/serializers/latest_sets_serializer.rb
@@ -1,0 +1,20 @@
+class LatestSetsSerializer < ActiveModel::Serializer
+  def as_json(*_args)
+    user.exercises.joins(:exercise_count_logs).
+      select(<<~SQL).
+        exercises.id AS exercise_id,
+        exercises.name AS exercise_name,
+        exercise_count_logs.count AS count
+      SQL
+      group('exercises.id, exercises.name, exercise_count_logs.count').
+      order('MAX(exercise_count_logs.created_at) DESC').
+      limit(3).
+      map { |exercise| exercise.attributes.slice(*%w[exercise_id exercise_name count]) }
+  end
+
+  private
+
+  def user
+    object
+  end
+end


### PR DESCRIPTION
This will show buttons for each of the user's three most recently-logged (distinct) set types, which the user can simply click rather than having to fill out the form (choosing an exercise from the dropdown and entering the reps in the set).

## Screenshot

![](http://take.ms/w4sdP)