### PR TITLE
Don't "commit" change to grocery item name until input is blurred

### DIFF
--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -11,7 +11,7 @@ li.grocery-item.flex.items-center(
     input(
       v-if='editingName'
       type='text'
-      v-model='item.name'
+      :value='item.name'
       @blur='stopEditingAndUpdateItemName()'
       @keydown.enter='stopEditingAndUpdateItemName()'
       ref='item-name-input'
@@ -66,6 +66,7 @@ export default {
 
     stopEditingAndUpdateItemName() {
       this.editingName = false;
+      this.item.name = this.$refs['item-name-input'].value;
       this.$store.dispatch('updateItem', {
         id: this.item.id,
         attributes: {


### PR DESCRIPTION
This avoids a UX bug wherein changing a grocery item's name could change its sort order in the list of grocery items, causing the input to move up or down in the list while editing. With this change, the item will only be resorted after blurring the input (since that is when we'll actually update `item.name`).

To accomplish this, we are now using one-way binding rather than two-way binding via `v-model`.