### PR TITLE
Don't enqueue a SaveRequest worker for requests to Admin controllers

### DIFF
--- a/config/initializers/request_logging.rb
+++ b/config/initializers/request_logging.rb
@@ -29,7 +29,9 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
     final_request_data.to_json,
   )
 
-  SaveRequest.perform_async(params['request_uuid'])
+  unless payload[:controller].constantize.ancestors.include?(Admin::ApplicationController)
+    SaveRequest.perform_async(params['request_uuid'])
+  end
 
   nil
 end


### PR DESCRIPTION
(Doing so causes errors, since we don't stash the necessary request data for requests made to `Admin::` controllers.)