### PR TITLE
Hide some horizontal line with a too-high z-index from element table

### DIFF
--- a/app/javascript/logs/components/log.vue
+++ b/app/javascript/logs/components/log.vue
@@ -95,4 +95,8 @@ export default {
 .description {
   font-weight: 200;
 }
+
+/deep/ .el-table::before {
+  display: none;
+}
 </style>


### PR DESCRIPTION
This appears obviously above the modal mask when switching logs from a text log.