### PR TITLE
Bump bundler from 1.17.2 to 1.17.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - export PATH="$HOME/.yarn/bin:$PATH"
 script:
   - "ruby --version && [ \"$(ruby --version | cut -c1-11)\" == 'ruby 2.5.1p' ]"
-  - "bundle --version && [ \"$(bundle --version)\" == 'Bundler version 1.17.2' ]"
+  - "bundle --version && [ \"$(bundle --version)\" == 'Bundler version 1.17.3' ]"
   - "node --version && [ \"$(node --version)\" == 'v10.0.0' ]"
   - "yarn --version && [ \"$(yarn --version)\" == '1.12.0' ]"
   - yarn install


### PR DESCRIPTION
This doesn't actually bump `bundler,` per se, but it gets CI passing and establishes the "official" version of `bundler` for use with this repo.