### PR TITLE
Fix `require` in .rubocop.yml so rubocop-performance runs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
-require: rubocop-performance
-require: rubocop-rails
+require:
+  - rubocop-performance
+  - rubocop-rails
 AllCops:
   EnabledByDefault: true
   Exclude:


### PR DESCRIPTION
Previously, `require: rubocop-rails` was "concealing" the `require: rubocop-performance`.

The warning that we were getting from rubocop (fixed by this change):
```
.rubocop.yml:1: `require` is concealed by line 2
```