### PR TITLE
Require separate rubocop-rails gem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
 require: rubocop-performance
+require: rubocop-rails
 AllCops:
   EnabledByDefault: true
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,7 @@ gem 'rest-client'
 gem 'rollbar'
 gem 'rubocop', require: false
 gem 'rubocop-performance', require: false
+gem 'rubocop-rails', require: false
 gem 'sass-rails', '~> 5.0'
 gem 'statsd-instrument'
 gem 'webpacker', '>= 4.0.0.pre.pre.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,6 +351,9 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     rubocop-performance (1.3.0)
       rubocop (>= 0.68.0)
+    rubocop-rails (2.0.0)
+      rack (>= 2.0)
+      rubocop (>= 0.70.0)
     ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     rubyzip (1.2.3)
@@ -457,6 +460,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-performance
+  rubocop-rails
   sass-rails (~> 5.0)
   selenium-webdriver
   shoulda-matchers (~> 4.0)


### PR DESCRIPTION
Per rubocop 0.71.0 (which we are currently on) post-install message:
> Rails cops will be removed from RuboCop 0.72. Use the `rubocop-rails` gem instead.