### PR TITLE
Don't log about unpermitter parameters

### DIFF
--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -8,6 +8,7 @@
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
   wrap_parameters format: [:json]
+  ActionController::Parameters.action_on_unpermitted_parameters = false
 end
 
 # To enable root element in JSON for ActiveRecord objects.


### PR DESCRIPTION
This is turned off by default in production, I think. Thus, this only affects `development` and `test`.

My primary motivation for turning this off is because is was logging stuff like `unpermitted_parameters=['request_uuid', 'request_uuid', 'request_uuid', 'request_uuid', 'request_uuid']`.