### PR TITLE
Use `JSON.pretty_generate` rather than `#ai` in invalid records email

### DIFF
--- a/app/views/invalid_records_mailer/invalid_records.haml
+++ b/app/views/invalid_records_mailer/invalid_records.haml
@@ -1,4 +1,4 @@
 %div There are one or more invalid records.
 
 %div
-  %code{style: 'font-family: monospace; white-space: pre;'}= @invalid_records_count_hash.ai(plain: true)
+  %code{style: 'font-family: monospace; white-space: pre;'}= JSON.pretty_generate(@invalid_records_count_hash)


### PR DESCRIPTION
`#ai` / `amazing_print` isn't available in `production`.