### PR TITLE
Remove sourceMap option from style-loader config in development

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -11,9 +11,6 @@ environment.loaders.append('style', {
   use: [
     {
       loader: 'style-loader',
-      options: {
-        sourceMap: true,
-      },
     },
     {
       loader: 'css-loader',

--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -1,4 +1,3 @@
-const webpack = require('webpack');
 const fs = require('fs');
 const merge = require('webpack-merge');
 const StyleLintPlugin = require('stylelint-webpack-plugin');


### PR DESCRIPTION
This should fix:
> ValidationError: Invalid options object. Style Loader has been
> initialised using an options object that does not match the API
> schema. [...] options has an unknown property 'sourceMap'.

Per https://github.com/webpack-contrib/style-loader/releases/tag/v1.0.0
> the `sourceMap` option was removed. The loader automatically inject
> source maps if the previous loader emit them