### PR TITLE
Configure Sidekiq to use Redis database 1

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+sidekiq_redis_options = {
+  db: 1,
+}
+
+Sidekiq.configure_client do |config|
+  config.redis = sidekiq_redis_options
+end
+
+Sidekiq.configure_server do |config|
+  config.redis = sidekiq_redis_options
+end


### PR DESCRIPTION
This creates some isolation between Sidekiq's usage of Redis and the rest of the application's usage of Redis.