### PR TITLE
Install specific version of bundler (1.17.3) on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
 env:
   - RAILS_ENV=test NODE_ENV=test SECRET_KEY_BASE=0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b
 before_install:
-  - gem install bundler
+  - gem install bundler -v '1.17.3'
   - . $HOME/.nvm/nvm.sh
   - nvm install 10.0.0
   - nvm use 10.0.0


### PR DESCRIPTION
Per the [release blog post][1], Heroku does not yet support bundler 2 (which was recently released), except with a custom buildpack. It seems safer to just stay on bundler 1 for now and wait for Heroku to add first class support for bundler 2 (which I am guessing will be relatively soon, anyway).

[1]: https://bundler.io/blog/2019/01/03/announcing-bundler-2.html