### PR TITLE
Fix webpacker compilation after 4.0.0-rc.2 upgrade

### DIFF
--- a/config/webpack/production.js
+++ b/config/webpack/production.js
@@ -1,7 +1,6 @@
 const webpack = require('webpack');
 const merge = require('webpack-merge');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const environment = require('./environment');
 const shared = require('./shared');
@@ -23,11 +22,6 @@ const productionConfig = merge(environmentConfig, shared, {
   mode: 'production',
   optimization: {
     minimizer: [
-      new UglifyJsPlugin({
-        cache: true,
-        parallel: true,
-        sourceMap: true,
-      }),
       new OptimizeCSSAssetsPlugin({}),
     ],
   },

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -68,9 +68,9 @@ test:
 
 production:
   <<: *default
-
-  # Production depends on precompilation of packs prior to booting for performance.
-  compile: false
-
   # Cache manifest.json for performance
   cache_manifest: true
+  # Production depends on precompilation of packs prior to booting for performance.
+  compile: false
+  # Tell Rails we want to serve compiled/extracted CSS files from public/packs/
+  extract_css: true


### PR DESCRIPTION
Apparently we are now minifying via some other means than `uglifyjs-webpack-plugin`. I think that we are actually having a _slight_ bump in bundle size, as a result, but it's essentially negligible.

Also, `extract_css: true` is now required in order that `asset_pack_path('home_app.css')` actually returns a path to our CSS.

Side note... we seem to be building CSS assets twice, e.g. we have a file `home_app-1bafbc7d.css` and `home_app-5f66070482667de2461e.css`, both exactly the same size. This is probably wasting time during the deploy process? I'm not sure if this is new or something that has been happening for a while, unbeknownst to me. I think they must both be getting compiled by webpack, in that they both have e.g. `.modal-container[data-v-7b17699e]{transform:scale(1.1)}`.