### PR TITLE
Update Ruby version in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ DEPENDENCIES
   webpacker (>= 4.0.0.pre.pre.2)
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.6.0p0
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
This should have been part of 4769fb8 / https://github.com/davidrunger/david_runger/pull/1294 (_Bump Ruby from 2.5.1 to 2.6.0_) but was accidentally omitted from that commit/PR.