### PR TITLE
Force Vue router to render fresh components via `key`

### DIFF
--- a/app/javascript/logs/components/log.vue
+++ b/app/javascript/logs/components/log.vue
@@ -82,12 +82,6 @@ export default {
       }
     },
   },
-
-  watch: {
-    $route() {
-      this.ensureLogEntriesHaveBeenFetched();
-    },
-  },
 };
 </script>
 

--- a/app/javascript/logs/components/new_log_entry_form.vue
+++ b/app/javascript/logs/components/new_log_entry_form.vue
@@ -69,12 +69,6 @@ export default {
       required: true,
     },
   },
-
-  watch: {
-    $route() {
-      this.focusLogEntryInput();
-    },
-  },
 };
 </script>
 

--- a/app/javascript/logs/logs.vue
+++ b/app/javascript/logs/logs.vue
@@ -3,7 +3,7 @@ div
   .center.mb1
     .h5.gray.pt1 {{bootstrap.current_user.email}}
     log-selector
-    router-view.mt3.mx3
+    router-view(:key='$route.fullPath').mt3.mx3
     hr.silver.m3
     el-collapse(v-model='expandedPanelNames')
       el-collapse-item(title = 'Create new log' name='new-log-form')


### PR DESCRIPTION
The fact that components were being re-used was requiring `watch`ing the `$route` for changes (to then `ensureLogEntriesHaveBeenFetched` and `focusLogEntryInput`). It was also causing a bug with our `vue-form` form validations; for example, after viewing a number-type log, then switching to a text log, `vue-form` was validating the text log's log entry input value as a number (i.e. still left over from the number log input validation).