### PR TITLE
Lazy load log entries on-demand

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -11,6 +11,7 @@ module.exports = {
   ],
 
   plugins: [
+    '@znck/prop-types/remove',
     '@babel/syntax-dynamic-import',
     '@babel/proposal-object-rest-spread',
     ['@babel/proposal-class-properties', { spec: true }],

--- a/app/controllers/api/log_entries_controller.rb
+++ b/app/controllers/api/log_entries_controller.rb
@@ -18,4 +18,14 @@ class Api::LogEntriesController < ApplicationController
     log_entry.destroy!
     render json: log_entry
   end
+
+  def index
+    log_id = params['log_id']
+
+    if log_id.present?
+      render json: current_user.logs.find(log_id).log_entries_ordered
+    else
+      render json: {error: 'log_id param is required'}, status: :bad_request
+    end
+  end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -6,7 +6,6 @@ class LogsController < ApplicationController
       current_user: UserSerializer.new(current_user),
       logs: ActiveModel::Serializer::CollectionSerializer.new(
         current_user.logs.includes(:log_inputs),
-        format: :brief,
       ),
       log_input_types: log_input_types,
     )

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -4,7 +4,10 @@ class LogsController < ApplicationController
     @body_class = 'sans-serif'
     bootstrap(
       current_user: UserSerializer.new(current_user),
-      logs: ActiveModel::Serializer::CollectionSerializer.new(current_user.logs.includes(:log_entries_ordered, :log_inputs)),
+      logs: ActiveModel::Serializer::CollectionSerializer.new(
+        current_user.logs.includes(:log_inputs),
+        format: :brief,
+      ),
       log_input_types: log_input_types,
     )
     render :index

--- a/app/javascript/log/components/log.vue
+++ b/app/javascript/log/components/log.vue
@@ -1,14 +1,22 @@
 <template lang='pug'>
 div
-  h1.h2.mt3.mb1 {{name}}
-  p.h5.mb2.description {{description}}
-  log-data-display(:log_inputs='log_inputs', :log_entries='log_entries')
-  new-log-entry-form(:log_id='log_id' :log_inputs='log_inputs')
+  h1.h2.mt3.mb1 {{log.name}}
+  p.h5.mb2.description {{log.description}}
+  div.mb2(v-if='log.log_entries === undefined').
+    Loading...
+  log-data-display(
+    v-else-if='log.log_entries.length'
+    :log_inputs='log.log_inputs'
+    :log_entries='log.log_entries'
+  )
+  div.mb2(v-else) There are no log entries for this log.
+  new-log-entry-form(:log_id='log.id' :log_inputs='log.log_inputs')
   .mt1
     el-button(@click='destroyLastEntry') Delete last entry
 </template>
 
 <script>
+import PropTypes from '@znck/prop-types';
 import _ from 'lodash';
 
 import DurationTimeseries from './data_renderers/duration_timeseries.vue'
@@ -47,6 +55,12 @@ export default {
     NewLogEntryForm,
   },
 
