### PR TITLE
Remove duplicated RSpec config settings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -82,11 +82,7 @@ RSpec.configure do |config|
 
   config.fail_if_no_examples = true
 
-  config.filter_run_when_matching(:focus)
-
-  config.fixture_path = Rails.root.join('spec/fixtures')
   config.global_fixtures = :all
-  config.use_transactional_fixtures
 
   config.include(FactoryBot::Syntax::Methods)
   config.include(Devise::Test::ControllerHelpers, type: :controller)


### PR DESCRIPTION
(And I think that `config.use_transactional_fixtures` might be doing nothing (just reading, not writing)? Anyway, we set it to `true` below.)