### PR TITLE
Source active_model_serializers from RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,8 +8,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-# source from 0-10-stable branch for Rails 6 compatibility (avoids deprecation warnings)
-gem 'active_model_serializers', github: 'rails-api/active_model_serializers', branch: '0-10-stable'
+gem 'active_model_serializers', '~> 0.10.10'
 gem 'administrate'
 gem 'browser'
 gem 'connection_pool'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,17 +15,6 @@ GIT
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
 
-GIT
-  remote: https://github.com/rails-api/active_model_serializers.git
-  revision: 6b093c965f75f87d5bbf0510e64b5193f4c6f157
-  branch: 0-10-stable
-  specs:
-    active_model_serializers (0.10.10)
-      actionpack (>= 4.1, < 6.1)
-      activemodel (>= 4.1, < 6.1)
-      case_transform (>= 0.2)
-      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -65,6 +54,11 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    active_model_serializers (0.10.10)
+      actionpack (>= 4.1, < 6.1)
+      activemodel (>= 4.1, < 6.1)
+      case_transform (>= 0.2)
+      jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
     activejob (6.0.1)
       activesupport (= 6.0.1)
       globalid (>= 0.3.6)
@@ -452,7 +446,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_model_serializers!
+  active_model_serializers (~> 0.10.10)
   administrate
   annotate
   awesome_print


### PR DESCRIPTION
We were sourcing via GitHub for Rails 6 compatibility. However, `active_model_serializers` 0.10.10 has been released, which [includes support for Rails 6][1], so we can now source from RubyGems.

[1]: https://github.com/rails-api/active_model_serializers/compare/v0.10.9..v0.10.10#diff-4ac32a78649ca5bdd8e0ba38b7006a1eR18