### PR TITLE
Remove unneeded version constraints from `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'active_model_serializers', '~> 0.10.10'
+gem 'active_model_serializers'
 gem 'administrate'
 gem 'browser'
 gem 'connection_pool'
@@ -24,17 +24,17 @@ gem 'oj'
 gem 'omniauth-google-oauth2'
 # remove once https://github.com/omniauth/omniauth/pull/809 is resolved
 gem 'omniauth-rails_csrf_protection'
-gem 'pg', '~> 1.2'
+gem 'pg'
 gem 'puma', '~> 5.0.0.beta1'
 gem 'pundit'
 gem 'rack-attack'
-gem 'rails', '>= 6.0.2.1', github: 'rails/rails'
+gem 'rails', github: 'rails/rails'
 gem 'redis'
 gem 'rollbar'
 gem 'sidekiq'
 gem 'sidekiq-scheduler', require: false # required manually in config/initializers/sidekiq.rb
 gem 'thread_safe'
-gem 'webpacker', '>= 4.0.0.pre.pre.2'
+gem 'webpacker'
 
 group :development, :test do
   gem 'amazing_print'
@@ -56,14 +56,14 @@ group :development do
   gem 'binding_of_caller'
   gem 'flamegraph' # Provides flamegraphs for rack-mini-profiler.
   gem 'letter_opener'
-  gem 'listen', '>= 3.0.5', '< 3.3'
+  gem 'listen'
   # Performance profiling. Should be listed after `pg` (and `rails`?) gems to get database
   # performance analysis.
   gem 'rack-mini-profiler', require: false
   gem 'spring'
   # We can go back to the offical spring-watcher-listen after upgrading to Rails 6.
   # See https://bit.ly/2Frtra3 (bug) and https://bit.ly/2Fpd50n (fix).
-  gem 'spring-watcher-listen', '~> 2.0.2', github: 'davidrunger/spring-watcher-listen'
+  gem 'spring-watcher-listen', github: 'davidrunger/spring-watcher-listen'
   gem 'stackprof' # Provides stack traces for flamegraph for rack-mini-profiler.
 end
 
@@ -75,14 +75,13 @@ group :test do
   gem 'fixture_builder'
   # note: to use guard-espect from command line, it will also have to be installed "globally"
   gem 'guard-espect', require: false, github: 'davidrunger/guard-espect'
-  # TEMP: list hashdiff explicitly in Gemfile to force 1.0.0.beta1; remove once 1.0.0 is released
-  gem 'hashdiff', '1.0.1'
+  gem 'hashdiff'
   # for testing ActiveModelSerializers
   gem 'json-schema'
   gem 'launchy' # for save_and_open_page in feature specs
   gem 'percy-capybara'
   gem 'rspec-rails'
   gem 'selenium-webdriver'
-  gem 'shoulda-matchers', '~> 4.3'
+  gem 'shoulda-matchers'
   gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -473,7 +473,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_model_serializers (~> 0.10.10)
+  active_model_serializers
   administrate
   amazing_print
   annotate
@@ -494,13 +494,13 @@ DEPENDENCIES
   flamegraph
   guard-espect!
   hamlit
-  hashdiff (= 1.0.1)
+  hashdiff
   httparty
   js-routes
   json-schema
   launchy
   letter_opener
-  listen (>= 3.0.5, < 3.3)
+  listen
   lograge
   memoist
   newrelic_rpm
@@ -508,7 +508,7 @@ DEPENDENCIES
   omniauth-google-oauth2
   omniauth-rails_csrf_protection
   percy-capybara
-  pg (~> 1.2)
+  pg
   pry
   pry-byebug
   pry-rails
@@ -516,7 +516,7 @@ DEPENDENCIES
   pundit
   rack-attack
   rack-mini-profiler
-  rails (>= 6.0.2.1)!
+  rails!
   redis
   rollbar
   rspec-rails
@@ -525,15 +525,15 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   selenium-webdriver
-  shoulda-matchers (~> 4.3)
+  shoulda-matchers
   sidekiq
   sidekiq-scheduler
   spring
-  spring-watcher-listen (~> 2.0.2)!
+  spring-watcher-listen!
   stackprof
   thread_safe
   webmock
-  webpacker (>= 4.0.0.pre.pre.2)
+  webpacker
 
 RUBY VERSION
    ruby 2.7.1p83


### PR DESCRIPTION
One advantage of removing these version constraints is that it causes less `git` noise in the `Gemfile`. We have configured Dependabot to bump gems even if doing so requires relaxing/changing the version constraint in the `Gemfile`. So having these version constraints wasn't really doing anything, anyway, other than causing changes in the `Gemfile` when dependabot bumped these gems.