### PR TITLE
Reduce the number of threads, processes, & Redis connections used

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-rails_max_threads = Integer(ENV.fetch('RAILS_MAX_THREADS') { 5 })
-$redis_pool = ConnectionPool.new(size: rails_max_threads, timeout: 1) { Redis.new }
+# See comments in config/initializers/sidekiq.rb for rationale re: pool size of 2.
+$redis_pool = ConnectionPool.new(size: 2, timeout: 1) { Redis.new }

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,14 +2,24 @@
 
 require 'sidekiq-scheduler' if Sidekiq.server?
 
-sidekiq_redis_options = {
-  db: 1,
-}
+# We'll give Sidekiq db 1. The app uses db 0 for its direct uses.
+build_sidekiq_redis_connection = proc { Redis.new(db: 1) }
 
 Sidekiq.configure_client do |config|
-  config.redis = sidekiq_redis_options
+  # Sidekiq Client Connection Pool size:
+  # We have 20 connections total from Heroku Redis Hobby Dev plan
+  # ... minus 7 connections used for Sidekiq below ...
+  # ... minus 5 connections for `rails console` and general padding ...
+  # ... leaves us with 8 connections total for the Rails server processes.
+  # We are running 2 processes, so each process gets 4 connections.
+  # We'll use 2 connections for the Sidekiq client pool (the line below) and 2 for the application.
+  config.redis = ConnectionPool.new(size: 2, &build_sidekiq_redis_connection)
 end
 
 Sidekiq.configure_server do |config|
-  config.redis = sidekiq_redis_options
+  # Sidekiq Server Connection Pool size:
+  # This is `(max_)concurrency + 5`.
+  # For concurrency (2), see config/sidekiq.yml.
+  # For why we are adding 5, see https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control
+  config.redis = ConnectionPool.new(size: 7, &build_sidekiq_redis_connection)
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,7 +23,7 @@ environment(ENV.fetch('RAILS_ENV') { 'development' })
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers(ENV.fetch('WEB_CONCURRENCY') { 3 })
+workers(ENV.fetch('WEB_CONCURRENCY') { 2 })
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,3 +1,7 @@
+:concurrency: 1 # I like to just use 1 thread in development so that the logs don't get intermixed
+production:
+  :concurrency: 2
+
 :schedule:
   AppStats:
     cron: '0/10 * * * * *'  # once every 10 minutes


### PR DESCRIPTION
This sets Sidekiq concurrency to 2, which is a significant decrease from the default (which I think is 10 and used to be 25). That's fine; we aren't really in a big rush to process our Sidekiq jobs. They can wait for each other. :)

This changes the fallback `WEB_CONCURRENCY` to 2, reflecting a change I have already made to the Heroku environment variable setting.

See the code changes for more details about the changes, and see the code comments for more details about the rationale.

To clarify the title a little:  _Reduce the number of **threads,** processes, & Redis connections used_ -- I am not explicitly reducing the number of threads per process (I am leaving `RAILS_MAX_THREADS=5`), but I am implicitly reducing the total number of server threads by decreasing the number of Puma processes (`WEB_CONCURRENCY`) from `3` to `2`.