### PR TITLE
Specify config.i18n.fallbacks as an array, not just `true`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify


### PR DESCRIPTION
See https://github.com/ruby-i18n/i18n/releases/tag/v1.1.0

(We don't use i18n yet (probably ever), so this doesn't actually matter, but we might as well be correct.)