### PR TITLE
Redirect to login_path when blocked by devise's `authenticate` method

### DIFF
--- a/app/lib/custom_failure_app.rb
+++ b/app/lib/custom_failure_app.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class CustomFailureApp < Devise::FailureApp
+  def route(_scope)
+    :login_path
+  end
+end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -267,10 +267,11 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  # config.warden do |manager|
-  #   manager.intercept_401 = false
-  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
-  # end
+  config.warden do |manager|
+    # manager.intercept_401 = false
+    # manager.default_strategies(scope: :user).unshift :some_external_strategy
+    manager.failure_app = CustomFailureApp
+  end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine


### PR DESCRIPTION
When a route is guarded by devise's `authenticate` method and a user is not logged in, devise redirects to `new_user_session_url`, if it exists. However, we have no such route (instead, we have `login_url`). This commit adds a `CustomFailureApp` (inheriting from `Devise::FailureApp`) that will redirect to that path (`login_path`) if a user tries to access an `authenticate` d route while not logged in.