### PR TITLE
Simplify Api::LogEntriesController#index action

### DIFF
--- a/app/javascript/logs/store.js
+++ b/app/javascript/logs/store.js
@@ -63,12 +63,20 @@ const actions = {
     axios.
       get(Routes.api_log_entries_path()).
       then(({ data }) => {
-        data.forEach(({ log_id, log_entries }) => { // eslint-disable-line camelcase
+        const entriesByLogId = {};
+        data.forEach(logEntry => {
+          const { log_id: logId } = logEntry;
+          entriesByLogId[logId] = entriesByLogId[logId] || [];
+          entriesByLogId[logId].push(logEntry);
+        });
+
+        Object.keys(entriesByLogId).forEach(logId => {
+          const logEntries = entriesByLogId[logId];
           commit(
             'setLogEntries',
             {
-              log: getters.logById({ logId: log_id }),
-              logEntries: log_entries,
+              log: getters.logById({ logId: parseInt(logId, 10) }),
+              logEntries,
             },
           );
         });

--- a/spec/controllers/api/log_entries_controller_spec.rb
+++ b/spec/controllers/api/log_entries_controller_spec.rb
@@ -156,27 +156,18 @@ RSpec.describe Api::LogEntriesController do
     context 'when a log_id param is not provided' do
       let(:params) { {} }
 
-      # rubocop:disable RSpec/ExampleLength
-      it 'returns data about all log entries of the current_user' do
+      it 'returns all log entries of the current_user' do
         get_index
 
         simplified_response_data =
-          response.parsed_body.map do |hash|
-            hash.transform_values do |value|
-              if value.is_a?(Array)
-                value.map { |log_entry| log_entry.slice('log_id') }.uniq
-              else
-                value
-              end
-            end
+          response.parsed_body.map do |log_entry|
+            log_entry.slice('id')
           end
         expected_simplified_response_data =
-          user.logs.map do |log|
-            {'log_id' => log.id, 'log_entries' => ['log_id' => log.id]}
-          end
-        expect(simplified_response_data).to eq(expected_simplified_response_data)
+          user.logs.map(&:log_entries).flatten.map { |log_entry| {'id' => log_entry.id} }
+
+        expect(simplified_response_data).to match_array(expected_simplified_response_data)
       end
-      # rubocop:enable RSpec/ExampleLength
     end
   end
 end


### PR DESCRIPTION
Previously, we were returning differently formatted JSON data, depending on whether the request was for the log entries of a single log or the log entries of all of the current user's logs.

This change simplifies the controller action by always returning the log entries data in the same format, regardless of whether we are returning the logs entries of one log or many logs.

This basically just moves the complexity from the backend to the frontend... but that feels slightly better. This complexity sort of feels like something that the frontend should manage.