### PR TITLE
Refactor data model behind logs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -76,6 +76,7 @@ Style/MethodCallWithArgsParentheses:
     - add_foreign_key
     - add_column
     - add_index
+    - change
     - change_column_null
     - create_table
     - datetime

--- a/app/controllers/api/log_entries_controller.rb
+++ b/app/controllers/api/log_entries_controller.rb
@@ -1,8 +1,7 @@
 class Api::LogEntriesController < ApplicationController
   def create
     log = current_user.logs.find(params.dig(:log_entry, :log_id))
-    log_entry_params =
-      params.require(:log_entry).permit(:log_id, data: log.log_inputs.pluck(:label)).to_h
+    log_entry_params = params.require(:log_entry).permit(:log_id, :data)
     @log_entry = log.log_entries.build(log_entry_params)
     if @log_entry.save
       # TODO: remove #reload; needed to work w/ #read_attribute_before_type_cast call in serializer
@@ -14,7 +13,7 @@ class Api::LogEntriesController < ApplicationController
   end
 
   def destroy
-    log_entry = LogEntry.find(params['id'])
+    log_entry = Log.find(params['log_id']).log_entries.find(params['id'])
     log_entry.destroy!
     render json: log_entry
   end
@@ -23,16 +22,27 @@ class Api::LogEntriesController < ApplicationController
     log_id = params['log_id']
 
     if log_id.present?
-      render json: current_user.logs.find(log_id).log_entries_ordered
+      render json: ActiveModel::Serializer::CollectionSerializer.new(
+        current_user.logs.find(log_id).log_entries_ordered,
+        each_serializer: LogEntrySerializer,
+      )
     else
       all_log_entries =
-        current_user.logs.includes(:log_entries_ordered).map do |log|
-          {
-            log_id: log.id,
-            log_entries: ActiveModel::Serializer::CollectionSerializer.new(log.log_entries_ordered),
-          }
-        end
-      render json: all_log_entries
+        current_user.logs.
+          includes(:number_log_entries_ordered, :text_log_entries_ordered).
+          map do |log|
+            {
+              log_id: log.id,
+              log_entries:
+                ActiveModel::Serializer::CollectionSerializer.new(
+                  log.log_entries_ordered,
+                  each_serializer: LogEntrySerializer,
+                ).to_a,
+            }
+          end
+      # `to_json` is necessary to avoid warning in logs.
+      # see https://github.com/rails-api/active_model_serializers/issues/2024
+      render json: all_log_entries.to_json
     end
   end
 end

--- a/app/controllers/api/logs_controller.rb
+++ b/app/controllers/api/logs_controller.rb
@@ -15,9 +15,10 @@ class Api::LogsController < ApplicationController
 
   def log_params
     params.require(:log).permit(
-      :name,
+      :data_label,
+      :data_type,
       :description,
-      log_inputs_attributes: %i[index label public_type],
+      :name,
     )
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -5,7 +5,7 @@ class LogsController < ApplicationController
     bootstrap(
       current_user: UserSerializer.new(current_user),
       logs: ActiveModel::Serializer::CollectionSerializer.new(
-        current_user.logs.order(:created_at).includes(:log_inputs),
+        current_user.logs.order(:created_at),
       ),
       log_input_types: log_input_types,
     )
@@ -15,11 +15,10 @@ class LogsController < ApplicationController
   private
 
   def log_input_types
-    available_input_types = LogInput::PUBLIC_TYPE_TO_TYPE_MAPPING.keys.map(&:to_s)
     [
-      {public_type: 'duration', label: 'Duration'},
-      {public_type: 'integer', label: 'Integer'},
-      {public_type: 'text', label: 'Text'},
-    ].select { |input_type| input_type[:public_type].in?(available_input_types) }
+      {data_type: 'duration', label: 'Duration'},
+      {data_type: 'number', label: 'Number'},
+      {data_type: 'text', label: 'Text'},
+    ]
   end
 end

--- a/app/javascript/log/components/data_renderers/duration_timeseries.vue
+++ b/app/javascript/log/components/data_renderers/duration_timeseries.vue
@@ -54,7 +54,7 @@ export default {
     logEntriesToChartData() {
       return this.log_entries.map(logEntry => ({
         t: logEntry.created_at,
-        y: new Date(`1970-01-01T${shortTimeStringToHhMmSsString(logEntry.data[this.data_label])}Z`),
+        y: new Date(`1970-01-01T${shortTimeStringToHhMmSsString(logEntry.data)}Z`),
       }))
     },
   },

