### PR TITLE
Remove unneeded `position: relative` style rule

### DIFF
--- a/app/javascript/logs/logs.vue
+++ b/app/javascript/logs/logs.vue
@@ -70,7 +70,6 @@ li.log-link-container {
 a.log-link {
   color: #e0e0e0;
   font-size: 100%;
-  position: relative;
   transition: 0.2s;
 
   &:hover {


### PR DESCRIPTION
This was part of an experiment that I mostly rolled back, except for this; it should never have been merged.