### PR TITLE
Delete duplicate/unused groceries logged-in-header `signOut` method

### DIFF
--- a/app/javascript/groceries/components/logged_in_header.vue
+++ b/app/javascript/groceries/components/logged_in_header.vue
@@ -12,16 +12,7 @@ el-menu.center
 import signOutMixin from 'lib/mixins/sign_out_mixin';
 
 export default {
-  methods: {
-    signOut() {
-      this.$http.delete(this.$routes.destroy_user_session_path({ format: 'json' })).
-        then(() => { window.location.assign(this.$routes.login_path()); });
-    },
-  },
-
   mixins: [signOutMixin],
-
-  props: {},
 };
 </script>
 


### PR DESCRIPTION
This method is also provided by the `signOutMixin`, so we don't need to register the method directly on the component itself, too.

Also delete unnecessary empty props declaration.