### PR TITLE
Revert "Automatically, immediately update Rack::Attack blocked IPs as needed"

### DIFF
--- a/app/controllers/admin/ip_blocks_controller.rb
+++ b/app/controllers/admin/ip_blocks_controller.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
 class Admin::IpBlocksController < Admin::ApplicationController
-  # rubocop:disable Rails/LexicallyScopedActionFilter
-  after_action :refresh_blocked_ips_list_in_memory, only: %i[create destroy update]
-  # rubocop:enable Rails/LexicallyScopedActionFilter
-
   def create
     IpBlock.create!(resource_params)
     redirect_to(admin_ip_blocks_path)
@@ -52,10 +48,4 @@ class Admin::IpBlocksController < Admin::ApplicationController
 
   # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
   # for more information
-
-  private
-
-  def refresh_blocked_ips_list_in_memory
-    Rack::Attack.cache_blocked_ips_in_memory
-  end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -17,6 +17,9 @@ class Rack::Attack
     wp1
     wp2
   ].map(&:freeze)).freeze
+  BLOCKED_IPS = Set.new(
+    (IpBlock.select(:id, :ip).find_each.map { |ip_block| ip_block.ip.freeze } rescue []),
+  ).freeze
 
   # Limit all IPs to 60 requests per clock minute
   # rubocop:disable Style/SymbolProc
@@ -24,16 +27,6 @@ class Rack::Attack
     req.ip
   end
   # rubocop:enable Style/SymbolProc
-
-  class << self
-    attr_reader :blocked_ips
-
-    def cache_blocked_ips_in_memory
-      @blocked_ips = Set.new(
-        (IpBlock.select(:id, :ip).find_each.map { |ip_block| ip_block.ip.freeze } rescue []),
-      ).freeze
-    end
-  end
 end
 
 # Block IPs requesting Wordpress paths etc.
@@ -55,7 +48,6 @@ Rack::Attack.blocklist('fail2ban pentesters') do |req|
   end
 end
 
-Rack::Attack.cache_blocked_ips_in_memory
 Rack::Attack.blocklist('blocked IPs') do |req|
-  req.ip.in?(Rack::Attack.blocked_ips)
+  req.ip.in?(Rack::Attack::BLOCKED_IPS)
 end


### PR DESCRIPTION
Reverts davidrunger/david_runger#2607

See discussion starting here: https://github.com/davidrunger/david_runger/pull/2607#issuecomment-631226941

**tl;dr:** We'll just have to restart our web dyno(s)/processes to register newly blocked (or modified, or deleted) IP addresses.