### PR TITLE
Tweak custom ActionMailer delivery_method definition/registration

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -101,6 +101,5 @@ Rails.application.configure do
   # Email
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  ActionMailer::Base.add_delivery_method(:mailgun_via_httparty, Mail::MailgunViaHttparty)
-  config.action_mailer.delivery_method = :mailgun_via_httparty
+  config.action_mailer.delivery_method = Email::MailgunViaHttparty
 end

--- a/lib/email/mailgun_via_httparty.rb
+++ b/lib/email/mailgun_via_httparty.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Mail::MailgunViaHttparty
+class Email::MailgunViaHttparty
   attr_accessor :message
 
   def initialize(_mail) ; end


### PR DESCRIPTION
1. definition: define under `Email` namespace rather than `Mail` namespace to avoid clash with the `Mail` class defined by the `mail` gem
2. registration: simply register the class directly (`config.action_mailer.delivery_method = Email::MailgunViaHttparty`) rather than using `ActionMailer::Base.add_delivery_method`