### PR TITLE
Remove graphite deploy-notification release command

### DIFF
--- a/bin/publish-graphite-release
+++ b/bin/publish-graphite-release
@@ -1,4 +1,0 @@
-short_sha=`cat SOURCE_VERSION | cut -c1-7`
-curl -X POST "$GRAPHITE_HTTP_USERNAME:$GRAPHITE_HTTP_PASSWORD@$GRAPHITE_HOST:8000/events/" \
-  -H "Content-Type: application/json" \
-  -d "{ \"what\": \"Deploy $short_sha\", \"tags\": \"deploy\", \"when\": `date +%s` }"

--- a/bin/release-tasks
+++ b/bin/release-tasks
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 
 bin/rails db:migrate
-bin/publish-graphite-release


### PR DESCRIPTION
The graphite deploy-notification release command is causing deploys to fail, since I deleted the Digital Ocean droplet last night.