### PR TITLE
Tweak some copy and other things in the 500 error page

### DIFF
--- a/public/500.html
+++ b/public/500.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
+  <title>500 Error - davidrunger.com</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
   .rails-default-error-page {
@@ -13,7 +13,7 @@
 
   .rails-default-error-page div.dialog {
     width: 95%;
-    max-width: 33em;
+    max-width: 36em;
     margin: 4em auto 0;
   }
 
@@ -27,10 +27,12 @@
 <body class="rails-default-error-page">
   <div class="dialog">
     <div>
+      <h1>Sorry, something went wrong.</h1>
+      <h2>500 Error</h2>
+      <h3>Internal Server Error</h3>
       <img src="/sob_emoji.png" alt='Sob emoji' title='Sob emoji'>
-      <h1>We're sorry, but something went wrong.</h1>
       <p>
-        Feel free to contact me,
+        Feel free to contact me at
         <a href='mailto:davidjrunger@gmail.com?subject=Your website is broken'>davidjrunger@gmail.com</a>.
       </p>
     </div>


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/8197963/58767938-7e523600-8547-11e9-9d02-958aedf954e1.png)

# After

![image](https://user-images.githubusercontent.com/8197963/58767941-827e5380-8547-11e9-834a-7fc1929f01ae.png)

# Also

Not seen in the screenshots is the fact that the `title` of the page has been changed from `We're sorry, but something went wrong (500)` to `500 Error - davidrunger.com`.