### PR TITLE
Add spaces inside all Ruby hash literals

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,7 +47,7 @@ Layout/SpaceBeforeBlockBraces:
 Layout/SpaceBeforeSemicolon:
   Enabled: false
 Layout/SpaceInsideHashLiteralBraces:
-  EnforcedStyle: no_space
+  EnforcedStyle: space
 Lint/RedundantSplatExpansion:
   Enabled: false
 Metrics/AbcSize:

--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -13,7 +13,7 @@ class Api::ItemsController < ApplicationController
     if @item.update(item_params)
       render json: @item
     else
-      render json: {errors: @item.errors.to_hash}, status: :unprocessable_entity
+      render json: { errors: @item.errors.to_hash }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/log_entries_controller.rb
+++ b/app/controllers/api/log_entries_controller.rb
@@ -7,7 +7,7 @@ class Api::LogEntriesController < ApplicationController
     if @log_entry.save
       render json: @log_entry, status: :created
     else
-      render json: {errors: @log_entry.errors.to_hash}, status: :unprocessable_entity
+      render json: { errors: @log_entry.errors.to_hash }, status: :unprocessable_entity
     end
   end
 
@@ -19,7 +19,7 @@ class Api::LogEntriesController < ApplicationController
     if @log_entry.update(log_entry_params)
       render json: @log_entry, status: :ok
     else
-      render json: {errors: @log_entry.errors.to_hash}, status: :unprocessable_entity
+      render json: { errors: @log_entry.errors.to_hash }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/log_shares_controller.rb
+++ b/app/controllers/api/log_shares_controller.rb
@@ -8,7 +8,7 @@ class Api::LogSharesController < ApplicationController
     if @log_share.save
       render json: @log_share, status: :created
     else
-      render json: {errors: @log_share.errors.to_hash}, status: :unprocessable_entity
+      render json: { errors: @log_share.errors.to_hash }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/logs_controller.rb
+++ b/app/controllers/api/logs_controller.rb
@@ -13,7 +13,7 @@ class Api::LogsController < ApplicationController
         errors=#{@log.errors.to_hash}
         attributes=#{@log.attributes}
       LOG
-      render json: {errors: @log.errors.to_hash}, status: :unprocessable_entity
+      render json: { errors: @log.errors.to_hash }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/api/stores_controller.rb
+++ b/app/controllers/api/stores_controller.rb
@@ -8,7 +8,7 @@ class Api::StoresController < ApplicationController
     if @store.save
       render json: @store, status: :created
     else
-      render json: {errors: @store.errors.to_hash}, status: :unprocessable_entity
+      render json: { errors: @store.errors.to_hash }, status: :unprocessable_entity
     end
   end
 
@@ -16,7 +16,7 @@ class Api::StoresController < ApplicationController
     if @store.update(store_params)
       render json: @store
     else
-      render json: {errors: @store.errors.to_hash}, status: :unprocessable_entity
+      render json: { errors: @store.errors.to_hash }, status: :unprocessable_entity
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -49,7 +49,7 @@ class ApplicationController < ActionController::Base
   end
 
   def render_json_error(message = 'There was a problem with your request', status = 400)
-    render json: {error: message}, status: status
+    render json: { error: message }, status: status
   end
 
   def user_not_authorized

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -28,10 +28,10 @@ class LogsController < ApplicationController
 
   def log_input_types
     [
-      {data_type: 'counter', label: 'Counter'},
-      {data_type: 'duration', label: 'Duration'},
-      {data_type: 'number', label: 'Number'},
-      {data_type: 'text', label: 'Text'},
+      { data_type: 'counter', label: 'Counter' },
+      { data_type: 'duration', label: 'Duration' },
+      { data_type: 'number', label: 'Number' },
+      { data_type: 'text', label: 'Text' },
     ]
   end
 end

--- a/app/form_objects/sms_message.rb
+++ b/app/form_objects/sms_message.rb
@@ -67,7 +67,7 @@ class SmsMessage
     ApplicationController.render(
       'sms_messages/grocery_list',
       layout: nil,
-      locals: {store: store},
+      locals: { store: store },
     ).rstrip
   end
 end

