### PR TITLE
Revert "Bump element-ui from 2.4.11 to 2.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clipboard": "^2.0.4",
     "compression-webpack-plugin": "^2.0.0",
     "css-loader": "^1.0.1",
-    "element-ui": "^2.5.0",
+    "element-ui": "^2.4.11",
     "eslint": "^5.12.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-import-resolver-webpack": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2870,10 +2870,9 @@ electron-to-chromium@^1.3.103:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.103.tgz#a695777efdbc419cad6cbb0e58458251302cd52f"
   integrity sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ==
 
-element-ui@^2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.5.0.tgz#f4a5e98c1514addcc591c5cc199e8fc2c5866e3f"
-  integrity sha512-T4QLzEPruFM58XQ6zXEGdd4AePhZqc2oWgOWgv03+nk9maZw6iisHTASkM8fXVasW1Wp723gg0Oy7R8DheAMwA==
+element-ui@^2.4.11:
+  version "2.4.11"
+  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.4.11.tgz#db6a2d37001b8fe5fff9f176fb58bb3908cfa9c9"
   dependencies:
     async-validator "~1.8.1"
     babel-helper-vue-jsx-merge-props "^2.0.0"


### PR DESCRIPTION
Reverts davidrunger/david_runger#1280

Something about the PR being reverted here broke the app:
![image](https://user-images.githubusercontent.com/8197963/51790815-f1d5d800-214e-11e9-9b11-fef30f535805.png)

See https://rollbar.com/davidjrunger/davidrunger/items/112/