### PR TITLE
Remove ignored `Request` ordering in fetch_locations rake task

### DIFF
--- a/lib/tasks/requests.rake
+++ b/lib/tasks/requests.rake
@@ -82,7 +82,7 @@ class RequestIpLookup
   end
 
   def requests_needing_ip_info
-    Request.where.not(ip: nil).where(location: nil, isp: nil).order(:id)
+    Request.where.not(ip: nil).where(location: nil, isp: nil)
   end
 end
 


### PR DESCRIPTION
Since we ultimately call `#find_each` on the relation, the ordering by `id` was generating this warning:

> Scoped order is ignored, it's forced to be batch order.