### PR TITLE
Add `thread_safe` gem (required by active_model_serializers)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,7 @@ gem 'sidekiq'
 gem 'sidekiq-scheduler', require: false # required manually in config/initializers/sidekiq.rb
 gem 'skylight'
 gem 'statsd-instrument'
+gem 'thread_safe'
 gem 'webpacker', '>= 4.0.0.pre.pre.2'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -451,6 +451,7 @@ GEM
     statsd-instrument (3.0.0)
     temple (0.8.2)
     thor (1.0.1)
+    thread_safe (0.3.6)
     thwait (0.1.0)
     tilt (2.0.10)
     tzinfo (2.0.1)
@@ -539,6 +540,7 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.2)!
   stackprof
   statsd-instrument
+  thread_safe
   webmock
   webpacker (>= 4.0.0.pre.pre.2)
 


### PR DESCRIPTION
`active_model_serializers` depends on this gem (`thread_safe`) but doesn't declare it as a dependency.

`rails` used to have it as a dependency (which was thus making `thread_safe` available for `active_model_serializers` to require), but that was recently [removed][1].

[1]: https://github.com/rails/rails/commit/bf34c808f9936ecb160914cace45c655ec0924c7#diff-e79a60dc6b85309ae70a6ea8261eaf95

Therefore, as a workaround, we'll add `thread_safe` to our own `Gemfile`.

We can undo this change if/when `active_model_serializers` resolves this bug (i.e. when they explicitly add `thread_safe` as a dependency or they remove their dependency on `thread_safe`).