### PR TITLE
Refactor SaveRequest worker from "C" to "A" rubycritic rating

### DIFF
--- a/.reek.yml
+++ b/.reek.yml
@@ -1,0 +1,6 @@
+---
+directories:
+  "app/workers":
+    # Sidekiq workers sometimes need to set an instance variable in #perform rather than #initialize
+    InstanceVariableAssumption:
+      enabled: false

--- a/app/workers/save_request/stashed_data_manager.rb
+++ b/app/workers/save_request/stashed_data_manager.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+class SaveRequest::StashedDataManager
+  extend Memoist
+
+  def initialize(request_id)
+    @request_id = request_id
+  end
+
+  memoize \
+  def stashed_data
+    initial_stashed_data.merge(final_stashed_data)
+  end
+
+  memoize \
+  def initial_request_data_redis_key
+    "request_data:#{@request_id}:initial"
+  end
+
+  memoize \
+  def initial_stashed_json
+    $redis_pool.with { |conn| conn.get(initial_request_data_redis_key) }
+  end
+
+  memoize \
+  def initial_stashed_data
+    JSON.parse(initial_stashed_json)
+  end
+
+  memoize \
+  def final_request_data_redis_key
+    "request_data:#{@request_id}:final"
+  end
+
+  memoize \
+  def final_stashed_json
+    $redis_pool.with { |conn| conn.get(final_request_data_redis_key) }
+  end
+
+  memoize \
+  def final_stashed_data
+    JSON.parse(final_stashed_json)
+  end
+
+  def delete_request_data
+    $redis_pool.with do |conn|
+      conn.del(
+        initial_request_data_redis_key,
+        final_request_data_redis_key,
+      )
+    end
+  end
+end

--- a/lib/error_logger.rb
+++ b/lib/error_logger.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ErrorLogger
+  def self.warn(message:, data: {}, error_klass: StandardError)
+    data_log_line = data.map { |key, value| "#{key}=#{value.inspect}" }.join(' ')
+    Rails.logger.warn("#{message}#{"; #{data_log_line}" if data_log_line.present?}")
+    Rollbar.warn(error_klass.new(message), data)
+  end
+end


### PR DESCRIPTION
This involved breaking out a new `SaveRequest::StashedDataManager` helper class and an `ErrorLog` module.

Overall, I don't know if it's that much of an improvement in readability/maintainability, if at all. The `SaveRequest` class certainly was doing a lot, though. Maybe this refactor does make it easier to follow.