### PR TITLE
Enable `rack-mini-profiler` in production for admin? users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'browser'
 gem 'connection_pool'
 gem 'dalli'
 gem 'devise'
+gem 'flamegraph' # Provides flamegraphs for rack-mini-profiler.
 gem 'hamlit'
 gem 'httparty'
 gem 'js-routes', require: false
@@ -28,11 +29,13 @@ gem 'pg'
 gem 'puma', '~> 5.0.0.beta1'
 gem 'pundit'
 gem 'rack-attack'
+gem 'rack-mini-profiler', require: false
 gem 'rails', github: 'rails/rails'
 gem 'redis'
 gem 'rollbar'
 gem 'sidekiq'
 gem 'sidekiq-scheduler', require: false # required manually in config/initializers/sidekiq.rb
+gem 'stackprof' # Provides stack traces for flamegraph for rack-mini-profiler.
 gem 'thread_safe'
 gem 'webpacker'
 
@@ -55,17 +58,14 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'flamegraph' # Provides flamegraphs for rack-mini-profiler.
   gem 'letter_opener'
   gem 'listen'
   # Performance profiling. Should be listed after `pg` (and `rails`?) gems to get database
   # performance analysis.
-  gem 'rack-mini-profiler', require: false
   gem 'spring'
   # We can go back to the offical spring-watcher-listen after upgrading to Rails 6.
   # See https://bit.ly/2Frtra3 (bug) and https://bit.ly/2Fpd50n (fix).
   gem 'spring-watcher-listen', github: 'davidrunger/spring-watcher-listen'
-  gem 'stackprof' # Provides stack traces for flamegraph for rack-mini-profiler.
 end
 
 group :test do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :authenticate_user
+  before_action :enable_rack_mini_profiler_if_admin
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
@@ -34,6 +35,12 @@ class ApplicationController < ActionController::Base
 
   def after_sign_out_path_for(_resource_or_scope)
     login_path
+  end
+
+  def enable_rack_mini_profiler_if_admin
+    if current_user&.admin?
+      Rack::MiniProfiler.authorize_request
+    end
   end
 
   def filtered_params

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -1,8 +1,14 @@
 # frozen_string_literal: true
 
-if Rails.env.development? && ENV['ENABLE_PROFILER'].present?
+if (Rails.env.development? && ENV['ENABLE_PROFILER'].present?) || Rails.env.production?
   require 'rack-mini-profiler'
 
-  # initialization is skipped so trigger it
   Rack::MiniProfilerRails.initialize!(Rails.application)
+
+  Rails.configuration.middleware.move_after(Rack::Deflater, Rack::MiniProfiler)
+
+  Rack::MiniProfiler.config.storage_options = {url: ENV['REDIS_URL']}
+  Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
+
+  Rack::MiniProfiler.config.authorization_mode = :whitelist
 end


### PR DESCRIPTION
I plan to use this to see if I can optimize log entry serialization times (and anything else).