### PR TITLE
Use DOMPurify for markdown sanitization rather than marked

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -16,8 +16,11 @@
 import EditableTextLogRow from 'logs/components/editable_text_log_row.vue';
 import NewLogEntryForm from 'logs/components/new_log_entry_form.vue';
 
+import createDOMPurify from 'dompurify';
 import marked from 'marked';
 import strftime from 'strftime';
+
+const DOMPurify = createDOMPurify(window);
 
 export default {
   components: {
@@ -39,7 +42,7 @@ export default {
           id: logEntry.id,
           createdAt: strftime('%b %-d %-l:%M%P', new Date(logEntry.created_at)),
           plaintext: logEntry.data,
-          html: marked(logEntry.data, { sanitize: true }),
+          html: DOMPurify.sanitize(marked(logEntry.data)),
         })).reverse();
 
       return sortedAndFormattedEntries;

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clipboard": "^2.0.4",
     "compression-webpack-plugin": "^3.0.0",
     "css-loader": "^3.2.0",
+    "dompurify": "^2.0.6",
     "element-ui": "^2.12.0",
     "eslint": "^5.16.0",
     "eslint-config-airbnb-base": "^14.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3140,6 +3140,11 @@ domhandler@^2.3.0:
   dependencies:
     domelementtype "1"
 
+dompurify@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.0.6.tgz#0a4196c211ce00e848240e52b1d49261af12a3be"
+  integrity sha512-1+AOpCYIKoLER/Ykd/Q/i11slhYy6T29/mmDrTsALH0JcMPB0pt9++8eDTGT70tv6ofmmeptrdqzZpmjMfFLRg==
+
 domutils@^1.5.1, domutils@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.7.0.tgz#56ea341e834e06e6748af7a1cb25da67ea9f8c2a"


### PR DESCRIPTION
In version 0.7.0 of marked, the sanitize option was deprecated ( see https://github.com/markedjs/marked/pull/ 1504 _Sanitize hardening_ ) and marked started recommending the use of another library for HTML sanitization. This PR fixes a deprecation warning about the `sanitize` option that was appearing in the JS console when viewing text logs.