### PR TITLE
Add assets:production_asset_server rake task

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -37,6 +37,54 @@ namespace :assets do
       abort
     end
   end
+
+  # Examples:
+  #
+  #   Rake::Task['assets:copy_webpacker_settings'].invoke('production', 'test', 'extract_css')
+  #
+  #   $ bin/rails 'assets:copy_webpacker_settings[production, development, extract_css source_path]'
+  desc 'Copy webpacker configuration settings from one env to another env'
+  task :copy_webpacker_settings, [:from_env, :to_env, :settings_to_copy] do |_task, args|
+    webpacker_config_path = 'config/webpacker.yml'
+    # rubocop:disable Security/YAMLLoad (this is trusted YAML; we don't need to load it "safely")
+    webpacker_config = YAML.load(File.read(webpacker_config_path))
+    # rubocop:enable Security/YAMLLoad
+
+    settings_to_copy = args[:settings_to_copy].split(/\s+/)
+    from_config = webpacker_config[args[:from_env]]
+    old_to_config = webpacker_config[args[:to_env]]
+
+    new_to_config = old_to_config.deep_dup
+    settings_to_copy.each do |setting|
+      if from_config[setting].nil?
+        new_to_config.delete(setting)
+      else
+        new_to_config[setting] = from_config[setting]
+      end
+    end
+
+    webpacker_config[args[:to_env]] = new_to_config
+
+    File.write(webpacker_config_path, YAML.dump(webpacker_config))
+  end
+
+  desc 'Boot a server in development that serves assets in a production-like manner'
+  task :production_asset_server do
+    begin
+      run_logged_system_command('rm -rf node_modules')
+      run_logged_system_command('rm -rf public/packs')
+      run_logged_system_command('rm -rf public/packs-test')
+      Rake::Task['assets:copy_webpacker_settings'].invoke(
+        'production',
+        'development',
+        'cache_manifest check_yarn_integrity compile dev_server extract_css',
+      )
+      run_logged_system_command('NODE_ENV=production DISABLE_SPRING=1 bin/rails assets:precompile')
+      run_logged_system_command('PRODUCTION_ASSET_CONFIG=1 DISABLE_SPRING=1 bin/rails server')
+    ensure
+      run_logged_system_command('git checkout config/webpacker.yml')
+    end
+  end
 end
 
 module SourceMapHelper


### PR DESCRIPTION
... via generalizing copy-webpacker-config task (moving it from `spec:copy_production_webpacker_settings_to_test` to `assets:copy_webpacker_settings` and adding argument for "from env" and "to env").