### PR TITLE
Switch `uglify` target to `forceAllTransforms` in `.babelrc.js`

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,28 +1,28 @@
 module.exports = {
-  "presets": [
-    ["@babel/preset-env", {
-      "modules": false,
-      "targets": {
-        "browsers": "> 1%",
-        "uglify": true
+  presets: [
+    ['@babel/preset-env', {
+      modules: false,
+      targets: {
+        browsers: '> 1%',
+        uglify: true
       },
-      "useBuiltIns": "entry"
+      useBuiltIns: 'entry'
     }]
   ],
 
-  "plugins": [
-    "@babel/syntax-dynamic-import",
-    "@babel/proposal-object-rest-spread",
-    ["@babel/proposal-class-properties", { "spec": true }],
-    "transform-vue-jsx",
+  plugins: [
+    '@babel/syntax-dynamic-import',
+    '@babel/proposal-object-rest-spread',
+    ['@babel/proposal-class-properties', { spec: true }],
+    'transform-vue-jsx',
   ],
 
-  "env": {
-    "test": {
-      "presets": [
-        ["env", {
-          "modules": false,
-          "targets": { "node": "current" }
+  env: {
+    test: {
+      presets: [
+        ['env', {
+          modules: false,
+          targets: { node: 'current' }
         }]
       ]
     },

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -4,8 +4,8 @@ module.exports = {
       modules: false,
       targets: {
         browsers: '> 1%',
-        uglify: true
       },
+      forceAllTransforms: (process.env.NODE_ENV === 'production'),
       useBuiltIns: 'entry'
     }]
   ],

--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,4 +1,4 @@
-{
+module.exports = {
   "presets": [
     ["@babel/preset-env", {
       "modules": false,
@@ -27,4 +27,4 @@
       ]
     },
   }
-}
+};


### PR DESCRIPTION
Fixes warning when running webpack-dev-server:
```
The uglify target has been deprecated. Set the top level
option `forceAllTransforms: true` instead.
```

Also, enable it only on production? I don't _think_ that this config setting is what actually _does_ minification, just determines some certain behavior with respect to how Babel transpiles our code?

Borrowing from this example:
https://github.com/babel/babel-preset-env/pull/264#issuecomment-294170305

Also:
* Move .babelrc to .babelrc.js
- This will allow more dynamic configuration.
* Convert .babelrc.js formatting from old JSON style to JS style
  - Remove double quotes from object keys
  - Convert double quotes to single quotes in other instances