### PR TITLE
Add Sidekiq middleware in development with more detailed logging

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -32,6 +32,15 @@ Sidekiq.configure_server do |config|
     config.server_middleware do |chain|
       require_relative '../../lib/middleware/set_config_sidekiq_middleware'
       chain.add(Middleware::SetConfigSidekiqMiddleware)
+
+      require_relative '../../lib/middleware/sidekiq_dev_logging'
+      chain.add(Middleware::SidekiqDevLogging)
+      # silence the default Sidekiq logger
+      class ::Sidekiq::JobLogger
+        def call(*_args)
+          yield
+        end
+      end
     end
   end
 end

--- a/lib/middleware/set_config_server_middleware.rb
+++ b/lib/middleware/set_config_server_middleware.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+# I'm not sure why it's necessary to explicitly define this module; I thought zeitwerk is supposed
+# to do it for us. Maybe it's because it gets loaded so early.
+module Middleware; end
+
 class Middleware::SetConfigServerMiddleware
   def initialize(app)
     @app = app

--- a/lib/middleware/sidekiq_dev_logging.rb
+++ b/lib/middleware/sidekiq_dev_logging.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class Middleware::SidekiqDevLogging
+  def call(worker, item, queue, &blk)
+    start = Time.current
+    begin
+      log_verbose(worker, item, queue, start, &blk)
+    # rubocop:disable Lint/RescueException
+    rescue Exception
+      # rubocop:enable Lint/RescueException
+      logger.info("fail: #{elapsed(start)} sec #{' ! ' * 20}\n\n".red)
+      raise
+    end
+  end
+
+  private
+
+  def log_verbose(worker, item, queue, start)
+    logger.info("start           #{' ▽ ' * 12}".red)
+    # the extra newline at the beginning of this string has a purpose, to left-align the
+    # worker class name in the terminal, rather than having it to the right of the tagged
+    # logging output
+    logger.info(<<~START_LOG.rstrip.freeze)
+
+      [#{queue.blue}] [#{worker.class.name.green}] [#{item['jid'].cyan}] [#{item['args'].to_s.yellow}]:
+    START_LOG
+    yield
+    logger.info(format("done: %.3f sec #{' △ ' * 12}\n\n", elapsed(start)).red)
+  end
+
+  def elapsed(start)
+    [(Time.current - start), 0.001].max.round(3)
+  end
+
+  def logger
+    Sidekiq.logger
+  end
+end


### PR DESCRIPTION
It looks like this:
![image](https://user-images.githubusercontent.com/8197963/67628115-fc2c1c00-f81d-11e9-8cdd-cd5dfac0557b.png)

It logs `[queue] [job class] [jid (job id)] [args]`, and also clear indicators for when the job starts and finishes. (The ActiveRecord logging seen in this screenshot is added elsewhere, in a git-ignored file.)