### PR TITLE
Declare missing `cause_error` variable

### DIFF
--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -26,6 +26,7 @@ class SaveRequest
     begin
       request.save!
     rescue => error
+      cause_error = error.cause
       logger.warn(<<~LOG.squish)
         Failed to store request data in redis.
         error_class=#{error.class}


### PR DESCRIPTION
I knew I should have added tests for this!