--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -17,7 +17,7 @@
 class IpBlock < ApplicationRecord
   validates :ip,
     presence: true,
-    length: {maximum: 15},
-    format: {with: /\A([0-9]{1,3}\.?){4}\z/},
+    length: { maximum: 15 },
+    format: { with: /\A([0-9]{1,3}\.?){4}\z/ },
     uniqueness: true
 end

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -39,7 +39,7 @@ class Log < ApplicationRecord
 
   validates :data_label, presence: true
   validates :data_type, presence: true, inclusion: DATA_TYPES.keys
-  validates :name, presence: true, uniqueness: {scope: :user_id}
+  validates :name, presence: true, uniqueness: { scope: :user_id }
   validates :slug, presence: true
 
   belongs_to :user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   devise :omniauthable, omniauth_providers: [:google_oauth2]
 
   validates :email, presence: true
-  validates :phone, format: {with: /\A[0-9\-.+()]+\z/}, allow_nil: true
+  validates :phone, format: { with: /\A[0-9\-.+()]+\z/ }, allow_nil: true
 
   has_many :logs, dependent: :destroy
   has_many :log_shares, through: :logs

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -20,7 +20,7 @@
 class Workout < ApplicationRecord
   belongs_to :user
 
-  validates :publicly_viewable, inclusion: {in: [false, true]}
+  validates :publicly_viewable, inclusion: { in: [false, true] }
   validates :rep_totals, presence: true
-  validates :time_in_seconds, presence: true, numericality: {greater_than: 0}
+  validates :time_in_seconds, presence: true, numericality: { greater_than: 0 }
 end

--- a/config/initializers/rack_profiler.rb
+++ b/config/initializers/rack_profiler.rb
@@ -7,7 +7,7 @@ if Rails.configuration.rack_mini_profiler_enabled
 
   Rails.configuration.middleware.move_after(Rack::Deflater, Rack::MiniProfiler)
 
-  Rack::MiniProfiler.config.storage_options = {url: ENV['REDIS_URL']}
+  Rack::MiniProfiler.config.storage_options = { url: ENV['REDIS_URL'] }
   Rack::MiniProfiler.config.storage = Rack::MiniProfiler::RedisStore
 
   Rack::MiniProfiler.config.authorization_mode = :whitelist

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
   root to: 'home#index'
   get 'upgrade_browser', to: 'home#upgrade_browser'
 
-  devise_for :users, controllers: {omniauth_callbacks: 'users/omniauth_callbacks'}
+  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
   devise_scope :user do
     delete 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
   end
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
     get 'logs/:slug', to: 'logs#index', as: :shared_log
   end
 
-  namespace :api, defaults: {format: :json} do
+  namespace :api, defaults: { format: :json } do
     resources :items, only: %i[update destroy]
     resources :log_entries, only: %i[create destroy index update]
     resources :log_shares, only: %i[create destroy]

--- a/db/datamigrate/convert_weight_logs_to_general_logs.rb
+++ b/db/datamigrate/convert_weight_logs_to_general_logs.rb
@@ -8,7 +8,7 @@ def convert_weight_logs_to_general_logs
     user.weight_logs.find_each do |weight_log_entry|
       weight_log.log_entries.create!(
         created_at: weight_log_entry.created_at,
-        data: {Weight: weight_log_entry.weight},
+        data: { Weight: weight_log_entry.weight },
       )
     end
   end

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::ItemsController do
     subject(:post_create) { post(:create, params: params) }
 
     context 'when the item params are valid' do
-      let(:valid_params) { {store_id: store.id, item: {name: 'Milk', store_id: store.id}} }
+      let(:valid_params) { { store_id: store.id, item: { name: 'Milk', store_id: store.id } } }
       let(:params) { valid_params }
 
       it 'returns a 201 status code' do
