### PR TITLE
Remove pghero

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,8 +25,6 @@ gem 'omniauth-google-oauth2'
 # remove once https://github.com/omniauth/omniauth/pull/809 is resolved
 gem 'omniauth-rails_csrf_protection'
 gem 'pg', '~> 1.2'
-gem 'pg_query', '>= 0.9.0'
-gem 'pghero'
 gem 'puma', '~> 4.3'
 gem 'pundit'
 gem 'rails', '>= 6.0.2.1', github: 'rails/rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -313,9 +313,6 @@ GEM
     parser (2.7.1.2)
       ast (~> 2.4.0)
     pg (1.2.3)
-    pg_query (1.2.0)
-    pghero (2.4.2)
-      activerecord (>= 5)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -508,8 +505,6 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   pg (~> 1.2)
-  pg_query (>= 0.9.0)
-  pghero
   pry
   pry-byebug
   pry-rails

--- a/app/workers/postgres_query_stats.rb
+++ b/app/workers/postgres_query_stats.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class PostgresQueryStats
-  include Sidekiq::Worker
-
-  def perform
-    Rake::Task['pghero:capture_query_stats'].invoke
-  end
-end

--- a/app/workers/postgres_space_stats.rb
+++ b/app/workers/postgres_space_stats.rb
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-class PostgresSpaceStats
-  include Sidekiq::Worker
-
-  def perform
-    Rake::Task['pghero:capture_space_stats'].invoke
-  end
-end

--- a/app/workers/truncate_tables.rb
+++ b/app/workers/truncate_tables.rb
@@ -61,8 +61,6 @@ class TruncateTables
     Rails.logger.info
 
     self.class.truncate(table: 'requests', timestamp: 'requested_at')
-    self.class.truncate(table: 'pghero_query_stats', timestamp: 'captured_at')
-    self.class.truncate(table: 'pghero_space_stats', timestamp: 'captured_at')
 
     Rails.logger.info('Done truncating tables')
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,6 @@ class DavidRunger::Application < Rails::Application
   # now being respected.
   $LOAD_PATH << File.join(Gem.loaded_specs['administrate'].full_gem_path, 'app', 'helpers').to_s
   $LOAD_PATH << File.join(Gem.loaded_specs['devise'].full_gem_path, 'app', 'helpers').to_s
-  $LOAD_PATH << File.join(Gem.loaded_specs['pghero'].full_gem_path, 'app', 'helpers').to_s
 
   ENV['FIXTURES_PATH'] = 'spec/fixtures'
 end

--- a/config/initializers/request_logging.rb
+++ b/config/initializers/request_logging.rb
@@ -7,7 +7,7 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
   next if Rails.env.test? && controller_name == 'AnonymousController'
 
   controller = controller_name.constantize
-  # We don't want to log requests to admin controllers or to pghero, for example.
+  # We don't want to log requests to admin controllers
   next unless controller.ancestors.include?(ApplicationController)
 
   request_id = payload[:headers]['action_dispatch.request_id']

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,7 +50,6 @@ Rails.application.routes.draw do
   end
 
   authenticate :user, ->(user) { user.admin? } do
-    mount PgHero::Engine, at: 'pghero'
     mount Sidekiq::Web => '/sidekiq'
   end
 

--- a/db/migrate/20200516091729_disable_pg_stat_statements_extension.rb
+++ b/db/migrate/20200516091729_disable_pg_stat_statements_extension.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class DisablePgStatStatementsExtension < ActiveRecord::Migration[6.1]
+  def up
+    ApplicationRecord.connection.execute('DROP EXTENSION IF EXISTS pg_stat_statements CASCADE;')
+  end
+
+  def down
+    ApplicationRecord.connection.execute('CREATE EXTENSION IF NOT EXISTS pg_stat_statements;')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_14_191430) do
+ActiveRecord::Schema.define(version: 2020_05_16_091729) do
 
   # These are extensions that must be enabled in order to support this database
-  enable_extension "pg_stat_statements"
   enable_extension "plpgsql"
 
   create_table "items", id: :serial, force: :cascade do |t|
@@ -53,26 +52,6 @@ ActiveRecord::Schema.define(version: 2020_05_14_191430) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "note"
-  end
-
-  create_table "pghero_query_stats", force: :cascade do |t|
-    t.text "database"
-    t.text "user"
-    t.text "query"
-    t.bigint "query_hash"
-    t.float "total_time"
-    t.bigint "calls"
-    t.datetime "captured_at"
-    t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"
-  end
-
-  create_table "pghero_space_stats", force: :cascade do |t|
-    t.text "database"
-    t.text "schema"
-    t.text "relation"
-    t.bigint "size"
-    t.datetime "captured_at"
-    t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
   end
 
   create_table "requests", force: :cascade do |t|


### PR DESCRIPTION
It was good while it lasted.

fixes https://rollbar.com/davidjrunger/davidrunger/items/220/

1. prints Ruby 2.7 warnings
2. not compatible with `rails` master (see Rollbar above)
3. not worth it; DB performance isn't a big problem for the app
4. tracking tables use/waste rows in database