### PR TITLE
Use HTTParty instead of RestClient to post source maps to Rollbar

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'puma', '~> 4.1'
 gem 'pundit'
 gem 'rails', '>= 6.0.0'
 gem 'redis', '~>4.1'
-gem 'rest-client'
 gem 'rollbar'
 gem 'rubocop', require: false
 gem 'rubocop-performance', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,8 +147,6 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
-    domain_name (0.5.20190701)
-      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.7.5)
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
@@ -189,9 +187,6 @@ GEM
       tilt
     hashdiff (1.0.0)
     hashie (3.6.0)
-    http-accept (1.7.0)
-    http-cookie (1.0.3)
-      domain_name (~> 0.5)
     httparty (0.17.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -254,7 +249,6 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.1.1)
     nenv (0.3.0)
-    netrc (0.11.0)
     newrelic_rpm (6.5.0.357)
     nio4r (2.4.0)
     nokogiri (1.10.4)
@@ -348,11 +342,6 @@ GEM
     responders (3.0.0)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
     rollbar (2.22.1)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -424,9 +413,6 @@ GEM
     tilt (2.0.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.6)
     unicode-display_width (1.6.0)
     warden (1.2.8)
       rack (>= 2.0.6)
@@ -487,7 +473,6 @@ DEPENDENCIES
   rack-mini-profiler
   rails (>= 6.0.0)
   redis (~> 4.1)
-  rest-client
   rollbar
   rspec-rails
   rubocop

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -121,13 +121,15 @@ module SourceMapHelper
     require('net/http/post/multipart')
 
     File.open(source_map_path) do |source_map_file|
-      response = RestClient.post(
+      response = HTTParty.post(
         ROLLBAR_SOURCE_MAP_URI,
-        access_token: ENV['ROLLBAR_ACCESS_TOKEN'],
-        environment: Rails.env,
-        version: ENV['SOURCE_VERSION'],
-        minified_url: source_url,
-        source_map: source_map_file,
+        body: {
+          access_token: ENV['ROLLBAR_ACCESS_TOKEN'],
+          environment: Rails.env,
+          version: ENV['SOURCE_VERSION'],
+          minified_url: source_url,
+          source_map: source_map_file,
+        },
       )
       puts <<~LOG
         Posted source map #{source_map_path} for #{source_url}.


### PR DESCRIPTION
This allows us to remove the RestClient dependency completely.

(We initially used RestClient rather than HTTParty because HTTParty didn't support posting files at the time. However, now it does.)