### PR TITLE
Fetch all log entries on page load

### DIFF
--- a/app/controllers/api/log_entries_controller.rb
+++ b/app/controllers/api/log_entries_controller.rb
@@ -25,7 +25,14 @@ class Api::LogEntriesController < ApplicationController
     if log_id.present?
       render json: current_user.logs.find(log_id).log_entries_ordered
     else
-      render json: {error: 'log_id param is required'}, status: :bad_request
+      all_log_entries =
+        current_user.logs.includes(:log_entries_ordered).map do |log|
+          {
+            log_id: log.id,
+            log_entries: ActiveModel::Serializer::CollectionSerializer.new(log.log_entries_ordered),
+          }
+        end
+      render json: all_log_entries
     end
   end
 end

--- a/app/javascript/log/logs.vue
+++ b/app/javascript/log/logs.vue
@@ -50,6 +50,8 @@ export default {
         this.$store.commit('showModal', { modalName: 'log-selector' });
       }
     })
+
+    this.$store.dispatch('fetchAllLogEntries');
   },
 
   data() {

--- a/app/javascript/log/store.js
+++ b/app/javascript/log/store.js
@@ -35,6 +35,22 @@ const actions = {
     });
   },
 
+  fetchAllLogEntries({ commit, getters }) {
+    axios.
+      get(Routes.api_log_entries_path()).
+      then(({ data }) => {
+        data.forEach(({ log_id, log_entries }) => {
+          commit(
+            'setLogEntries',
+            {
+              log: getters.logById({ logId: log_id }),
+              logEntries: log_entries,
+            },
+          );
+        });
+      });
+  },
+
   fetchLogEntries({ commit, getters }, { logId }) {
     axios.
       get(Routes.api_log_entries_path({ log_id: logId })).


### PR DESCRIPTION
In a39b4e6 / #1486 , we stopped including log entries in the bootstrap data (for a faster initial page load).

This has the downside, though, that the user might have to wait a little while for the log entries to be loaded after viewing a log.

This PR adds an immediate fetch to eager-load the log entries for all logs after page load. Thus, hopefully by the time that the user selects a log, the log entries for that log (and all other logs) will have already been loaded, and the user won't experience any delay in fetching the log entries, and will solely experience a performance enhancement from #1486 in that the log entries are no longer serialized prior to page load.