### PR TITLE
Return 404 rather than 500 when route doesn't match

### DIFF
--- a/config/initializers/monkeypatches.rb
+++ b/config/initializers/monkeypatches.rb
@@ -7,8 +7,8 @@ module DavidRunger::DebugExceptionsPatch
     exception = wrapper.exception
     if exception.is_a?(ActionController::RoutingError)
       data = {
-        method: env['REQUEST_METHOD'],
-        path: env['REQUEST_PATH'],
+        method: env.method,
+        path: env.path,
         status: wrapper.status_code,
         exception: "#{exception.class.name}[#{exception.message}]",
       }

--- a/lib/david_runger/log_formatter.rb
+++ b/lib/david_runger/log_formatter.rb
@@ -6,7 +6,9 @@ class DavidRunger::LogFormatter < Lograge::Formatters::KeyValue
     action = data[:action] # e.g. 'index'
 
     # convert to 'api/log_entries#index'
-    data[:action] = "#{controller.sub(/Controller\z/, '').underscore}##{action}"
+    if controller && action
+      data[:action] = "#{controller.sub(/Controller\z/, '').underscore}##{action}"
+    end
 
     @data = data
   end


### PR DESCRIPTION
Also, fix logging of request method and path for 404s. (I'm not sure what exactly changed, or when...)