### PR TITLE
Stop showing new log form on log show pages (only show on index page)

### DIFF
--- a/app/javascript/logs/components/logs_index.vue
+++ b/app/javascript/logs/components/logs_index.vue
@@ -3,16 +3,31 @@ section
   ul
     li.log-link-container.m1.h2(v-for='log in logs')
       router-link.log-link(:to='{ name: "log", params: { slug: log.slug }}') {{log.name}}
+  el-collapse(v-model='expandedPanelNames')
+    el-collapse-item(title = 'Create new log' name='new-log-form')
+      new-log-form
 </template>
 
 <script>
 import { mapState } from 'vuex';
 
+import NewLogForm from './new_log_form.vue';
+
 export default {
+  components: {
+    NewLogForm,
+  },
+
   computed: {
     ...mapState([
       'logs',
     ]),
+  },
+
+  data() {
+    return {
+      expandedPanelNames: [],
+    };
   },
 
   title() {

--- a/app/javascript/logs/logs.vue
+++ b/app/javascript/logs/logs.vue
@@ -9,9 +9,6 @@ div
   .center
     log-selector
     router-view(:key='$route.fullPath').m3
-    el-collapse(v-if='!isSharedLog' v-model='expandedPanelNames')
-      el-collapse-item(title = 'Create new log' name='new-log-form')
-        new-log-form
 </template>
 
 <script>
@@ -19,13 +16,11 @@ import { mapGetters, mapState } from 'vuex';
 import 'toastify-js/src/toastify.css';
 
 import signOutMixin from 'lib/mixins/sign_out_mixin';
-import NewLogForm from './components/new_log_form.vue';
 import LogSelector from './components/log_selector.vue';
 
 export default {
   components: {
     LogSelector,
-    NewLogForm,
   },
 
   computed: {
@@ -55,12 +50,6 @@ export default {
         this.$store.commit('showModal', { modalName: 'log-selector' });
       }
     });
-  },
-
-  data() {
-    return {
-      expandedPanelNames: [],
-    };
   },
 
   mixins: [signOutMixin],


### PR DESCRIPTION
This will clean up the buttons/actions/controls/settings at the bottom of the log show page somewhat, which is somewhat cluttered already and which is going to become further cluttered (as we add, for example, the ability to schedule log reminders).