### PR TITLE
Allow adding notes for a store and include notes in store SMS message

### DIFF
--- a/app/controllers/api/stores_controller.rb
+++ b/app/controllers/api/stores_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::StoresController < ApplicationController
+  using BlankParamsAsNil
+
   before_action :set_store, only: %i[destroy update]
 
   def create
@@ -33,6 +35,6 @@ class Api::StoresController < ApplicationController
   end
 
   def store_params
-    params.require(:store).permit(:name, :viewed_at)
+    params.require(:store).permit(:name, :notes, :viewed_at).blank_params_as_nil(%w[notes])
   end
 end

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -20,6 +20,21 @@ div.mt1.mb2.ml3.mr2
     el-button.copy-to-clipboard(size='mini') Copy to clipboard
     span(v-if='wasCopiedRecently') Copied!
 
+  div.mb1
+    h3.h3 Notes
+    el-input(
+      v-if='editingNotes'
+      type='textarea'
+      placeholder='Member phone number: 619-867-5309'
+      v-model='store.notes'
+      @blur='stopEditingAndUpdateStoreNotes()'
+      ref='store-notes-input'
+    )
+    p.pre-wrap(v-else)
+      | {{store.notes || 'No notes yet'}}
+      a.edit-store.js-link.gray.ml1(@click='editStoreNotes')
+        i.el-icon-edit-outline
+
   vue-form.col-5.flex(@submit.prevent='postNewItem' :state='formstate')
     validate.float-left
       el-input.item-name-input(
@@ -87,6 +102,7 @@ export default {
   data() {
     return {
       editingName: false,
+      editingNotes: false,
       formstate: {},
       itemsToZero: [],
       newItemName: '',
@@ -155,6 +171,12 @@ export default {
       setTimeout(this.focusStoreNameInput);
     },
 
+    editStoreNotes() {
+      this.editingNotes = true;
+      // wait a tick for input to render, then focus it
+      setTimeout(this.focusStoreNotesInput);
+    },
+
     focusStoreNameInput(callsAlready = 0) {
       if (!this.editingName) return;
 
@@ -164,6 +186,18 @@ export default {
       } else if (callsAlready < 20) {
         // the storeNameInput hasn't had time to render yet; retry later
         setTimeout(() => { this.focusStoreNameInput(callsAlready + 1); }, 50);
+      }
+    },
+
+    focusStoreNotesInput(callsAlready = 0) {
+      if (!this.editingNotes) return;
+
+      const storeNotesInput = this.$refs['store-notes-input'];
+      if (storeNotesInput) {
+        storeNotesInput.focus();
+      } else if (callsAlready < 20) {
+        // the storeNotesInput hasn't had time to render yet; retry later
+        setTimeout(() => { this.focusStoreNotesInput(callsAlready + 1); }, 50);
       }
     },
 
@@ -227,6 +261,16 @@ export default {
         },
       });
     },
+
+    stopEditingAndUpdateStoreNotes() {
+      this.editingNotes = false;
+      this.$store.dispatch('updateStore', {
+        id: this.store.id,
+        attributes: {
+          notes: this.store.notes,
+        },
+      });
+    },
   },
 
   props: {
@@ -271,5 +315,9 @@ export default {
   left: inherit;
   right: 50%;
   transform: translateX(50%);
+}
+
+.pre-wrap {
+  white-space: pre-wrap;
 }
 </style>

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -7,6 +7,7 @@
 #  created_at :datetime         not null
 #  id         :bigint           not null, primary key
 #  name       :string           not null
+#  notes      :text
 #  updated_at :datetime         not null
 #  user_id    :bigint
 #  viewed_at  :datetime

--- a/app/serializers/store_serializer.rb
+++ b/app/serializers/store_serializer.rb
@@ -7,6 +7,7 @@
 #  created_at :datetime         not null
 #  id         :bigint           not null, primary key
 #  name       :string           not null
+#  notes      :text
 #  updated_at :datetime         not null
 #  user_id    :bigint
 #  viewed_at  :datetime
@@ -17,6 +18,6 @@
 #
 
 class StoreSerializer < ActiveModel::Serializer
-  attributes :id, :name, :viewed_at
+  attributes :id, :name, :notes, :viewed_at
   has_many :items
 end

--- a/app/views/sms_messages/grocery_list.text.erb
+++ b/app/views/sms_messages/grocery_list.text.erb
@@ -1,4 +1,7 @@
 == <%= store.name %>
+<% if store.notes.present? %>
+Notes: <%= store.notes %>
+<% end %>
 <% store.items.needed.sort_by { |item| item.name.downcase }.each do |item| %>
 - <%= item.name %> (<%= item.needed %>)
 <% end %>

--- a/db/migrate/20200602225318_add_notes_to_stores.rb
+++ b/db/migrate/20200602225318_add_notes_to_stores.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddNotesToStores < ActiveRecord::Migration[6.1]
+  def change
+    add_column :stores, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_05_31_013949) do
+ActiveRecord::Schema.define(version: 2020_06_02_225318) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 2020_05_31_013949) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "viewed_at"
+    t.text "notes"
     t.index ["user_id"], name: "index_stores_on_user_id"
   end
 

--- a/spec/factories/stores.rb
+++ b/spec/factories/stores.rb
@@ -7,6 +7,7 @@
 #  created_at :datetime         not null
 #  id         :bigint           not null, primary key
 #  name       :string           not null
+#  notes      :text
 #  updated_at :datetime         not null
 #  user_id    :bigint
 #  viewed_at  :datetime
@@ -21,5 +22,6 @@ FactoryBot.define do
     name { Faker::Company.name }
     association :user
     viewed_at { [nil, 1.month.ago, 1.day.ago].sample }
+    notes { 'member phone number: 619-867-5309' }
   end
 end

--- a/spec/form_objects/sms_message_spec.rb
+++ b/spec/form_objects/sms_message_spec.rb
@@ -50,16 +50,20 @@ RSpec.describe SmsMessage do
       sms_message.send(:grocery_store_items_needed_message_body)
     end
 
-    it 'includes the store name and items needed (name & quantity)' do
+    let(:expected_message) do
       needed_items_list =
         store.items.needed.
           sort_by { |item| item.name.downcase }.
           map { |item| "- #{item.name} (#{item.needed})" }
-      expected_message = <<~EXPECTED_MESSAGE.rstrip
+
+      <<~EXPECTED_MESSAGE.rstrip
         == #{store.name}
+        Notes: #{store.notes}
         #{needed_items_list.join("\n")}
       EXPECTED_MESSAGE
+    end
 
+    it 'includes the store name and items needed (name & quantity)' do
       expect(grocery_store_items_needed_message_body).to eq(expected_message)
     end
   end


### PR DESCRIPTION
For example, I might want to include a reminder that 4088675309 can be provided at checkout as a phone number to get Food4Less discounts (I think).