### PR TITLE
Tweak styling of text logs

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -92,11 +92,16 @@ ol {
 }
 
 table {
+  margin: 15px 0;
   color: #aaa;
   font-size: 14px;
 
   tr {
     border-bottom: 1px solid #999;
+
+    &:last-of-type {
+      border-bottom: none;
+    }
   }
 
   td {

--- a/app/javascript/logs/components/log.vue
+++ b/app/javascript/logs/components/log.vue
@@ -1,20 +1,21 @@
 <template lang='pug'>
-div
-  h1.h2.mt3.mb1 {{log.name}}
-  p.h5.mb2.description {{log.description}}
-  new-log-entry-form(v-if='renderInputAtTop' :log='log')
-  div.mb2(v-if='log.log_entries === undefined').
-    Loading...
-  log-data-display(
-    v-else-if='log.log_entries.length'
-    :data_label='log.data_label'
-    :data_type='log.data_type'
-    :log_entries='log.log_entries'
-  )
-  div.my2(v-else) There are no log entries for this log.
-  new-log-entry-form(v-if='!renderInputAtTop' :log='log')
-  .mt1
-    el-button(@click='destroyLastEntry') Delete last entry
+.flex.justify-center
+  .container
+    h1.h2.mt3.mb1 {{log.name}}
+    p.h5.mb2.description {{log.description}}
+    new-log-entry-form(v-if='renderInputAtTop' :log='log')
+    div.mb2(v-if='log.log_entries === undefined').
+      Loading...
+    log-data-display(
+      v-else-if='log.log_entries.length'
+      :data_label='log.data_label'
+      :data_type='log.data_type'
+      :log_entries='log.log_entries'
+    )
+    div.my2(v-else) There are no log entries for this log.
+    new-log-entry-form(v-if='!renderInputAtTop' :log='log')
+    .mt1
+      el-button(@click='destroyLastEntry') Delete last entry
 </template>
 
 <script>
@@ -90,6 +91,10 @@ export default {
 </script>
 
 <style scoped>
+.container {
+  max-width: 1000px;
+}
+
 .description {
   font-weight: 200;
 }


### PR DESCRIPTION
The text logs were being displayed in an ugly left-aligned way if the content of the log entries wasn't lengthy.