### PR TITLE
Refactor modal display logic and data structure

### DIFF
--- a/app/javascript/components/modal.vue
+++ b/app/javascript/components/modal.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-transition(name='modal')
+transition(name='modal' v-if="showingModal({ modalName: name })")
   div.modal-mask.fixed.flex.flex-column.items-center.justify-center.col-12.top-0.left-0.vh-100.z1(
     ref='mask'
     @click='handleClickMask'
@@ -9,25 +9,27 @@ transition(name='modal')
 </template>
 
 <script>
+import { mapGetters } from 'vuex';
 import keycode from 'keycode';
 
 export default {
-  methods: {
-    closeModal() {
-      this.$store.commit('setShowModal', { value: false });
-      this.$store.commit('setShowNeedPhoneNumberModal', { value: false });
-    },
+  computed: {
+    ...mapGetters([
+      'showingModal',
+    ]),
+  },
 
+  methods: {
     handleClickMask(event) {
       // make sure we don't close the modal when clicks within the modal propagate up
       if (event.target === this.$refs.mask) {
-        this.closeModal();
+        this.$store.commit('hideModal', { modalName: this.name });
       }
     },
 
     handleKeydown(e) {
       if (e.which === keycode('escape')) {
-        this.closeModal();
+        this.$store.commit('hideTopModal');
       }
     },
   },
@@ -36,11 +38,19 @@ export default {
     window.removeEventListener('keydown', this.handleKeydown);
   },
 
-  mounted() {
-    window.addEventListener('keydown', this.handleKeydown);
+  created() {
+    // since there might be multiple modals, ensure we only register the keydown listener once
+    if (!window.davidrunger.modalKeydownListenerRegistered) {
+      window.addEventListener('keydown', this.handleKeydown);
+      window.davidrunger.modalKeydownListenerRegistered = true;
+    }
   },
 
   props: {
+    name: {
+      type: String,
+      required: true,
+    },
     width: {
       type: String,
       required: true,

--- a/app/javascript/groceries/components/need_phone_number_modal.vue
+++ b/app/javascript/groceries/components/need_phone_number_modal.vue
@@ -1,11 +1,11 @@
 <template lang="pug">
-Modal(v-if="showNeedPhoneNumberModal" width='85%', maxWidth='400px')
+Modal(name='set-phone-number' width='85%', maxWidth='400px')
   slot
     h2.bold.fonst-size-1.mb2 We need your phone number, first
     p Click #[a(:href='editUserPath') here] to enter your phone number.
     div.flex.justify-around.mt2
       el-button(
-        @click="$store.commit('setShowNeedPhoneNumberModal', { value: false })"
+        @click="$store.commit('hideModal', { modalName: 'set-phone-number' })"
         type='text'
       ) Cancel
 </template>

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -40,7 +40,7 @@ div.mt1.mb2.ml3.mr2
   ul.items-list.mt0.mb0
     Item(v-for='item in sortedItems' :item="item" :key="item.id")
 
-  Modal(v-if="showModal" width='85%', maxWidth='400px')
+  Modal(name='check-in-shopping-trip' width='85%' maxWidth='400px')
     slot
       h3.bold.fonst-size-2.mb2.
         What did you get?
@@ -60,7 +60,7 @@ div.mt1.mb2.ml3.mr2
           plain
         ) Set checked items to 0 needed
         el-button(
-          @click="$store.commit('setShowModal', { value: false })"
+          @click="$store.commit('hideModal', { modalName: 'check-in-shopping-trip' })"
           type='text'
         ) Cancel
 
@@ -108,7 +108,6 @@ export default {
 
     ...mapState([
       'current_user',
-      'showModal',
     ]),
 
     neededItems() {
@@ -151,13 +150,13 @@ export default {
     handleTripCheckinModalSubmit() {
       this.$store.dispatch('zeroItems', { items: this.itemsToZero.slice() });
       this.itemsToZero = [];
-      this.$store.commit('setShowModal', { value: false });
+      this.$store.commit('hideModal', { modalName: 'check-in-shopping-trip' });
     },
 
     handleTextItemsToPhoneClick() {
       const currentUserPhone = this.current_user.phone;
       if (isEmpty(currentUserPhone)) {
-        this.$store.commit('setShowNeedPhoneNumberModal', { value: true });
+        this.$store.commit('showModal', { modalName: 'set-phone-number' });
       } else {
         this.createItemsNeededTextMessage();
       }
@@ -165,7 +164,7 @@ export default {
 
     initializeTripCheckinModal() {
       this.itemsToZero = this.neededItems;
-      this.$store.commit('setShowModal', { value: true });
+      this.$store.commit('showModal', { modalName: 'check-in-shopping-trip' });
     },
 
     // we need `function` for correct `this`

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -23,6 +23,14 @@ export const mutations = {
     state.pendingRequests -= 1;
   },
 
+  hideModal(state, { modalName }) {
+    state.modalsShowing = state.modalsShowing.filter(showingModal => showingModal !== modalName);
+  },
+
+  hideTopModal(state) {
+    state.modalsShowing = state.modalsShowing.slice(0, -1); // all but the last element
+  },
+
   incrementPendingRequests(state) {
     state.pendingRequests += 1;
   },
@@ -36,12 +44,10 @@ export const mutations = {
     state.collectingDebounces = value;
   },
 
-  setShowModal(state, { value }) {
-    state.showModal = value;
-  },
-
-  setShowNeedPhoneNumberModal(state, { value }) {
-    state.showNeedPhoneNumberModal = value;
+  showModal(state, { modalName }) {
+    if (state.modalsShowing.indexOf(modalName) === -1) {
+      state.modalsShowing.push(modalName);
+    }
   },
 };
 
@@ -93,6 +99,12 @@ const getters = {
   debouncingOrWaitingOnNetwork(state) {
     return state.collectingDebounces || (state.pendingRequests > 0);
   },
+
+  showingModal(state) {
+    return ({ modalName }) => {
+      return state.modalsShowing.indexOf(modalName) !== -1;
+    };
+  },
 };
 
 // export for testing
@@ -104,8 +116,7 @@ export function initialState(bootstrap) {
     stores: bootstrap.stores,
     pendingRequests: 0,
     postingStore: false,
-    showModal: false,
-    showNeedPhoneNumberModal: false,
+    modalsShowing: [],
   };
 }
 

--- a/spec/javascript/groceries/components/store.spec.js
+++ b/spec/javascript/groceries/components/store.spec.js
@@ -24,6 +24,7 @@ describe('Store', function () { // eslint-disable-line func-names, prefer-arrow-
       items: [{ id: 23, name: 'humus', needed: 2 }],
     };
     const bootstrap = {
+      current_user: { id: 2 },
       stores: [store],
     };
     wrapper = mount(


### PR DESCRIPTION
This commit refactors the modal display logic and data structure, generalizing it to accommodate an arbitrary number of modals (as long as each modal is given a unique `name` prop).

This refactor also eliminates the necessity of adding a data attribute to indicate whether each specific modal is showing / not showing and eliminates the necessity of adding mutations for showing/hiding each modal that might be used.

There will be a slight performance penalty, in that we are now doing some array scanning (and other array operations) rather than manipulating specific booleans indicating the show/hide state of each individual modal, but this should be negligible. This performance penalty could be minimized somewhat by storing the show/hide state of each modal in an object rather than in an array, but then that would somewhat complicate the `hideTopModal` mutation, in contrast to the simplicity of just using an array as a stack where we know/assume that the last element in the array is the most recently opened modal.

This refactor is particularly motivated by the fact that we will be adding a third modal (which will contain a selector to choose a specific log to show, rather than the current system in which we show all logs at once).