### PR TITLE
Don't allow editing of user's last_activity_at via admin

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -54,7 +54,6 @@ class UserDashboard < Administrate::BaseDashboard
     stores
     items
     email
-    last_activity_at
   ].freeze
 
   # Overwrite this method to customize how users are displayed


### PR DESCRIPTION
`last_activity_at` is basically a read-only/informational field. I cannot think of a reason that an admin would want to edit this field for a user.

# Before

![image](https://user-images.githubusercontent.com/8197963/83803495-8a446c80-a661-11ea-98a0-a7eaf9cca71f.png)

# After

![image](https://user-images.githubusercontent.com/8197963/83803543-a0eac380-a661-11ea-8a7c-0fc1461e3696.png)