### PR TITLE
Remove "App Academy Picture Flashcard App" project

### DIFF
--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -288,27 +288,6 @@ div.font-nunito
           library to automatically inject the extension's JavaScript and CSS assets into any page
           visited during an integration test.
 
-    Project
-      span(slot='title') App Academy Picture Flashcard App
-      span(slot='technologies') jQuery, object-oriented JavaScript
-      div(slot='links')
-        a(href='https://davidrunger.github.io/aa-picture-game/') Live
-        span #{' - '}
-        a(href='https://github.com/davidrunger/aa-picture-game') GitHub
-      PerformantImage(slot='image' alt='App Academy Picture Game' lazy=true)
-        source(type='png' src='~img/aa-picture-game.png')
-        source(type='webp' src='~img/aa-picture-game.webp')
-      div(slot='overview')
-        p.
-          This is a simple little tool built with jQuery for App Academy that we would always use to
-          help students and staff learn each other's names at the beginning of a new cohort. It's
-          very effective!
-      ul(slot='tech-list')
-        li.
-          An awesome loading spinner (built upon the work of
-          #[a(href='http://codepen.io/ZevanRosser/pen/ilfHK') Zevan Rosser]).
-        li Fuzzy string matching, so you get partial credit for a nearly-correct guess.
-
   .parallax-outer
     .parallax-inner.parallax-inner--macbook-2
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7808,7 +7808,7 @@ postcss@^6.0.21, postcss@^6.0.22, postcss@^6.0.6:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.23, postcss@^7.0.5, postcss@^7.0.6, postcss@^7.0.7:
+postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.23, postcss@^7.0.5, postcss@^7.0.6, postcss@^7.0.7:
   version "7.0.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.23.tgz#9f9759fad661b15964f3cfc3140f66f1e05eadc1"
   integrity sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==


### PR DESCRIPTION
I just deleted the `aa-picture-game` repo, because it had PII of App Academy students (names and photos), which they might not want to be on the public record associated with this game etc. Therefore, the live site and the GitHub links don't work anymore. Therefore, let's remove this project from the davidrunger.com homepage.