### PR TITLE
Remove unused selectedLogName from Vuex store

### DIFF
--- a/app/javascript/logs/logs.vue
+++ b/app/javascript/logs/logs.vue
@@ -34,7 +34,6 @@ export default {
 
     ...mapState([
       'logs',
-      'selectedLogName',
     ]),
   },
 

--- a/app/javascript/logs/store.js
+++ b/app/javascript/logs/store.js
@@ -107,7 +107,6 @@ export function logVuexStoreFactory(bootstrap) {
       ...ModalVuex.state,
       currentUser: bootstrap.current_user,
       logs: bootstrap.logs,
-      selectedLogName: null,
     },
     actions,
     getters,


### PR DESCRIPTION
Maybe this was once used? But it doesn't seem to be currently.