### PR TITLE
Remove comment re where to get chromedriver versions from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ before_install:
   - nvm install 12.13.0
   - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.19.1
   - export PATH="$HOME/.yarn/bin:$PATH"
-  # To get a different version of chromedriver, see http://chromedriver.chromium.org/downloads
   - CHROMEDRIVER_VERSION=$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
   - curl -o tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
   - unzip -d "$HOME/bin/" tmp/chromedriver.zip


### PR DESCRIPTION
This comment was relevant when we had the chromedriver version hardcoded in our `.travis.yml`. It's no longer relevant now that we are automatically downloading the latest released version of chromedriver (since 9db8ddf).