### PR TITLE
Follow devise convention for session redirect key (user_return_to)

### DIFF
--- a/app/controllers/admin/application_controller.rb
+++ b/app/controllers/admin/application_controller.rb
@@ -17,7 +17,7 @@ class Admin::ApplicationController < Administrate::ApplicationController
       redirect_to(root_path)
     else
       flash[:alert] = 'You must sign in first.'
-      session['user_redirect_to'] = request.path
+      session['user_return_to'] = request.path
       redirect_to(login_path)
     end
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
     return if user_signed_in?
 
     flash[:alert] = 'You must sign in first.'
-    session['user_redirect_to'] = request.path
+    session['user_return_to'] = request.path
     redirect_to(login_path)
   end
 

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,6 +7,6 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user = User.from_omniauth!(request.env['omniauth.auth'])
     sign_in(user)
     NewUserMailer.user_created(user.id).deliver_later
-    redirect_to(session.delete('user_redirect_to') || groceries_path)
+    redirect_to(session.delete('user_return_to') || groceries_path)
   end
 end


### PR DESCRIPTION
This way, when we follow redirects (specifically, in our redirect to `user_redirect_to` in `Users::OmniauthCallbacksController`), we can follow redirects that have been set either by our own application code or by devise.