### PR TITLE
Don't set GEM_PATH env variable

### DIFF
--- a/buildpack-run.sh
+++ b/buildpack-run.sh
@@ -4,6 +4,5 @@ gem_parent_dir="vendor/heroku/ruby/2.6.0"
 
 mkdir -p $gem_parent_dir
 mkdir -p vendor/heroku/bin
-export GEM_PATH="$GEM_PATH:$gem_parent_dir"
 
 gem install foreman --install-dir "$gem_parent_dir" --bindir vendor/heroku/bin


### PR DESCRIPTION
I doubt that this persists from the deploy dyno to the actual web dynos. Therefore, I doubt that it's actually helping anything. (Further evidence: I deployed this and the website it still up.) Therefore, let's remove it.