### PR TITLE
Add index on requests.isp

### DIFF
--- a/db/migrate/20191116132514_add_index_on_requests_isp.rb
+++ b/db/migrate/20191116132514_add_index_on_requests_isp.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AddIndexOnRequestsIsp < ActiveRecord::Migration[6.0]
+  disable_ddl_transaction!
+
+  def change
+    add_index :requests, :isp, algorithm: :concurrently
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_22_044440) do
+ActiveRecord::Schema.define(version: 2019_11_16_132514) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_stat_statements"
@@ -84,6 +84,7 @@ ActiveRecord::Schema.define(version: 2019_10_22_044440) do
     t.string "location"
     t.string "isp"
     t.string "request_id"
+    t.index ["isp"], name: "index_requests_on_isp"
     t.index ["request_id"], name: "index_requests_on_request_id", unique: true
     t.index ["requested_at"], name: "index_requests_on_requested_at"
     t.index ["user_id"], name: "index_requests_on_user_id"


### PR DESCRIPTION
This is recommended by pghero (via `/pghero/queries`) and should help with the [`Request.where.not(ip: nil).where(location: nil, isp: nil).order(:id)` query](https://github.com/davidrunger/david_runger/pull/2042) in `RequestIpLookup#requests_needing_ip_info` in `lib/tasks/requests.rake`.