### PR TITLE
Add `require: false` for `brakeman` and `fasterer` gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,11 +39,11 @@ gem 'webpacker', '>= 4.0.0.pre.pre.2'
 
 group :development, :test do
   gem 'awesome_print'
-  gem 'brakeman'
+  gem 'brakeman', require: false
   gem 'dotenv-rails', require: 'dotenv/rails-now'
   gem 'factory_bot_rails'
   gem 'faker'
-  gem 'fasterer'
+  gem 'fasterer', require: false
   gem 'fixture_builder'
   gem 'pry'
   gem 'pry-byebug'


### PR DESCRIPTION
We just need these gems to be available for execution via the command line and CI, etc.; we don't need to load them as part of the application.