### PR TITLE
Bump element-ui from 2.4.11 to 2.5.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "clipboard": "^2.0.4",
     "compression-webpack-plugin": "^2.0.0",
     "css-loader": "^1.0.1",
-    "element-ui": "^2.4.11",
+    "element-ui": "^2.5.2",
     "eslint": "^5.12.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-import-resolver-webpack": "^0.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2870,9 +2870,10 @@ electron-to-chromium@^1.3.103:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.103.tgz#a695777efdbc419cad6cbb0e58458251302cd52f"
   integrity sha512-tObPqGmY9X8MUM8i3MEimYmbnLLf05/QV5gPlkR8MQ3Uj8G8B2govE1U4cQcBYtv3ymck9Y8cIOu4waoiykMZQ==
 
-element-ui@^2.4.11:
-  version "2.4.11"
-  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.4.11.tgz#db6a2d37001b8fe5fff9f176fb58bb3908cfa9c9"
+element-ui@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/element-ui/-/element-ui-2.5.2.tgz#3f38b75d54bb0df2da2682cc60dcd1993be4bfb1"
+  integrity sha512-Iiw/6AmPbcpXy1BdSIAk9cmLtpZ6geus3/TI/d20t/kKXmSRpyh7vx6hvH+9a7n0RiHAJiCxwgUvw1bjuuGIXw==
   dependencies:
     async-validator "~1.8.1"
     babel-helper-vue-jsx-merge-props "^2.0.0"


### PR DESCRIPTION
The [2.5.1][1] and [2.5.2][2] releases have some bugfixes for an issue(s) that were in 2.5.0 (which we upgraded to in #1280 and reverted in #1281).

[1]: https://github.com/ElemeFE/element/releases/tag/v2.5.1
[1]: https://github.com/ElemeFE/element/releases/tag/v2.5.2