### PR TITLE
Remove foreman from Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
 env:
   - RAILS_ENV=test NODE_ENV=test SECRET_KEY_BASE=0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b
 before_install:
-  - gem install bundler -v '1.17.3' --no-document
+  - gem install bundler -v '1.17.2' --no-document
   - . $HOME/.nvm/nvm.sh
   - nvm install 10.15.3
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.15.2
@@ -25,7 +25,7 @@ before_install:
   - unzip -d "$HOME/bin/" tmp/chromedriver.zip
 script:
   - ruby --version && [ "$(ruby --version | cut -c1-11)" == 'ruby 2.6.3p' ]
-  - bundle --version && [ "$(bundle --version)" == 'Bundler version 1.17.3' ]
+  - bundle --version && [ "$(bundle --version)" == 'Bundler version 1.17.2' ]
   - node --version && [ "$(node --version)" == 'v10.15.3' ]
   - yarn --version && [ "$(yarn --version)" == '1.15.2' ]
   - yarn install

--- a/Gemfile
+++ b/Gemfile
@@ -14,8 +14,6 @@ gem 'administrate', github: 'thoughtbot/administrate' # source from master for R
 gem 'browser'
 gem 'devise'
 gem 'dotenv-rails', require: 'dotenv/rails-now'
-# foreman >= 0.64.0 has stricter version locks for its `dotenv` and `thor` dependencies
-gem 'foreman', '~> 0.63.0', require: false
 gem 'hamlit'
 gem 'httparty'
 gem 'js-routes', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,9 +170,6 @@ GEM
       activesupport (>= 2)
       hashdiff
     flamegraph (0.9.5)
-    foreman (0.63.0)
-      dotenv (>= 0.7)
-      thor (>= 0.13.6)
     formatador (0.2.5)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -466,7 +463,6 @@ DEPENDENCIES
   faker
   fixture_builder
   flamegraph
-  foreman (~> 0.63.0)
   guard-espect!
   hamlit
   hashdiff (= 1.0.0)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bundle exec foreman start -f Procfile.multi
+web: vendor/heroku/ruby/2.6.0/gems/foreman-0.85.0/bin/foreman start -f Procfile.multi
 release: bin/release-tasks

--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+gem_parent_dir="vendor/heroku/ruby/2.6.0"
+
+mkdir -p $gem_parent_dir
+mkdir -p vendor/heroku/bin
+export GEM_PATH="$GEM_PATH:$gem_parent_dir"
+
+gem install foreman --install-dir "$gem_parent_dir" --bindir vendor/heroku/bin

--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# we have a low enough volume of requests that without `STDOUT.sync = true` there is a notable delay
+# in logs being written (due to log buffering); set this value so that logs are written in real time
+STDOUT.sync = true
+
 Rails.application.configure do
   config.lograge.enabled = (Rails.env.production? || ENV['LOGRAGE_ENABLED'].present?)
 


### PR DESCRIPTION
Instead, we will install foreman separately from the bundled gems using the [heroku-buildpack-run][1] buildpack, which I have added to the Heroku app via `heroku buildpacks:add https://github.com/weibeld/heroku-buildpack-run`. That buildpack will execute `buildpack-run.sh`, which is also added in this commit.

Also, update to Ruby 2.7.0-preview1, because I wanted it for `Module#const_source_location` to debug this change.

[1]: https://elements.heroku.com/buildpacks/weibeld/heroku-buildpack-run