### PR TITLE
Add server middleware for setting config per request

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,14 @@ class DavidRunger::Application < Rails::Application
   config.active_record.default_timezone = :utc
 
   config.middleware.insert_after(ActionDispatch::Static, Rack::Deflater) # gzip all responses
+  if Rails.env.development?
+    # require_relative is ugly but ~necessary: https://github.com/rails/rails/issues/25525
+    require_relative '../lib/middleware/set_config_server_middleware'
+    config.middleware.insert_after(
+      Rack::Deflater,
+      Middleware::SetConfigServerMiddleware,
+    )
+  end
 
   extra_load_paths = [
     Rails.root.join('lib'),

--- a/lib/middleware/set_config_server_middleware.rb
+++ b/lib/middleware/set_config_server_middleware.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Middleware::SetConfigServerMiddleware
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    Runger.config.memoize_settings_from_redis
+    @app.call(env)
+  end
+end


### PR DESCRIPTION
This is handy to toggle settings on/off without having to restart the server. (The settings live in a secret `Runger.config` object that I define in a git-ignored file.)