### PR TITLE
Focus log entry input whenever log/route is changed

### DIFF
--- a/app/javascript/log/components/log.vue
+++ b/app/javascript/log/components/log.vue
@@ -86,7 +86,7 @@ export default {
   },
 
   watch: {
-    log() {
+    $route() {
       this.ensureLogEntriesHaveBeenFetched();
     },
   },

--- a/app/javascript/log/components/new_log_entry_form.vue
+++ b/app/javascript/log/components/new_log_entry_form.vue
@@ -29,6 +29,12 @@ export default {
   },
 
   methods: {
+    focusLogEntryInput() {
+      setTimeout(() => {
+        this.$refs['log-input'][0].focus();
+      });
+    },
+
     postNewLogEntry() {
       if (this.formstate.$invalid) return;
 
@@ -44,9 +50,7 @@ export default {
   },
 
   mounted() {
-    setTimeout(() => {
-      this.$refs['log-input'][0].focus();
-    });
+    this.focusLogEntryInput();
   },
 
   props: {
@@ -57,6 +61,12 @@ export default {
     log_inputs: {
       type: Array,
       required: true,
+    },
+  },
+
+  watch: {
+    $route() {
+      this.focusLogEntryInput();
     },
   },
 };


### PR DESCRIPTION
Previously, only the initial log that was viewed would have its input autofocused (which was done via the `mounted` lifecycle hook). Since vue router is now re-using the same component(s), the `mounted` hook was not being called when viewing any subsequent logs, and thus the log entry input was not being autofocused.