### PR TITLE
Specify config file rather than list of queues when booting Sidekiq

### DIFF
--- a/Procfile.multi
+++ b/Procfile.multi
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
-sidekiq: bin/sidekiq -q default -q mailers -q essential
+sidekiq: bin/sidekiq --config config/sidekiq.yml
 statsd: node_modules/.bin/statsd statsd-config.js


### PR DESCRIPTION
This should be more maintainable. When adding a new queue, we'll just add it to `config/sidekiq.yml`, and we won't have to also add it to a list of queues in `Procfile.multi`.