### PR TITLE
Remove `spring-commands-rspec` gem and `Guardfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,7 +61,6 @@ group :development do
   # performance analysis.
   gem 'rack-mini-profiler', require: false
   gem 'spring'
-  gem 'spring-commands-rspec'
   # We can go back to the offical spring-watcher-listen after upgrading to Rails 6.
   # See https://bit.ly/2Frtra3 (bug) and https://bit.ly/2Fpd50n (fix).
   gem 'spring-watcher-listen', '~> 2.0.2', github: 'davidrunger/spring-watcher-listen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -434,8 +434,6 @@ GEM
       simplecov-html (~> 0.11)
     simplecov-html (0.12.2)
     spring (2.1.0)
-    spring-commands-rspec (1.0.4)
-      spring (>= 0.9.1)
     sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -531,7 +529,6 @@ DEPENDENCIES
   sidekiq
   sidekiq-scheduler
   spring
-  spring-commands-rspec
   spring-watcher-listen (~> 2.0.2)!
   stackprof
   thread_safe

--- a/Guardfile
+++ b/Guardfile
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-::Guard::TARGET_SPEC_FILE ||= ENV['GUARDED_FILE']
-
-guard :espect, cmd: 'spring rspec', all_on_start: true do
-  watch(%r{^(app|config|lib|spec)/.+\.rb$}) { ::Guard::TARGET_SPEC_FILE }
-end


### PR DESCRIPTION
These were added in 99fb80d , and I am not using them. (Rather, I use `personal/Guardfile` (via `gal`), which is outside of version control.)