### PR TITLE
Add specs for Api::LogEntriesController#index

### DIFF
--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -2,6 +2,8 @@ inherit_from:
   - ../.rubocop.yml
 Lint/AmbiguousBlockAssociation:
   Enabled: false
+Performance/ChainArrayAllocation:
+  Enabled: false
 Style/IpAddresses:
   Enabled: false
 Style/MethodCallWithArgsParentheses:


### PR DESCRIPTION
The spec when there is no `log_id` param is pretty ugly... but whatever.