### PR TITLE
Log Sidekiq details (queue, args, etc) with puts rather than logger in dev

### DIFF
--- a/lib/middleware/sidekiq_dev_logging.rb
+++ b/lib/middleware/sidekiq_dev_logging.rb
@@ -20,8 +20,7 @@ class Middleware::SidekiqDevLogging
     # the extra newline at the beginning of this string has a purpose, to left-align the
     # worker class name in the terminal, rather than having it to the right of the tagged
     # logging output
-    logger.info(<<~START_LOG.rstrip.freeze)
-
+    puts(<<~START_LOG.rstrip.freeze)
       [#{queue.blue}] [#{worker.class.name.green}] [#{item['jid'].cyan}] [#{item['args'].to_s.yellow}]:
     START_LOG
     yield


### PR DESCRIPTION
This eliminates the need for an extra newline in the message and avoids a wasted re-logging of the default sidekiq logger tags (TID (thread id) etc.).