### PR TITLE
Bump hashdiff from 0.4.0 to 1.0.0beta1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,8 @@ end
 group :test do
   gem 'capybara'
   gem 'guard-espect', require: false, github: 'davidrunger/guard-espect'
+  # TEMP: list hashdiff explicitly in Gemfile to force 1.0.0.beta1; remove once 1.0.0 is released
+  gem 'hashdiff', '1.0.0.beta1'
   gem 'launchy' # for save_and_open_page in feature specs
   gem 'selenium-webdriver'
   gem 'shoulda-matchers', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -189,7 +189,7 @@ GEM
       temple (>= 0.8.0)
       thor
       tilt
-    hashdiff (0.4.0)
+    hashdiff (1.0.0.beta1)
     hashie (3.6.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
@@ -463,6 +463,7 @@ DEPENDENCIES
   foreman (~> 0.63.0)
   guard-espect!
   hamlit
+  hashdiff (= 1.0.0.beta1)
   httparty
   js-routes
   launchy


### PR DESCRIPTION
This should remove this deprecation warning that is printed when booting
a Rails process:
> The HashDiff constant used by this gem conflicts with another gem of a similar name.  As of version 1.0 the HashDiff constant will be completely removed and replaced by Hashdiff.  For more information see https://github.com/liufengyun/hashdiff/issues/ 45.