### PR TITLE
Include IP address in web logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,9 +20,10 @@ class ApplicationController < ActionController::Base
     TouchActivityAt.perform_async(current_user.id, Float(@request_time))
   end
 
-  # add user_id to event payload so that we can include it in logs
+  # add additional data here for inclusion in logs
   def append_info_to_payload(payload)
     super(payload)
+    payload[:ip] = request.remote_ip
     payload[:user_id] = current_user.id if current_user.present?
   end
 

--- a/lib/david_runger/log_builder.rb
+++ b/lib/david_runger/log_builder.rb
@@ -13,7 +13,8 @@ class DavidRunger::LogBuilder
       exception: exception_log,
       params: params_log,
       status: status_code_log,
-      user_id: user_id_log,
+      ip: payload[:ip], # comes from ApplicationController#append_info_to_payload
+      user_id: payload[:user_id], # comes from ApplicationController#append_info_to_payload,
     }.compact
   end
 
@@ -45,9 +46,5 @@ class DavidRunger::LogBuilder
   def status_code_log
     # Devise annoyingly sets payload[:status] to 401 sometimes even when an exception has occurred
     exception.present? ? 500 : payload[:status]
-  end
-
-  def user_id_log
-    payload[:user_id] # comes from ApplicationController#append_info_to_payload
   end
 end


### PR DESCRIPTION
This makes it easier to such across multiple requests from a single IP if there isn't a user logged in (and especially if the machine/program making the request doesn't store cookies).