### PR TITLE
Include id in logged params

### DIFF
--- a/lib/david_runger/log_builder.rb
+++ b/lib/david_runger/log_builder.rb
@@ -2,7 +2,7 @@
 
 class DavidRunger::LogBuilder
   # these params are logged already or unimportant
-  OMITTED_PARAMS = %w[controller action format id request_uuid].map(&:freeze).freeze
+  OMITTED_PARAMS = %w[controller action format request_uuid].map(&:freeze).freeze
 
   def initialize(event)
     @event = event


### PR DESCRIPTION
I am not sure why I ever omitted this. Probably because I was thinking that the `id` param can just be seen in the URL. However:
1. it's worth including explicitly in the params, even so
2. the `id` param won't necessarily be in the URL; it could be in a POST request body, for example