### PR TITLE
Alias login routes for devise

### DIFF
--- a/app/lib/custom_failure_app.rb
+++ b/app/lib/custom_failure_app.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-class CustomFailureApp < Devise::FailureApp
-  def route(_scope)
-    :login_path
-  end
-end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -267,11 +267,10 @@ Devise.setup do |config|
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.
   #
-  config.warden do |manager|
-    # manager.intercept_401 = false
-    # manager.default_strategies(scope: :user).unshift :some_external_strategy
-    manager.failure_app = CustomFailureApp
-  end
+  # config.warden do |manager|
+  #   manager.intercept_401 = false
+  #   manager.default_strategies(scope: :user).unshift :some_external_strategy
+  # end
 
   # ==> Mountable engine configurations
   # When using Devise inside an engine, let's call it `MyEngine`, and this engine

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,11 @@ Rails.application.routes.draw do
     delete 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
   end
   get 'login', to: 'sessions#new'
+  # https://stackoverflow.com/a/46218826/4009384
+  Rails.application.routes.named_routes.tap do |named_routes|
+    named_routes['new_session'] = named_routes['login']
+    named_routes['new_user_session'] = named_routes['login']
+  end
 
   get 'groceries', to: 'groceries#index'
 


### PR DESCRIPTION
Sometimes Devise tries to redirect to `new_user_session_path` or `new_session_path`. This makes such routes available.

Fixes https://rollbar.com/davidjrunger/davidrunger/items/151/