--- a/app/javascript/log/components/data_renderers/integer_timeseries.vue
+++ b/app/javascript/log/components/data_renderers/integer_timeseries.vue
@@ -29,7 +29,7 @@ export default {
     logEntriesToChartData() {
       return this.log_entries.map(logEntry => ({
         t: logEntry.created_at,
-        y: logEntry.data[this.data_label],
+        y: logEntry.data,
       }))
     },
   },

--- a/app/javascript/log/components/data_renderers/text_log.vue
+++ b/app/javascript/log/components/data_renderers/text_log.vue
@@ -26,7 +26,7 @@ export default {
     formattedLogEntries() {
       return this.log_entries.map(logEntry => ({
         createdAt: strftime('%b %-d %-l:%M%P', new Date(logEntry.created_at)),
-        text: logEntry.data[this.data_label],
+        text: logEntry.data,
       }))
     },
   },

--- a/app/javascript/log/components/log.vue
+++ b/app/javascript/log/components/log.vue
@@ -6,11 +6,12 @@ div
     Loading...
   log-data-display(
     v-else-if='log.log_entries.length'
-    :log_inputs='log.log_inputs'
+    :data_label='log.data_label'
+    :data_type='log.data_type'
     :log_entries='log.log_entries'
   )
   div.mb2(v-else) There are no log entries for this log.
-  new-log-entry-form(:log_id='log.id' :log_inputs='log.log_inputs')
+  new-log-entry-form(:log='log')
   .mt1
     el-button(@click='destroyLastEntry') Delete last entry
 </template>
@@ -25,26 +26,21 @@ import NewLogEntryForm from './new_log_entry_form.vue'
 
 const PUBLIC_TYPE_TO_DATA_RENDERER_MAPPING = {
   duration: DurationTimeseries,
-  integer: IntegerTimeseries,
+  number: IntegerTimeseries,
   text: TextLog,
 };
 
 const LogDataDisplay = {
   functional: true,
   render (h, context) {
-    if (context.props.log_inputs.length === 1) {
-      const logInput = context.props.log_inputs[0];
-      const publicType = logInput.public_type;
-      const dataLabel = logInput.label;
-      const DataRenderer = PUBLIC_TYPE_TO_DATA_RENDERER_MAPPING[publicType];
+    const DataRenderer = PUBLIC_TYPE_TO_DATA_RENDERER_MAPPING[context.props.data_type];
 
-      return h(DataRenderer, {
-        props: {
-          log_entries: context.props.log_entries,
-          data_label: dataLabel,
-        },
-      });
-    }
+    return h(DataRenderer, {
+      props: {
+        log_entries: context.props.log_entries,
+        data_label: context.props.data_label,
+      },
+    });
   },
 }
 

--- a/app/javascript/log/components/new_log_entry_form.vue
+++ b/app/javascript/log/components/new_log_entry_form.vue
@@ -1,14 +1,11 @@
 <template lang='pug'>
 div
   vue-form.px1(@submit.prevent='postNewLogEntry' :state='formstate')
-    validate.mb1(
-      v-for='log_input in log_inputs'
-      :key='log_input.label'
-    )
+    validate.mb1
       el-input(
-        :placeholder='log_input.label'
-        v-model='newLogEntryData[log_input.label]'
-        name='log_input.label'
+        :placeholder='log.data_label'
+        v-model='newLogEntryData'
+        name='log.data_label'
         required
         ref='log-input'
       )
