### PR TITLE
Request user's phone number when user asks for text without one

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,7 @@ class ApplicationController < ActionController::Base
   before_action :count_request, unless: -> { DavidRunger::LogSkip.should_skip?(params: params) }
   before_action :check_for_supported_browser!
   before_action :authenticate_user
+  before_action :store_redirect_location
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
@@ -24,6 +25,12 @@ class ApplicationController < ActionController::Base
     flash[:alert] = 'You must sign in first.'
     session['user_redirect_to'] = request.path
     redirect_to(login_path)
+  end
+
+  def store_redirect_location
+    if params['redirect_to'].present?
+      session['redirect_to'] = params['redirect_to']
+    end
   end
 
   def bootstrap(data)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,6 @@
 class UsersController < ApplicationController
+  using BlankParamsAsNil
+
   before_action :ensure_own_account
 
   def edit
@@ -6,13 +8,21 @@ class UsersController < ApplicationController
   end
 
   def update
-    current_user.update!(user_params)
+    if current_user.update(user_params)
+      redirect_location = session.delete('redirect_to') || edit_user_path(current_user)
+      redirect_to(redirect_location)
+    else
+      render :edit
+    end
   end
 
   private
 
   def user_params
-    params.require(:user).permit(:phone)
+    params.
+      require(:user).
+      permit(:phone).
+      blank_params_as_nil(%w[phone])
   end
 
   def ensure_own_account

--- a/app/form_objects/sms_message.rb
+++ b/app/form_objects/sms_message.rb
@@ -22,6 +22,8 @@ class SmsMessage
   end
 
   def send!
+    return false if ENV['NEXMO_API_KEY'].blank?
+
     nexmo_response = NexmoClient.send_text!(number: @user.phone, message: message_body)
     if nexmo_response.success?
       save_sms_record(nexmo_response)

--- a/app/javascript/components/modal.vue
+++ b/app/javascript/components/modal.vue
@@ -2,7 +2,7 @@
 transition(name='modal')
   div.modal-mask.fixed.flex.flex-column.items-center.justify-center.col-12.top-0.left-0.vh-100.z1(
     ref='mask'
-    @click='closeModal'
+    @click='handleClickMask'
   )
     div.modal-container.p3.bg-white.rounded(:style='{ width: width, maxWidth: maxWidth }')
       slot
