### PR TITLE
Fix UsersController spec flakiness caused by nondeterministic phone

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe UsersController do
   describe '#update' do
     subject(:patch_update_user) { patch(:update, params: { id: user.id, user: user_params }) }
 
-    let(:new_phone_number) { "1555#{rand(10_000_000)}" }
+    let(:new_phone_number) { "1555#{rand(10_000_000).to_s.rjust(7, '9')}" }
     let(:user_params) { { phone: new_phone_number } }
 
     before { user.update!(phone: '11231231234') }


### PR DESCRIPTION
Example build failure that was probably caused by `rand(10_000_000)` generating a number less than 1,000,000 (i.e. 6 digits or less, making the phone number be therefore too short): https://travis-ci.org/github/davidrunger/david_runger/builds/694774154 .

Such flakiness should be made impossible by the change in this PR.