### PR TITLE
Allow loading of `Devise::Mailer` now that it won't error

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -60,14 +60,3 @@ class DavidRunger::Application < Rails::Application
 
   ENV['FIXTURES_PATH'] = 'spec/fixtures'
 end
-
-# necessary to avoid an error that otherwise occurs when Zeitwerk eager-loads the application. The
-# error (e.g. "expected file
-# /home/travis/build/davidrunger/david_runger/vendor/bundle/ruby/2.6.0/gems/devise-4.6.2/app/mailers/devise/mailer.rb
-# to define constant Devise::Mailer, but didn't") is caused by the fact that we aren't using
-# ActionMailer, and Devise only defines `Devise::Mailer` `if defined?(ActionMailer)` (see
-# https://github.com/plataformatec/devise/blob/v4.6.2/app/mailers/devise/mailer.rb#L3).
-absolute_devise_gem_path = Gem.loaded_specs['devise'].full_gem_path
-absolute_devise_mailer_path =
-  File.join(absolute_devise_gem_path, 'app', 'mailers', 'devise', 'mailer.rb')
-Rails.autoloaders.main.do_not_eager_load(absolute_devise_mailer_path)


### PR DESCRIPTION
We are now using `ActionMailer`, so the code being deleted in this PR is no longer needed.