### PR TITLE
Add http_logger gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'http_logger'
   gem 'letter_opener'
   gem 'listen'
   # Performance profiling. Should be listed after `pg` (and `rails`?) gems to get database

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -219,6 +219,7 @@ GEM
       tilt
     hashdiff (1.0.1)
     hashie (4.1.0)
+    http_logger (0.6.0)
     httparty (0.18.0)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
@@ -503,6 +504,7 @@ DEPENDENCIES
   guard-espect!
   hamlit
   hashdiff
+  http_logger
   httparty
   immigrant
   js-routes


### PR DESCRIPTION
This is all that it takes to have HTTP requests logged in development! 😄 

![image](https://user-images.githubusercontent.com/8197963/83940436-de05a180-a798-11ea-85c9-fd57ba426826.png)

Per https://github.com/railsware/http_logger : 

> Log your http api calls just like SQL queries

I agree. Isn't it equally important -- or probably more -- to log HTTP requests as it is to log SQL queries (which are logged by default)?