### PR TITLE
Remove meta description tag from groceries app

### DIFF
--- a/app/controllers/groceries_controller.rb
+++ b/app/controllers/groceries_controller.rb
@@ -1,10 +1,6 @@
 class GroceriesController < ApplicationController
   def show
     @title = 'Groceries'
-    @description = <<~DESCRIPION.squish
-      A free and convenient online app for keeping track of groceries and other items that you want
-      or need
-    DESCRIPION
     bootstrap(
       current_user: UserSerializer.new(current_user),
       stores:


### PR DESCRIPTION
I think that the main relevance of the meta description tag is for SEO, but since this page isn't crawlable by bots (since it is for logged-in users only), there doesn't seem to be a lot of point in it. (Plus, there was a typo in the heredoc.)