### PR TITLE
Fix response code typo (unprecessable_entity => unprocessable_entity)

### DIFF
--- a/app/controllers/api/logs_controller.rb
+++ b/app/controllers/api/logs_controller.rb
@@ -6,7 +6,7 @@ class Api::LogsController < ApplicationController
       render json: @log
     else
       StatsD.increment('logs.create.failure')
-      render json: {errors: @log.errors.to_h}, status: :unprecessable_entity
+      render json: {errors: @log.errors.to_h}, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/logs_controller.rb
+++ b/app/controllers/api/logs_controller.rb
@@ -6,6 +6,7 @@ class Api::LogsController < ApplicationController
       render json: @log
     else
       StatsD.increment('logs.create.failure')
+      Rails.logger.info("Failed to create log. errors=#{@log.errors.to_h} log=#{@log.attributes}")
       render json: {errors: @log.errors.to_h}, status: :unprocessable_entity
     end
   end

--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -6,6 +6,16 @@ RSpec.describe Api::LogsController do
     context 'when the log being created is invalid' do
       let(:invalid_params) { {log: {name: ''}} }
 
+      it 'logs info about the log and why it is invalid' do
+        allow(Rails.logger).to receive(:info).and_call_original
+
+        post(:create, params: invalid_params)
+
+        expect(Rails.logger).
+          to have_received(:info).
+          with(/Failed to create log. errors={:name=>"can't be blank"} log={.*"name"=>"".*}/)
+      end
+
       it 'returns a 422 status code' do
         post(:create, params: invalid_params)
         expect(response.status).to eq(422)

--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe Api::LogsController do
+  before { sign_in(user) }
+  let(:user) { users(:user) }
+
+  describe '#create' do
+    context 'when the log being created is invalid' do
+      let(:invalid_params) { {log: {name: ''}} }
+
+      it 'returns a 422 status code' do
+        post(:create, params: invalid_params)
+        expect(response.status).to eq(422)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This typo was causing a 500 error to be sent to the client when trying to create an invalid log (due to Rails not understanding the `:unprecessable_entity` response code and erroring), rather than a 422 response code to be sent (as intended, and as will now occur).

Also, log (via `Rails.logger.info`) some details about what the problem was.