### PR TITLE
Autocorrect statically defined FactoryBot values to use blocks

### DIFF
--- a/spec/factories/exercise_count_logs.rb
+++ b/spec/factories/exercise_count_logs.rb
@@ -18,7 +18,7 @@
 FactoryBot.define do
   factory :exercise_count_log do
     exercise { Exercise.first! }
-    count 5
-    note 'This set was really hard, but I did it!'
+    count { 5 }
+    note { 'This set was really hard, but I did it!' }
   end
 end

--- a/spec/factories/exercises.rb
+++ b/spec/factories/exercises.rb
@@ -16,6 +16,6 @@
 FactoryBot.define do
   factory :exercise do
     user { User.first! }
-    name 'Chin-ups'
+    name { 'Chin-ups' }
   end
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -16,7 +16,7 @@
 
 FactoryBot.define do
   factory :item do
-    name 'milk'
-    needed 1
+    name { 'milk' }
+    needed { 1 }
   end
 end

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -37,29 +37,29 @@ FactoryBot.define do
   CHROME
 
   factory :request do
-    user_id nil
-    url 'http://davidrunger.com'
-    handler 'home#index'
-    referer nil
-    params Hash.new
+    user_id { nil }
+    url { 'http://davidrunger.com' }
+    handler { 'home#index' }
+    referer { nil }
+    params { Hash.new }
     add_attribute(:method) { 'GET' }
-    format 'html'
-    status 200
-    view 12
-    db 8
-    ip '77.88.47.71'
-    user_agent chrome_user_agent
+    format { 'html' }
+    status { 200 }
+    view { 12 }
+    db { 8 }
+    ip { '77.88.47.71' }
+    user_agent { chrome_user_agent }
     requested_at { 1.week.ago }
-    bot false
+    bot { false }
   end
 
   trait :bot do
-    user_agent bot_user_agent
-    bot true
+    user_agent { bot_user_agent }
+    bot { true }
   end
 
   trait :chrome do
-    user_agent chrome_user_agent
-    bot false
+    user_agent { chrome_user_agent }
+    bot { false }
   end
 end

--- a/spec/factories/sms_records.rb
+++ b/spec/factories/sms_records.rb
@@ -19,11 +19,11 @@
 
 FactoryBot.define do
   factory :sms_record do
-    error nil
+    error { nil }
     sequence(:nexmo_id) { |n| n.to_s.rjust(8, '0') }
     cost { [0.005, 0.006, 0.007].sample }
-    status '0'
-    to '16303906690'
+    status { '0' }
+    to { '16303906690' }
     association :user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -19,6 +19,6 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     last_activity_at { 2.months.ago }
-    phone '16303906690'
+    phone { '16303906690' }
   end
 end

--- a/spec/factories/weight_logs.rb
+++ b/spec/factories/weight_logs.rb
@@ -16,7 +16,7 @@
 
 FactoryBot.define do
   factory :weight_log do
-    weight 167.0
-    note 'Finally, I achieved my goal weight!'
+    weight { 167.0 }
+    note { 'Finally, I achieved my goal weight!' }
   end
 end


### PR DESCRIPTION
```
rubocop \
  --require rubocop-rspec \
  --only FactoryBot/AttributeDefinedStatically \
  --auto-correct
```