### PR TITLE
Avoid factory_bot warning about deprecated `configuration` method

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -95,11 +95,12 @@ RSpec.configure do |config|
   config.before(:suite) do
     # Reset FactoryBot sequences to an arbitrarily high number to avoid collisions with
     # fixture_builder-built fixtures.
-    FactoryBot.configuration.sequences.each do |sequence|
+    #
+    # It seems naughty to be reaching in to FactoryBot `Internal`s here, but I (Runger) am not sure
+    # we have a great alternative available.
+    FactoryBot::Internal.configuration.sequences.each do |sequence|
       sequence.instance_variable_set(:@value, FactoryBot::Sequence::EnumeratorAdapter.new(10_000))
     end
-    # It seems naughty to be reaching in to FactoryBot `Internal`s here, but I (Runger) think it's
-    # better than the alternative of not using inline sequences.
     FactoryBot::Internal.inline_sequences.each do |sequence|
       sequence.instance_variable_set(:@value, FactoryBot::Sequence::EnumeratorAdapter.new(10_000))
     end


### PR DESCRIPTION
Logged when executing specs:
> DEPRECATION WARNING: configuration is deprecated and will be removed from factory_bot 6.0 (called from block (2 levels) in <top (required)> at /Users/david/workspace/david_runger/spec/spec_helper.rb:98)

Fixed by explicitly accessing `FactoryBot::Internal`s, which of course seems a bit "wrong", but I don't think we have a choice, really (other than to stop using FixtureBuilder?, which I think is basically what necessitates this hack).