### PR TITLE
Fix N+1 query for log_shares in LogsController#index

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -18,7 +18,7 @@ class LogsController < ApplicationController
     @body_class = 'sans-serif'
     bootstrap(
       current_user: UserSerializer.new(current_user),
-      logs: ActiveModel::Serializer::CollectionSerializer.new(logs),
+      logs: ActiveModel::Serializer::CollectionSerializer.new(logs.includes(:log_shares)),
       log_input_types: log_input_types,
     )
     render :index


### PR DESCRIPTION
I think that this N+1 query was introduced by [this change][1].

[1]: https://github.com/davidrunger/david_runger/commit/04e7ba63adece190c0cbea7b8a7161aa14bcee59#diff-d909da8368cd0eb9ddf3de2115adf7a1R26

# Before

![image](https://user-images.githubusercontent.com/8197963/83341125-9fea1880-a294-11ea-88fd-25d7966b0823.png)

# After

![image](https://user-images.githubusercontent.com/8197963/83341128-ad070780-a294-11ea-9a1d-a3c2fe9ecee3.png)