### PR TITLE
Show only one log at a time; implement Slack-like log selector

### DIFF
--- a/app/javascript/log/components/log_selector.vue
+++ b/app/javascript/log/components/log_selector.vue
@@ -1,0 +1,105 @@
+<template lang='pug'>
+Modal(name='log-selector' width='85%', maxWidth='400px')
+  slot
+    input(
+      type='text'
+      v-model='searchString'
+      @keydown.enter='selectHighlightedLog'
+      @keydown.up='decrementHighlightedLogIndex'
+      @keydown.down='incrementHighlightedLogIndex'
+      ref='log-search-input'
+    )
+    div(v-for='(logName, index) in orderedMatches')
+      a.js-link(
+        @click='selectLog(logName)'
+        :class='{bold: (index === highlightedLogIndex)}'
+      ) {{logName}}
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import FuzzySet from 'fuzzyset.js';
+
+export default {
+  computed: {
+    ...mapState([
+      'logs',
+    ]),
+
+    logNames() {
+      return this.logs.map(log => log.name);
+    },
+
+    orderedMatches() {
+      if (!this.searchString) {
+        return this.logNames;
+      }
+
+      const matches = this.fuzzySet.get(this.searchString, '', 0) || [];
+      return matches.map(([_score, string]) => string);
+    },
+
+    showingLogSelector() {
+      return this.$store.getters.showingModal({ modalName: 'log-selector' });
+    },
+  },
+
+  created() {
+    this.fuzzySet = FuzzySet();
+    this.logNames.forEach(logName => {
+      this.fuzzySet.add(logName);
+    });
+  },
+
+  data() {
+    return {
+      highlightedLogIndex: 0,
+      searchString: '',
+    };
+  },
+
+  methods: {
+    decrementHighlightedLogIndex() {
+      if (this.highlightedLogIndex > 0) {
+        this.highlightedLogIndex--;
+      }
+    },
+
+    incrementHighlightedLogIndex() {
+      if (this.highlightedLogIndex < this.orderedMatches.length) {
+        this.highlightedLogIndex++;
+      }
+    },
+
+    selectHighlightedLog() {
+      const highlightedLogNate = this.orderedMatches[this.highlightedLogIndex];
+      if (highlightedLogNate) {
+        this.selectLog(highlightedLogNate);
+      }
+    },
+
+    selectLog(logName) {
+      this.$store.dispatch('selectLog', { logName });
+      this.highlightedLogIndex = 0;
+      this.searchString = '';
+    },
+  },
+
+  watch: {
+    // reset highlightedLogIndex to 0 whenever the matched logs changes (e.g. the user types more)
+    orderedMatches() {
+      this.highlightedLogIndex = 0;
+    },
+
+    showingLogSelector() {
+      // wait a tick for input to render, then focus it
+      setTimeout(() => {
+        const logSearchInput = this.$refs['log-search-input'];
+        if (logSearchInput) {
+          logSearchInput.focus()
+        }
+      });
+    },
+  },
+};
+</script>

--- a/app/javascript/log/components/new_log_entry_form.vue
+++ b/app/javascript/log/components/new_log_entry_form.vue
@@ -10,6 +10,7 @@ div
         v-model='newLogEntryData[log_input.label]'
         name='log_input.label'
         required
+        ref='log-input'
       )
     el-input(
       type='submit'
@@ -46,6 +47,12 @@ export default {
         window.location.reload();
       });
     },
