### PR TITLE
Unify `db:create` & `db:schema:load` into a single command in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ script:
   - bin/rubocop $(git ls-tree -r HEAD --name-only) --force-exclusion --format clang
   - bin/brakeman --quiet
   - ./node_modules/.bin/stylelint app/**/*.{css,scss,vue} --max-warnings 0
-  - bin/rails db:create
-  - bin/rails db:schema:load
+  - bin/rails db:create db:schema:load
   - bin/database_consistency # needs to come after creating the DB & loading the schema
   - bin/rails immigrant:check_keys
   - bin/annotate --models --show-indexes --sort --exclude tests && git diff --exit-code


### PR DESCRIPTION
In testing on my local machine, unifying these commands is about 12 seconds faster (~16 seconds vs ~28 seconds before). In Travis, it looks like we'll save more like 6 or 7 seconds (based on the time for the `bin/rails db:create db:schema:load` in the build of this branch vs the time for the `bin/rails db:create` and `bin/rails db:schema:load` commands in the most recent two `master` builds on Travis).