### PR TITLE
Add hover effect for grocery items

### DIFF
--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -96,13 +96,21 @@ export default {
 }
 
 li.grocery-item {
-  background: rgba(255, 255, 255, 0.5);
+  background: rgba(255, 255, 255, 0.6);
   margin: 5px 0;
   padding: 6px;
+
+  &:not(.unneeded):hover {
+    background: rgba(255, 255, 255, 0.8);
+  }
 
   &.unneeded {
     background: rgba(255, 255, 255, 0.3);
     color: rgba(0, 0, 0, 0.55);
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.5);
+    }
   }
 }
 </style>


### PR DESCRIPTION
This will make it easier to make sure that one is deleting the right item on a wide screen (since the delete button is far away from the item name, then).

Screencast: http://screens.davidrunger.com/2018-11-04-11-26-00-9q05g.mp4