### PR TITLE
Remove redundant setting of CSRF token in Axios headers

### DIFF
--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -3,12 +3,6 @@ import Vue from 'shared/customized_vue';
 import Vuex from 'vuex';
 import _ from 'lodash';
 
-const csrfMetaTag = document.querySelector('meta[name="csrf-token"]');
-if (csrfMetaTag) {
-  const csrfToken = csrfMetaTag.getAttribute('content');
-  axios.defaults.headers.common['X-CSRF-Token'] = csrfToken;
-}
-
 // export for testing
 export const mutations = {
   deleteItem(state, { item, store }) {


### PR DESCRIPTION
This is [done][1] in `customized_vue.js` already, so we don't need to also do it in `app/javascript/groceries/store.js`.

[1]: https://github.com/davidrunger/david_runger/blob/dde427c/app/javascript/shared/customized_vue.js#L38-L42