### PR TITLE
Only stash request data in Redis if we will log a Request

### DIFF
--- a/app/controllers/concerns/request_recordable.rb
+++ b/app/controllers/concerns/request_recordable.rb
@@ -11,7 +11,7 @@ module RequestRecordable
 
   included do
     prepend_before_action :set_request_time
-    before_action :store_initial_request_data_in_redis
+    before_action :store_initial_request_data_in_redis, if: :inherits_from_application_controller?
   end
 
   def store_initial_request_data_in_redis
@@ -42,6 +42,11 @@ module RequestRecordable
   end
 
   private
+
+  def inherits_from_application_controller?
+    # We don't want to log requests to admin controllers or to pghero, for example.
+    self.class.ancestors.include?(ApplicationController)
+  end
 
   def initial_request_data_redis_key
     "request_data:#{request.request_id || fail('No request_id')}:initial"


### PR DESCRIPTION
The criterion that we are using to determine whether we will log a Request is simply whether or not the controller in question inherits from `ApplicationController`. This excludes requests to PgHero pages and to Admin pages, for example.