### PR TITLE
Use `read_attribute_before_type_cast('created_at')` for log entries

### DIFF
--- a/app/serializers/log_entry_serializer.rb
+++ b/app/serializers/log_entry_serializer.rb
@@ -19,7 +19,7 @@ class LogEntrySerializer < ActiveModel::Serializer
   attributes :id, :created_at, :data, :log_id, :note
 
   def created_at
-    log_entry.created_at.utc.iso8601
+    log_entry.read_attribute_before_type_cast('created_at').iso8601
   end
 
   private


### PR DESCRIPTION
I'm hoping that this will speed up log serialization a little bit. I'm going to merge it without a performance benchmark, because I don't trust a non-performance benchmark of this, anyway.