@@ -28,12 +28,12 @@ RSpec.describe Api::ItemsController do
     subject(:patch_update) { patch(:update, params: params) }
 
     let(:item) { items(:item) }
-    let(:base_params) { {id: item.id} }
+    let(:base_params) { { id: item.id } }
 
     context 'when attempting to update the item of another user' do
       let(:owning_user) { item.store.user }
       let(:user) { User.where.not(id: owning_user).first! }
-      let(:params) { base_params.merge(item: {name: item.name + ' Changed'}) }
+      let(:params) { base_params.merge(item: { name: item.name + ' Changed' }) }
 
       it 'does not update the item' do
         expect { patch_update }.not_to change { item.reload.attributes }
@@ -46,7 +46,7 @@ RSpec.describe Api::ItemsController do
     end
 
     context 'when the item is being updated with invalid params' do
-      let(:invalid_params) { {item: {name: ''}} }
+      let(:invalid_params) { { item: { name: '' } } }
       let(:params) { base_params.merge(invalid_params) }
 
       it 'does not update the item' do
@@ -60,7 +60,7 @@ RSpec.describe Api::ItemsController do
     end
 
     context 'when the item is being updated with valid params' do
-      let(:valid_params) { {item: {name: item.name + ' Changed'}} }
+      let(:valid_params) { { item: { name: item.name + ' Changed' } } }
       let(:params) { base_params.merge(valid_params) }
 
       it 'updates the item' do
@@ -75,7 +75,7 @@ RSpec.describe Api::ItemsController do
   end
 
   describe '#destroy' do
-    subject(:delete_destroy) { delete(:destroy, params: {id: item.id}) }
+    subject(:delete_destroy) { delete(:destroy, params: { id: item.id }) }
 
     let(:item) { items(:item) }
 

--- a/spec/controllers/api/log_entries_controller_spec.rb
+++ b/spec/controllers/api/log_entries_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Api::LogEntriesController do
     subject(:post_create) { post(:create, params: params) }
 
     context 'when the log entry params are invalid' do
-      let(:invalid_params) { {log_entry: {data: nil, log_id: log.id}} }
+      let(:invalid_params) { { log_entry: { data: nil, log_id: log.id } } }
       let(:params) { invalid_params }
 
       it 'returns a 422 status code' do
@@ -22,7 +22,7 @@ RSpec.describe Api::LogEntriesController do
 
     context 'when the log entry params are valid' do
       let(:log) { user.logs.where(data_type: 'number').first! }
-      let(:valid_params) { {log_entry: {data: 122, log_id: log.id}} }
+      let(:valid_params) { { log_entry: { data: 122, log_id: log.id } } }
       let(:params) { valid_params }
 
       it 'returns a 201 status code' do
@@ -38,7 +38,7 @@ RSpec.describe Api::LogEntriesController do
 
       context 'when there is a note in the log entry params' do
         let(:params_with_note) do
-          valid_params.deep_merge(log_entry: {note: 'Had a lot of salt yesterday'})
+          valid_params.deep_merge(log_entry: { note: 'Had a lot of salt yesterday' })
         end
 
         it 'creates a log entry with a note' do
@@ -56,12 +56,12 @@ RSpec.describe Api::LogEntriesController do
     subject(:patch_update) { patch(:update, params: params) }
 
     let(:log_entry) { logs(:text_log).log_entries.first! }
-    let(:base_params) { {id: log_entry.id} }
+    let(:base_params) { { id: log_entry.id } }
 
     context 'when attempting to update the log entry of another user' do
       let(:owning_user) { log_entry.log.user }
       let(:user) { User.where.not(id: owning_user).first! }
-      let(:params) { base_params.merge(log_entry: {data: log_entry.data + ' ...changed.'}) }
+      let(:params) { base_params.merge(log_entry: { data: log_entry.data + ' ...changed.' }) }
 
       it 'does not update the log_entry' do
         expect { patch_update }.not_to change { log_entry.reload.attributes }
@@ -74,7 +74,7 @@ RSpec.describe Api::LogEntriesController do
     end
 
     context 'when the log entry is being updated with invalid params' do
