### PR TITLE
Make text log background color the same as overall logs background

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -105,7 +105,7 @@ ol {
 }
 
 .el-table tr {
-  background: black;
+  background: var(--main-bg-color);
 }
 
 .el-table--enable-row-hover .el-table__body tr:hover > td {

--- a/app/javascript/logs/logs.vue
+++ b/app/javascript/logs/logs.vue
@@ -65,8 +65,12 @@ export default {
 </script>
 
 <style lang='scss'>
+:root {
+  --main-bg-color: #111;
+}
+
 body {
-  background: #111;
+  background: var(--main-bg-color);
   color: #e0e0e0;
 }
 


### PR DESCRIPTION
... using CSS variables for the first time in my life! Easy enough. :)

(The reason that we need to explicitly set the background color of `.el-table tr` elements is to override the default background color that is provided by ElementUI.)