### PR TITLE
Include store name in SMS grocery list messages

### DIFF
--- a/app/form_objects/sms_message.rb
+++ b/app/form_objects/sms_message.rb
@@ -60,10 +60,10 @@ class SmsMessage
 
   def grocery_store_items_needed_message_body
     store = @user.stores.find(@message_params['store_id'])
-    store.items.
-      where('items.needed > 0').
-      sort_by { |item| item.name.downcase }.
-      map { |item| "#{item.name} (#{item.needed})" }.
-      join("\n")
+    ApplicationController.render(
+      'sms_messages/grocery_list',
+      layout: nil,
+      locals: {store: store},
+    ).rstrip
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -18,4 +18,6 @@ class Item < ApplicationRecord
   belongs_to :store
 
   validates :name, presence: true
+
+  scope :needed, -> { where('items.needed > 0') }
 end

--- a/app/views/sms_messages/grocery_list.text.erb
+++ b/app/views/sms_messages/grocery_list.text.erb
@@ -1,0 +1,4 @@
+== <%= store.name %>
+<% store.items.needed.sort_by { |item| item.name.downcase }.each do |item| %>
+- <%= item.name %> (<%= item.needed %>)
+<% end %>

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe Item do
+  subject(:item) { items(:item) }
+
+  it { should belong_to(:store) }
+
+  describe '::needed' do
+    context 'when `needed` is greater than 0' do
+      before { item.update!(needed: 1) }
+
+      it 'includes the item' do
+        expect(Item.needed.where(id: item.id)).to exist
+      end
+    end
+
+    context 'when `needed` is less than or equal to 0' do
+      before { item.update!(needed: 0) }
+
+      it 'does not include the item' do
+        expect(Item.needed.where(id: item.id)).not_to exist
+      end
+    end
+  end
+end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -13,6 +13,6 @@ FixtureBuilder.configure do |fbuilder|
   fbuilder.factory do
     user = name(:user, create(:user)).first
     store = name(:store, create(:store, user: user)).first
-    create(:item, store: store)
+    name(:item, create(:item, store: store))
   end
 end


### PR DESCRIPTION
Also, refactor a little:
* add `Item.needed` scope
* use ERB template for text message (Unfortunately, we cannot indent the code in the ERB template without producing indentation in the resulting rendered message. :-/)