### PR TITLE
Call `Oj.optimize_rails` in a (new) initializer, to actually use Oj

### DIFF
--- a/config/initializers/oj.rb
+++ b/config/initializers/oj.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Oj.optimize_rails


### PR DESCRIPTION
I realized from this https://github.com/evilmartians/terraforming-rails/tree/master/tools/gem_tracker tool that I wasn't actually using the `oj` gem.

Ironically, actually, that tool didn't really prove that I wasn't using `oj`, because -- since `oj` is a C extension -- that tool makes it look like `oj` isn't being used even when it _is_ being used.

However, the fact that the tool said that `oj` isn't being used got me to investigate, and it turns out that, indeed, we weren't using `oj`. But now we are!, and we will enjoy faster JSON serialization because of it.