### PR TITLE
Remove `redis` version constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,7 @@ gem 'puma', '~> 5.0.0.beta1'
 gem 'pundit'
 gem 'rack-attack'
 gem 'rails', '>= 6.0.2.1', github: 'rails/rails'
-gem 'redis', '~>4.1'
+gem 'redis'
 gem 'rollbar'
 gem 'sidekiq'
 gem 'sidekiq-scheduler', require: false # required manually in config/initializers/sidekiq.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -517,7 +517,7 @@ DEPENDENCIES
   rack-attack
   rack-mini-profiler
   rails (>= 6.0.2.1)!
-  redis (~> 4.1)
+  redis
   rollbar
   rspec-rails
   rubocop


### PR DESCRIPTION
We had a version constraint when we initially added `redis` in 0ee63a5 , because that [was recommended by the `redis` README.md][1] at the time. We don't need this version constraint, though.

[1]: https://github.com/redis/redis-rb/tree/71efca9f8a40b1defd51b35890c6837e5d6032dd