### PR TITLE
Increment currentRoundIndex if greater than or equal, not just equal

### DIFF
--- a/app/javascript/workout/workout_plan.vue
+++ b/app/javascript/workout/workout_plan.vue
@@ -97,7 +97,7 @@ export default {
         this.timeElapsedString = this.timer.getTimeValues().toString();
         this.secondsElapsed = this.timer.getTotalTimeValues().seconds;
 
-        if (this.secondsElapsed === this.nextRoundStartAtSeconds) {
+        if (this.secondsElapsed >= this.nextRoundStartAtSeconds) {
           this.currentRoundIndex++;
           this.nextRoundStartTimer = new Timer();
           this.nextRoundStartTimer.start({


### PR DESCRIPTION
Fixes (I think) this bug where the next-round timer could get stuck at a certain round:

![image](https://user-images.githubusercontent.com/8197963/81486849-9c6eee80-920c-11ea-9058-ed5c28e01ada.png)