### PR TITLE
Correctly reference log entry to delete; do so without page reload

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,8 +10,6 @@ module.exports = {
     'eslint:recommended',
   ],
   globals: {
-    expect: false,
-    _: false,
     Routes: false,
   },
   overrides: [

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - bin/rails spec:rb
   - bin/rails spec:poll_js
   - bin/rails spec:run_js
-  - ./node_modules/.bin/eslint --max-warnings 0 --ext .js,.vue app/javascript/
+  - ./node_modules/.bin/eslint --max-warnings 0 --ext .js,.vue app/javascript/ spec/javascript/
 notifications:
   email:
     on_success: never

--- a/app/javascript/log/components/log.vue
+++ b/app/javascript/log/components/log.vue
@@ -17,7 +17,6 @@ div
 
 <script>
 import { mapGetters } from 'vuex';
-import _ from 'lodash';
 
 import DurationTimeseries from './data_renderers/duration_timeseries.vue'
 import IntegerTimeseries from './data_renderers/integer_timeseries.vue'
@@ -70,11 +69,9 @@ export default {
       var confirmation = confirm(
         `Are you sure that you want to delete the last entry from the ${this.log.name} log?`
       );
+
       if (confirmation === true) {
-        const logEntryToDestroy = _(this.log_entries).sortBy('created_at').last();
-        this.$http.
-          delete(this.$routes.api_log_entry_path({ id: logEntryToDestroy.id })).
-          then(() => window.location.reload());
+        this.$store.dispatch('deleteLastLogEntry', { log: this.log });
       }
     },
 

--- a/app/javascript/log/store.js
+++ b/app/javascript/log/store.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import Vue from 'vue';
 import Vuex from 'vuex';
+import _ from 'lodash';
 
 import * as ModalVuex from 'shared/modal_store';
 
@@ -9,6 +10,10 @@ const mutations = {
 
   addLogEntry(_state, { log, logEntry }) {
     log.log_entries.push(logEntry);
+  },
+
+  deleteLogEntry(_state, { log, logEntry: logEntryToDelete }) {
+    log.log_entries = log.log_entries.filter(logEntry => logEntry !== logEntryToDelete);
   },
 
   setLogEntries(state, { log, logEntries }) {
@@ -29,6 +34,13 @@ const actions = {
       const log = getters.logById({ logId });
       commit('addLogEntry', { log, logEntry: data });
     });
+  },
+
+  deleteLastLogEntry({ commit }, { log }) {
+    const lastLogEntry = _(log.log_entries).sortBy('created_at').last();
+    axios.
+      delete(Routes.api_log_entry_path({ id: lastLogEntry.id })).
+      then(() => { commit('deleteLogEntry', { log, logEntry: lastLogEntry }); });
   },
 
   fetchAllLogEntries({ commit, getters }) {

--- a/app/javascript/shared/common.js
+++ b/app/javascript/shared/common.js
@@ -1,1 +1,8 @@
+import _ from 'lodash';
+
 import 'shared/routes';
+
+// undefine global lodash (except for tests); see https://github.com/lodash/lodash/issues/2550
+if (window.davidrunger && window.davidrunger.env !== 'test') {
+  _.noConflict();
+}

--- a/spec/javascript/.eslintrc.js
+++ b/spec/javascript/.eslintrc.js
@@ -1,0 +1,6 @@
+module.exports = {
+  globals: {
+    expect: false,
+    _: false,
+  },
+};

--- a/spec/javascript/headless_runner.js
+++ b/spec/javascript/headless_runner.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const { runner } = require('mocha-headless-chrome');
 
 runner({ file: 'http://localhost:8080/packs-test/mocha_runner.html' }).

--- a/spec/javascript/log/components/log.spec.js
+++ b/spec/javascript/log/components/log.spec.js
@@ -69,5 +69,31 @@ describe('Log', function () { // eslint-disable-line func-names
 
       confirmMock.verify();
     });
+
+    describe('when the user confirms that they want to delete the log entry', () => {
+      let dispatchMock;
+
+      beforeEach(() => {
+        confirmMock = confirmMock.returns(true);
+        dispatchMock =
+          sinon.mock(wrapper.vm.$store).
+            expects('dispatch').
+            withExactArgs(
+              'deleteLastLogEntry',
+              { log: wrapper.vm.log },
+            );
+      });
+
+      afterEach(() => {
+        wrapper.vm.$store.dispatch.restore();
+      });
+
+      it('dispatches a deleteLastLogEntry action', () => {
+        wrapper.vm.destroyLastEntry();
+
+        confirmMock.verify();
+        dispatchMock.verify();
+      });
+    });
   });
 });


### PR DESCRIPTION
This PR fixes a bug wherein clicking the "Delete last entry" button when viewing a log did not actually delete the last log entry.

This bug was due to the same change that introduced the bug that was fixed in https://github.com/davidrunger/david_runger/pull/1520/ (_Fix undefined log name in delete-last-log-entry confirmation message_).

This bug was introduced via this change: https://github.com/davidrunger/david_runger/commit/e522ab38d9935278cc1f5db7e07c922a6da5d538#diff-b8e0c29abca6d5ed1f3add9e5c9a0accR79

That change in #1486 (Lazy load log entries on-demand) started just passing a `log` prop to the Log component, rather than passing each prop individually (`log_entries`, `log_name`, `log_id`, etc.).

Tests should have protected against this bug, but they were lacking. A test has been added in this PR to cover regressions.

In addition to fixing the bug, this PR also changes the delete-last-log-entry UX to not rely on a page refresh but rather to delete the last log entry directly on the client side after the AJAX request completes successfully.