@@ -13,15 +13,22 @@ import keycode from 'keycode';
 
 export default {
   methods: {
-    closeModal(e) {
+    closeModal() {
+      this.$store.commit('setShowModal', { value: false });
+      this.$store.commit('setShowNeedPhoneNumberModal', { value: false });
+    },
+
+    handleClickMask(event) {
       // make sure we don't close the modal when clicks within the modal propagate up
-      if (e.target === this.$refs.mask) {
-        this.$store.commit('setShowModal', { value: false });
+      if (event.target === this.$refs.mask) {
+        this.closeModal();
       }
     },
 
     handleKeydown(e) {
-      if (e.which === keycode('escape')) this.$store.commit('setShowModal', { value: false });
+      if (e.which === keycode('escape')) {
+        this.closeModal();
+      }
     },
   },
 

--- a/app/javascript/groceries/components/need_phone_number_modal.vue
+++ b/app/javascript/groceries/components/need_phone_number_modal.vue
@@ -1,0 +1,32 @@
+<template lang="pug">
+Modal(v-if="showNeedPhoneNumberModal" width='85%', maxWidth='400px')
+  slot
+    h2.bold.fonst-size-1.mb2 We need your phone number, first
+    p Click #[a(:href='editUserPath') here] to enter your phone number.
+    div.flex.justify-around.mt2
+      el-button(
+        @click="$store.commit('setShowNeedPhoneNumberModal', { value: false })"
+        type='text'
+      ) Cancel
+</template>
+
+<script>
+import { mapState } from 'vuex';
+
+export default {
+  computed: {
+    ...mapState([
+      'current_user',
+      'showNeedPhoneNumberModal',
+    ]),
+
+    editUserPath() {
+      return this.$routes.edit_user_path({
+        id: this.current_user.id,
+        redirect_to: this.$routes.groceries_path(),
+        _options: {}, // providing `_options` seems to be necessary to put query params in the path
+      });
+    },
+  },
+};
+</script>

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -6,7 +6,7 @@ div.mt1.mb2.ml3.mr2
   div.mb2
     el-button(id="show-modal" @click='initializeTripCheckinModal()' size='mini').
       Check in shopping trip
-    el-button(@click='createItemsNeededTextMessage' size='mini') Text items to phone
+    el-button(@click='handleTextItemsToPhoneClick' size='mini') Text items to phone
     el-button.copy-to-clipboard(size='mini') Copy to clipboard
     span(v-if='wasCopiedRecently') Copied!
 
@@ -53,18 +53,22 @@ div.mt1.mb2.ml3.mr2
           @click="$store.commit('setShowModal', { value: false })"
           type='text'
         ) Cancel
+
+  NeedPhoneNumberModal
 </template>
 
 <script>
 import { mapGetters, mapState } from 'vuex';
-import { debounce, sortBy } from 'lodash';
+import { debounce, isEmpty, sortBy } from 'lodash';
 import ClipboardJS from 'clipboard';
 
 import Item from './item.vue';
+import NeedPhoneNumberModal from './need_phone_number_modal.vue';
 
 export default {
   components: {
     Item,
+    NeedPhoneNumberModal,
   },
 
   data() {
@@ -92,6 +96,7 @@ export default {
     ]),
 
     ...mapState([
+      'current_user',
       'showModal',
     ]),
 
@@ -118,6 +123,15 @@ export default {
       this.$store.dispatch('zeroItems', { items: this.itemsToZero.slice() });
       this.itemsToZero = [];
       this.$store.commit('setShowModal', { value: false });
+    },
+
+    handleTextItemsToPhoneClick() {
+      const currentUserPhone = this.current_user.phone;
+      if (isEmpty(currentUserPhone)) {
+        this.$store.commit('setShowNeedPhoneNumberModal', { value: true });
+      } else {
+        this.createItemsNeededTextMessage();
+      }
     },
 
     initializeTripCheckinModal() {

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -39,6 +39,10 @@ export const mutations = {
   setShowModal(state, { value }) {
     state.showModal = value;
   },
+
+  setShowNeedPhoneNumberModal(state, { value }) {
+    state.showNeedPhoneNumberModal = value;
+  },
 };
 
 const actions = {
@@ -92,10 +96,12 @@ export function initialState(bootstrap) {
   return {
     ...bootstrap,
     collectingDebounces: false,
+    current_user: bootstrap.current_user,
     stores: bootstrap.stores,
     pendingRequests: 0,
     postingStore: false,
     showModal: false,
+    showNeedPhoneNumberModal: false,
   };
 }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,8 @@ class User < ApplicationRecord
 
   devise :omniauthable, omniauth_providers: [:google_oauth2]
 
+  validates :phone, format: {with: /\A[0-9\-.+()]+\z/}, allow_nil: true
+
   has_many :logs, dependent: :destroy
   has_many :requests, dependent: :destroy
   has_many :sms_records, dependent: :destroy

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -16,5 +16,5 @@
 #
 
 class UserSerializer < ActiveModel::Serializer
-  attributes :email, :id
+  attributes :email, :id, :phone
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -36,6 +36,7 @@ class DavidRunger::Application < Rails::Application
 
   extra_load_paths = [
     Rails.root.join('lib'),
+    Rails.root.join(*%w[lib refinements]),
     Rails.root.join(*%w[app controllers lib]),
   ]
   config.autoload_paths.concat(extra_load_paths)

--- a/lib/refinements/blank_params_as_nil.rb
+++ b/lib/refinements/blank_params_as_nil.rb
@@ -1,0 +1,14 @@
+module BlankParamsAsNil
+  refine ActionController::Parameters do
+    def blank_params_as_nil(params)
+      params.each do |param|
+        value = self[param]
+        if value && value.blank?
+          self[param] = nil
+        end
+      end
+
+      self
+    end
+  end
+end

--- a/spec/controllers/text_messages_controller_spec.rb
+++ b/spec/controllers/text_messages_controller_spec.rb
@@ -20,9 +20,16 @@ RSpec.describe Api::TextMessagesController do
       describe 'when the user may send SMS messages' do
         verify { expect(user.may_send_sms?).to eq(true) }
 
-        it 'attempts to send a text message' do
-          expect(NexmoClient).to receive(:send_text!).and_call_original
-          post(:create, params: params)
+        context 'when NEXMO_API_KEY is set in ENV' do
+          before do
+            expect(ENV).to receive(:[]).with('NEXMO_API_KEY').and_return('DEFabc123')
+            allow(ENV).to receive(:[]).and_call_original # pass other calls through
+          end
+
+          it 'attempts to send a text message' do
+            expect(NexmoClient).to receive(:send_text!).and_call_original
+            post(:create, params: params)
+          end
         end
       end
 


### PR DESCRIPTION
There is a serious need for refactoring/cleanup re: `setShowModal`/`setShowNeedPhoneNumberModal`. Rather than having separate attributes in the store for `showModal`/`showNeedPhoneNumberModal`, these should probably be consolidated into a single action like `openModal(modalName)` that maniuplates a single data structure that contains a list of open modals (and the order in which they were opened, in order to display them in the correct "order", i.e. most-recently opened modal "on top").