### PR TITLE
Switch from 6-field sidekiq-scheduler cron format to 5-field format

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -9,8 +9,8 @@ production:
 
 :schedule:
   AppStats:
-    cron: '0/10 * * * * *'  # once every 10 minutes
+    cron: '*/10 * * * *'  # once every 10 minutes
   RedisStats:
-    cron: '0 * * * * *'  # once every minute
+    cron: '* * * * *'  # once every minute
   SidekiqStats:
-    cron: '0 * * * * *'  # once every minute
+    cron: '* * * * *'  # once every minute


### PR DESCRIPTION
The 5-field format seems to be way more common.