### PR TITLE
Add sidekiq-scheduler and add skeleton `Stats` worker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'rubocop-performance', require: false
 gem 'rubocop-rails', require: false
 gem 'rubocop-rspec', require: false
 gem 'sidekiq'
+gem 'sidekiq-scheduler', require: false # required manually in config/initializers/sidekiq.rb
 gem 'statsd-instrument'
 gem 'webpacker', '>= 4.0.0.pre.pre.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
     erubi (1.9.0)
+    et-orbi (1.2.2)
+      tzinfo
     execjs (2.7.0)
     factory_bot (5.1.1)
       activesupport (>= 4.2.0)
@@ -168,6 +170,9 @@ GEM
       hashdiff
     flamegraph (0.9.5)
     formatador (0.2.5)
+    fugit (1.3.3)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     guard (2.15.0)
@@ -298,6 +303,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.1.0)
       activesupport (>= 3.0.0)
+    raabro (1.1.6)
     rack (2.0.7)
     rack-mini-profiler (1.1.0)
       rack (>= 1.2.0)
@@ -383,6 +389,8 @@ GEM
       rubocop (>= 0.68.1)
     ruby-progressbar (1.10.1)
     rubyzip (2.0.0)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
     sassc (2.2.1)
       ffi (~> 1.9)
@@ -404,6 +412,11 @@ GEM
       rack (>= 2.0.0)
       rack-protection (>= 2.0.0)
       redis (>= 4.1.0)
+    sidekiq-scheduler (3.0.0)
+      redis (>= 3, < 5)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 3)
+      tilt (>= 1.4.0)
     spring (2.1.0)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -493,6 +506,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda-matchers (~> 4.1)
   sidekiq
+  sidekiq-scheduler
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.2)!

--- a/app/workers/stats.rb
+++ b/app/workers/stats.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Stats
+  include Sidekiq::Worker
+
+  def perform
+    StatsD.gauge('counts.users', User.count)
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'sidekiq-scheduler' if Sidekiq.server?
+
 sidekiq_redis_options = {
   db: 1,
 }

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,3 @@
+:schedule:
+  Stats:
+    cron: '0 * * * * *'  # once per minute

--- a/statsd-config.js
+++ b/statsd-config.js
@@ -9,6 +9,12 @@
 //   dumpMessages: true,
 //   backends: ['./backends/console'],
 // }
+//
+// NOTE NOTE NOTE NOTE NOTE NOTE
+//   The `process.env.XYZ` stuff does not work solely based off of a `.env` file.
+//   Export those variables into the local environment or temporarily copy them into this file.
+// NOTE NOTE NOTE NOTE NOTE NOTE
+//
 
 {
   graphite: {


### PR DESCRIPTION
The `Stats` worker can be used to send various metrics to StatsD. To start with, it just keeps track of how many users we have.

Another possible future use for `sidekiq-scheduler` might be to send myself an email summary of the requests that were made each day or something.