### PR TITLE
Move parent onto its own line in item.spec.js

### DIFF
--- a/spec/javascript/groceries/components/item.spec.js
+++ b/spec/javascript/groceries/components/item.spec.js
@@ -36,7 +36,8 @@ describe('Item', function () { // eslint-disable-line func-names, prefer-arrow-c
           item,
         },
         store: groceryVuexStoreFactory(bootstrap),
-      });
+      },
+    );
   });
 
   it('renders item.name in a span', () => {


### PR DESCRIPTION
`eslint` was previously complaining about me doing this, I think, but evidently it's not complaining now (maybe because of some fix).