### PR TITLE
Don't install development or production gems on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,9 @@ before_install:
   - CHROMEDRIVER_VERSION=$(wget -qO- https://chromedriver.storage.googleapis.com/LATEST_RELEASE)
   - curl -o tmp/chromedriver.zip https://chromedriver.storage.googleapis.com/$CHROMEDRIVER_VERSION/chromedriver_linux64.zip
   - unzip -d "$HOME/bin/" tmp/chromedriver.zip
+install:
+  - bundle config set without 'development:production'
+  - bundle install --jobs=3 --retry=3
 script:
   - ruby --version && [ "$(ruby --version | cut -c1-11)" == 'ruby 2.6.5p' ]
   - bundle --version && [ "$(bundle --version)" == 'Bundler version 2.1.2' ]


### PR DESCRIPTION
Maybe this will make Travis runs sometimes execute a little bit faster? Anyway, isn't this the point of having a `test` group in the `Gemfile`?