### PR TITLE
Specify a React version for eslint-plugin-react in .eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,5 +61,8 @@ module.exports = {
         ),
       },
     },
+    react: {
+      version: '16.4.2',
+    },
   },
 };


### PR DESCRIPTION
Note that we are not even using React, but we are using `eslint-plugin-react` (for linting JSX, I guess, which we _are_ using). Added in c902c01 / #607.

Specifying a React version (I just chose the latest current React version) removes the following warning:
```
Warning: React version not specified in eslint-plugin-react settings. See https://github.com/yannickcr/eslint-plugin-react#configuration.
```