### PR TITLE
Change text log input from type="text" to a <textarea>

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -62,5 +62,6 @@ export default {
 <style>
 .el-table .cell {
   word-break: initial;
+  white-space: pre;
 }
 </style>

--- a/app/javascript/logs/components/new_log_entry_form.vue
+++ b/app/javascript/logs/components/new_log_entry_form.vue
@@ -8,6 +8,7 @@ div
         name='log.data_label'
         required
         ref='log-input'
+        :type='inputType'
       )
     el-input(
       type='submit'
@@ -18,6 +19,18 @@ div
 
 <script>
 export default {
+  computed: {
+    inputType() {
+      if (['text'].indexOf(this.log.data_type) >= 0) {
+        return 'textarea';
+      } else if (['number'].indexOf(this.log.data_type) >= 0) {
+        return 'number';
+      } else {
+        return 'text';
+      }
+    },
+  },
+
   data() {
     return {
       formstate: {},
@@ -64,3 +77,9 @@ export default {
   },
 };
 </script>
+
+<style>
+textarea {
+  font-family: sans-serif;
+}
+</style>


### PR DESCRIPTION
Also:
1. show multi-line text log entries with newlines (`white-space: pre;`)
2. ensure that textarea font-family is sans-serif; for some insane reason it is monospace on Firefox