### PR TITLE
Remove ActiveRecord::TestFixtures#run_in_transaction? monkeypatch

### DIFF
--- a/config/initializers/monkeypatches.rb
+++ b/config/initializers/monkeypatches.rb
@@ -21,15 +21,3 @@ module DavidRunger::DebugExceptionsPatch
 end
 
 ActionDispatch::DebugExceptions.prepend(DavidRunger::DebugExceptionsPatch)
-
-#
-# This fixes what seems to be a bug introduced by
-# https://github.com/rails/rails/pull/ 37770
-# "Modify ActiveRecord::TestFixtures to not rely on AS::TestCase:"
-#
-module ActiveRecord::TestFixtures
-  def run_in_transaction?
-    use_transactional_tests &&
-      !self.class.uses_transaction?(method_name) # this monkeypatch changes `name` to `method_name`
-  end
-end


### PR DESCRIPTION
This ([added here](https://github.com/davidrunger/david_runger/pull/2152)) is no longer needed since we [bumped to rspec-rails 4.0](https://github.com/davidrunger/david_runger/pull/2401) (?).