### PR TITLE
Don't validate presence of Request#db time

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -33,7 +33,7 @@ class Request < ApplicationRecord
 
   belongs_to :user, optional: true
 
-  validates :url, :handler, :method, :format, :ip, :requested_at, :db, :status, presence: true
+  validates :url, :handler, :method, :format, :ip, :requested_at, :status, presence: true
 
   # rubocop:disable Layout/MultilineMethodArgumentLineBreaks
   scope :recent, ->(time_period = 1.day) {

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -3,6 +3,11 @@
 require 'spec_helper'
 
 RSpec.describe Request do
+  describe 'validations' do
+    it { is_expected.not_to validate_presence_of(:db) }
+    it { is_expected.not_to validate_presence_of(:view) }
+  end
+
   describe '::recent' do
     # rubocop:disable RSpec/MultipleExpectations
     context 'when called without an argument' do


### PR DESCRIPTION
Apparently it's not present for some requests (e.g. https://rollbar.com/davidjrunger/davidrunger/items/50/occurrences/102203186214/ ). I could set it to `0` instead of `nil`, but that seems somewhat misleading. If it's not there, I'd somewhat prefer to actually preserve that information.