### PR TITLE
Fix administrate asset loading in development by declaring the assets

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,5 @@
 //= link_tree ../images
 //= link_directory ../stylesheets .css
+
+//= link administrate/application.css
+//= link administrate/application.js


### PR DESCRIPTION
When attempting to visit admin locally, I was getting error messages in the browser saying to make the changes that are in this commit. Doing so resolved the issue. I'm not sure why this is now needed, or at what point this became necessary.