### PR TITLE
Require rubocop-performance and fix cop name re: array indentation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,4 @@
+require: rubocop-performance
 AllCops:
   EnabledByDefault: true
   Exclude:
@@ -16,7 +17,7 @@ Layout/ClassStructure:
       - private_methods
 Layout/DotPosition:
   EnforcedStyle: trailing
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented


### PR DESCRIPTION
The incorrect cop name was unfortunately breaking all rubocop linting.

The failure to require rubocop-performance meant that listing it in the Gemfile was basically doing nothing.