### PR TITLE
Wrap selected log around top/bottom when user arrows past end of list

### DIFF
--- a/app/javascript/log/components/log_selector.vue
+++ b/app/javascript/log/components/log_selector.vue
@@ -68,12 +68,18 @@ export default {
     decrementHighlightedLogIndex() {
       if (this.highlightedLogIndex > 0) {
         this.highlightedLogIndex--;
+      } else {
+        // wrap around from the top of the list to the bottom
+        this.highlightedLogIndex = this.orderedMatches.length - 1;
       }
     },
 
     incrementHighlightedLogIndex() {
-      if (this.highlightedLogIndex < this.orderedMatches.length) {
+      if (this.highlightedLogIndex < this.orderedMatches.length - 1) {
         this.highlightedLogIndex++;
+      } else {
+        // wrap back around to the top of the list
+        this.highlightedLogIndex = 0;
       }
     },
 


### PR DESCRIPTION
Implementation detail: I could have used a modulus operator and just let the index grow infinitely large or small, but that seemed a little sloppy, even though the code would have been a little simpler (or, at least, terser).