### PR TITLE
Move username anonymization logic to User model

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -45,4 +45,15 @@ class User < ApplicationRecord
   def sms_usage
     sms_records.sum(:cost)
   end
+
+  def partially_anonymized_username
+    email_username, email_domain = email.split('@')
+
+    if email_username.length >= 8
+      partially_anonymized_email_username = "#{email_username[0..2]}...#{email_username[-3..-1]}"
+      [partially_anonymized_email_username, email_domain].join('@')
+    else
+      "User #{id}"
+    end
+  end
 end

--- a/app/serializers/workout_serializer.rb
+++ b/app/serializers/workout_serializer.rb
@@ -26,15 +26,7 @@ class WorkoutSerializer < ActiveModel::Serializer
   end
 
   def username
-    user = workout.user
-    email_username, email_domain = user.email.split('@')
-
-    if email_username.length >= 8
-      partially_anonymized_email_username = "#{email_username[0..2]}...#{email_username[-3..-1]}"
-      [partially_anonymized_email_username, email_domain].join('@')
-    else
-      "User #{user.id}"
-    end
+    workout.user.partially_anonymized_username
   end
 
   private

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -61,4 +61,28 @@ RSpec.describe User do
       expect(sms_usage).to eq(sms_cost_1 + sms_cost_2)
     end
   end
+
+  describe '#partially_anonymized_username' do
+    subject(:partially_anonymized_username) { user.partially_anonymized_username }
+
+    context "when the user's email is short" do
+      before { user.update!(email: 'a@b.c') }
+
+      it "returns a string based on the user's id" do
+        expect(partially_anonymized_username).to eq("User #{user.id}")
+      end
+    end
+
+    context "when the user's email is not particularly short" do
+      let(:email) { '0123456789@b.c' }
+
+      before { user.update!(email: email) }
+
+      it "returns a partially anonymized string based on the user's email" do
+        expect(partially_anonymized_username).not_to include(email)
+        expect(partially_anonymized_username).not_to include(email.split('@').first.presence!)
+        expect(partially_anonymized_username).to eq(email.sub('3456', '...'))
+      end
+    end
+  end
 end


### PR DESCRIPTION
(from `WorkoutSerializer`)

Additionally, we add in this PR explicit spec coverage for both anonymization cases (i.e. depending on whether the user's email is lengthy or short). This will fix flip-flopping test coverage metrics that resulted from sometimes faker providing a short email and sometimes a longer email.