### PR TITLE
Change REQUEST_DATA_TTL from 1.hour to 21.days; delete data after use

### DIFF
--- a/app/controllers/concerns/request_recordable.rb
+++ b/app/controllers/concerns/request_recordable.rb
@@ -12,7 +12,9 @@ module RequestRecordable
   end
   include Helpers
 
-  REQUEST_DATA_TTL = Integer(1.hour) # seconds to store data in Redis to later turn into a `Request`
+  # The number of seconds to store request data in Redis (to later turn into a `Request`). Set to
+  # 21.days because that's ~ how long Sidekiq (which processes this data) will attempt retries for.
+  REQUEST_DATA_TTL = Integer(21.days)
 
   included do
     prepend_before_action :set_request_time

--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -26,13 +26,10 @@ class SaveRequest
     begin
       request.save!
     rescue => error
-      cause_error = error.cause
       logger.warn(<<~LOG.squish)
         Failed to store request data in redis.
         error_class=#{error.class}
         error_message=#{error.message}
-        cause_error_class=#{cause_error&.class}
-        cause_error_message=#{cause_error&.message}
         request_attributes=#{request_attributes.inspect}
       LOG
 

--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -38,6 +38,12 @@ class SaveRequest
 
       # wrap the original exception in Request::CreateRequestError by re-raising
       raise(Request::CreateRequestError, 'Failed to store request data in redis')
+    else
+      # we no longer need the data, so delete it now (rather than waiting for REQUEST_DATA_TTL)
+      $redis.del(
+        initial_request_data_redis_key(request_uuid: @request_uuid),
+        final_request_data_redis_key,
+      )
     end
   end
 
@@ -60,9 +66,13 @@ class SaveRequest
     initial_stashed_data.merge(final_stashed_data)
   end
 
+  def final_request_data_redis_key
+    "request_data:#{@request_uuid}:final"
+  end
+
   memoize \
   def final_stashed_json
-    $redis.get("request_data:#{@request_uuid}:final")
+    $redis.get(final_request_data_redis_key)
   end
 
   memoize \


### PR DESCRIPTION
Since Sidekiq will retry jobs for up to ~21 days, we want to leave the data in Redis for up to that long.

However, in order to avoid having a bunch of no-longer-needed data build up in Redis because of this new, longer TTL, we will now also explicitly delete the data from Redis after we successfully create a request from it, rather than just waiting for the TTL to expire (as we were doing before).