### PR TITLE
Remove ApplicationJob

### DIFF
--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationJob < ActiveJob::Base
-end


### PR DESCRIPTION
The `ApplicationJob` definition references `ActiveJob::Base` which is no longer being loaded as of c51a40b / #1566. It's causing the application to fail to boot in production. This only shows up in production because of eager loading; in development we simply weren't trying to load `ApplicationJob`.

Since we aren't using `ApplicationJob`, the fix is just to remove it.