### PR TITLE
Use Rack::Attack to ban pentesters (requesting Wordpress paths, etc)

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -20,7 +20,7 @@ Rails.application.configure do
     config.action_controller.perform_caching = true
     config.action_controller.enable_fragment_cache_logging = true
 
-    config.cache_store = :dalli_store
+    config.cache_store = :mem_cache_store
     config.public_file_server.headers = {
       'Cache-Control' => "public, max-age=#{Integer(2.days)}",
     }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,7 +47,7 @@ Rails.application.configure do
 
   # Use a different cache store in production.
   config.cache_store =
-    :dalli_store,
+    :mem_cache_store,
     ENV['MEMCACHIER_SERVERS'],
     {
       password: ENV['MEMCACHIER_PASSWORD'],

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,10 +1,46 @@
 # frozen_string_literal: true
 
 class Rack::Attack
+  BANNED_PATH_FRAGMENTS = Set.new(%w[
+    env
+    old-wp
+    passwd
+    php
+    phpformbuilder
+    phpmyadmin
+    phpmyadmin
+    plugins
+    wordpress
+    wp
+    wp-admin
+    wp-login
+    wp1
+    wp2
+  ])
+
   # Limit all IPs to 60 requests per clock minute
   # rubocop:disable Style/SymbolProc
   throttle('req/ip', limit: 60, period: 1.minute) do |req|
     req.ip
   end
   # rubocop:enable Style/SymbolProc
+end
+
+# Block IPs requesting Wordpress paths etc.
+# After 2 blocked requests in a day, block all requests from that IP for 1 year.
+Rack::Attack.blocklist('fail2ban pentesters') do |req|
+  # `filter` returns truthy value if request fails the checks or if it's from a previously banned IP
+  Rack::Attack::Fail2Ban.filter(
+    "pentesters-#{req.ip}",
+    maxretry: 2,
+    findtime: 1.day,
+    bantime: 4.weeks, # memcached struggles to handle values much longer than this
+  ) do
+    fragments = req.path.split(%r{/|\.|\?})
+    fragments.map!(&:presence)
+    fragments.compact!
+    fragments.any? do |fragment|
+      fragment.downcase.in?(Rack::Attack::BANNED_PATH_FRAGMENTS)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,7 +23,7 @@ abort('The Rails environment is running in production mode!') if Rails.env.produ
 require 'rspec/rails'
 require 'capybara/rails'
 require 'capybara/rspec'
-require 'active_support/cache/dalli_store'
+require 'active_support/cache/mem_cache_store'
 require 'sidekiq/testing'
 require 'mail'
 
@@ -109,7 +109,7 @@ RSpec.configure do |config|
   # rubocop:enable RSpec/HookArgument
 
   config.before(:each, :cache) do
-    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::DalliStore.new)
+    allow(Rails).to receive(:cache).and_return(ActiveSupport::Cache::MemCacheStore.new)
   end
 
   config.after(:each, type: :controller) do


### PR DESCRIPTION
I had to switch from `dalli_store` to `mem_cache_store` to avoid a bug about "undefined method `dup_value!'".