### PR TITLE
Remove Encoding::UndefinedConversionError rescue when stashing data

### DIFF
--- a/app/controllers/concerns/request_recordable.rb
+++ b/app/controllers/concerns/request_recordable.rb
@@ -22,9 +22,6 @@ module RequestRecordable
         request_data.to_json,
       )
     end
-  rescue Encoding::UndefinedConversionError => error
-    Rails.logger.info("Error storing request data in Redis, error=#{error.inspect}")
-    Rollbar.info(error)
   rescue
     # wrap the original exception in StashRequestError by raising and immediately rescuing
     begin


### PR DESCRIPTION
This was added in #134 / 3297e7a .

My motivation for removing this special rescue is that the lines being deleted are untested, and I think they might not be needed anymore (based on the fact that I don't think that any of these errors have been logged to Rollbar recently).