### PR TITLE
Add rubocop-performance gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,8 @@ AllCops:
   Exclude:
     - 'db/schema.rb'
   TargetRubyVersion: 2.4
+Bundler/GemComment:
+  Enabled: false
 Layout/ClassStructure:
   ExpectedOrder:
       - module_inclusion

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'redis', '~>4.1'
 gem 'rest-client'
 gem 'rollbar'
 gem 'rubocop', require: false
+gem 'rubocop-performance', require: false
 gem 'sass-rails', '~> 5.0'
 gem 'statsd-instrument'
 gem 'webpacker', '>= 4.0.0.pre.pre.2'

--- a/Gemfile
+++ b/Gemfile
@@ -52,8 +52,8 @@ group :development do
   # Provides flamegraphs for rack-mini-profiler.
   gem 'flamegraph'
   gem 'listen', '>= 3.0.5', '< 3.2'
-  # Performance profiling. Should be listed after `pg` (and `rails`?) gems to get database performance
-  # analysis.
+  # Performance profiling. Should be listed after `pg` (and `rails`?) gems to get database
+  # performance analysis.
   gem 'rack-mini-profiler'
   gem 'spring'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -338,6 +338,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.0.0)
+      rubocop (>= 0.58.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.4)
@@ -435,6 +437,7 @@ DEPENDENCIES
   rollbar
   rspec-rails
   rubocop
+  rubocop-performance
   sass-rails (~> 5.0)
   shoulda-matchers (~> 4.0)
   spring


### PR DESCRIPTION
Per post-install message from rubocop:

```
❯ gem install rubocop
Fetching rubocop-0.67.2.gem
Performance Cops will be removed from RuboCop 0.68. Use rubocop-performance gem instead.
```