### PR TITLE
Close logs quick-selector when route changes; stop managing manually

### DIFF
--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -76,6 +76,8 @@ const getters = {
   ...ModalVuex.getters,
 
   currentStore(state) {
+    if (!state.stores) return null;
+
     return (
       _(state.stores).filter('viewed_at').sortBy(['viewed_at']).last() ||
       state.stores[0]

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -111,3 +111,5 @@ export function groceryVuexStoreFactory(bootstrap) {
     mutations,
   });
 }
+
+export default groceryVuexStoreFactory(window.davidrunger.bootstrap);

--- a/app/javascript/lib/event_bus.js
+++ b/app/javascript/lib/event_bus.js
@@ -2,8 +2,10 @@
 // This can be expanded in the future to include a payload, too.
 // This would require using CustomEvent rather than Event, and possibly a polyfill for IE.
 
+// returns a function that unsubscribes from the event
 export function on(eventName, callback) {
   window.addEventListener(eventName, callback);
+  return () => { window.removeEventListener(eventName, callback); };
 }
 
 export function emit(eventName) {

--- a/app/javascript/logs/components/log_selector.vue
+++ b/app/javascript/logs/components/log_selector.vue
@@ -19,13 +19,14 @@ Modal(
         router-link.log-link(
           :to='{ name: "log", params: { slug: log.slug }}'
           :class='{bold: (index === highlightedLogIndex)}'
-          @click.native='resetQuickSelector'
         ) {{log.name}}
 </template>
 
 <script>
 import { mapGetters, mapState } from 'vuex';
 import FuzzySet from 'fuzzyset.js';
+
+import { on } from 'lib/event_bus';
 
 export default {
   computed: {
@@ -62,6 +63,11 @@ export default {
     this.logNames.forEach(logName => {
       this.fuzzySet.add(logName);
     });
+    this.unsubscribeFromRouteChanges = on('groceries:route-changed', this.resetQuickSelector);
+  },
+
+  destroyed() {
+    this.unsubscribeFromRouteChanges();
   },
 
   data() {
@@ -103,7 +109,6 @@ export default {
 
     selectLog(log) {
       this.$router.push({ name: 'log', params: { slug: log.slug }});
-      this.resetQuickSelector();
     },
   },
 

--- a/app/javascript/logs/router.js
+++ b/app/javascript/logs/router.js
@@ -2,6 +2,7 @@ import VueRouter from 'vue-router';
 
 import Log from 'logs/components/log.vue';
 import LogsIndex from 'logs/components/logs_index.vue';
+import { emit } from 'lib/event_bus';
 
 const routes = [
   { path: '/logs',  name: 'logs-index', component: LogsIndex },
@@ -11,6 +12,11 @@ const routes = [
 const router = new VueRouter({
   mode: 'history',
   routes,
+});
+
+router.beforeEach((to, from, next) => {
+  emit('groceries:route-changed');
+  next();
 });
 
 export default router;

--- a/app/javascript/packs/groceries_app.js
+++ b/app/javascript/packs/groceries_app.js
@@ -1,5 +1,5 @@
 import { renderApp } from 'shared/customized_vue';
 import Groceries from 'groceries/groceries.vue';
-import { groceryVuexStoreFactory } from 'groceries/store';
+import store from 'groceries/store';
 
-renderApp(Groceries, { store: groceryVuexStoreFactory(window.davidrunger.bootstrap) });
+renderApp(Groceries, { store });

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -10,7 +10,7 @@
     = csrf_meta_tags
     %script{type: "text/javascript"}
       window.davidrunger = {env: '#{Rails.env}'};
-      window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript((@bootstrap_data || {}).to_json))}")
+      window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript((@bootstrap_data || {}).to_json))}");
 
     - if Rails.env.development? && !ENV['PRODUCTION_ASSET_CONFIG'].present?
       = javascript_pack_tag('styles', defer: true)

--- a/spec/javascript/mocha_runner.html
+++ b/spec/javascript/mocha_runner.html
@@ -10,11 +10,11 @@
     window.davidrunger = { env: 'test' };
   </script>
   <script src="http://localhost:8080/packs-test/mocha.js"></script>
-  <script>mocha.setup('bdd')</script>
+  <script>window.mocha.setup('bdd');</script>
   <script src="http://localhost:8080/packs-test/spec_index.js"></script>
   <script>
-    mocha.checkLeaks();
-    mocha.run();
+    window.mocha.checkLeaks();
+    window.mocha.run();
   </script>
 </body>
 </html>

--- a/spec/javascript/mocha_runner.html
+++ b/spec/javascript/mocha_runner.html
@@ -7,7 +7,7 @@
 <body>
   <div id="mocha"></div>
   <script>
-    window.davidrunger = { env: 'test' };
+    window.davidrunger = { env: 'test', bootstrap: {} };
   </script>
   <script src="http://localhost:8080/packs-test/mocha.js"></script>
   <script>window.mocha.setup('bdd');</script>


### PR DESCRIPTION
This change fixes a bug wherein command-clicking (Mac) a log link from within the logs quick-selector would close the quick-selector. The quick selector should remain open so that multiple logs can be opened from the quick selector via command-clicking.

Since command-clicking doesn't trigger a route change within the current tab, this change (close the logs quick-selector when the route changes, and stop managing the appearance of the quick-selector manually) results in the quick selector remaining open when command-clicking links, as desired.

At first I was going to move the quick-selector state (`highlightedLogIndex`, `searchString`) into the Vuex store, so that the router could dispatch Vuex actions to reset the quick selector state when the route changes.

However, I ended up instead just having the router emit a `'groceries:route-changed'` event that can be listened for by the quick selector, and then the quick selector can manage resetting its own state. This was a simpler/smaller change, and I think it largely "feels right" in terms of the router shouldn't necessarily "know" about Vuex actions to update the state of the logs quick-selector.