### PR TITLE
List all logs on logs landing page

### DIFF
--- a/app/javascript/log/logs.vue
+++ b/app/javascript/log/logs.vue
@@ -11,6 +11,11 @@ div
       :log_inputs='selectedLog.log_inputs'
       :log_entries='selectedLog.log_entries'
     )
+    section(v-if='!selectedLog')
+      hr.silver.mt2.mb3.mx3
+      ul
+        li.m1.h2(v-for='log in logs')
+          a.js-link(@click="$store.dispatch('selectLog', { logName: log.name })") {{log.name}}
     hr.silver.m3
     el-collapse(v-model='expandedPanelNames')
       el-collapse-item(title = 'Create new log' name='new-log-form')
@@ -37,6 +42,7 @@ export default {
     ]),
 
     ...mapState([
+      'logs',
       'selectedLogName',
     ]),
   },

--- a/spec/javascript/log/logs.spec.js
+++ b/spec/javascript/log/logs.spec.js
@@ -1,0 +1,77 @@
+import 'spec_helper';
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import Logs from 'log/logs.vue';
+import { logVuexStoreFactory } from 'log/store';
+import * as util from 'test_utils';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('Logs', function () { // eslint-disable-line func-names
+  let bootstrap;
+  let vuexStore;
+  let wrapper;
+
+  const userId = 1;
+  const userEmail = 'davidjrunger@gmail.com';
+
+  const heightLogName = 'Height';
+  const weightLogName = 'Weight';
+
+  beforeEach(() => {
+    bootstrap = {
+      current_user: {
+        id: userId,
+        email: userEmail,
+      },
+      log_input_types: [
+        { public_type: 'duration', label: 'Duration' },
+        { public_type: 'integer', label: 'Integer' },
+        { public_type: 'text', label: 'Text' },
+      ],
+      logs: [
+        {
+          id: 1,
+          log_entries: [],
+          log_inputs: [{ label: 'Weight (in lbs)', public_type: 'integer' }],
+          name: weightLogName,
+        },
+        {
+          id: 2,
+          log_entries: [],
+          log_inputs: [{ label: 'Height (in inches)', public_type: 'integer' }],
+          name: heightLogName,
+        },
+      ],
+    };
+    vuexStore = logVuexStoreFactory(bootstrap);
+    wrapper = mount(
+      Logs,
+      {
+        localVue,
+        mocks: { bootstrap },
+        store: vuexStore,
+        stubs: {
+          // Needed for some reason to render el-select/el-option in new_log_form.vue.
+          // https://github.com/vuejs/vue-test-utils/issues/958#issuecomment-441421427
+          transition: false,
+        },
+      },
+    );
+  });
+
+  it('is a Vue instance', () => {
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+
+  it("shows the current user's email", () => {
+    expect(wrapper.text()).toMatch(userEmail);
+  });
+
+  it('links to each log', () => {
+    [heightLogName, weightLogName].forEach(logName => {
+      expect(util.findAll(wrapper, `a.js-link:text(${logName})`)).toExist();
+    });
+  });
+});


### PR DESCRIPTION
![2019-04-21-12-14-45-yf0uo(1)](https://user-images.githubusercontent.com/8197963/56475076-1e407e00-6438-11e9-968e-00b8ec169456.png)

* It looks a lot better than the almost empty page that we had before / It makes it more obvious when the page has loaded
* It allows log selection for users who don't know the quick-selector keyboard shortcut / It's convenient to be able to select a log using just the mouse

Also, add missing unit test harness for Logs Vue component.