### PR TITLE
Add rubycritic gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development, :test do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
+  gem 'rubycritic', require: false, github: 'whitesmith/rubycritic'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,22 @@ GIT
       listen (>= 2.7, < 4.0)
       spring (>= 1.2, < 3.0)
 
+GIT
+  remote: https://github.com/whitesmith/rubycritic.git
+  revision: f292376faa15a5457726f5f0a8f39839b3aed49c
+  specs:
+    rubycritic (4.3.1)
+      flay (~> 2.8)
+      flog (~> 4.4)
+      launchy (= 2.4.3)
+      parser (>= 2.6.0)
+      rainbow (~> 3.0)
+      reek (~> 5.0, < 6.0)
+      ruby_parser (~> 3.8)
+      simplecov (~> 0.17.0)
+      tty-which (~> 0.4.0)
+      virtus (~> 1.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -98,6 +114,10 @@ GEM
     autoprefixer-rails (9.7.1)
       execjs
     awesome_print (1.8.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bcrypt (3.1.13)
     better_errors (2.5.1)
       coderay (>= 1.0.0)
@@ -120,11 +140,15 @@ GEM
     case_transform (0.2)
       activesupport
     childprocess (3.0.0)
+    codeclimate-engine-rb (0.4.1)
+      virtus (~> 1.0)
     codecov (0.1.16)
       json
       simplecov
       url
     coderay (1.1.2)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     colorize (0.8.1)
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
@@ -135,6 +159,8 @@ GEM
     datetime_picker_rails (0.0.7)
       momentjs-rails (>= 2.8.1)
     debug_inspector (0.0.3)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     devise (4.7.1)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -147,7 +173,9 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
+    equalizer (0.0.11)
     erubi (1.9.0)
+    erubis (2.7.0)
     et-orbi (1.2.2)
       tzinfo
     execjs (2.7.0)
@@ -169,6 +197,15 @@ GEM
       activesupport (>= 2)
       hashdiff
     flamegraph (0.9.5)
+    flay (2.12.1)
+      erubis (~> 2.7.0)
+      path_expander (~> 1.0)
+      ruby_parser (~> 3.0)
+      sexp_processor (~> 4.0)
+    flog (4.6.4)
+      path_expander (~> 1.0)
+      ruby_parser (~> 3.1, > 3.1.0)
+      sexp_processor (~> 4.8)
     formatador (0.2.5)
     fugit (1.3.3)
       et-orbi (~> 1.1, >= 1.1.8)
@@ -196,6 +233,7 @@ GEM
       multi_xml (>= 0.5.2)
     i18n (1.8.2)
       concurrent-ruby (~> 1.0)
+    ice_nine (0.11.2)
     jaro_winkler (1.5.4)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
@@ -221,6 +259,7 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    kwalify (0.7.2)
     launchy (2.4.3)
       addressable (~> 2.3)
     letter_opener (1.7.0)
@@ -287,6 +326,7 @@ GEM
     parallel (1.19.1)
     parser (2.7.0.1)
       ast (~> 2.4.0)
+    path_expander (1.1.0)
     pg (1.2.2)
     pg_query (1.2.0)
     pghero (2.4.1)
@@ -299,6 +339,7 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    psych (3.1.0)
     public_suffix (4.0.3)
     puma (4.3.1)
       nio4r (~> 2.0)
@@ -346,6 +387,12 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     redis (4.1.3)
+    reek (5.6.0)
+      codeclimate-engine-rb (~> 0.4.0)
+      kwalify (~> 0.7.0)
+      parser (>= 2.5.0.0, < 2.8, != 2.5.1.1)
+      psych (~> 3.1.0)
+      rainbow (>= 2.0, < 4.0)
     regexp_parser (1.6.0)
     request_store (1.4.1)
       rack (>= 1.4)
@@ -421,7 +468,7 @@ GEM
       rufus-scheduler (~> 3.2)
       sidekiq (>= 3)
       tilt (>= 1.4.0)
-    simplecov (0.16.1)
+    simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
@@ -442,10 +489,16 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    tty-which (0.4.2)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unicode-display_width (1.6.0)
     url (0.3.2)
+    virtus (1.0.5)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     warden (1.2.8)
       rack (>= 2.0.6)
     webmock (3.8.0)
@@ -518,6 +571,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
+  rubycritic!
   selenium-webdriver
   shoulda-matchers (~> 4.2)
   sidekiq


### PR DESCRIPTION
We won't run this on CI just yet. For now, the purpose of adding this gem is to allow executing `rubycritic` locally:
```
bundle exec rubycritic `find app -type d -not -name dashboards -d 1` lib
```