### PR TITLE
gzip responses (including HTML and JSON)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,7 @@ group :development do
   gem 'listen', '>= 3.0.5', '< 3.3'
   # Performance profiling. Should be listed after `pg` (and `rails`?) gems to get database
   # performance analysis.
-  gem 'rack-mini-profiler'
+  gem 'rack-mini-profiler', require: false
   gem 'spring'
   gem 'spring-commands-rspec'
   # We can go back to the offical spring-watcher-listen after upgrading to Rails 6.

--- a/config/application.rb
+++ b/config/application.rb
@@ -31,6 +31,7 @@ class DavidRunger::Application < Rails::Application
   config.time_zone = 'America/Los_Angeles'
   config.active_record.default_timezone = :utc
 
+  config.middleware.insert_after(ActionDispatch::Static, Rack::Deflater) # gzip all responses
   config.middleware.insert_after(Rack::MethodOverride, RequestUuid)
 
   extra_load_paths = [

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+if Rails.env.development? && ENV['ENABLE_PROFILER'].present?
+  require 'rack-mini-profiler'
+
+  # initialization is skipped so trigger it
+  Rack::MiniProfilerRails.initialize!(Rails.application)
+end


### PR DESCRIPTION
It turns out that `rack-mini-profiler` changes the `Accept-Encoding` header to `"identity"` when active, so now we'll deactivate `rack-mini-profiler` by default (and instead require an `ENABLE_PROFILER` env variable in order to activate `rack-mini-profiler`) so that we'll have gzipping the rest of the time.