### PR TITLE
Link to Papertrail search for IP addresses on Request admin show page

### DIFF
--- a/app/fields/ip_address_field.rb
+++ b/app/fields/ip_address_field.rb
@@ -10,4 +10,8 @@ class IpAddressField < Administrate::Field::Base
   def spiceworks_ip_url
     "https://community.spiceworks.com/tools/ip-lookup/results?hostname=#{data}"
   end
+
+  def papertrail_ip_url
+    "https://my.papertrailapp.com/systems/davidrunger/events?q=#{data}"
+  end
 end

--- a/app/views/fields/ip_address_field/_index.html.erb
+++ b/app/views/fields/ip_address_field/_index.html.erb
@@ -1,1 +1,1 @@
-<%= link_to(field.to_s, field.spiceworks_ip_url) %>
+<%= field.to_s %>

--- a/app/views/fields/ip_address_field/_show.html.erb
+++ b/app/views/fields/ip_address_field/_show.html.erb
@@ -1,1 +1,1 @@
-<%= link_to(field.to_s, field.spiceworks_ip_url) %>
+<%= field.to_s %> (<%= link_to('Spiceworks', field.spiceworks_ip_url) %>, <%= link_to('Papertrail', field.papertrail_ip_url) %>)


### PR DESCRIPTION
Also, remove the Spiceworks link from the index page (since we don't have room for both the Spiceworks and the Papertrail URL there, and it seems random to link to just one or the other).