### PR TITLE
Use buttons (not links) for EditableTextLogRow "Save" and "Cancel"

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -106,6 +106,14 @@ ol {
   max-width: 1000px;
 }
 
+.el-button--mini {
+  padding: 6px 10px;
+}
+
+.el-button + .el-button {
+  margin-left: 5px;
+}
+
 table {
   margin: 15px 0;
   color: #aaa;

--- a/app/javascript/logs/components/editable_text_log_row.vue
+++ b/app/javascript/logs/components/editable_text_log_row.vue
@@ -6,8 +6,9 @@ tr
     el-input(v-model='newPlaintext' type='textarea' ref='textInput')
   td.left-align(v-else v-html='logEntry.html')
 
-  td(v-if='editing').
-    #[a.js-link(@click='updateLogEntry') Save] #[a.js-link(@click='cancelEditing') Cancel]
+  td(v-if='editing')
+    el-button(@click='updateLogEntry' size='mini') Save
+    el-button(@click='cancelEditing' size='mini') Cancel
   td(v-else)
     a.js-link(@click='editing = true') Edit
 </template>


### PR DESCRIPTION
This allows tabbing out of the textarea to the "Save" and "Cancel" buttons in Firefox (which doesn't seem to support tabbing to links?).