### PR TITLE
Switch to new `ActiveSupport::ParameterFilter` class

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,7 @@ class ApplicationController < ActionController::Base
   end
 
   def filtered_params
-    filter = ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters)
+    filter = ActiveSupport::ParameterFilter.new(Rails.application.config.filter_parameters)
     filter.filter(params)
   end
 


### PR DESCRIPTION
(...from `ActionDispatch::Http::ParameterFilter`).

This is deprecated; see message that is logged 7 times when running `bin/rails spec:rb`:
> DEPRECATION WARNING: ActionDispatch::Http::ParameterFilter is deprecated and will be removed from Rails 6.1. Use ActiveSupport::ParameterFilter instead. (called from filtered_params at app/controllers/application_controller.rb:59)