### PR TITLE
Add skylight.yml config to enable Sidekiq performance tracking

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,0 +1,2 @@
+---
+enable_sidekiq: true


### PR DESCRIPTION
https://www.skylight.io/support/background-jobs

Those docs do say this:
> if you use environment variables to configure Skylight, follow these instructions [...] `SKYLIGHT_ENABLE_SIDEKIQ=true`

On `master` / production right now, I am currently configuring Skylight exclusively using an environment variable (`SKYLIGHT_AUTHENTICATION`). Hopefully we can also use `config/skylight.yml`, i.e. we can mix-and-match ENV variable config and YAML config?