### PR TITLE
Increase log font size in log selector on hover; other visual tweaks

### DIFF
--- a/app/javascript/logs/components/log_selector.vue
+++ b/app/javascript/logs/components/log_selector.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 Modal(name='log-selector' width='85%', maxWidth='400px')
   slot
-    input(
+    input.mb2(
       type='text'
       v-model='searchString'
       @keydown.enter='selectHighlightedLog'
@@ -9,8 +9,8 @@ Modal(name='log-selector' width='85%', maxWidth='400px')
       @keydown.down='incrementHighlightedLogIndex'
       ref='log-search-input'
     )
-    div(v-for='(logName, index) in orderedMatches')
-      a.js-link(
+    div.log-link-container(v-for='(logName, index) in orderedMatches')
+      a.log-link.js-link(
         @click='selectLog(logName)'
         :class='{bold: (index === highlightedLogIndex)}'
       ) {{logName}}
@@ -123,3 +123,19 @@ export default {
   },
 };
 </script>
+
+<style lang='scss' scoped>
+div.log-link-container {
+  // specify the height so that changing the font on hover size doesn't push other links up/down
+  height: 26px;
+}
+
+a.log-link {
+  transition: font-size 0.2s;
+  font-size: 100%;
+
+  &:hover {
+    font-size: 115%;
+  }
+}
+</style>


### PR DESCRIPTION
I noticed that, when using the mouse to select a log, it wasn't always clear to me which log I was hovering over / which log would be selected if I clicked. Providing a hover effect makes it clear.