### PR TITLE
Add padding (`p2`) around Google login button

### DIFF
--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -174,7 +174,7 @@
   </style>
 <% end %>
 
-<div class="flex justify-center">
+<div class="flex justify-center p2">
   <div id="my-signin2">
     <div class="abcRioButton abcRioButtonBlue" style="height: 50px;width: 240px;">
       <div class="abcRioButtonContentWrapper">


### PR DESCRIPTION
Otherwise, the button smashes awkwardly right up against the top of the screen (if there is no flash message).