### PR TITLE
Remove ApplicationMailer

### DIFF
--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
-  layout 'mailer'
-end


### PR DESCRIPTION
This references `ActionMailer::Base` which is no longer being loaded as of c51a40b / #1566. It's causing the application to fail to boot in production.