### PR TITLE
Enable Sidekiq (testing SaveRequest, etc.) in home page feature test

### DIFF
--- a/app/workers/fetch_ip_info_for_request.rb
+++ b/app/workers/fetch_ip_info_for_request.rb
@@ -29,7 +29,7 @@ class FetchIpInfoForRequest
 
   memoize \
   def ip_info_from_api(ip)
-    logger.info("Querying ip-api.com for info about IP address '#{ip}'")
+    Rails.logger.info("Querying ip-api.com for info about IP address '#{ip}'")
     raw_ip_info_from_api = HTTParty.get("http://ip-api.com/json/#{ip}").parsed_response
     isp, city, state, country = raw_ip_info_from_api.values_at(*%w[isp city region countryCode])
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,6 +24,7 @@ require 'rspec/rails'
 require 'capybara/rails'
 require 'capybara/rspec'
 require 'active_support/cache/dalli_store'
+require 'sidekiq/testing'
 
 WebMock.enable!
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
This gives us some integration test coverage for the `SaveRequest` and `FetchIpInfoForRequest` Sidekiq workers.