### PR TITLE
Switch `babel-core` to `@babel/core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,12 +14,12 @@
     ">10%"
   ],
   "dependencies": {
+    "@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@gerhobbelt/nomnom": "gerhobbelt/nomnom#master",
     "@rails/webpacker": "^4.0.0-pre.2",
     "autoprefixer": "^9.1.3",
     "axios": "^0.18.0",
-    "babel-core": "^6.26.3",
     "babel-helper-vue-jsx-merge-props": "^2.0.3",
     "babel-loader": "^8.0.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,7 +8,7 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/core@^7.0.0-rc.1":
+"@babel/core@^7.0.0", "@babel/core@^7.0.0-rc.1":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.0.0.tgz#0cb0c0fd2e78a0a2bec97698f549ae9ce0b99515"
   dependencies:
@@ -1159,7 +1159,7 @@ babel-code-frame@^6.26.0:
     esutils "^2.0.2"
     js-tokens "^3.0.2"
 
-babel-core@^6.26.0, babel-core@^6.26.3:
+babel-core@^6.26.0:
   version "6.26.3"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.26.3.tgz#b2e2f09e342d0f0c88e2f02e067794125e75c207"
   dependencies:


### PR DESCRIPTION
Part of babel version 7 changes, it seems.

Deploys are currently failing (specifically bin/rails assets:precompile). Hopefully this PR will fix that.

https://github.com/davidrunger/david_runger/pull/942 was a first attempt to fix the failing deploys, but it was unsuccessful.

I figured out how to repro the deploy issues locally (mostly `NODE_ENV=production bin/rails assets:precompile`), and this change seems to fix them. 🙏 