### PR TITLE
Remove no-longer-user RequestDataBuilder#browser method

### DIFF
--- a/app/controllers/lib/request_data_builder.rb
+++ b/app/controllers/lib/request_data_builder.rb
@@ -38,10 +38,6 @@ class RequestDataBuilder
 
   private
 
-  def browser
-    Browser.new(raw_user_agent)
-  end
-
   def raw_user_agent
     @raw_user_agent ||= @request.user_agent
   end


### PR DESCRIPTION
The need for this method was eliminated in 7213aa9 .

Credit to the [`rails_best_practices` gem](https://github.com/flyerhzm/rails_best_practices) for finding this unused method. (It generates too many other false positives to be worth adding to the `Gemfile` and running in CI, though. Plus, it has a decent amount of overlap with rubocop, so it's somewhat redundant.)