### PR TITLE
Stop loading rake tasks in Sidekiq

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -28,9 +28,6 @@ Sidekiq.configure_server do |config|
   # For why we are adding 5, see https://github.com/mperham/sidekiq/wiki/Using-Redis#complete-control
   config.redis = ConnectionPool.new(size: 7, &build_sidekiq_redis_connection)
 
-  # Allow executing rake tasks via Sidekiq workers
-  Rails.application.load_tasks
-
   if Rails.env.development?
     config.server_middleware do |chain|
       require_relative '../../lib/middleware/set_config_sidekiq_middleware'


### PR DESCRIPTION
This was added in https://github.com/davidrunger/david_runger/commit/674f7d24ec2857afba90dc3ee98b21159ed9a16e .

As of https://github.com/davidrunger/david_runger/pull/2571 , we no longer have any Sidekiq jobs that execute a rake task, so this isn't needed anymore.

This change should reduce Sidekiq's memory usage.