### PR TITLE
Use $(...) rather than backticks in rubocop command in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,13 +19,13 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
   - export PATH="$HOME/.yarn/bin:$PATH"
 script:
-  - "ruby --version && [ \"$(ruby --version | cut -c1-11)\" == 'ruby 2.6.3p' ]"
-  - "bundle --version && [ \"$(bundle --version)\" == 'Bundler version 1.17.3' ]"
-  - "node --version && [ \"$(node --version)\" == 'v10.15.3' ]"
-  - "yarn --version && [ \"$(yarn --version)\" == '1.15.2' ]"
+  - ruby --version && [ "$(ruby --version | cut -c1-11)" == 'ruby 2.6.3p' ]
+  - bundle --version && [ "$(bundle --version)" == 'Bundler version 1.17.3' ]
+  - node --version && [ "$(node --version)" == 'v10.15.3' ]
+  - yarn --version && [ "$(yarn --version)" == '1.15.2' ]
   - yarn install
   - bin/rails spec:setup_js > /dev/null 2>&1 &
-  - bundle exec rubocop `git ls-tree -r HEAD --name-only` --force-exclusion --format clang
+  - bundle exec rubocop $(git ls-tree -r HEAD --name-only) --force-exclusion --format clang
   - ./node_modules/.bin/stylelint app/**/*.{css,scss,vue} --max-warnings 0
   - bin/rails db:create
   - bin/rails db:schema:load


### PR DESCRIPTION
This suggestion was made by ShellCheck. ShellCheck also suggested quoting the value (https://github.com/koalaman/shellcheck/wiki/SC2046), but we don't want to do that, because we actually do want the output of `git ls-tree -r HEAD --name-only` to be handled as separate, space separated "words".