### PR TITLE
Change all kebab-case components in Vue templates to PascalCased

### DIFF
--- a/app/javascript/logs/components/data_renderers/counter_bar_graph.vue
+++ b/app/javascript/logs/components/data_renderers/counter_bar_graph.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
 .chart-container
-  bar-graph(
+  BarGraph(
     :chart-data='chartMetadata'
     :height='300'
     :options='CHART_OPTIONS'

--- a/app/javascript/logs/components/data_renderers/duration_timeseries.vue
+++ b/app/javascript/logs/components/data_renderers/duration_timeseries.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
 .chart-container
-  line-chart(
+  LineChart(
     :chart-data='chartMetadata'
     :height='300'
     :options='CHART_OPTIONS'

--- a/app/javascript/logs/components/data_renderers/integer_timeseries.vue
+++ b/app/javascript/logs/components/data_renderers/integer_timeseries.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
 .chart-container
-  line-chart(
+  LineChart(
     :chart-data='chartMetadata'
     :height='300'
     :options='CHART_OPTIONS'

--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 .flex.justify-center
   .container
-    new-log-entry-form(:log='log')
+    NewLogEntryForm(:log='log')
     table
       EditableTextLogRow(
         v-for='logEntry in formattedLogEntries'

--- a/app/javascript/logs/components/log.vue
+++ b/app/javascript/logs/components/log.vue
@@ -5,7 +5,7 @@ div
   p.h5.mb2.description {{log.description}}
   div.mb2(v-if='log.log_entries === undefined').
     Loading...
-  log-data-display(
+  LogDataDisplay(
     v-else-if='log.log_entries.length'
     :data_label='log.data_label'
     :data_type='log.data_type'
@@ -14,7 +14,7 @@ div
   )
   div.my2(v-else) There are no log entries for this log.
   .controls(v-if='isOwnLog')
-    new-log-entry-form(v-if='!renderInputAtTop' :log='log')
+    NewLogEntryForm(v-if='!renderInputAtTop' :log='log')
     .mt1
       el-button(@click='destroyLastEntry') Delete last entry
     .mt1
@@ -76,7 +76,7 @@ div
 
   Modal(name='edit-log-reminder-schedule' width='85%' maxWidth='600px' backgroundClass='bg-black')
     slot
-      log-reminder-schedule-form(:log='log')
+      LogReminderScheduleForm(:log='log')
 </template>
 
 <script>

--- a/app/javascript/logs/components/logs_index.vue
+++ b/app/javascript/logs/components/logs_index.vue
@@ -5,7 +5,7 @@ section
       router-link.log-link(:to='{ name: "log", params: { slug: log.slug }}') {{log.name}}
   el-collapse(v-model='expandedPanelNames')
     el-collapse-item(title = 'Create new log' name='new-log-form')
-      new-log-form
+      NewLogForm
 </template>
 
 <script>

--- a/app/javascript/logs/logs.vue
+++ b/app/javascript/logs/logs.vue
@@ -7,7 +7,7 @@ div
       ul.dropdown-content.bg-black.gray
         li.p1(@click='signOut') Sign out
   .center
-    log-selector
+    LogSelector
     router-view(:key='$route.fullPath').m3
 </template>
 

--- a/app/javascript/workout/new_workout_form.vue
+++ b/app/javascript/workout/new_workout_form.vue
@@ -55,12 +55,12 @@
         ) Initialize Workout!
     div.my2
       h2.h2 Previous workouts
-      workouts-table(
+      WorkoutsTable(
         :isOwnWorkouts='true'
         :workouts='bootstrap.workouts'
       )
     div.my2
-      publicly-shared-workouts
+      PubliclySharedWorkouts
 </template>
 
 <script>

--- a/app/javascript/workout/publicly_shared_workouts.vue
+++ b/app/javascript/workout/publicly_shared_workouts.vue
@@ -4,7 +4,7 @@ div.my2
   div(v-if='workouts === null') Loading...
   div(v-else-if='workouts.length === 0') None
   div(v-else)
-    workouts-table(:workouts='workouts')
+    WorkoutsTable(:workouts='workouts')
 </template>
 
 <script>

--- a/app/javascript/workout/workout.vue
+++ b/app/javascript/workout/workout.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
   div(v-if='workout')
-    workout-plan(v-bind='workout')
-  new-workout-form(
+    WorkoutPlan(v-bind='workout')
+  NewWorkoutForm(
     v-else
     v-on:workout-initialized='onWorkoutInitialized'
   )


### PR DESCRIPTION
This makes it easier to search for the components. The components are imported in PascalCase, so let's keep it that way in the template, too.

Plus, this even helps with autocomplete.