### PR TITLE
Remove unnecessary manual `require 'spec_helper'`s

### DIFF
--- a/spec/config/scheduled_sidekiq_jobs_spec.rb
+++ b/spec/config/scheduled_sidekiq_jobs_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 # rubocop:disable RSpec/DescribeClass
 RSpec.describe 'Sidekiq scheduled jobs' do
   # rubocop:enable RSpec/DescribeClass

--- a/spec/fields/user_agent_field_spec.rb
+++ b/spec/fields/user_agent_field_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe UserAgentField do
   subject(:field) { UserAgentField.new(:user_agent, raw_user_agent, page) }
 

--- a/spec/form_objects/sms_message_spec.rb
+++ b/spec/form_objects/sms_message_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe SmsMessage do
   subject(:sms_message) { SmsMessage.new(**sms_message_params) }
 

--- a/spec/lib/email/mailgun_via_http_spec.rb
+++ b/spec/lib/email/mailgun_via_http_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Email::MailgunViaHttp do
   subject(:mailgun_via_http) { Email::MailgunViaHttp.new({}) }
 

--- a/spec/lib/error_logger_spec.rb
+++ b/spec/lib/error_logger_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe ErrorLogger do
   subject(:error_logger) { ErrorLogger }
 

--- a/spec/lib/refinements/blank_params_as_nil_spec.rb
+++ b/spec/lib/refinements/blank_params_as_nil_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe BlankParamsAsNil do
   using BlankParamsAsNil
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Item do
   subject(:item) { items(:item) }
 

--- a/spec/models/log_share_spec.rb
+++ b/spec/models/log_share_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe LogShare do
   subject(:log_share) { log_shares(:log_share) }
 

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Log do
   subject(:log) { logs(:number_log) }
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe Request do
   describe 'validations' do
     it { is_expected.not_to validate_presence_of(:format) }

--- a/spec/models/sms_record_spec.rb
+++ b/spec/models/sms_record_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe SmsRecord do
   subject(:sms_record) { sms_records(:sms_record) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe User do
   subject(:user) { users(:user) }
 

--- a/spec/policies/sms_record_policy_spec.rb
+++ b/spec/policies/sms_record_policy_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe SmsRecordPolicy do
   let(:user) { users(:user) }
 

--- a/spec/workers/fetch_ip_info_for_request_spec.rb
+++ b/spec/workers/fetch_ip_info_for_request_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe FetchIpInfoForRequest do
   subject(:worker) { FetchIpInfoForRequest.new }
 

--- a/spec/workers/touch_activity_at_spec.rb
+++ b/spec/workers/touch_activity_at_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe TouchActivityAt do
   subject(:worker) { TouchActivityAt.new }
 

--- a/spec/workers/truncate_tables_spec.rb
+++ b/spec/workers/truncate_tables_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-
 RSpec.describe TruncateTables do
   subject(:worker) { TruncateTables.new }
 


### PR DESCRIPTION
`spec_helper.rb` is required automatically by RSpec via `--require spec_helper` in `.rspec`.