### PR TITLE
Execute FetchLocations worker every minute (not every 10 minutes)

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,7 +11,7 @@ production:
   AppStats:
     cron: '*/10 * * * *'  # every 10 minutes
   FetchLocations:
-    cron: '*/10 * * * *'  # every 10 minutes
+    cron: '* * * * *'  # every minute
   PostgresQueryStats:
     cron: '26 * * * *'  # hourly at 26 minutes after
   PostgresSpaceStats:


### PR DESCRIPTION
When we were executing the `requests:fetch_locations` rake task via Heroku Scheduler, we were executing it every 10 minutes because that is the minimum interval that Heroku supports. However, executing it every minute is possible now that we are scheduling the task via Sidekiq, and it will be better to execute each minute (so that we don't have to wait as long for location data).