+  created() {
+    if (!this.log.log_entries) {
+      this.$store.dispatch('fetchLogEntries', { logId: this.log.id });
+    }
+  },
+
   methods: {
     destroyLastEntry() {
       var confirmation = confirm(
@@ -62,26 +76,13 @@ export default {
   },
 
   props: {
-    log_entries: {
-      type: Array,
-      required: true,
-    },
-    log_id: {
-      type: Number,
-      required: true,
-    },
-    log_inputs: {
-      type: Array,
-      required: true,
-    },
-    description: {
-      type: String,
-      required: false,
-    },
-    name: {
-      type: String,
-      required: true,
-    },
+    log: PropTypes.shape({
+      log_entries: PropTypes.array, // not required because we want to be able to lazy-load
+      id: PropTypes.number.isRequired,
+      log_inputs: PropTypes.array.isRequired,
+      description: PropTypes.string,
+      name: PropTypes.string.isRequired,
+    }).isRequired,
   },
 };
 </script>

--- a/app/javascript/log/logs.vue
+++ b/app/javascript/log/logs.vue
@@ -5,12 +5,8 @@ div
     log-selector
     log(
       v-if='selectedLog'
-      :key='selectedLog.name'
-      :description='selectedLog.description'
-      :name='selectedLog.name'
-      :log_id='selectedLog.id'
-      :log_inputs='selectedLog.log_inputs'
-      :log_entries='selectedLog.log_entries'
+      :key='selectedLog.id'
+      :log='selectedLog'
     )
     section(v-if='!selectedLog')
       hr.silver.mt2.mb3.mx3

--- a/app/javascript/log/store.js
+++ b/app/javascript/log/store.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import Vue from 'vue';
 import Vuex from 'vuex';
 
 import * as ModalVuex from 'shared/modal_store';
@@ -12,6 +13,10 @@ const mutations = {
 
   selectLog(state, { logName }) {
     state.selectedLogName = logName;
+  },
+
+  setLogEntries(state, { log, logEntries }) {
+    Vue.set(log, 'log_entries', logEntries);
   },
 };
 
@@ -28,6 +33,20 @@ const actions = {
       const log = getters.logById({ logId });
       commit('addLogEntry', { log, logEntry: data });
     });
+  },
+
+  fetchLogEntries({ commit, getters }, { logId }) {
+    axios.
+      get(Routes.api_log_entries_path({ log_id: logId })).
+      then(({ data }) => {
+        commit(
+          'setLogEntries',
+          {
+            log: getters.logById({ logId }),
+            logEntries: data,
+          },
+        );
+      });
   },
 
   selectLog({ commit }, { logName }) {

--- a/app/serializers/log_serializer.rb
+++ b/app/serializers/log_serializer.rb
@@ -17,20 +17,7 @@
 class LogSerializer < ActiveModel::Serializer
   attributes :description, :id, :name
 
-  has_many :log_entries, unless: -> { instance_options[:format] == :brief } do
-    ordered_entries = object.log_entries_ordered
-    is_text_log = object.log_inputs.any? { |input| input.type == 'LogInputs::TextLogInput' }
-    is_text_log ? ordered_entries.last(3) : ordered_entries
-  end
   has_many :log_inputs
-
-  # def log_entries
-  #   ActiveModel::Serializer::CollectionSerializer.new(log.log_entries)
-  # end
-
-  # def log_
-  #   ActiveModel::Serializer::CollectionSerializer.new(log.log_entries)
-  # end
 
   private
 

--- a/app/serializers/log_serializer.rb
+++ b/app/serializers/log_serializer.rb
@@ -17,7 +17,7 @@
 class LogSerializer < ActiveModel::Serializer
   attributes :description, :id, :name
 
-  has_many :log_entries do
+  has_many :log_entries, unless: -> { instance_options[:format] == :brief } do
     ordered_entries = object.log_entries_ordered
     is_text_log = object.log_inputs.any? { |input| input.type == 'LogInputs::TextLogInput' }
     is_text_log ? ordered_entries.last(3) : ordered_entries

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
 
   namespace :api, defaults: {format: :json} do
     resources :items, only: %i[update destroy]
-    resources :log_entries, only: %i[create destroy]
+    resources :log_entries, only: %i[create destroy index]
     resources :logs, only: %i[create]
     resources :stores, only: %i[create update destroy] do
       resources :items, only: %i[create]

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "@babel/preset-env": "^7.4.4",
     "@rails/webpacker": "^4.0.2",
+    "@znck/prop-types": "^0.6.1",
     "autoprefixer": "^9.5.1",
     "axios": "^0.18.0",
     "babel-loader": "^8.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1042,6 +1042,13 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
+"@znck/prop-types@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@znck/prop-types/-/prop-types-0.6.1.tgz#77d4f6a55b504944f138cabdcd0873b2e86d7eaa"
+  integrity sha512-QUAQCfw+KEsJOqHq3qc9NzJ/8Hg7IBeAxkbl6BLwcjiqvpTkb/FMGAgXFAYZiYKBPW7Q/eo0D4RNto87USyEhw==
+  dependencies:
+    vue "2.*"
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -9020,7 +9027,7 @@ vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
 
-vue@^2.6.10:
+vue@2.*, vue@^2.6.10:
   version "2.6.10"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.6.10.tgz#a72b1a42a4d82a721ea438d1b6bf55e66195c637"
   integrity sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ==


### PR DESCRIPTION
This allows us to remove the log entries from the bootstrap data. This should speed up the initial page load a lot and should overall be more efficient so that we don't spend time serializing log entries that might never be viewed.