-      let(:invalid_params) { {log_entry: {data: ''}} }
+      let(:invalid_params) { { log_entry: { data: '' } } }
       let(:params) { base_params.merge(invalid_params) }
 
       it 'does not update the log_entry' do
@@ -88,7 +88,7 @@ RSpec.describe Api::LogEntriesController do
     end
 
     context 'when the log entry is being updated with valid params' do
-      let(:valid_params) { {log_entry: {data: log_entry.data + ' ...changed.'}} }
+      let(:valid_params) { { log_entry: { data: log_entry.data + ' ...changed.' } } }
       let(:params) { base_params.merge(valid_params) }
 
       it 'updates the log_entry' do
@@ -155,7 +155,7 @@ RSpec.describe Api::LogEntriesController do
     subject(:get_index) { get(:index, params: params) }
 
     context 'when a log_id param is provided' do
-      let(:params) { {log_id: log.id} }
+      let(:params) { { log_id: log.id } }
 
       it 'returns data only about that particular log' do
         get_index
@@ -183,7 +183,7 @@ RSpec.describe Api::LogEntriesController do
             log_entry.slice('id')
           end
         expected_simplified_response_data =
-          user.logs.map(&:log_entries).flatten.map { |log_entry| {'id' => log_entry.id} }
+          user.logs.map(&:log_entries).flatten.map { |log_entry| { 'id' => log_entry.id } }
 
         expect(simplified_response_data).to match_array(expected_simplified_response_data)
       end

--- a/spec/controllers/api/log_shares_controller_spec.rb
+++ b/spec/controllers/api/log_shares_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Api::LogSharesController do
     subject(:post_create) { post(:create, params: params) }
 
     context 'when the log share params are invalid' do
-      let(:invalid_params) { {log_share: {email: nil, log_id: log.id}} }
+      let(:invalid_params) { { log_share: { email: nil, log_id: log.id } } }
       let(:params) { invalid_params }
 
       it 'returns a 422 status code' do
@@ -20,7 +20,7 @@ RSpec.describe Api::LogSharesController do
     end
 
     context 'when the log share params are valid' do
-      let(:valid_params) { {log_share: {email: Faker::Internet.email, log_id: log.id}} }
+      let(:valid_params) { { log_share: { email: Faker::Internet.email, log_id: log.id } } }
       let(:params) { valid_params }
 
       it 'returns a 201 status code' do
@@ -35,7 +35,7 @@ RSpec.describe Api::LogSharesController do
   end
 
   describe '#destroy' do
-    subject(:delete_destroy) { delete(:destroy, params: {id: log_share.id}) }
+    subject(:delete_destroy) { delete(:destroy, params: { id: log_share.id }) }
 
     let(:log_share) { log_shares(:log_share) }
 

--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Api::LogsController do
     end
 
     context 'when the log being created is invalid' do
-      let(:invalid_params) { {log: {name: ''}} }
+      let(:invalid_params) { { log: { name: '' } } }
       let(:params) { invalid_params }
 
       # rubocop:disable RSpec/MultipleExpectations
@@ -77,7 +77,7 @@ RSpec.describe Api::LogsController do
       let(:log) { logs(:number_log) }
 
       context 'when the params have `publicly_viewable: true`' do
-        let(:params) { {id: log.id, log: {publicly_viewable: true}} }
+        let(:params) { { id: log.id, log: { publicly_viewable: true } } }
 
         it 'changes the log to `publicly_viewable: true`' do
           expect { patch_update }.
@@ -105,7 +105,7 @@ RSpec.describe Api::LogsController do
   end
 
   describe '#destroy' do
-    subject(:delete_destroy) { delete(:destroy, params: {id: log.id}) }
+    subject(:delete_destroy) { delete(:destroy, params: { id: log.id }) }
 
     let(:log) { logs(:number_log) }
 

--- a/spec/controllers/api/stores_controller_spec.rb
+++ b/spec/controllers/api/stores_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::StoresController do
     subject(:post_create) { post(:create, params: params) }
 
     context 'when the store being created is invalid' do
