### PR TITLE
Add Sidekiq middleware to set config before each job

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -27,4 +27,11 @@ Sidekiq.configure_server do |config|
   # For concurrency (2), see config/sidekiq.yml.
   # For why we are adding 5, see https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control
   config.redis = ConnectionPool.new(size: 7, &build_sidekiq_redis_connection)
+
+  if Rails.env.development?
+    config.server_middleware do |chain|
+      require_relative '../../lib/middleware/set_config_sidekiq_middleware'
+      chain.add(Middleware::SetConfigSidekiqMiddleware)
+    end
+  end
 end

--- a/lib/middleware/set_config_sidekiq_middleware.rb
+++ b/lib/middleware/set_config_sidekiq_middleware.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Middleware::SetConfigSidekiqMiddleware
+  def call(_worker, _job_hash, _queue)
+    Runger.config.memoize_settings_from_redis
+    # rubocop:disable Lint/Debugger, Metrics/LineLength
+    binding.pry if Runger.config.pause_sidekiq? && (!$stop_skipping_at || (Time.current >= $stop_skipping_at))
+    # rubocop:enable Lint/Debugger, Metrics/LineLength
+    yield
+  end
+end


### PR DESCRIPTION
This is handy to toggle settings on/off without having to restart the server. (The settings live in a secret `Runger.config` object that I define in a git-ignored file.)