### PR TITLE
Specify word-break: initial for text log text

### DIFF
--- a/app/javascript/log/components/data_renderers/text_log.vue
+++ b/app/javascript/log/components/data_renderers/text_log.vue
@@ -43,3 +43,9 @@ export default {
   },
 };
 </script>
+
+<style>
+.el-table .cell {
+  word-break: initial;
+}
+</style>


### PR DESCRIPTION
This overrides a style rule that is added by Element UI.