-      let(:invalid_params) { {store: {name: ''}} }
+      let(:invalid_params) { { store: { name: '' } } }
       let(:params) { invalid_params }
 
       it 'does not create a store' do
@@ -23,7 +23,7 @@ RSpec.describe Api::StoresController do
     end
 
     context 'when the store being created is valid' do
-      let(:valid_params) { {store: {name: 'Walmart'}} }
+      let(:valid_params) { { store: { name: 'Walmart' } } }
       let(:params) { valid_params }
 
       it 'creates a store' do
@@ -41,12 +41,12 @@ RSpec.describe Api::StoresController do
     subject(:patch_update) { patch(:update, params: params) }
 
     let(:store) { stores(:store) }
-    let(:base_params) { {id: store.id} }
+    let(:base_params) { { id: store.id } }
 
     context 'when attempting to update the store of another user' do
       let(:owning_user) { store.user }
       let(:user) { User.where.not(id: owning_user).first! }
-      let(:params) { base_params.merge(store: {name: store.name + ' Changed'}) }
+      let(:params) { base_params.merge(store: { name: store.name + ' Changed' }) }
 
       it 'does not update the store' do
         expect { patch_update }.not_to change { store.reload.attributes }
@@ -59,7 +59,7 @@ RSpec.describe Api::StoresController do
     end
 
     context 'when the store is being updated with invalid params' do
-      let(:invalid_params) { {store: {name: ''}} }
+      let(:invalid_params) { { store: { name: '' } } }
       let(:params) { base_params.merge(invalid_params) }
 
       it 'does not update the store' do
@@ -73,7 +73,7 @@ RSpec.describe Api::StoresController do
     end
 
     context 'when the store is being updated with valid params' do
-      let(:valid_params) { {store: {name: store.name + ' Changed'}} }
+      let(:valid_params) { { store: { name: store.name + ' Changed' } } }
       let(:params) { base_params.merge(valid_params) }
 
       it 'updates the store' do
@@ -88,7 +88,7 @@ RSpec.describe Api::StoresController do
   end
 
   describe '#destroy' do
-    subject(:delete_destroy) { delete(:destroy, params: {id: store.id}) }
+    subject(:delete_destroy) { delete(:destroy, params: { id: store.id }) }
 
     let(:store) { stores(:store) }
 

--- a/spec/controllers/api/workouts_controller_spec.rb
+++ b/spec/controllers/api/workouts_controller_spec.rb
@@ -9,7 +9,9 @@ RSpec.describe Api::WorkoutsController do
     subject(:post_create) { post(:create, params: params) }
 
     context 'when the item params are valid' do
-      let(:valid_params) { { workout: { time_in_seconds: 600, rep_totals: { chinups: 2, pushups: 9 } } } }
+      let(:valid_params) do
+        { workout: { time_in_seconds: 600, rep_totals: { chinups: 2, pushups: 9 } } }
+      end
       let(:params) { valid_params }
 
       it 'returns a 201 status code' do

--- a/spec/controllers/api/workouts_controller_spec.rb
+++ b/spec/controllers/api/workouts_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Api::WorkoutsController do
     subject(:post_create) { post(:create, params: params) }
 
     context 'when the item params are valid' do
-      let(:valid_params) { {workout: {time_in_seconds: 600, rep_totals: {chinups: 2, pushups: 9}}} }
+      let(:valid_params) { { workout: { time_in_seconds: 600, rep_totals: { chinups: 2, pushups: 9 } } } }
       let(:params) { valid_params }
 
       it 'returns a 201 status code' do

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe ApplicationController do
 
       context 'when a request is made with a redirect_to param' do
         let(:redirect_to_path) { '/runger' }
-        let(:params) { {redirect_to: redirect_to_path} }
+        let(:params) { { redirect_to: redirect_to_path } }
 
         it "stores the value of the redirect_to param in the user's session" do
           expect { get_index }.to change { session['redirect_to'] }.from(nil).to(redirect_to_path)

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -6,10 +6,10 @@ RSpec.describe UsersController do
   let(:user) { users(:user) }
 
   describe '#update' do
