### PR TITLE
Add Sidekiq stats tracking, and `essential` Sidekiq queue

### DIFF
--- a/app/workers/redis_stats.rb
+++ b/app/workers/redis_stats.rb
@@ -3,6 +3,8 @@
 class RedisStats
   include Sidekiq::Worker
 
+  sidekiq_options(queue: :essential)
+
   FLOAT_METRIC_NAMES = %w[
     instantaneous_input_kbps
     instantaneous_output_kbps

--- a/app/workers/sidekiq_stats.rb
+++ b/app/workers/sidekiq_stats.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+class SidekiqStats
+  extend Memoist
+  include Sidekiq::Worker
+
+  sidekiq_options(queue: :essential)
+
+  OVERALL_STATS = %i[
+    dead_size
+    enqueued
+    failed
+    processed
+    processes_size
+    retry_size
+    scheduled_size
+    workers_size
+  ].freeze
+
+  def perform
+    track_overall_stats
+    track_queue_stats
+  end
+
+  private
+
+  memoize \
+  def stats
+    Sidekiq::Stats.new
+  end
+
+  memoize \
+  def queues
+    (SIDEKIQ_QUEUES + stats.queues.keys).uniq
+  end
+
+  def track(metric_name, value)
+    StatsD.gauge("sidekiq.#{metric_name}", value)
+  end
+
+  def track_overall_stats
+    OVERALL_STATS.each do |stat_name|
+      stat_value = stats.public_send(stat_name)
+      track(stat_name, stat_value)
+    end
+  end
+
+  def track_queue_stats
+    queues.each do |queue_name|
+      queue = Sidekiq::Queue.new(queue_name)
+      track("#{queue_name}.size", queue.size)
+      track("#{queue_name}.latency", queue.latency)
+    end
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,11 @@
 
 require 'sidekiq-scheduler' if Sidekiq.server?
 
+# rubocop:disable Security/YAMLLoad
+sidekiq_config = YAML.load(File.read('config/sidekiq.yml'))
+# rubocop:enable Security/YAMLLoad
+SIDEKIQ_QUEUES = sidekiq_config[:queues].map { |queue_name, _priority| queue_name.freeze }.freeze
+
 # We'll give Sidekiq db 1. The app uses db 0 for its direct uses.
 build_sidekiq_redis_connection = proc { Redis.new(db: 1) }
 

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -2,8 +2,15 @@
 production:
   :concurrency: 2
 
+:queues:
+  - ['essential', 12] # ideally we'd run this queue on a separate process, but that'd cost money :(
+  - ['default', 3]
+  - ['mailers', 1]
+
 :schedule:
   AppStats:
     cron: '0/10 * * * * *'  # once every 10 minutes
   RedisStats:
+    cron: '0 * * * * *'  # once every minute
+  SidekiqStats:
     cron: '0 * * * * *'  # once every minute


### PR DESCRIPTION
The `essential` queue is for monitoring jobs that we don't want to get blocked by other processes. (Ideally we'd run this queue on an entirely separate Sidekiq process, but we can't spare another 6+ Redis connections.)

All jobs executed in this queue should be expected to execute quickly. I might look into whether there is some way that I can kill any jobs that take longer than 5 seconds or something.