+  },
+
+  mounted() {
+    setTimeout(() => {
+      this.$refs['log-input'][0].focus();
+    });
   },
 
   props: {

--- a/app/javascript/log/logs.vue
+++ b/app/javascript/log/logs.vue
@@ -2,25 +2,66 @@
 div
   .center.mb1
     .h5.gray.pt1 {{bootstrap.current_user.email}}
+    log-selector
     log(
-      v-for='log in bootstrap.logs'
-      :key='log.name'
-      :name='log.name'
-      :log_id='log.id'
-      :log_inputs='log.log_inputs'
-      :log_entries='log.log_entries'
+      v-if='selectedLog'
+      :key='selectedLog.name'
+      :name='selectedLog.name'
+      :log_id='selectedLog.id'
+      :log_inputs='selectedLog.log_inputs'
+      :log_entries='selectedLog.log_entries'
     )
-    new-log-form
+    hr.silver.m3
+    el-collapse(v-model='expandedPanelNames')
+      el-collapse-item(title = 'Create new log' name='new-log-form')
+        new-log-form
 </template>
 
 <script>
+import { mapGetters, mapState } from 'vuex';
+
 import NewLogForm from './components/new_log_form.vue';
 import Log from './components/log.vue';
+import LogSelector from './components/log_selector.vue';
 
 export default {
   components: {
-    NewLogForm,
     Log,
+    LogSelector,
+    NewLogForm,
+  },
+
+  computed: {
+    ...mapGetters([
+      'selectedLog',
+    ]),
+
+    ...mapState([
+      'selectedLogName',
+    ]),
+  },
+
+  created() {
+    document.addEventListener('keydown', (event) => {
+      if ((event.key === 'k') && (event.metaKey == true)) {
+        this.$store.commit('showModal', { modalName: 'log-selector' });
+      }
+    })
+  },
+
+  data() {
+    return {
+      expandedPanelNames: [],
+    };
   },
 };
 </script>
+
+<style scoped>
+/deep/ .el-collapse-item {
+  [role='tab']:focus,
+  [role='button']:focus {
+    outline: none;
+  }
+}
+</style>

--- a/app/javascript/log/store.js
+++ b/app/javascript/log/store.js
@@ -1,14 +1,38 @@
 import Vuex from 'vuex';
 
-const mutations = {};
-const actions = {};
-const getters = {};
+import * as ModalVuex from 'shared/modal_store';
+
+const mutations = {
+  ...ModalVuex.mutations,
+
+  selectLog(state, { logName }) {
+    state.selectedLogName = logName;
+  },
+};
+
+const actions = {
+  selectLog({ commit }, { logName }) {
+    commit('selectLog', { logName });
+    commit('hideModal', { modalName: 'log-selector' });
+  },
+};
+
+const getters = {
+  ...ModalVuex.getters,
+
+  selectedLog(state) {
+    return state.logs.find(log => log.name === state.selectedLogName);
+  },
+};
 
 // eslint-disable-next-line import/prefer-default-export
 export function logVuexStoreFactory(bootstrap) {
   return new Vuex.Store({
     state: {
+      ...ModalVuex.state,
       currentUser: bootstrap.current_user,
+      logs: bootstrap.logs,
+      selectedLogName: null,
     },
     actions,
     getters,

--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -16,6 +16,8 @@ import 'element-ui/lib/theme-chalk/table-column.css';
 import {
   Button,
   Card,
+  Collapse,
+  CollapseItem,
   Icon,
   Input,
   Menu,
@@ -66,6 +68,8 @@ Vue.use(VueForm);
 
 Vue.use(Button);
 Vue.use(Card);
+Vue.use(Collapse);
+Vue.use(CollapseItem);
 Vue.use(Icon);
 Vue.use(Input);
 Vue.use(Menu);

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-vue": "^5.2.2",
     "file-loader": "^3.0.1",
+    "fuzzyset.js": "^0.0.8",
     "gator": "^1.2.4",
     "glob": "^7.1.3",
     "js-yaml": "^3.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3682,6 +3682,11 @@ functional-red-black-tree@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
 
+fuzzyset.js@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/fuzzyset.js/-/fuzzyset.js-0.0.8.tgz#398311fb54a5f84221db2cb143ac8cf1e523ae50"
+  integrity sha512-wymI6DYJgCBDFUrIyA/M2gIjJPEWj40pnCf04+Dma0PaprQRrTRh9/Cmz1wl9jCJxA+iqrCqNrGYuq7lVOtzXQ==
+
 gator@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/gator/-/gator-1.2.4.tgz#ff668518415ef5f46ce5992fce06bba539efff16"


### PR DESCRIPTION
**See screencast:** http://screens.davidrunger.com/2019-04-06-14-17-32-0ewfl.mp4
This demonstrates using arrow keys to select a log, using fuzzy search, and clicking to select a log.

This change will:
1. lessen the memory/computational demands on the browser when a user has a lot of logs / log entries (by requiring the browser to only render one log at a time)
2. make it easier to navigate to a log using the fuzzy-search Slack-like selector implemented in this PR (as opposed to scrolling the page to find it, as before)

This also sets us up to not load all of the user's log entries into the `bootstrap` data (and instead request the log entries for a given log only when the log is viewed (or maybe eager-load the data via AJAX in the background)), which will provide a faster initial page load.

There's still a lot of work to be done, as well, in terms of improving the behavior after a user enters a new log entry. Currently, since we just reload `/logs`, the page reloads and the log that was being shown goes away; to see the new value in the log, the user would have to reselect the log.

I think that this PR lays a good foundation, though, in terms of setting us up to improve the above two issues/opportunities.