### PR TITLE
Change text log white-space CSS rule from `pre` to `pre-wrap`

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -66,7 +66,7 @@ export default {
 
 .el-table .cell {
   word-break: initial;
-  white-space: pre;
+  white-space: pre-wrap;
 }
 
 .el-table tr {


### PR DESCRIPTION
`pre` was causing lengthy lines to be ellipsized when the line had more text than the width of the div or whatever. In contrast, `pre-wrap` causes lengthy lines to ... you guessed it ... be "wrapped", thereby showing all of the text.