@@ -24,14 +21,14 @@ export default {
   data() {
     return {
       formstate: {},
-      newLogEntryData: {},
+      newLogEntryData: null,
     };
   },
 
   methods: {
     focusLogEntryInput() {
       setTimeout(() => {
-        this.$refs['log-input'][0].focus();
+        this.$refs['log-input'].focus();
       });
     },
 
@@ -41,11 +38,11 @@ export default {
       this.$store.dispatch(
         'addLogEntry',
         {
-          logId: this.log_id,
+          logId: this.log.id,
           newLogEntryData: this.newLogEntryData,
         },
       );
-      this.newLogEntryData = {};
+      this.newLogEntryData = null;
     },
   },
 
@@ -54,12 +51,8 @@ export default {
   },
 
   props: {
-    log_id: {
-      type: Number,
-      required: true,
-    },
-    log_inputs: {
-      type: Array,
+    log: {
+      type: Object,
       required: true,
     },
   },

--- a/app/javascript/log/components/new_log_form.vue
+++ b/app/javascript/log/components/new_log_form.vue
@@ -7,37 +7,34 @@ div
         validate.mb1
           el-input(
             placeholder='Name'
-            v-model='newLogName'
-            name='newLogName'
+            v-model='newLog.name'
+            name='newLog.name'
             required
           )
         el-input.mb1(
           type='textarea'
           placeholder='Details/Description'
-          v-model='newLogDescription'
-          name='newLogDescription'
+          v-model='newLog.description'
+          name='newLog.description'
         )
-        validate.mb1(
-          v-for='(logInput, index) in newLogInputs'
-          :key='index'
-        )
+        validate.mb1
           el-input.mb1(
             placeholder='Label'
-            v-model='logInput.label'
-            name='logInput.log_input_id'
+            v-model='newLog.data_label'
+            name='newLog.data_label'
             required
           )
           el-select(
             placeholder='Type'
-            v-model='logInput.public_type'
-            name='logInput.public_type'
+            v-model='newLog.data_type'
+            name='newLog.data_type'
             required
           )
             el-option(
-              v-for='inputType in bootstrap.log_input_types'
-              :key='inputType.public_type'
-              :label='inputType.label'
-              :value='inputType.public_type'
+              v-for='dataType in bootstrap.log_input_types'
+              :key='dataType.data_type'
+              :label='dataType.label'
+              :value='dataType.data_type'
             )
         el-input(
           type='submit'
@@ -51,9 +48,12 @@ export default {
   data() {
     return {
       formstate: {},
-      newLogDescription: '',
-      newLogName: '',
-      newLogInputs: [{}],
+      newLog: {
+        data_label: '',
+        data_type: '',
+        description: '',
+        name: '',
+      },
       postingLog: false,
     };
   },
@@ -64,18 +64,8 @@ export default {
 
       this.postingLog = true;
 
-      const payload = {
-        log: {
-          description: this.newLogDescription,
-          name: this.newLogName,
-          log_inputs_attributes: this.newLogInputs.map((input, i) => {
-            input.index = i;
-            return input;
-          }),
-        },
-      };
-      this.$http.post(this.$routes.api_logs_path(), payload).then(() => {
-        this.newLogName = '';
+      this.$http.post(this.$routes.api_logs_path(), { log: this.newLog }).then(() => {
+        this.newLog = {};
         this.postingLog = false;
         window.location.reload();
       });

--- a/app/javascript/log/store.js
+++ b/app/javascript/log/store.js
@@ -39,7 +39,11 @@ const actions = {
   deleteLastLogEntry({ commit }, { log }) {
     const lastLogEntry = _(log.log_entries).sortBy('created_at').last();
     axios.
-      delete(Routes.api_log_entry_path({ id: lastLogEntry.id })).
+      delete(Routes.api_log_entry_path({
+        id: lastLogEntry.id,
+        log_id: log.id,
+        _options: {}, // providing `_options` seems to be necessary to put query params in the path
+      })).
       then(() => { commit('deleteLogEntry', { log, logEntry: lastLogEntry }); });
   },
 

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -3,6 +3,8 @@
 # Table name: logs
 #
 #  created_at  :datetime         not null
+#  data_label  :string           not null
+#  data_type   :string           not null
 #  description :string
 #  id          :bigint           not null, primary key
 #  name        :string           not null
@@ -17,21 +19,60 @@
 #
 
 class Log < ApplicationRecord
+  DATA_TYPES = {
+    'duration' => {
+      association: :text_log_entries,
+      ordered_association: :text_log_entries_ordered,
+    },
+    'number' => {
+      association: :number_log_entries,
+      ordered_association: :number_log_entries_ordered,
+    },
+    'text' => {
+      association: :text_log_entries,
+      ordered_association: :text_log_entries_ordered,
+    },
+  }.transform_keys(&:freeze).transform_values(&:freeze).freeze
+
+  validates :data_label, presence: true
+  validates :data_type, presence: true, inclusion: DATA_TYPES.keys
   validates :name, presence: true, uniqueness: {scope: :user_id}
 
   belongs_to :user
 
-  has_many :log_entries, dependent: :destroy
-  has_many :log_entries_ordered,
-    -> { order(:created_at) },
-    class_name: 'LogEntry',
+  has_many :number_log_entries,
+    class_name: 'LogEntries::NumberLogEntry',
     dependent: :destroy,
     inverse_of: :log
+  has_many :number_log_entries_ordered,
+    -> { order(:created_at) },
+    class_name: 'LogEntries::NumberLogEntry',
+    dependent: :destroy,
+    inverse_of: :log
+
+  has_many :text_log_entries,
+    class_name: 'LogEntries::TextLogEntry',
+    dependent: :destroy,
+    inverse_of: :log
+  has_many :text_log_entries_ordered,
+    -> { order(:created_at) },
+    class_name: 'LogEntries::TextLogEntry',
+    dependent: :destroy,
+    inverse_of: :log
+
   has_many :log_inputs, dependent: :destroy
 
   accepts_nested_attributes_for :log_inputs
 
   before_save :set_slug, if: -> { name_changed? }
+
+  def log_entries
+    public_send(DATA_TYPES[data_type][:association])
+  end
+
+  def log_entries_ordered
+    public_send(DATA_TYPES[data_type][:ordered_association])
+  end
 
   def set_slug
     self.slug = name.downcase.gsub(%r{\s+|\.+|\\|/}, '-').gsub(/[^[:alnum:]\-_]/, '')

--- a/app/models/log_entries/number_log_entry.rb
+++ b/app/models/log_entries/number_log_entry.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: number_log_entries
+#
+#  created_at :datetime         not null
+#  data       :float            not null
+#  id         :bigint           not null, primary key
+#  log_id     :bigint           not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_number_log_entries_on_log_id  (log_id)
+#
+
+class LogEntries::NumberLogEntry < LogEntry
+  self.table_name = 'number_log_entries'
+end

--- a/app/models/log_entries/text_log_entry.rb
+++ b/app/models/log_entries/text_log_entry.rb
@@ -1,0 +1,18 @@
+# == Schema Information
+#
+# Table name: text_log_entries
+#
+#  created_at :datetime         not null
+#  data       :text             not null
+#  id         :bigint           not null, primary key
+#  log_id     :bigint           not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_text_log_entries_on_log_id  (log_id)
+#
+
+class LogEntries::TextLogEntry < LogEntry
+  self.table_name = 'text_log_entries'
+end

--- a/app/models/log_inputs/integer_log_input.rb
+++ b/app/models/log_inputs/integer_log_input.rb
@@ -3,10 +3,10 @@
 # Table name: log_inputs
 #
 #  created_at :datetime         not null
-#  id         :bigint(8)        not null, primary key
+#  id         :bigint           not null, primary key
 #  index      :integer          default(0), not null
 #  label      :string           not null
-#  log_id     :bigint(8)        not null
+#  log_id     :bigint           not null
 #  type       :string           not null
 #  updated_at :datetime         not null
 #

--- a/app/models/log_inputs/text_log_input.rb
+++ b/app/models/log_inputs/text_log_input.rb
@@ -3,10 +3,10 @@
 # Table name: log_inputs
 #
 #  created_at :datetime         not null
-#  id         :bigint(8)        not null, primary key
+#  id         :bigint           not null, primary key
 #  index      :integer          default(0), not null
 #  label      :string           not null
-#  log_id     :bigint(8)        not null
+#  log_id     :bigint           not null
 #  type       :string           not null
 #  updated_at :datetime         not null
 #

--- a/app/serializers/log_serializer.rb
+++ b/app/serializers/log_serializer.rb
@@ -3,6 +3,8 @@
 # Table name: logs
 #
 #  created_at  :datetime         not null
+#  data_label  :string           not null
+#  data_type   :string           not null
 #  description :string
 #  id          :bigint           not null, primary key
 #  name        :string           not null
@@ -17,7 +19,5 @@
 #
 
 class LogSerializer < ActiveModel::Serializer
-  attributes :description, :id, :name, :slug
-
-  has_many :log_inputs
+  attributes :data_label, :data_type, :description, :id, :name, :slug
 end

--- a/db/datamigrate/copy_log_entries_to_type_specific_tables.rb
+++ b/db/datamigrate/copy_log_entries_to_type_specific_tables.rb
@@ -1,0 +1,33 @@
+def copy_log_entries_to_type_specific_tables!
+  # iterate by log so that we know the type of log input
+  Log.find_each do |log|
+    log_input = log.log_inputs.first!
+    new_log_entry_class =
+      case log_input.type
+      # (durations are recorded as strings, like "42:10")
+      when 'LogInputs::DurationLogInput'
+        LogEntries::TextLogEntry
+      when 'LogInputs::IntegerLogInput'
+        LogEntries::NumberLogEntry
+      when 'LogInputs::TextLogInput'
+        LogEntries::TextLogEntry
+      end
+    data_key = log_input.label
+
+    log.log_entries.find_each do |log_entry|
+      old_data = log_entry.data[data_key]
+      data =
+        if new_log_entry_class == LogEntries::NumberLogEntry
+          Float(old_data.to_s.gsub(/[^\d\.]/, ''))
+        else
+          old_data
+        end
+
+      new_log_entry_class.create!(
+        created_at: log_entry.created_at, # updated_at will reflect the actual time of creation
+        data: data,
+        log: log,
+      )
+    end
+  end
+end

--- a/db/datamigrate/copy_log_inputs_to_logs.rb
+++ b/db/datamigrate/copy_log_inputs_to_logs.rb
@@ -1,0 +1,20 @@
+def copy_log_inputs_to_logs!
+  LogInput.find_each do |log_input|
+    log = log_input.log
+
+    data_type =
+      case log_input.type
+      when 'LogInputs::DurationLogInput'
+        'duration'
+      when 'LogInputs::IntegerLogInput'
+        'number'
+      when 'LogInputs::TextLogInput'
+        'text'
+      end
+
+    log.update!(
+      data_type: data_type,
+      data_label: log_input.label,
+    )
+  end
+end

--- a/db/migrate/20190519192128_create_separate_log_entry_tables_per_type.rb
+++ b/db/migrate/20190519192128_create_separate_log_entry_tables_per_type.rb
@@ -1,0 +1,25 @@
+require Rails.root.join('db', 'datamigrate', 'copy_log_entries_to_type_specific_tables.rb')
+
+class CreateSeparateLogEntryTablesPerType < ActiveRecord::Migration[5.2]
+  def change
+    create_table :text_log_entries do |t|
+      t.references :log, null: false, foreign_key: true
+      t.text :data, null: false
+
+      t.timestamps
+    end
+
+    create_table :number_log_entries do |t|
+      t.references :log, null: false, foreign_key: true
+      t.float :data, null: false
+
+      t.timestamps
+    end
+
+    copy_log_entries_to_type_specific_tables!
+
+    # rubocop:disable Rails/ReversibleMigration
+    drop_table :log_entries
+    # rubocop:enable Rails/ReversibleMigration
+  end
+end

--- a/db/migrate/20190519204038_store_log_input_info_on_logs_table.rb
+++ b/db/migrate/20190519204038_store_log_input_info_on_logs_table.rb
@@ -1,0 +1,11 @@
+class StoreLogInputInfoOnLogsTable < ActiveRecord::Migration[5.2]
+  def change
+    change_table :logs, bulk: true do |t|
+      t.text :data_label
+      t.text :data_type
+    end
+
+    ApplicationRecord.connection.schema_cache.clear!
+    Log.reset_column_information
+  end
+end

--- a/db/migrate/20190519213938_copy_log_inputs_to_logs.rb
+++ b/db/migrate/20190519213938_copy_log_inputs_to_logs.rb
@@ -1,0 +1,7 @@
+require Rails.root.join('db', 'datamigrate', 'copy_log_inputs_to_logs.rb')
+
+class CopyLogInputsToLogs < ActiveRecord::Migration[5.2]
+  def change
+    copy_log_inputs_to_logs!
+  end
+end

--- a/db/migrate/20190519213939_change_log_columns_to_not_nullable.rb
+++ b/db/migrate/20190519213939_change_log_columns_to_not_nullable.rb
@@ -1,0 +1,10 @@
+class ChangeLogColumnsToNotNullable < ActiveRecord::Migration[5.2]
+  def change
+    # rubocop:disable Rails/ReversibleMigration
+    change_table :logs, bulk: true do |t|
+      t.change :data_label, :string, null: false
+      t.change :data_type, :string, null: false
+    end
+    # rubocop:enable Rails/ReversibleMigration
+  end
+end

--- a/db/migrate/20190519214027_drop_log_inputs_table.rb
+++ b/db/migrate/20190519214027_drop_log_inputs_table.rb
@@ -1,0 +1,7 @@
+class DropLogInputsTable < ActiveRecord::Migration[5.2]
+  def change
+    # rubocop:disable Rails/ReversibleMigration
+    drop_table :log_inputs
+    # rubocop:enable Rails/ReversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_07_145454) do
+ActiveRecord::Schema.define(version: 2019_05_19_214027) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -25,24 +25,6 @@ ActiveRecord::Schema.define(version: 2019_05_07_145454) do
     t.index ["store_id"], name: "index_items_on_store_id"
   end
 
-  create_table "log_entries", force: :cascade do |t|
-    t.bigint "log_id", null: false
-    t.jsonb "data", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["log_id"], name: "index_log_entries_on_log_id"
-  end
-
-  create_table "log_inputs", force: :cascade do |t|
-    t.bigint "log_id", null: false
-    t.string "type", null: false
-    t.string "label", null: false
-    t.integer "index", default: 0, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["log_id", "index"], name: "index_log_inputs_on_log_id_and_index", unique: true
-  end
-
   create_table "logs", force: :cascade do |t|
     t.bigint "user_id", null: false
     t.string "name", null: false
@@ -50,8 +32,18 @@ ActiveRecord::Schema.define(version: 2019_05_07_145454) do
     t.datetime "updated_at", null: false
     t.string "description"
     t.string "slug", null: false
+    t.string "data_label", null: false
+    t.string "data_type", null: false
     t.index ["user_id", "name"], name: "index_logs_on_user_id_and_name", unique: true
     t.index ["user_id", "slug"], name: "index_logs_on_user_id_and_slug", unique: true
+  end
+
+  create_table "number_log_entries", force: :cascade do |t|
+    t.bigint "log_id", null: false
+    t.float "data", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["log_id"], name: "index_number_log_entries_on_log_id"
   end
 
   create_table "pghero_query_stats", force: :cascade do |t|
@@ -115,6 +107,14 @@ ActiveRecord::Schema.define(version: 2019_05_07_145454) do
     t.index ["user_id"], name: "index_stores_on_user_id"
   end
 
+  create_table "text_log_entries", force: :cascade do |t|
+    t.bigint "log_id", null: false
+    t.text "data", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["log_id"], name: "index_text_log_entries_on_log_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", null: false
     t.datetime "created_at", null: false
@@ -126,10 +126,10 @@ ActiveRecord::Schema.define(version: 2019_05_07_145454) do
   end
 
   add_foreign_key "items", "stores"
-  add_foreign_key "log_entries", "logs"
-  add_foreign_key "log_inputs", "logs"
   add_foreign_key "logs", "users"
+  add_foreign_key "number_log_entries", "logs"
   add_foreign_key "requests", "users"
   add_foreign_key "sms_records", "users"
   add_foreign_key "stores", "users"
+  add_foreign_key "text_log_entries", "logs"
 end

--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Api::LogsController do
 
         expect(Rails.logger).
           to have_received(:info).
-          with(/Failed to create log. errors={:name=>"can't be blank"} log={.*"name"=>"".*}/)
+          with(/Failed to create log. errors={.*:name=>"can't be blank".*} log={.*"name"=>"".*}/)
       end
 
       it 'returns a 422 status code' do


### PR DESCRIPTION
This is a pretty big backend change. Hopefully there are no user-facing changes! :)

Primarily the change here is to:
1. drop the concept of "log inputs" and instead assume that each log only has one input; the information about this input is now stored on the `Log` model itself.
2. no longer store log data in `jsonb` column that contains a bunch of duplicate information for each log entry; instead create separate new tables, one which will store numeric values and one which will store text values

There is some remaining cleanup that can still be done (for example, deleting the `LogInput` model), but some of it needs to wait until after this change deploys (e.g. so that the `LogInput` model can facilitate one of the datamigrations in this PR).