### PR TITLE
Warn if navigating away from groceries app w/ network request pending

### DIFF
--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -26,6 +26,8 @@ li.grocery-item(:class='{unneeded: item.needed <= 0, "appear-vertically": isJust
 <script>
 import { debounce } from 'lodash';
 
+import { DEBOUNCE_TIME } from 'groceries/constants';
+
 export default {
   data() {
     return {
@@ -79,7 +81,7 @@ export default {
       // set collectingDebounces to false _after_ incrementing pendingRequests so that
       // debouncingOrWaitingOnNetwork stays consistently true
       this.$store.commit('setCollectingDebounces', { value: false });
-    }, 500),
+    }, DEBOUNCE_TIME),
   },
 
   props: {

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -72,6 +72,7 @@ import { mapGetters, mapState } from 'vuex';
 import { debounce, isEmpty, sortBy } from 'lodash';
 import ClipboardJS from 'clipboard';
 
+import { DEBOUNCE_TIME } from 'groceries/constants';
 import Item from './item.vue';
 import NeedPhoneNumberModal from './need_phone_number_modal.vue';
 
@@ -176,7 +177,7 @@ export default {
       this.$http.patch(this.$routes.api_item_path(itemId), payload).then(() => {
         this.$store.commit('decrementPendingRequests');
       });
-    }, 500),
+    }, DEBOUNCE_TIME),
 
     postNewItem() {
       if (this.formstate.$invalid) return;

--- a/app/javascript/groceries/constants.js
+++ b/app/javascript/groceries/constants.js
@@ -1,0 +1,1 @@
+export const DEBOUNCE_TIME = 333; // milliseconds

--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -20,7 +20,23 @@ export default {
   computed: {
     ...mapGetters([
       'currentStore',
+      'debouncingOrWaitingOnNetwork',
     ]),
+  },
+
+  created() {
+    window.addEventListener('beforeunload', this.warnIfRequestPending);
+  },
+
+  methods: {
+    warnIfRequestPending(event) {
+      if (this.debouncingOrWaitingOnNetwork) {
+        event.preventDefault();
+        // Chrome requires returnValue to be set
+        // https://developer.mozilla.org/en-US/docs/Web/API/Window/beforeunload_event
+        event.returnValue = '';
+      }
+    },
   },
 
   props: {},


### PR DESCRIPTION
When I use the groceries app, I wait to make sure that network requests have finished (i.e. been collected by debouncing and then sent across the network and returned) before leaving. This is a little annoying.

By having the app warn if I am leaving while there is one or more network requests pending, I won't have to watch for it myself anymore. I can just leave the app as quickly as I want to and trust that the app will warn me if I am leaving too soon.

I got this idea from Gmail, which seems to do something similar.