### PR TITLE
Unschedule pghero rake task jobs

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -11,10 +11,6 @@ production:
 :schedule:
   AppStats:
     cron: '*/10 * * * *' # every 10 minutes
-  PostgresQueryStats:
-    cron: '26 * * * *' # hourly at 26 minutes after
-  PostgresSpaceStats:
-    cron: '47 22 * * * America/Los_Angeles' # daily at 10:47pm PT
   Stats::Redis:
     cron: '* * * * *' # every minute
   SidekiqStats:


### PR DESCRIPTION
These raise an error ( see https://rollbar.com/davidjrunger/davidrunger/items/207/ ) since we merged https://github.com/davidrunger/david_runger/pull/2515 which brings in https://github.com/rails/rails/pull/ 39097 , specifically this change https://github.com/rails/rails/pull/39097/ files#diff-4fa9fd7e27dd7280b0c72f619e18095bR58-R59 which causes the relevant column types hash to not be populated with a certain key/value that `pghero` expects.

Hopefully we can re-enable these scheduled jobs once `rails` or `pghero` fixes this issue.