### PR TITLE
Delete ApplicationController#after_sign_out_path_for method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,10 +33,6 @@ class ApplicationController < ActionController::Base
     redirect_to(login_path)
   end
 
-  def after_sign_out_path_for(_resource_or_scope)
-    login_path
-  end
-
   def enable_rack_mini_profiler_if_admin
     if Rails.configuration.rack_mini_profiler_enabled && current_user&.admin?
       Rack::MiniProfiler.authorize_request


### PR DESCRIPTION
As far as I can tell, it's not being used for anything. It looks like it _would_ be used if we ever were to sign out via a "full page" HTTP request, but since I think that the only place in our code where users can currently sign out is via an AJAX request ([here](https://github.com/davidrunger/david_runger/blob/2b7fa633ea5b7664ff0acc6cdd9615ec244b5c67/app/javascript/lib/mixins/sign_out_mixin.js#L3-L6)), I don't think this method ever gets hit currently.

It was added in 13c051f .