### PR TITLE
Load rake tasks in Sidekiq server; invoke tasks directly in workers

### DIFF
--- a/app/workers/fetch_locations.rb
+++ b/app/workers/fetch_locations.rb
@@ -4,6 +4,6 @@ class FetchLocations
   include Sidekiq::Worker
 
   def perform
-    system('bin/rails requests:fetch_locations') || fail('requests:fetch_locations failed')
+    Rake::Task['requests:fetch_locations'].invoke
   end
 end

--- a/app/workers/postgres_query_stats.rb
+++ b/app/workers/postgres_query_stats.rb
@@ -4,6 +4,6 @@ class PostgresQueryStats
   include Sidekiq::Worker
 
   def perform
-    system('bin/rails pghero:capture_query_stats') || fail('pghero:capture_query_stats failed')
+    Rake::Task['pghero:capture_query_stats'].invoke
   end
 end

--- a/app/workers/postgres_space_stats.rb
+++ b/app/workers/postgres_space_stats.rb
@@ -4,6 +4,6 @@ class PostgresSpaceStats
   include Sidekiq::Worker
 
   def perform
-    system('bin/rails pghero:capture_space_stats') || fail('pghero:capture_space_stats failed')
+    Rake::Task['pghero:capture_space_stats'].invoke
   end
 end

--- a/app/workers/truncate_tables.rb
+++ b/app/workers/truncate_tables.rb
@@ -4,6 +4,6 @@ class TruncateTables
   include Sidekiq::Worker
 
   def perform
-    system('bin/rails db:truncate_tables') || fail('db:truncate_tables failed')
+    Rake::Task['db:truncate_tables'].invoke
   end
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -28,6 +28,9 @@ Sidekiq.configure_server do |config|
   # For why we are adding 5, see https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control
   config.redis = ConnectionPool.new(size: 7, &build_sidekiq_redis_connection)
 
+  # Allow executing rake tasks via Sidekiq workers
+  Rails.application.load_tasks
+
   if Rails.env.development?
     config.server_middleware do |chain|
       require_relative '../../lib/middleware/set_config_sidekiq_middleware'


### PR DESCRIPTION
This will use a little bit of memory (most of it wasted, since most rake tasks will never be executed via a Sidekiq worker) but the upside is that it allows us to execute rake tasks within the Sidekiq workers themselves rather than via invoking a system command, which was causing weird memory behavior (high total memory usage, usage of swap memory).