### PR TITLE
Add (optional) `description` for Logs

### DIFF
--- a/app/controllers/api/logs_controller.rb
+++ b/app/controllers/api/logs_controller.rb
@@ -14,6 +14,10 @@ class Api::LogsController < ApplicationController
   private
 
   def log_params
-    params.require(:log).permit(:name, log_inputs_attributes: %i[index label public_type])
+    params.require(:log).permit(
+      :name,
+      :description,
+      log_inputs_attributes: %i[index label public_type],
+    )
   end
 end

--- a/app/javascript/log/components/log.vue
+++ b/app/javascript/log/components/log.vue
@@ -1,6 +1,7 @@
 <template lang='pug'>
 div
-  .h2.my2 {{name}}
+  h1.h2.mt3.mb1 {{name}}
+  p.h5.mb2.description {{description}}
   log-data-display(:log_inputs='log_inputs', :log_entries='log_entries')
   new-log-entry-form(:log_id='log_id' :log_inputs='log_inputs')
   .mt1
@@ -73,6 +74,10 @@ export default {
       type: Array,
       required: true,
     },
+    description: {
+      type: String,
+      required: false,
+    },
     name: {
       type: String,
       required: true,
@@ -80,3 +85,9 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+.description {
+  font-weight: 200;
+}
+</style>

--- a/app/javascript/log/components/new_log_form.vue
+++ b/app/javascript/log/components/new_log_form.vue
@@ -11,6 +11,12 @@ div
             name='newLogName'
             required
           )
+        el-input.mb1(
+          type='textarea'
+          placeholder='Details/Description'
+          v-model='newLogDescription'
+          name='newLogDescription'
+        )
         validate.mb1(
           v-for='(logInput, index) in newLogInputs'
           :key='index'
@@ -45,6 +51,7 @@ export default {
   data() {
     return {
       formstate: {},
+      newLogDescription: '',
       newLogName: '',
       newLogInputs: [{}],
       postingLog: false,
@@ -59,6 +66,7 @@ export default {
 
       const payload = {
         log: {
+          description: this.newLogDescription,
           name: this.newLogName,
           log_inputs_attributes: this.newLogInputs.map((input, i) => {
             input.index = i;

--- a/app/javascript/log/logs.vue
+++ b/app/javascript/log/logs.vue
@@ -6,6 +6,7 @@ div
     log(
       v-if='selectedLog'
       :key='selectedLog.name'
+      :description='selectedLog.description'
       :name='selectedLog.name'
       :log_id='selectedLog.id'
       :log_inputs='selectedLog.log_inputs'

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -2,11 +2,12 @@
 #
 # Table name: logs
 #
-#  created_at :datetime         not null
-#  id         :bigint(8)        not null, primary key
-#  name       :string           not null
-#  updated_at :datetime         not null
-#  user_id    :bigint(8)        not null
+#  created_at  :datetime         not null
+#  description :string
+#  id          :bigint(8)        not null, primary key
+#  name        :string           not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint(8)        not null
 #
 # Indexes
 #

--- a/app/serializers/log_serializer.rb
+++ b/app/serializers/log_serializer.rb
@@ -15,7 +15,7 @@
 #
 
 class LogSerializer < ActiveModel::Serializer
-  attributes :id, :name
+  attributes :description, :id, :name
 
   has_many :log_entries do
     ordered_entries = object.log_entries_ordered

--- a/app/serializers/log_serializer.rb
+++ b/app/serializers/log_serializer.rb
@@ -2,11 +2,12 @@
 #
 # Table name: logs
 #
-#  created_at :datetime         not null
-#  id         :bigint(8)        not null, primary key
-#  name       :string           not null
-#  updated_at :datetime         not null
-#  user_id    :bigint(8)        not null
+#  created_at  :datetime         not null
+#  description :string
+#  id          :bigint(8)        not null, primary key
+#  name        :string           not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint(8)        not null
 #
 # Indexes
 #

--- a/db/migrate/20190427223736_add_description_to_logs.rb
+++ b/db/migrate/20190427223736_add_description_to_logs.rb
@@ -1,0 +1,5 @@
+class AddDescriptionToLogs < ActiveRecord::Migration[5.2]
+  def change
+    add_column :logs, :description, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_23_163411) do
+ActiveRecord::Schema.define(version: 2019_04_27_223736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -48,6 +48,7 @@ ActiveRecord::Schema.define(version: 2018_09_23_163411) do
     t.string "name", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "description"
     t.index ["user_id", "name"], name: "index_logs_on_user_id_and_name", unique: true
   end
 


### PR DESCRIPTION
This can be used to explain in additional detail what a log is for (i.e. more than just the `name` of the log).