### PR TITLE
Store raw user agent in requests; add UserAgentField type for Admin

### DIFF
--- a/app/controllers/lib/request_data_builder.rb
+++ b/app/controllers/lib/request_data_builder.rb
@@ -29,13 +29,7 @@ class RequestDataBuilder
       params: @filtered_params.except(*BORING_PARAMS),
       referer: @request.referer,
       ip: @request.ip,
-      user_agent: <<-USER_AGENT.squish,
-        #{browser.name}
-        #{browser.version}
-        #{browser.platform.name}
-        mobile=#{browser.device.mobile? || false}
-        raw=#{raw_user_agent}
-      USER_AGENT
+      user_agent: raw_user_agent,
       bot: (browser.bot? || false),
       requested_at: @request_time,
     }

--- a/app/dashboards/request_dashboard.rb
+++ b/app/dashboards/request_dashboard.rb
@@ -20,7 +20,7 @@ class RequestDashboard < Administrate::BaseDashboard
     view: Field::Number,
     db: Field::Number,
     ip: IpAddressField,
-    user_agent: Field::String,
+    user_agent: UserAgentField,
     requested_at: BriefTimeField,
     bot: Field::Boolean,
     location: Field::String,
@@ -41,6 +41,7 @@ class RequestDashboard < Administrate::BaseDashboard
     :location,
     :ip,
     :isp,
+    :user_agent,
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES

--- a/app/fields/user_agent_field.rb
+++ b/app/fields/user_agent_field.rb
@@ -1,0 +1,24 @@
+require 'administrate/field/base'
+
+class UserAgentField < Administrate::Field::Base
+  def raw_user_agent
+    data
+  end
+
+  def summary_info
+    browser_name = browser.name
+    browser_version = browser.version
+    browser_platform = browser.platform.name
+    if [browser_name, browser_version, browser_platform].all?(&:present?)
+      "#{browser_name} #{browser_version} on #{browser_platform}"
+    else
+      data
+    end
+  end
+
+  private
+
+  def browser
+    Browser.new(data)
+  end
+end

--- a/app/views/fields/user_agent_field/_form.html.erb
+++ b/app/views/fields/user_agent_field/_form.html.erb
@@ -1,0 +1,6 @@
+<div class="field-unit__label">
+  <%= f.label field.attribute %>
+</div>
+<div class="field-unit__field">
+  <%= f.text_field field.attribute %>
+</div>

--- a/app/views/fields/user_agent_field/_index.html.erb
+++ b/app/views/fields/user_agent_field/_index.html.erb
@@ -1,0 +1,1 @@
+<span title='<%= field.raw_user_agent %>'><%= field.summary_info %></span>

--- a/app/views/fields/user_agent_field/_show.html.erb
+++ b/app/views/fields/user_agent_field/_show.html.erb
@@ -1,0 +1,1 @@
+<span title='<%= field.raw_user_agent %>'><%= field.summary_info %></span>


### PR DESCRIPTION
This will make admin views of the request index and show pages slower, but it will speed up actual user requests to the rest of our pages, since we won't be doing user agent parsing blocking the response to users.

This uses the `browser` gem to parse outs ummary information about the `user_agent` for display in admin (rather than using browser when stashing the request data into Redis).