### PR TITLE
Explicitly define `Email` module and load w/ `require_relative`

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -107,5 +107,6 @@ Rails.application.configure do
   # Email
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
+  require_relative('../../lib/email/mailgun_via_httparty.rb')
   config.action_mailer.delivery_method = Email::MailgunViaHttparty
 end

--- a/lib/email/mailgun_via_httparty.rb
+++ b/lib/email/mailgun_via_httparty.rb
@@ -1,23 +1,27 @@
 # frozen_string_literal: true
 
-class Email::MailgunViaHttparty
-  attr_accessor :message
+# rubocop:disable Style/ClassAndModuleChildren
+module Email
+  class MailgunViaHttparty
+    attr_accessor :message
 
-  def initialize(_mail) ; end
+    def initialize(_mail) ; end
 
-  def deliver!(mail)
-    HTTParty.post(
-      "#{ENV['MAILGUN_URL']}/messages",
-      basic_auth: {
-        username: 'api',
-        password: ENV['MAILGUN_API_KEY'],
-      },
-      body: {
-        from: mail['From'].to_s,
-        to: mail['To'].to_s,
-        subject: mail.subject,
-        html: mail.body.to_s,
-      },
-    )
+    def deliver!(mail)
+      HTTParty.post(
+        "#{ENV['MAILGUN_URL']}/messages",
+        basic_auth: {
+          username: 'api',
+          password: ENV['MAILGUN_API_KEY'],
+        },
+        body: {
+          from: mail['From'].to_s,
+          to: mail['To'].to_s,
+          subject: mail.subject,
+          html: mail.body.to_s,
+        },
+      )
+    end
   end
 end
+# rubocop:enable Style/ClassAndModuleChildren


### PR DESCRIPTION
I'm not sure why this is necessary, but whatever. Probably something to do with the recent upgrade from Ruby 2.6.5 to 2.7.0 or the `rails` and other gem upgrades that we did as part of that.

Hopefully this will fix this deploy error:
```
NameError: uninitialized constant Email
/tmp/build_0374fc3f09e4c5f1f494ddce3c9a8ed0/config/environments/production.rb:110:in `block in <top (required)>'
```
-- https://dashboard.heroku.com/apps/48504e5f-cae2-4879-af32-dfea82258fc5/activity/builds/eea5972d-b1cc-4dca-91a3-e80c7a009768