### PR TITLE
Bump bundler version from 1.17.3 to 2.1.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - unzip -d "$HOME/bin/" tmp/chromedriver.zip
 script:
   - ruby --version && [ "$(ruby --version | cut -c1-11)" == 'ruby 2.6.5p' ]
-  - bundle --version && [ "$(bundle --version)" == 'Bundler version 1.17.3' ]
+  - bundle --version && [ "$(bundle --version)" == 'Bundler version 2.1.2' ]
   - node --version && [ "$(node --version)" == 'v12.13.0' ]
   - yarn --version && [ "$(yarn --version)" == '1.19.1' ]
   - chromedriver --version # print chromedriver version, but don't check it, because it changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,4 +511,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   1.17.3
+   2.1.2


### PR DESCRIPTION
`bundle update --bundler`

Heroku will use version 2.0.2, I think ([source](https://devcenter.heroku.com/articles/ruby-support#libraries)), but I couldn't figure out how to uninstall 2.1.2 on my machine, so `bundle update --bundler` produced `2.1.2` in the `Gemfile.lock`. Whatever, though. Shouldn't make any difference.