### PR TITLE
Change rubocop Metrics/LineLength to Layout/LineLength

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,12 @@ Layout/FirstArgumentIndentation:
   Enabled: false # this rule doesn't play nicely with the way that I like to use `memoize`
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
+Layout/LineLength:
+  IgnoredPatterns:
+    # ignore line length if the line is a comment without any spaces; it's probably not something we
+    # can fix (e.g. a long file path)
+    - !ruby/regexp /^ *#? [\S]+$/
+  Max: 100
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 Layout/SpaceBeforeBlockBraces:
@@ -47,12 +53,6 @@ Metrics/BlockLength:
   Enabled: false
 Metrics/ClassLength:
   Enabled: false
-Metrics/LineLength:
-  IgnoredPatterns:
-    # ignore line length if the line is a comment without any spaces; it's probably not something we
-    # can fix (e.g. a long file path)
-    - !ruby/regexp /^ *#? [\S]+$/
-  Max: 100
 Metrics/MethodLength:
   Max: 30
 Naming/RescuedExceptionsVariableName:

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -100,9 +100,9 @@ Rails.application.configure do
   # these configuration options.
   # config.active_record.database_selector = { delay: 2.seconds }
   # config.active_record.database_resolver = ActiveRecord::Middleware::DatabaseSelector::Resolver
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   # config.active_record.database_resolver_context = ActiveRecord::Middleware::DatabaseSelector::Resolver::Session
-  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Layout/LineLength
 
   # Email
   config.action_mailer.perform_deliveries = true

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 
 # Be sure to restart your server when you modify this file.
 
@@ -10,4 +10,4 @@
 # You can also remove all the silencers if you're trying to debug a problem that might stem from framework code.
 # Rails.backtrace_cleaner.remove_silencers!
 
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/LineLength
+# rubocop:disable Layout/LineLength
 
 # Be sure to restart your server when you modify this file.
 
@@ -30,4 +30,4 @@
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy-Report-Only
 # Rails.application.config.content_security_policy_report_only = true
 
-# rubocop:enable Metrics/LineLength
+# rubocop:enable Layout/LineLength

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -8,9 +8,9 @@ Devise.setup do |config|
   # confirmation, reset password and unlock tokens in the database.
   # Devise will use the `secret_key_base` as its `secret_key`
   # by default. You can change it below and use your own secret key.
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   # config.secret_key = 'c6c04e70cbae96857368f659652a3a191466b9848f20923b5b8e65ac9c5eebd45b2d5e646cc071dd9ae87ad17e156117538c214cfdc272e837cbc5afffa799af'
-  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Layout/LineLength
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
@@ -112,9 +112,9 @@ Devise.setup do |config|
   config.stretches = Rails.env.test? ? 1 : 11
 
   # Set up a pepper to generate the hashed password.
-  # rubocop:disable Metrics/LineLength
+  # rubocop:disable Layout/LineLength
   # config.pepper = 'ea809e8704a59a18f9eb88acb2ee49b4d84731671eded028d00d17b13ca7088f08013c5626674f9093b5f6b538523425bd8fb6758ae89578829d0215d7fad6f0'
-  # rubocop:enable Metrics/LineLength
+  # rubocop:enable Layout/LineLength
 
   # Send a notification to the original email when the user's email is changed.
   config.send_email_changed_notification = true

--- a/lib/middleware/set_config_sidekiq_middleware.rb
+++ b/lib/middleware/set_config_sidekiq_middleware.rb
@@ -3,9 +3,9 @@
 class Middleware::SetConfigSidekiqMiddleware
   def call(_worker, _job_hash, _queue)
     Runger.config.memoize_settings_from_redis
-    # rubocop:disable Lint/Debugger, Metrics/LineLength
+    # rubocop:disable Lint/Debugger, Layout/LineLength
     binding.pry if Runger.config.pause_sidekiq? && (!$stop_skipping_at || (Time.current >= $stop_skipping_at))
-    # rubocop:enable Lint/Debugger, Metrics/LineLength
+    # rubocop:enable Lint/Debugger, Layout/LineLength
     yield
   end
 end


### PR DESCRIPTION
Apparently rubocop changed this. :shrug: Seeing ".rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout" when running rubocop.