### PR TITLE
Add additional metadata to `<head>` (`og:image`, etc.)

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -3,10 +3,23 @@
   %head
     %meta{charset: 'UTF-8'}
     %meta{name: 'viewport', content: 'width=device-width, initial-scale=1'}
-    %meta{name: 'author', content: 'David Runger'}
+
+    -# title
+    - title = "#{@title.present? ? "#{@title} - " : ''}David Runger"
+    %title= title
+    %meta{name: 'title', content: title}
+    %meta{property: 'og:title', content: title}
+
+    -# other metadata
+    - if current_page?(controller: 'home', action: 'index')
+      %meta{name: 'author', content: 'David Runger'}
+      %meta{property: 'og:type', content: 'website'}
+      %meta{property: 'og:url', content: 'https://www.davidrunger.com/'}
+      %meta{property: 'og:image', content: image_url('david.jpg')}
     - if @description.present?
       %meta{name: 'description', content: @description}
-    %title #{@title.present? ? "#{@title} - " : ''}David Runger
+      %meta{property: 'og:description', content: @description}
+
     = csrf_meta_tags
     %script{type: "text/javascript"}
       window.davidrunger = {env: '#{Rails.env}'};


### PR DESCRIPTION
The image doesn't look quite right on websites that are looking for a more horizontal image / try to coerce the image dimensions, but whatever; I don't really care. It gets the point across, as it is.

https://metatags.io/

![image](https://user-images.githubusercontent.com/8197963/82979835-e55ccc00-9f9c-11ea-90a2-5fb4d6229396.png)
