### PR TITLE
Validate the present of the log data label on the client side

### DIFF
--- a/app/javascript/logs/components/new_log_form.vue
+++ b/app/javascript/logs/components/new_log_form.vue
@@ -24,6 +24,7 @@ div
             name='newLog.data_label'
             required
           )
+        validate.mb1
           el-select(
             placeholder='Type'
             v-model='newLog.data_type'


### PR DESCRIPTION
Previously, there was one `validate` element that contained two inputs (`newLog.data_label` and `newLog.data_type`), so if either was present (or maybe just of the latter, `newLog.data_type`, was present?) then the form would be (wrongly) considered valid.