### PR TITLE
Remove `requests.bot` column and usage in code

### DIFF
--- a/app/controllers/lib/request_data_builder.rb
+++ b/app/controllers/lib/request_data_builder.rb
@@ -30,7 +30,6 @@ class RequestDataBuilder
       referer: @request.referer,
       ip: @request.ip,
       user_agent: raw_user_agent,
-      bot: (browser.bot? || false),
       requested_at: @request_time,
     }
   end

--- a/app/dashboards/request_dashboard.rb
+++ b/app/dashboards/request_dashboard.rb
@@ -22,7 +22,6 @@ class RequestDashboard < Administrate::BaseDashboard
     ip: IpAddressField,
     user_agent: UserAgentField,
     requested_at: BriefTimeField,
-    bot: Field::Boolean,
     location: Field::String,
     isp: Field::String,
   }.freeze
@@ -36,7 +35,6 @@ class RequestDashboard < Administrate::BaseDashboard
     :id,
     :user,
     :handler,
-    :bot,
     :requested_at,
     :location,
     :ip,
@@ -62,7 +60,6 @@ class RequestDashboard < Administrate::BaseDashboard
     :isp,
     :user_agent,
     :requested_at,
-    :bot,
     :location,
   ].freeze
 
@@ -83,7 +80,6 @@ class RequestDashboard < Administrate::BaseDashboard
     :ip,
     :user_agent,
     :requested_at,
-    :bot,
   ].freeze
 
   # Overwrite this method to customize how requests are displayed

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -2,7 +2,6 @@
 #
 # Table name: requests
 #
-#  bot          :boolean          default(FALSE), not null
 #  db           :integer
 #  format       :string           not null
 #  handler      :string           not null
@@ -33,9 +32,7 @@ class Request < ApplicationRecord
   belongs_to :user, optional: true
 
   validates :url, :handler, :method, :format, :ip, :requested_at, presence: true
-  validates :bot, inclusion: [true, false]
 
-  scope :human, -> { where(bot: false) }
   scope :recent, (lambda do |time_period = 1.day|
     where('requests.requested_at > ?', Time.current - time_period.to_i) # use #to_i bc of DST stuff
   end)

--- a/config/initializers/request_logging.rb
+++ b/config/initializers/request_logging.rb
@@ -53,7 +53,6 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
     db: payload[:db_runtime],
     ip: stashed_data['ip'],
     user_agent: stashed_data['user_agent'],
-    bot: stashed_data['bot'],
     requested_at: requested_at,
   }
 

--- a/db/migrate/20180923163411_remove_bot_column_from_requests.rb
+++ b/db/migrate/20180923163411_remove_bot_column_from_requests.rb
@@ -1,0 +1,5 @@
+class RemoveBotColumnFromRequests < ActiveRecord::Migration[5.2]
+  def change
+    remove_column(:requests, :bot, :boolean)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_09_180038) do
+ActiveRecord::Schema.define(version: 2018_09_23_163411) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -85,7 +85,6 @@ ActiveRecord::Schema.define(version: 2018_09_09_180038) do
     t.string "ip", null: false
     t.string "user_agent"
     t.datetime "requested_at", null: false
-    t.boolean "bot", default: false, null: false
     t.string "location"
     t.string "isp"
     t.index ["requested_at"], name: "index_requests_on_requested_at"

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -2,7 +2,6 @@
 #
 # Table name: requests
 #
-#  bot          :boolean          default(FALSE), not null
 #  db           :integer
 #  format       :string           not null
 #  handler      :string           not null
@@ -27,11 +26,6 @@
 #
 
 FactoryBot.define do
-  bot_user_agent = <<-BOT.squish
-    Generic Browser 0 Other mobile=false raw=Mozilla/5.0 (compatible; Googlebot/2.1;
-    +http://www.google.com/bot.html)
-  BOT
-
   chrome_user_agent = <<-CHROME.squish
     Chrome 57 Macintosh mobile=false raw=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_4)
     AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.133 Safari/537.36
@@ -51,16 +45,9 @@ FactoryBot.define do
     ip { '77.88.47.71' }
     user_agent { chrome_user_agent }
     requested_at { 1.week.ago }
-    bot { false }
-  end
-
-  trait :bot do
-    user_agent { bot_user_agent }
-    bot { true }
   end
 
   trait :chrome do
     user_agent { chrome_user_agent }
-    bot { false }
   end
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,18 +1,6 @@
 require 'spec_helper'
 
 RSpec.describe Request do
-  describe '::human' do
-    subject { Request.human }
-
-    let!(:human_request) { create(:request, :chrome) }
-    let!(:bot_request) { create(:request, :bot) }
-
-    it 'includes only human requests' do
-      expect(subject).to include(human_request)
-      expect(subject).not_to include(bot_request)
-    end
-  end
-
   describe '::recent' do
     context 'called without an argument' do
       subject { Request.recent }


### PR DESCRIPTION
First, I don't even really use this column anymore; it's basically redundant with the parsed user agent column that we are now showing on the Request admin show & index pages.

Second, even if I were still using this, then it would probably be better to compute this value live, rather than cacheing it in the database as we have been doing up until now (this PR).