### PR TITLE
Format line graph timestamp nicely and in local time in hover tooltip

### DIFF
--- a/app/javascript/components/charts/line_chart.js
+++ b/app/javascript/components/charts/line_chart.js
@@ -28,7 +28,13 @@ export const optionsDefaults = {
   maintainAspectRatio: false,
   responsive: true,
   scales: {
-    xAxes: [axisOptions],
+    xAxes: [{
+      ...axisOptions,
+      type: 'time',
+      time: {
+        tooltipFormat: 'MMMM DD YYYY, h:mma',
+      },
+    }],
     yAxes: [axisOptions],
   },
   tooltips: {


### PR DESCRIPTION
# Before

![image](https://user-images.githubusercontent.com/8197963/83072129-154eb280-a023-11ea-95d8-f347debe8d9c.png)

# After

![image](https://user-images.githubusercontent.com/8197963/83072030-ea645e80-a022-11ea-8672-93f48b9ba22c.png)