### PR TITLE
Address CVE-2015-9284

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'lograge'
 gem 'newrelic_rpm'
 gem 'oj'
 gem 'omniauth-google-oauth2'
+# remove once https://github.com/omniauth/omniauth/pull/809 is resolved
+gem 'omniauth-rails_csrf_protection'
 gem 'pg', '~> 1.1'
 gem 'pg_query', '>= 0.9.0'
 gem 'pghero'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,9 @@ GEM
     omniauth-oauth2 (1.6.0)
       oauth2 (~> 1.1)
       omniauth (~> 1.9)
+    omniauth-rails_csrf_protection (0.1.2)
+      actionpack (>= 4.2)
+      omniauth (>= 1.3.1)
     orm_adapter (0.5.0)
     parallel (1.17.0)
     parser (2.6.3.0)
@@ -474,6 +477,7 @@ DEPENDENCIES
   newrelic_rpm
   oj
   omniauth-google-oauth2
+  omniauth-rails_csrf_protection
   pg (~> 1.1)
   pg_query (>= 0.9.0)
   pghero

--- a/app/views/sessions/new.haml
+++ b/app/views/sessions/new.haml
@@ -1,1 +1,1 @@
-= link_to('Sign in with Google', user_google_oauth2_omniauth_authorize_path)
+= button_to('Sign in with Google', user_google_oauth2_omniauth_authorize_path)


### PR DESCRIPTION
See https://github.com/omniauth/omniauth/pull/ 809 for more info.

Unfortunately, because of the change of "Sign in with Google" from a link to a button (so that it will be a POST rather than a GET), the sign-in-with-Google page now looks uglier than ever. That's okay, though. Making that page look pretty is on my to-do list.