### PR TITLE
Remove Request::ordered scope

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -36,5 +36,4 @@ class Request < ApplicationRecord
   scope :recent, (lambda do |time_period = 1.day|
     where('requests.requested_at > ?', Time.current - time_period.to_i) # use #to_i bc of DST stuff
   end)
-  scope :ordered, ->() { order('requests.requested_at') }
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -26,15 +26,4 @@ RSpec.describe Request do
       end
     end
   end
-
-  describe '::ordered' do
-    subject { Request.ordered }
-
-    let!(:newer_request) { create(:request, requested_at: 2.hours.ago) }
-    let!(:older_request) { create(:request, requested_at: 2.days.ago) }
-
-    it 'orders the requests by requested_at' do
-      expect(subject).to eq([older_request, newer_request])
-    end
-  end
 end


### PR DESCRIPTION
I never use this. I think I initially added it to make it more convenient to look at requests using production `rails console` or something. But now I have the admin Requests index page for that.