### PR TITLE
Remove not-null constraint on requests.format column

### DIFF
--- a/db/migrate/20191021155831_remove_requests_format_not_null_constraint.rb
+++ b/db/migrate/20191021155831_remove_requests_format_not_null_constraint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveRequestsFormatNotNullConstraint < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null :requests, :format, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_17_084423) do
+ActiveRecord::Schema.define(version: 2019_10_21_155831) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -74,7 +74,7 @@ ActiveRecord::Schema.define(version: 2019_06_17_084423) do
     t.string "referer"
     t.jsonb "params"
     t.string "method", null: false
-    t.string "format", null: false
+    t.string "format"
     t.integer "status"
     t.integer "view"
     t.integer "db"


### PR DESCRIPTION
This corresponds to our recent removal of the validation at the model level (https://github.com/davidrunger/david_runger/pull/1946).

Fixes https://rollbar.com/davidjrunger/davidrunger/items/140/