### PR TITLE
Show "browser unsupported" message if user is on Internet Explorer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :count_request, unless: -> { DavidRunger::LogSkip.should_skip?(params: params) }
+  before_action :check_for_supported_browser!
   before_action :authenticate_user
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
@@ -32,6 +33,12 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(_resource_or_scope)
     login_path
+  end
+
+  def check_for_supported_browser!
+    if !browser.modern? # "modern" is defined in config/initializers/browser.rb
+      render plain: "I don't support #{browser.name} #{browser.version}. Try a modern browser. :)"
+    end
   end
 
   def count_request

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,0 @@
-module ApplicationHelper
-  def browser
-    @browser ||= Browser.new(request.user_agent)
-  end
-end

--- a/config/initializers/browser.rb
+++ b/config/initializers/browser.rb
@@ -1,0 +1,2 @@
+Browser.modern_rules.clear
+Browser.modern_rules << ->(browser) { !browser.ie? }


### PR DESCRIPTION
Resolves https://rollbar.com/davidjrunger/davidrunger/items/96
Resolves https://rollbar.com/davidjrunger/davidrunger/items/97

The first error is a JavaScript error, `ReferenceError: 'Promise' is undefined`. Apparently IE 11 doesn't have `Promise`s. I could polyfill them, and did so successfully locally, but a few styling things were somewhat badly broken, too. At that point, I figured it's just not worth it, and did this instead.

The second error is a system error from Rollbar, `Possible source map configuration error: line and column number combination not found in source map`. I'm guessing that IE just sent some crappy, wrong stack trace or something.

## Before (blank page, JavaScript error)

![image](https://user-images.githubusercontent.com/8197963/45404468-ece71080-b613-11e8-834e-1dc18f7dd289.png)

## After

![image](https://user-images.githubusercontent.com/8197963/45404471-f5d7e200-b613-11e8-92a2-1c191c440637.png)