### PR TITLE
Avoid yarn installing twice during deploys (second try)

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,3 +6,11 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
+
+if Rails.env.production? && DeployAssetsHelper.on_heroku?
+  # https://github.com/heroku/heroku-buildpack-ruby/pull/892#issuecomment-548897899
+  assets_precompile_task = Rake.application.tasks.find { |task| task.name == 'assets:precompile' }
+  if assets_precompile_task.present?
+    assets_precompile_task.prerequisites.delete('yarn:install')
+  end
+end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -167,14 +167,6 @@ module SourceMapHelper
 end
 
 if Rails.env.production?
-  if DeployAssetsHelper.on_heroku?
-    # https://github.com/heroku/heroku-buildpack-ruby/pull/892#issuecomment-548897899
-    assets_precompile_task = Rake.application.tasks.find { |task| task.name == 'assets:precompile' }
-    if assets_precompile_task.present?
-      assets_precompile_task.prerequisites.delete('yarn:install')
-    end
-  end
-
   Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
     if DeployAssetsHelper.on_heroku?
       Rake::Task['assets:upload_source_maps'].invoke


### PR DESCRIPTION
This builds on https://github.com/davidrunger/david_runger/pull/2003 . Hopefully this attempt will actually work. I think that the problem with that attempt is that the `assets:precompile` rake task hadn't yet been enhanced with `yarn:install` at the time that we tried to remove `yarn:install` from its prerequisites. I got the hint to do it in `Rakefile` from https://github.com/heroku/heroku-buildpack-ruby/issues/ 654#issuecomment-387226196 .