### PR TITLE
Align home page headline subheader text to the right (& add padding)

### DIFF
--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -396,6 +396,11 @@ p:first-of-type {
   }
 }
 
+#headline-subtitle {
+  text-align: right;
+  padding-top: 6px;
+}
+
 #header {
   position: fixed;
   // performance hint to create a new compositor layer, so we don't re-paint on scroll


### PR DESCRIPTION
I think it looks better.

# Before

![image](https://user-images.githubusercontent.com/8197963/83340919-77f9b580-a292-11ea-8c49-1083be3fb27a.png)

# After

![image](https://user-images.githubusercontent.com/8197963/83340925-80ea8700-a292-11ea-991e-c39b4b4c26ed.png)