### PR TITLE
Don't serialize log_shares when rendering a shared log for other user

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -18,7 +18,11 @@ class LogsController < ApplicationController
     @body_class = 'sans-serif'
     bootstrap(
       current_user: UserSerializer.new(current_user),
-      logs: ActiveModel::Serializer::CollectionSerializer.new(logs.includes(:log_shares)),
+      logs: ActiveModel::Serializer::CollectionSerializer.new(
+        logs.includes(:log_shares),
+        scope: current_user,
+        scope_name: :current_user,
+      ),
       log_input_types: log_input_types,
     )
     render :index

--- a/app/serializers/log_serializer.rb
+++ b/app/serializers/log_serializer.rb
@@ -25,5 +25,15 @@ class LogSerializer < ActiveModel::Serializer
   attributes :data_label, :data_type, :description, :id, :name, :publicly_viewable, :slug
 
   belongs_to :user, serializer: LogOwnerSerializer
-  has_many :log_shares
+  has_many :log_shares, if: :own_log?
+
+  def own_log?
+    current_user == log.user
+  end
+
+  private
+
+  def log
+    object
+  end
 end


### PR DESCRIPTION
This fixes a privacy/security vulnerability. A user with whom a log has been shared shouldn't know which specific other users that log has been shared with. Prior to this PR, a user with whom a log has been shared could ascertain that information by inspecting the bootstrap data when viewing a shared log.

See documentation for the `scope` feature used in this PR here: https://github.com/rails-api/active_model_serializers/blob/0-10-stable/docs/general/serializers.md#scope