### PR TITLE
Extract modal Vuex stuff into separate file

### DIFF
--- a/app/javascript/groceries/components/need_phone_number_modal.vue
+++ b/app/javascript/groceries/components/need_phone_number_modal.vue
@@ -17,7 +17,6 @@ export default {
   computed: {
     ...mapState([
       'current_user',
-      'showNeedPhoneNumberModal',
     ]),
 
     editUserPath() {

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -3,8 +3,12 @@ import Vue from 'shared/customized_vue';
 import Vuex from 'vuex';
 import _ from 'lodash';
 
+import * as ModalVuex from 'shared/modal_store';
+
 // export for testing
 export const mutations = {
+  ...ModalVuex.mutations,
+
   deleteItem(state, { item, store }) {
     store.items = store.items.filter(storeItem => storeItem !== item);
   },
@@ -15,14 +19,6 @@ export const mutations = {
 
   decrementPendingRequests(state) {
     state.pendingRequests -= 1;
-  },
-
-  hideModal(state, { modalName }) {
-    state.modalsShowing = state.modalsShowing.filter(showingModal => showingModal !== modalName);
-  },
-
-  hideTopModal(state) {
-    state.modalsShowing = state.modalsShowing.slice(0, -1); // all but the last element
   },
 
   incrementPendingRequests(state) {
@@ -36,12 +32,6 @@ export const mutations = {
 
   setCollectingDebounces(state, { value }) {
     state.collectingDebounces = value;
-  },
-
-  showModal(state, { modalName }) {
-    if (state.modalsShowing.indexOf(modalName) === -1) {
-      state.modalsShowing.push(modalName);
-    }
   },
 };
 
@@ -83,6 +73,8 @@ const actions = {
 };
 
 const getters = {
+  ...ModalVuex.getters,
+
   currentStore(state) {
     return (
       _(state.stores).filter('viewed_at').sortBy(['viewed_at']).last() ||
@@ -93,24 +85,18 @@ const getters = {
   debouncingOrWaitingOnNetwork(state) {
     return state.collectingDebounces || (state.pendingRequests > 0);
   },
-
-  showingModal(state) {
-    return ({ modalName }) => {
-      return state.modalsShowing.indexOf(modalName) !== -1;
-    };
-  },
 };
 
 // export for testing
 export function initialState(bootstrap) {
   return {
     ...bootstrap,
+    ...ModalVuex.state,
     collectingDebounces: false,
     current_user: bootstrap.current_user,
     stores: bootstrap.stores,
     pendingRequests: 0,
     postingStore: false,
-    modalsShowing: [],
   };
 }
 

--- a/app/javascript/shared/modal_store.js
+++ b/app/javascript/shared/modal_store.js
@@ -1,0 +1,27 @@
+export const mutations = {
+  hideModal(state, { modalName }) {
+    state.modalsShowing = state.modalsShowing.filter(showingModal => showingModal !== modalName);
+  },
+
+  hideTopModal(state) {
+    state.modalsShowing = state.modalsShowing.slice(0, -1); // all but the last element
+  },
+
+  showModal(state, { modalName }) {
+    if (state.modalsShowing.indexOf(modalName) === -1) {
+      state.modalsShowing.push(modalName);
+    }
+  },
+};
+
+export const getters = {
+  showingModal(state) {
+    return ({ modalName }) => {
+      return state.modalsShowing.indexOf(modalName) !== -1;
+    };
+  },
+};
+
+export const state = {
+  modalsShowing: [],
+};


### PR DESCRIPTION
This will allow us to "mix in" modal functionality into any Vuex store that we would like (e.g. the logs Vuex store, which currently doesn't have any modal-related functionality).

I considered using Vuex modules, but that seems to make things a lot more verbose and annoying. Thus, I'm just importing the modal Vuex functionality and splatting it into the groceries store. (I will do the same with the logs store in an upcoming PR.)