### PR TITLE
Change casing of "check in shopping trip" button to sentence case

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -5,7 +5,7 @@ div.mt1.mb2.ml3.mr2
     span.spinner--circle.ml1(v-if='debouncingOrWaitingOnNetwork')
   div.mb2
     el-button(id="show-modal" @click='initializeTripCheckinModal()' size='mini').
-      Check In Shopping Trip
+      Check in shopping trip
     el-button(@click='createItemsNeededTextMessage' size='mini') Text items to phone
     el-button.copy-to-clipboard(size='mini') Copy to clipboard
     span(v-if='wasCopiedRecently') Copied!


### PR DESCRIPTION
This makes the casing of the (now) "Check in shopping trip" button consistent with the "Text items to phone" and "Copy to clipboard buttons".

![image](https://user-images.githubusercontent.com/8197963/51442919-f73aaa80-1c96-11e9-9dd5-f22f125676a1.png)