### PR TITLE
Bump Ruby from 2.6.0 to 2.6.2 (for real)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
   directories:
     - node_modules
 rvm:
-  - "2.6.0"
+  - "2.6.2"
 services:
   - postgresql
 addons:
@@ -20,7 +20,7 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.12.0
   - export PATH="$HOME/.yarn/bin:$PATH"
 script:
-  - "ruby --version && [ \"$(ruby --version | cut -c1-11)\" == 'ruby 2.6.0p' ]"
+  - "ruby --version && [ \"$(ruby --version | cut -c1-11)\" == 'ruby 2.6.2p' ]"
   - "bundle --version && [ \"$(bundle --version)\" == 'Bundler version 1.17.3' ]"
   - "node --version && [ \"$(node --version)\" == 'v10.0.0' ]"
   - "yarn --version && [ \"$(yarn --version)\" == '1.12.0' ]"

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.6.0'
+ruby '2.6.2'
 
 git_source(:github) do |repo_name|
   repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -446,7 +446,7 @@ DEPENDENCIES
   webpacker (>= 4.0.0.pre.pre.2)
 
 RUBY VERSION
-   ruby 2.6.0p0
+   ruby 2.6.2p47
 
 BUNDLED WITH
    1.17.2


### PR DESCRIPTION
I thought that I had done this in #1419 / 6472007 , but actually all that did was change the Ruby version that I was using locally...