### PR TITLE
Render correct template (index, not show) for groceries#index action

### DIFF
--- a/app/controllers/groceries_controller.rb
+++ b/app/controllers/groceries_controller.rb
@@ -8,6 +8,6 @@ class GroceriesController < ApplicationController
       stores:
         ActiveModel::Serializer::CollectionSerializer.new(current_user.stores.includes(:items)),
     )
-    render :show
+    render :index
   end
 end

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -13,11 +13,14 @@ end
 namespace :spec do
   desc 'Run Ruby specs'
   task :rb do
-    Rake::Task['spec:copy_production_webpacker_settings_to_test'].
-      invoke('cache_manifest compile extract_css source_path')
-    run_logged_system_command('bin/webpack --silent')
-    run_logged_system_command('bin/rspec --format documentation')
-    run_logged_system_command('git checkout config/webpacker.yml')
+    begin
+      Rake::Task['spec:copy_production_webpacker_settings_to_test'].
+        invoke('cache_manifest compile extract_css source_path')
+      run_logged_system_command('RAILS_ENV=test NODE_ENV=test bin/webpack --silent')
+      run_logged_system_command('bin/rspec --format documentation')
+    ensure
+      run_logged_system_command('git checkout config/webpacker.yml')
+    end
   end
 
   desc 'Set up JavaScript specs'

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe 'Groceries app' do
+  let(:user) { users(:user) }
+
+  context 'when user is signed in' do
+    before { sign_in(user) }
+
+    it 'renders expected content' do
+      visit groceries_path
+
+      expect(page).to have_text(user.email)
+
+      store = user.stores.reorder(viewed_at: :desc).first!
+      expect(page).to have_text(store.name)
+      expect(page).to have_button('Check in shopping trip')
+      expect(page).to have_button('Text items to phone')
+      expect(page).to have_button('Copy to clipboard')
+
+      item = store.items.first!
+      expect(page).to have_text("#{item.name} (#{item.needed})")
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -76,6 +76,7 @@ RSpec.configure do |config|
 
   config.include(FactoryBot::Syntax::Methods)
   config.include(Devise::Test::ControllerHelpers, type: :controller)
+  config.include(Devise::Test::IntegrationHelpers, type: :feature)
 
   config.after(:each, type: :controller) do
     Devise.sign_out_all_scopes


### PR DESCRIPTION
This fixes a 500 error that is occurring when trying to view the groceries app.