### PR TITLE
Bump chromedriver from 75.0.3770.90 to 76.0.3809.68

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
   - export PATH="$HOME/.yarn/bin:$PATH"
   # To get a different version of chromedriver, see http://chromedriver.chromium.org/downloads
-  - curl -o tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/75.0.3770.90/chromedriver_linux64.zip
+  - curl -o tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/76.0.3809.68/chromedriver_linux64.zip
   - unzip -d "$HOME/bin/" tmp/chromedriver.zip
 script:
   - ruby --version && [ "$(ruby --version | cut -c1-11)" == 'ruby 2.6.3p' ]


### PR DESCRIPTION
Travis is currently installing Chrome 76; let's update chromedriver to the same version.

It would be nice to automate this so that I don't have to keep updating the chromedriver version manually. I think that there is a gem that does this, although I am hesitant to depend on a gem. Another alternative would be to make some requests to some Chrome site(s) and parse the respose(s) to get the appropriate download link programmatically.