### PR TITLE
Source active_model_serializers from Rubygems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-# source from fork for now for Rails 6 compatibility
-# PR: https://github.com/rails-api/active_model_serializers/pull/2334
-gem 'active_model_serializers',
-  github: 'sikachu/active_model_serializers',
-  branch: '0-10-stable-relax-rails-version'
+gem 'active_model_serializers'
 gem 'administrate', github: 'thoughtbot/administrate' # source from master for Rails 6 compatibility
 gem 'browser'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,17 +16,6 @@ GIT
       spring (>= 1.2, < 3.0)
 
 GIT
-  remote: https://github.com/sikachu/active_model_serializers.git
-  revision: a829bc05b08010e077e8372186cc01b33dc5060c
-  branch: 0-10-stable-relax-rails-version
-  specs:
-    active_model_serializers (0.10.9)
-      actionpack (>= 4.1, < 6.1)
-      activemodel (>= 4.1, < 6.1)
-      case_transform (>= 0.2)
-      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
-
-GIT
   remote: https://github.com/thoughtbot/administrate.git
   revision: 1b3b33c82b06c16eff934e3f55f3b405ecd47256
   specs:
@@ -82,6 +71,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
+    active_model_serializers (0.10.9)
+      actionpack (>= 4.1, < 6)
+      activemodel (>= 4.1, < 6)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.0.rc1)
       activesupport (= 6.0.0.rc1)
       globalid (>= 0.3.6)
@@ -446,7 +440,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_model_serializers!
+  active_model_serializers
   administrate!
   annotate
   awesome_print


### PR DESCRIPTION
We were sourcing it for a brief moment from someone's GitHub branch for Rails 6 compatibility. That branch has been merged into active_model_serializers and released, so let's go back to sourcing from Rubygems.