### PR TITLE
Create IpBlock for pentesters who reach fail2ban limit

### DIFF
--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -10,6 +10,14 @@
 #  reason     :text
 #  updated_at :datetime         not null
 #
+# Indexes
+#
+#  index_ip_blocks_on_ip  (ip) UNIQUE
+#
 class IpBlock < ApplicationRecord
-  validates :ip, presence: true, length: {maximum: 15}, format: {with: /\A([0-9]{1,3}\.?){4}\z/}
+  validates :ip,
+    presence: true,
+    length: {maximum: 15},
+    format: {with: /\A([0-9]{1,3}\.?){4}\z/},
+    uniqueness: true
 end

--- a/config/initializers/monkeypatches.rb
+++ b/config/initializers/monkeypatches.rb
@@ -33,3 +33,14 @@ module PresenceBangMonkeypatch
   end
 end
 Object.prepend(PresenceBangMonkeypatch)
+
+# Emit an event when an IP address is banned via Rack::Attack's fail2ban system.
+# (Rack::Attack emits other events like this already, but not one specifically in this scenario.)
+module InstrumentFail2BanEvent
+  def ban!(discriminator, _bantime)
+    return_value = super
+    ActiveSupport::Notifications.instrument('fail2banned.rack_attack', discriminator: discriminator)
+    return_value
+  end
+end
+Rack::Attack::Fail2Ban.singleton_class.prepend(InstrumentFail2BanEvent)

--- a/db/migrate/20200523013408_add_unique_index_on_ip_blocks_ip.rb
+++ b/db/migrate/20200523013408_add_unique_index_on_ip_blocks_ip.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnIpBlocksIp < ActiveRecord::Migration[6.1]
+  def change
+    add_index :ip_blocks, :ip, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_20_022949) do
+ActiveRecord::Schema.define(version: 2020_05_23_013408) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2020_05_20_022949) do
     t.text "reason"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["ip"], name: "index_ip_blocks_on_ip", unique: true
   end
 
   create_table "items", force: :cascade do |t|

--- a/spec/factories/ip_blocks.rb
+++ b/spec/factories/ip_blocks.rb
@@ -10,6 +10,10 @@
 #  reason     :text
 #  updated_at :datetime         not null
 #
+# Indexes
+#
+#  index_ip_blocks_on_ip  (ip) UNIQUE
+#
 FactoryBot.define do
   factory :ip_block do
     ip { Faker::Internet.ip_v4_address }


### PR DESCRIPTION
This way, we can (a) better track these blocks and (b) block the pentesters for longer.