### PR TITLE
Move save-workout confirmation from `window.confirm` to proper modal

### DIFF
--- a/app/javascript/packs/workout_app.js
+++ b/app/javascript/packs/workout_app.js
@@ -1,4 +1,5 @@
 import { renderApp } from 'shared/customized_vue';
 import WorkoutApp from 'workout/workout.vue';
+import store from 'workout/store';
 
-renderApp(WorkoutApp);
+renderApp(WorkoutApp, { store });

--- a/app/javascript/workout/confirm_workout_modal.vue
+++ b/app/javascript/workout/confirm_workout_modal.vue
@@ -1,0 +1,71 @@
+<template lang="pug">
+Modal(:name='modalName' width='85%', maxWidth='400px')
+  slot
+    h2.bold.mb2 Confirm workout
+    div #[b Minutes:] {{(timeInSeconds / 60).toFixed(1)}}
+    div #[b Rep totals:] {{JSON.stringify(repTotals)}}
+    div.flex.justify-around.mt2
+      el-button(
+        @click="$store.commit('hideModal', { modalName })"
+        type='text'
+      ) Cancel
+      el-button(
+        type='primary'
+        @click='saveWorkout'
+      ) Save workout
+</template>
+
+<script>
+import { get } from 'lodash';
+import Toastify from 'toastify-js';
+import 'toastify-js/src/toastify.css';
+
+export default {
+  data() {
+    return {
+      modalName: 'confirm-workout',
+    };
+  },
+
+  methods: {
+    saveWorkout() {
+      this.$http.post(this.$routes.api_workouts_path(), {
+        workout: {
+          time_in_seconds: this.timeInSeconds,
+          rep_totals: this.repTotals,
+        },
+      }).then((response) => {
+        if (response.status === 201) {
+          Toastify({
+            text: 'Workout completion logged successfully!',
+            className: 'success',
+            position: 'center',
+            duration: 2500,
+          }).showToast();
+
+          this.$store.commit('hideModal', { modalName: this.modalName });
+        }
+      }).catch((error) => {
+        const errorMessage = get(error, 'response.data.error', 'Something went wrong');
+        Toastify({
+          text: errorMessage,
+          className: 'error',
+          position: 'center',
+          duration: 2500,
+        }).showToast();
+      });
+    },
+  },
+
+  props: {
+    repTotals: {
+      type: Object,
+      required: true,
+    },
+    timeInSeconds: {
+      type: Number,
+      required: true,
+    },
+  },
+};
+</script>

--- a/app/javascript/workout/store.js
+++ b/app/javascript/workout/store.js
@@ -1,0 +1,32 @@
+import Vuex from 'vuex';
+
+import * as ModalVuex from 'shared/modal_store';
+
+const mutations = {
+  ...ModalVuex.mutations,
+};
+
+const actions = {};
+
+const getters = {
+  ...ModalVuex.getters,
+};
+
+function initialState(bootstrap) {
+  return {
+    ...bootstrap,
+    ...ModalVuex.state,
+  };
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export function workoutVuexStoreFactory(bootstrap) {
+  return new Vuex.Store({
+    state: initialState(bootstrap),
+    actions,
+    getters,
+    mutations,
+  });
+}
+
+export default workoutVuexStoreFactory(window.davidrunger.bootstrap);


### PR DESCRIPTION
This will allow flexibility in the UX for tweaking rep counts before submitting the workout and/or marking the workout as publicly viewable, which we'll likely leverage in the future. In the meantime, the formatting is nicer than a `window.confirm` dialog.