### PR TITLE
Render numeric logs (graphs) at full width

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -1,17 +1,20 @@
 <template lang='pug'>
-div
-  table
-    EditableTextLogRow(
-      v-for='logEntry in formattedLogEntries'
-      :key='logEntry.id'
-      :logEntry='logEntry'
-    )
-  el-button(v-if='!showAllEntries' @click='showAllEntries = true').
-    Show all entries
+.flex.justify-center
+  .container
+    new-log-entry-form(:log='log')
+    table
+      EditableTextLogRow(
+        v-for='logEntry in formattedLogEntries'
+        :key='logEntry.id'
+        :logEntry='logEntry'
+      )
+    el-button(v-if='!showAllEntries' @click='showAllEntries = true').
+      Show all entries
 </template>
 
 <script>
 import EditableTextLogRow from 'logs/components/editable_text_log_row.vue';
+import NewLogEntryForm from 'logs/components/new_log_entry_form.vue';
 
 import marked from 'marked';
 import strftime from 'strftime';
@@ -19,6 +22,7 @@ import strftime from 'strftime';
 export default {
   components: {
     EditableTextLogRow,
+    NewLogEntryForm,
   },
 
   computed: {
@@ -51,6 +55,10 @@ export default {
   props: {
     data_label: {
       type: String,
+      required: true,
+    },
+    log: {
+      type: Object,
       required: true,
     },
     log_entries: {
@@ -89,6 +97,10 @@ ol {
       position: absolute;
     }
   }
+}
+
+.container {
+  max-width: 1000px;
 }
 
 table {

--- a/app/javascript/logs/components/log.vue
+++ b/app/javascript/logs/components/log.vue
@@ -1,21 +1,20 @@
 <template lang='pug'>
-.flex.justify-center
-  .container
-    h1.h2.mt3.mb1 {{log.name}}
-    p.h5.mb2.description {{log.description}}
-    new-log-entry-form(v-if='renderInputAtTop' :log='log')
-    div.mb2(v-if='log.log_entries === undefined').
-      Loading...
-    log-data-display(
-      v-else-if='log.log_entries.length'
-      :data_label='log.data_label'
-      :data_type='log.data_type'
-      :log_entries='log.log_entries'
-    )
-    div.my2(v-else) There are no log entries for this log.
-    new-log-entry-form(v-if='!renderInputAtTop' :log='log')
-    .mt1
-      el-button(@click='destroyLastEntry') Delete last entry
+div
+  h1.h2.mt3.mb1 {{log.name}}
+  p.h5.mb2.description {{log.description}}
+  div.mb2(v-if='log.log_entries === undefined').
+    Loading...
+  log-data-display(
+    v-else-if='log.log_entries.length'
+    :data_label='log.data_label'
+    :data_type='log.data_type'
+    :log='log'
+    :log_entries='log.log_entries'
+  )
+  div.my2(v-else) There are no log entries for this log.
+  new-log-entry-form(v-if='!renderInputAtTop' :log='log')
+  .mt1
+    el-button(@click='destroyLastEntry') Delete last entry
 </template>
 
 <script>
@@ -39,6 +38,7 @@ const LogDataDisplay = {
 
     return h(DataRenderer, {
       props: {
+        log: context.props.log,
         log_entries: context.props.log_entries,
         data_label: context.props.data_label,
       },
@@ -91,10 +91,6 @@ export default {
 </script>
 
 <style scoped>
-.container {
-  max-width: 1000px;
-}
-
 .description {
   font-weight: 200;
 }


### PR DESCRIPTION
This was broken in b26e9a4 , which caused the graphs to not render at the full page width.