### PR TITLE
Remove suggestedMin for yAxes in integer_timeseries.vue

### DIFF
--- a/app/javascript/logs/components/data_renderers/integer_timeseries.vue
+++ b/app/javascript/logs/components/data_renderers/integer_timeseries.vue
@@ -44,13 +44,6 @@ export default {
             source: 'auto',
           },
         }],
-        yAxes: [
-          {
-            ticks: {
-              suggestedMin: 167,
-            },
-          },
-        ],
       },
     };
   },


### PR DESCRIPTION
This allows Chart.js to choose a better y-axis range for us.