### PR TITLE
Use a Redis connection pool (rather than Redis instance directly)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ end
 gem 'active_model_serializers', github: 'rails-api/active_model_serializers', branch: '0-10-stable'
 gem 'administrate', github: 'thoughtbot/administrate' # source from master for Rails 6 compatibility
 gem 'browser'
+gem 'connection_pool'
 gem 'devise'
 gem 'dotenv-rails', require: 'dotenv/rails-now'
 gem 'hamlit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -465,6 +465,7 @@ DEPENDENCIES
   binding_of_caller
   browser
   capybara
+  connection_pool
   devise
   dotenv-rails
   factory_bot_rails

--- a/app/controllers/concerns/request_recordable.rb
+++ b/app/controllers/concerns/request_recordable.rb
@@ -15,11 +15,13 @@ module RequestRecordable
   end
 
   def store_initial_request_data_in_redis
-    $redis.setex(
-      initial_request_data_redis_key,
-      REQUEST_DATA_TTL,
-      request_data.to_json,
-    )
+    $redis_pool.with do |conn|
+      conn.setex(
+        initial_request_data_redis_key,
+        REQUEST_DATA_TTL,
+        request_data.to_json,
+      )
+    end
   rescue Encoding::UndefinedConversionError => error
     Rails.logger.info("Error storing request data in Redis, error=#{error.inspect}")
     Rollbar.info(error)

--- a/app/workers/redis_stats.rb
+++ b/app/workers/redis_stats.rb
@@ -55,11 +55,12 @@ class RedisStats
   ].freeze
 
   def perform
-    @info_hash = $redis.info
+    @info_hash = $redis_pool.with(&:info)
 
     track_integers
     track_floats
     track_databases
+    track_connection_pool
   end
 
   private
@@ -92,6 +93,11 @@ class RedisStats
         track("#{database}.#{metric}", Integer(value))
       end
     end
+  end
+
+  def track_connection_pool
+    track('connection_pool.size', $redis_pool.size)
+    track('connection_pool.available', $redis_pool.available)
   end
 
   def database_keys

--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -46,10 +46,12 @@ class SaveRequest
   private
 
   def delete_request_data
-    $redis.del(
-      initial_request_data_redis_key,
-      final_request_data_redis_key,
-    )
+    $redis_pool.with do |conn|
+      conn.del(
+        initial_request_data_redis_key,
+        final_request_data_redis_key,
+      )
+    end
   end
 
   memoize \
@@ -64,7 +66,7 @@ class SaveRequest
 
   memoize \
   def initial_stashed_json
-    $redis.get(initial_request_data_redis_key)
+    $redis_pool.with { |conn| conn.get(initial_request_data_redis_key) }
   end
 
   memoize \
@@ -81,7 +83,7 @@ class SaveRequest
 
   memoize \
   def final_stashed_json
-    $redis.get(final_request_data_redis_key)
+    $redis_pool.with { |conn| conn.get(final_request_data_redis_key) }
   end
 
   memoize \

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,3 +1,4 @@
 # frozen_string_literal: true
 
-$redis = Redis.new
+rails_max_threads = Integer(ENV.fetch('RAILS_MAX_THREADS') { 5 })
+$redis_pool = ConnectionPool.new(size: rails_max_threads, timeout: 1) { Redis.new }

--- a/config/initializers/request_logging.rb
+++ b/config/initializers/request_logging.rb
@@ -22,11 +22,13 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
     db: payload[:db_runtime],
   }
 
-  $redis.setex(
-    "request_data:#{request_id}:final",
-    ::RequestRecordable::REQUEST_DATA_TTL,
-    final_request_data.to_json,
-  )
+  $redis_pool.with do |conn|
+    conn.setex(
+      "request_data:#{request_id}:final",
+      ::RequestRecordable::REQUEST_DATA_TTL,
+      final_request_data.to_json,
+    )
+  end
 
   controller_name = payload[:controller]
   controller = controller_name.constantize


### PR DESCRIPTION
The two naive approaches for connecting to a database (Redis, in this case) are:
1. just use a single global Redis connection for the whole Rails app, e.g. `$redis = Redis.new` in an initialzier and then `$redis.get('some_key')` in application code; this was our approach prior to this commit
2. initialize a new Redis connection each time that we need to interact with Redis (e.g. `Redis.new.get('some_key')` in application code)

---

The disadvantage of #1 is that Thread B might be blocked waiting for the connection, if the single, global connection is already in use by Thread A:

> at best, your threads will block while they wait for the connection to be free, and at worst, one thread will receive the results of another thread's query!

-- https://mailchi.mp/railsspeed/should-you-be-using-puma-with-multiple-threads?e=cd6e8b0ab8

---

The disadvantage of #2 is that it wastes time establishing the connection:

> Opening and maintaining a database connection for each user, especially requests made to a dynamic database-driven website application, is costly and wastes resources.

-- https://en.wikipedia.org/w/index.php?title=Connection_pool&oldid=913204739

---

The approach implemented in this PR -- connection pooling -- achieves the best of both worlds by creating multiple connections (on demand) but then reusing them after creation.