### PR TITLE
Enforce that there is no space before JavaScript function args paren

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -46,6 +46,11 @@ module.exports = {
     }],
     'quotes': ['warn', 'single', { avoidEscape: true }],
     'semi': ['warn', 'always'],
+    'space-before-function-paren': ['warn', {
+      anonymous: 'always',
+      named: 'never',
+      asyncArrow: 'always',
+    }],
   },
   settings: {
     'import/resolver': {

--- a/app/javascript/home/components/home_section.vue
+++ b/app/javascript/home/components/home_section.vue
@@ -10,7 +10,7 @@
 <script>
 export const Header = {
   functional: true,
-  render (h, context) {
+  render(h, context) {
     return h('h1', { class: 'h1 bold mb2' }, context.props.title);
   },
 };

--- a/app/javascript/logs/components/data_renderers/duration_timeseries.vue
+++ b/app/javascript/logs/components/data_renderers/duration_timeseries.vue
@@ -70,13 +70,15 @@ export default {
         }],
         yAxes: [{
           ticks: {
-            userCallback: function(v) { return epochMsToHhMmSs(v); },
+            userCallback(v) {
+              return epochMsToHhMmSs(v);
+            },
           },
         }],
       },
       tooltips: {
         callbacks: {
-          label: function(tooltipItem, _data) {
+          label(tooltipItem, _data) {
             return epochMsToHhMmSs(tooltipItem.yLabel);
           },
         },

--- a/app/javascript/logs/components/log.vue
+++ b/app/javascript/logs/components/log.vue
@@ -33,7 +33,7 @@ const PUBLIC_TYPE_TO_DATA_RENDERER_MAPPING = {
 
 const LogDataDisplay = {
   functional: true,
-  render (h, context) {
+  render(h, context) {
     const DataRenderer = PUBLIC_TYPE_TO_DATA_RENDERER_MAPPING[context.props.data_type];
 
     return h(DataRenderer, {


### PR DESCRIPTION
... via a new `'space-before-function-paren': ['warn', 'never']` eslint rule.

... and auto-fix existing violations:
```
./node_modules/.bin/eslint  --fix --max-warnings 0 --ext .js,.vue app/javascript/ spec/javascript/
```