### PR TITLE
Check only bundler major and minor version numbers (not patch)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - unzip -d "$HOME/bin/" tmp/chromedriver.zip
 script:
   - ruby --version && [ "$(ruby --version | cut -c1-11)" == 'ruby 2.6.5p' ]
-  - bundle --version && [ "$(bundle --version)" == 'Bundler version 2.1.2' ]
+  - bundle --version && [ "$(bundle --version | cut -c1-20)" == 'Bundler version 2.1.' ]
   - node --version && [ "$(node --version)" == 'v12.13.0' ]
   - yarn --version && [ "$(yarn --version)" == '1.19.1' ]
   - chromedriver --version # print chromedriver version, but don't check it, because it changes


### PR DESCRIPTION
This will avoid failures if/when Travis randomly bumps the bundler patch version.