### PR TITLE
Stop loading unused parts of Rails

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -4,12 +4,9 @@ require_relative 'boot'
 
 require 'rails'
 require 'active_model/railtie'
-require 'active_job/railtie'
 require 'active_record/railtie'
 require 'action_controller/railtie'
-require 'action_mailer/railtie'
 require 'action_view/railtie'
-require 'sprockets/railtie'
 
 # require_relative is ugly but ~necessary: https://github.com/rails/rails/issues/25525
 require_relative '../app/middleware/request_uuid'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,7 +15,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # suggested by devise
-  config.action_mailer.default_url_options = {host: 'localhost', port: 3000}
+  # config.action_mailer.default_url_options = {host: 'localhost', port: 3000}
 
   # Enable/disable caching. By default caching is disabled.
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
@@ -32,9 +32,9 @@ Rails.application.configure do
   end
 
   # Don't care if the mailer can't send.
-  config.action_mailer.raise_delivery_errors = false
+  # config.action_mailer.raise_delivery_errors = false
 
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
   # Use a real queuing backend for Active Job (and separate queues per environment)
   # config.active_job.queue_adapter     = :resque
   # config.active_job.queue_name_prefix = "david_runger_#{Rails.env}"
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,12 +29,12 @@ Rails.application.configure do
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
-  config.action_mailer.perform_caching = false
+  # config.action_mailer.perform_caching = false
 
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-  config.action_mailer.delivery_method = :test
+  # config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr


### PR DESCRIPTION
I don't think we are using ActiveJob, ActionMailer, or Sprockets, so let's not waste time/memory loading them.