### PR TITLE
Fix undefined log name in delete-last-log-entry confirmation message

### DIFF
--- a/app/javascript/log/components/log.vue
+++ b/app/javascript/log/components/log.vue
@@ -68,7 +68,7 @@ export default {
   methods: {
     destroyLastEntry() {
       var confirmation = confirm(
-        `Are you sure that you want to delete the last entry from the ${this.name} log?`
+        `Are you sure that you want to delete the last entry from the ${this.log.name} log?`
       );
       if (confirmation === true) {
         const logEntryToDestroy = _(this.log_entries).sortBy('created_at').last();

--- a/spec/javascript/log/components/log.spec.js
+++ b/spec/javascript/log/components/log.spec.js
@@ -1,0 +1,73 @@
+import { mount, createLocalVue } from '@vue/test-utils';
+import Vuex from 'vuex';
+import { sync } from 'vuex-router-sync';
+import sinon from 'sinon';
+
+import 'spec_helper';
+import Log from 'log/components/log.vue';
+import { logVuexStoreFactory } from 'log/store';
+import router from 'log/router';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('Log', function () { // eslint-disable-line func-names
+  let bootstrap;
+  let vuexStore;
+  let wrapper;
+
+  const weightLogName = 'Weight';
+
+  beforeEach(() => {
+    bootstrap = {
+      logs: [
+        {
+          id: 1,
+          log_entries: [],
+          log_inputs: [{ label: 'Weight (in lbs)', public_type: 'integer' }],
+          name: weightLogName,
+        },
+      ],
+    };
+    vuexStore = logVuexStoreFactory(bootstrap);
+    sync(vuexStore, router);
+    wrapper = mount(
+      Log,
+      {
+        localVue,
+        mocks: {
+          bootstrap,
+        },
+        router,
+        store: vuexStore,
+      },
+    );
+  });
+
+  it('is a Vue instance', () => {
+    expect(wrapper.isVueInstance()).toBeTruthy();
+  });
+
+  describe('#destroyLastEntry', () => {
+    let confirmMock;
+
+    beforeEach(() => {
+      confirmMock = sinon.mock(window).expects('confirm')
+    });
+
+    afterEach(() => {
+      window.confirm.restore();
+    });
+
+    it('shows a confirmation message that mentions the log name', () => {
+      confirmMock =
+        confirmMock.withExactArgs(
+          sinon.match(new RegExp(`delete the last entry from the ${weightLogName} log?`)),
+        );
+
+      wrapper.vm.destroyLastEntry();
+
+      confirmMock.verify();
+    });
+  });
+});


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/8197963/57970753-00ccda00-793a-11e9-8cd5-3aa9032468c1.png)

# After

![image](https://user-images.githubusercontent.com/8197963/57970726-ba777b00-7939-11e9-8bb4-56fe06da9148.png)