-    subject(:patch_update_user) { patch(:update, params: {id: user.id, user: user_params}) }
+    subject(:patch_update_user) { patch(:update, params: { id: user.id, user: user_params }) }
 
     let(:new_phone_number) { "1555#{rand(10_000_000)}" }
-    let(:user_params) { {phone: new_phone_number} }
+    let(:user_params) { { phone: new_phone_number } }
 
     before { user.update!(phone: '11231231234') }
 

--- a/spec/factories/workouts.rb
+++ b/spec/factories/workouts.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
   factory :workout do
     association :user
     time_in_seconds { Integer(45.minutes) }
-    rep_totals { {chinups: 100, pushups: 300} }
+    rep_totals { { chinups: 100, pushups: 300 } }
     publicly_viewable { false }
   end
 end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe 'Home page' do
           'as' => 'AS20001 Charter Communications Inc',
           'query' => '76.167.213.95',
         }.to_json,
-        headers: {'content-type' => 'application/json; charset=utf-8'},
+        headers: { 'content-type' => 'application/json; charset=utf-8' },
       )
   end
 
@@ -61,7 +61,7 @@ RSpec.describe 'Home page' do
       Full stack web developer
     HEADLINE
 
-    Percy.snapshot(page, {name: 'Homepage'})
+    Percy.snapshot(page, { name: 'Homepage' })
 
     expect(ip_info_request_stub).to have_been_requested
   end

--- a/spec/form_objects/sms_message_spec.rb
+++ b/spec/form_objects/sms_message_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SmsMessage do
   let(:user) { users(:user) }
   let(:message_type) { 'grocery_store_items_needed' }
   let(:store) { user.stores.first! }
-  let(:message_params) { {'store_id' => store.id} }
+  let(:message_params) { { 'store_id' => store.id } }
 
   describe 'validations' do
     subject(:error_messages) do

--- a/spec/lib/error_logger_spec.rb
+++ b/spec/lib/error_logger_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe ErrorLogger do
 
     it 'calls Rollbar.warn with the expected arguments' do
       expect(Rollbar).to receive(:warn).
-        with(StandardError, {user_id: 123}).
+        with(StandardError, { user_id: 123 }).
         and_call_original
 
       warn

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,7 @@ Capybara.default_driver = :rack_test
 Capybara.javascript_driver = :chrome_headless
 # allow loading JS & CSS assets via `save_and_open_page` when running `rails s`
 Capybara.asset_host = 'http://localhost:3000'
-Capybara.server = :puma, {Silent: true}
+Capybara.server = :puma, { Silent: true }
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are

--- a/spec/support/vendor_api/nexmo_test_api.rb
+++ b/spec/support/vendor_api/nexmo_test_api.rb
@@ -7,7 +7,7 @@ module NexmoTestApi
     WebMock.stub_request(:post, 'https://rest.nexmo.com/sms/json').
       to_return(
         status: 200,
-        headers: {'Content-Type' => 'application/json'},
+        headers: { 'Content-Type' => 'application/json' },
         body: JSON.dump(single_message_response),
       )
   end
@@ -17,7 +17,7 @@ module NexmoTestApi
     WebMock.stub_request(:post, 'https://rest.nexmo.com/sms/json').
       to_return(
         status: 400,
-        headers: {'Content-Type' => 'application/json'},
+        headers: { 'Content-Type' => 'application/json' },
         body: JSON.dump('errors' => ['something went wrong']),
       )
   end


### PR DESCRIPTION
```
bin/rubocop `git ls-tree -r HEAD --name-only` --force-exclusion --only Layout/SpaceInsideHashLiteralBraces --auto-correct
```

I'm making this change because 71% of respondents to this survey https://metaredux.com/posts/2020/05/26/rubocop-defaults-survey-results.html said they use spaces in Ruby hash literals, and I want to follow the prevailing convention.