### PR TITLE
Make IP address last column in admin requests view

### DIFF
--- a/app/dashboards/request_dashboard.rb
+++ b/app/dashboards/request_dashboard.rb
@@ -37,9 +37,9 @@ class RequestDashboard < Administrate::BaseDashboard
     :handler,
     :requested_at,
     :location,
-    :ip,
     :isp,
     :user_agent,
+    :ip,
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES


### PR DESCRIPTION
The IP address is the least interesting column; therefore show it last. Usually I look at ISP, location, and browser, and IP address was in between those columns, breaking them up visually (suboptimal).