### PR TITLE
Don't specify headers required for ip-api.com stub in Home spec

### DIFF
--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -3,13 +3,6 @@
 RSpec.describe 'Home page' do
   let!(:ip_info_request_stub) do
     stub_request(:get, 'http://ip-api.com/json/127.0.0.1').
-      with(
-        headers: {
-          'Accept' => '*/*',
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-          'User-Agent' => 'Ruby',
-        },
-      ).
       to_return(
         status: 200,
         body: {


### PR DESCRIPTION
We expect to get a similar response regardless of which (sane) headers we submit, so it's not really worthwhile (in terms of spec brittleness and verbosity) to check which headers we submit in the test's request stub.

I had originally specified the headers just because they were in the suggested stub that `webmock` printed when I had first executed the relevant test without having yet stubbed the request at all.