### PR TITLE
Parse & render text logs as markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "js-yaml": "^3.13.1",
     "keycode": "^2.2.0",
     "lodash": "^4.17.11",
+    "marked": "^0.6.2",
     "mini-css-extract-plugin": "^0.7.0",
     "node-pre-gyp": "^0.13.0",
     "node-sass": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5187,6 +5187,11 @@ markdown-table@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
+marked@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
+  integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
+
 mathml-tag-names@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mathml-tag-names/-/mathml-tag-names-2.1.0.tgz#490b70e062ee24636536e3d9481e333733d00f2c"


### PR DESCRIPTION
This allows better-formatted numbered lists, bold, italics, links, etc.