### PR TITLE
Enforce the use of trailing semicolons in JavaScript

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,6 +45,7 @@ module.exports = {
       minProperties: 99,
     }],
     'quotes': ['warn', 'single', { avoidEscape: true }],
+    'semi': ['warn', 'always'],
   },
   settings: {
     'import/resolver': {

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -143,7 +143,7 @@ export default {
         storeNameInput.focus();
       } else if (callsAlready < 20) {
         // the storeNameInput hasn't had time to render yet; retry later
-        setTimeout(() => { this.focusStoreNameInput(callsAlready + 1) }, 50);
+        setTimeout(() => { this.focusStoreNameInput(callsAlready + 1); }, 50);
       }
     },
 

--- a/app/javascript/log/components/data_renderers/duration_timeseries.vue
+++ b/app/javascript/log/components/data_renderers/duration_timeseries.vue
@@ -16,7 +16,7 @@ function epochMsToHhMmSs(epochMs) {
     substr(11, 8).
     replace(/^00:/, '').
     replace(/^0+/, '').
-    replace(/^:00$/, '0')
+    replace(/^:00$/, '0');
 }
 
 function shortTimeStringToHhMmSsString(timeString) {
@@ -55,7 +55,7 @@ export default {
       return this.log_entries.map(logEntry => ({
         t: logEntry.created_at,
         y: new Date(`1970-01-01T${shortTimeStringToHhMmSsString(logEntry.data)}Z`),
-      }))
+      }));
     },
   },
 
@@ -76,7 +76,7 @@ export default {
         }],
         yAxes: [{
           ticks: {
-            userCallback: function(v) { return epochMsToHhMmSs(v) },
+            userCallback: function(v) { return epochMsToHhMmSs(v); },
           },
         }],
       },

--- a/app/javascript/log/components/data_renderers/integer_timeseries.vue
+++ b/app/javascript/log/components/data_renderers/integer_timeseries.vue
@@ -30,7 +30,7 @@ export default {
       return this.log_entries.map(logEntry => ({
         t: logEntry.created_at,
         y: logEntry.data,
-      }))
+      }));
     },
   },
 

--- a/app/javascript/log/components/log.vue
+++ b/app/javascript/log/components/log.vue
@@ -20,10 +20,10 @@ div
 <script>
 import { mapGetters } from 'vuex';
 
-import DurationTimeseries from './data_renderers/duration_timeseries.vue'
-import IntegerTimeseries from './data_renderers/integer_timeseries.vue'
-import TextLog from './data_renderers/text_log.vue'
-import NewLogEntryForm from './new_log_entry_form.vue'
+import DurationTimeseries from './data_renderers/duration_timeseries.vue';
+import IntegerTimeseries from './data_renderers/integer_timeseries.vue';
+import TextLog from './data_renderers/text_log.vue';
+import NewLogEntryForm from './new_log_entry_form.vue';
 
 const PUBLIC_TYPE_TO_DATA_RENDERER_MAPPING = {
   duration: DurationTimeseries,
@@ -43,7 +43,7 @@ const LogDataDisplay = {
       },
     });
   },
-}
+};
 
 export default {
   components: {

--- a/app/javascript/log/components/log_selector.vue
+++ b/app/javascript/log/components/log_selector.vue
@@ -116,7 +116,7 @@ export default {
       setTimeout(() => {
         const logSearchInput = this.$refs['log-search-input'];
         if (logSearchInput) {
-          logSearchInput.focus()
+          logSearchInput.focus();
         }
       });
     },

--- a/app/javascript/log/logs.vue
+++ b/app/javascript/log/logs.vue
@@ -46,7 +46,7 @@ export default {
       if ((event.key === 'k') && (event.metaKey == true)) {
         this.$store.commit('showModal', { modalName: 'log-selector' });
       }
-    })
+    });
   },
 
   data() {

--- a/app/javascript/log/router.js
+++ b/app/javascript/log/router.js
@@ -1,4 +1,4 @@
-import VueRouter from 'vue-router'
+import VueRouter from 'vue-router';
 
 import Log from 'log/components/log.vue';
 import LogsIndex from 'log/components/logs_index.vue';
@@ -6,7 +6,7 @@ import LogsIndex from 'log/components/logs_index.vue';
 const routes = [
   { path: '/logs',  name: 'logs-index', component: LogsIndex },
   { path: '/logs/:slug', name: 'log', component: Log },
-]
+];
 
 const router = new VueRouter({
   mode: 'history',

--- a/spec/javascript/headless_runner.js
+++ b/spec/javascript/headless_runner.js
@@ -6,11 +6,11 @@ runner({ file: 'http://localhost:8080/packs-test/mocha_runner.html' }).
   then(({ result }) => {
     const { stats } = result;
     if (stats.passes <= 0) {
-      console.error('No tests passed!')
+      console.error('No tests passed!');
       process.exit(1);
     }
     if (stats.failures > 0) {
-      console.error(`${stats.failures} test(s) failed!`)
+      console.error(`${stats.failures} test(s) failed!`);
       process.exit(1);
     }
   }).catch(error => {

--- a/spec/javascript/log/components/log.spec.js
+++ b/spec/javascript/log/components/log.spec.js
@@ -52,7 +52,7 @@ describe('Log', function () { // eslint-disable-line func-names
     let confirmMock;
 
     beforeEach(() => {
-      confirmMock = sinon.mock(window).expects('confirm')
+      confirmMock = sinon.mock(window).expects('confirm');
     });
 
     afterEach(() => {


### PR DESCRIPTION
Also, autocorrect missing trailing semicolons with eslint

```
./node_modules/.bin/eslint --fix --max-warnings 0 --ext .js,.vue app/javascript/ spec/javascript/
```