### PR TITLE
Only show last 3 text log entries; order by created_at

### DIFF
--- a/app/serializers/log_serializer.rb
+++ b/app/serializers/log_serializer.rb
@@ -16,7 +16,14 @@
 class LogSerializer < ActiveModel::Serializer
   attributes :id, :name
 
-  has_many :log_entries
+  has_many :log_entries do
+    ordered_entries = object.log_entries.order(:created_at)
+    if object.log_inputs.pluck(:type).include?('LogInputs::TextLogInput')
+      ordered_entries.last(3)
+    else
+      ordered_entries
+    end
+  end
   has_many :log_inputs
 
   # def log_entries


### PR DESCRIPTION
My dream journal entries were starting to take up way too much space on the page. This limits them.

A future feature would be to allow some means to also view older entries, but for now with my dream journal this is not really a feature that I care about, so I'm not going to implement that for now.