### PR TITLE
Don't show associations (requests, stores, items) in admin user form

### DIFF
--- a/app/dashboards/user_dashboard.rb
+++ b/app/dashboards/user_dashboard.rb
@@ -50,9 +50,6 @@ class UserDashboard < Administrate::BaseDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    requests
-    stores
-    items
     email
   ].freeze
 


### PR DESCRIPTION
There's little/no need for an admin to manipulate these associations.

# Before

![image](https://user-images.githubusercontent.com/8197963/83804189-9b41ad80-a662-11ea-843d-53776b8750df.png)

# After

![image](https://user-images.githubusercontent.com/8197963/83804221-a4327f00-a662-11ea-9042-a7aa908eed52.png)