### PR TITLE
Remove coveralls

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,6 @@ end
 group :test do
   gem 'capybara'
   gem 'codecov', require: false
-  gem 'coveralls', require: false
   # note: to use guard-espect from command line, it will also have to be installed "globally"
   gem 'guard-espect', require: false, github: 'davidrunger/guard-espect'
   # TEMP: list hashdiff explicitly in Gemfile to force 1.0.0.beta1; remove once 1.0.0 is released

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,12 +128,6 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
-    coveralls (0.8.23)
-      json (>= 1.8, < 3)
-      simplecov (~> 0.16.1)
-      term-ansicolor (~> 1.3)
-      thor (>= 0.19.4, < 2.0)
-      tins (~> 1.6)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.5)
@@ -445,12 +439,9 @@ GEM
     stackprof (0.2.15)
     statsd-instrument (3.0.0)
     temple (0.8.2)
-    term-ansicolor (1.7.1)
-      tins (~> 1.0)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    tins (1.22.2)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
@@ -487,7 +478,6 @@ DEPENDENCIES
   capybara
   codecov
   connection_pool
-  coveralls
   dalli
   devise
   dotenv-rails

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![codecov](https://codecov.io/gh/davidrunger/david_runger/branch/master/graph/badge.svg)](https://codecov.io/gh/davidrunger/david_runger)
-[![Coverage Status](https://coveralls.io/repos/github/davidrunger/david_runger/badge.svg?branch=master)](https://coveralls.io/github/davidrunger/david_runger?branch=master)
 [![Build Status](https://travis-ci.org/davidrunger/david_runger.svg?branch=master)](https://travis-ci.org/davidrunger/david_runger)
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=davidrunger/david_runger)](https://dependabot.com)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,14 +8,9 @@ require 'webmock'
 require 'webmock/rspec'
 require 'pundit/rspec'
 if ENV['CI'] == 'true'
-  # https://docs.coveralls.io/ruby-on-rails
   require 'simplecov'
   require 'codecov'
-  require 'coveralls'
-  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
-    SimpleCov::Formatter::Codecov,
-    Coveralls::SimpleCov::Formatter,
-  ])
+  SimpleCov.formatter = SimpleCov::Formatter::Codecov
   SimpleCov.start do
     add_filter(%r{^/spec/})
   end


### PR DESCRIPTION
**Reasons:**
1. it's essentially redundant with `codecov`, which is better
2. it has some dependencies that make it difficult/impossible to install a working version of `rubycritic`

Issue #1 wasn't a pressing concern, so I tabled it / waited to see how things would play out, but now that I am encountering issue #2, it seems worthwhile to remove `coveralls`.