### PR TITLE
Use inner join when serializing today's exercise counts

### DIFF
--- a/app/serializers/exercise_counts_today_serializer.rb
+++ b/app/serializers/exercise_counts_today_serializer.rb
@@ -15,7 +15,7 @@
 
 class ExerciseCountsTodaySerializer < ActiveModel::Serializer
   def as_json(*_args)
-    user.exercises.left_joins(:exercise_count_logs).
+    user.exercises.joins(:exercise_count_logs).
       where('exercise_count_logs.created_at > ?', Time.current.beginning_of_day).
       group('exercises.name').
       select(['exercises.name', 'SUM(exercise_count_logs.count) AS count']).


### PR DESCRIPTION
We only want to list the exercises that the user has actually done today (and the `where('exercise_count_logs.created_at > ?', Time.current.beginning_of_day)` enforces this) so using a `LEFT JOIN` instead of an `INNER JOIN` is pointless (and might be slightly less performant?), so let's just use an `INNER JOIN`.