### PR TITLE
Source administrate from RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ end
 
 # source from 0-10-stable branch for Rails 6 compatibility (avoids deprecation warnings)
 gem 'active_model_serializers', github: 'rails-api/active_model_serializers', branch: '0-10-stable'
-gem 'administrate', github: 'thoughtbot/administrate' # source from master for Rails 6 compatibility
+gem 'administrate'
 gem 'browser'
 gem 'connection_pool'
 gem 'devise'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -26,22 +26,6 @@ GIT
       case_transform (>= 0.2)
       jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
 
-GIT
-  remote: https://github.com/thoughtbot/administrate.git
-  revision: 5a74e1c2ebc07f8956cd4277bebcc87144af38bf
-  specs:
-    administrate (0.12.0)
-      actionpack (>= 4.2)
-      actionview (>= 4.2)
-      activerecord (>= 4.2)
-      autoprefixer-rails (>= 6.0)
-      datetime_picker_rails (~> 0.0.7)
-      jquery-rails (>= 4.0)
-      kaminari (>= 1.0)
-      momentjs-rails (~> 2.8)
-      sassc-rails (~> 2.1)
-      selectize-rails (~> 0.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -102,6 +86,17 @@ GEM
       zeitwerk (~> 2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    administrate (0.12.0)
+      actionpack (>= 4.2)
+      actionview (>= 4.2)
+      activerecord (>= 4.2)
+      autoprefixer-rails (>= 6.0)
+      datetime_picker_rails (~> 0.0.7)
+      jquery-rails (>= 4.0)
+      kaminari (>= 1.0)
+      momentjs-rails (~> 2.8)
+      sassc-rails (~> 2.1)
+      selectize-rails (~> 0.6)
     annotate (3.0.2)
       activerecord (>= 3.2, < 7.0)
       rake (>= 10.4, < 13.0)
@@ -458,7 +453,7 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers!
-  administrate!
+  administrate
   annotate
   awesome_print
   better_errors


### PR DESCRIPTION
We were sourcing from `master` via GitHub for Rails 6 compatibility. `administrate` [0.12.0][1] has since been released, though, which has Rails 6 compatibility, so sourcing from `master` is no longer necessary.

[1]: https://github.com/thoughtbot/administrate/releases/tag/v0.12.0