### PR TITLE
Use #include? rather than in? in sidekiq.yml

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,10 @@
 {
+  "env": {
+    "S3_ACCESS_KEY_ID": { "description": "S3 ACCESS KEY ID", "value": "" },
+    "S3_SECRET_ACCESS_KEY": { "description": "S3 SECRET ACCESS KEY", "value": "" },
+    "S3_BUCKET": { "description": "S3 BUCKET", "value": "" },
+    "S3_REGION": { "description": "S3 REGION", "value": "" }
+  },
   "environments": {
     "review": {
       "addons": [
@@ -11,6 +17,12 @@
         { "url": "heroku/ruby" },
         { "url": "https://github.com/weibeld/heroku-buildpack-run" }
       ],
+      "env": {
+        "S3_ACCESS_KEY_ID": "FAKETEST123",
+        "S3_SECRET_ACCESS_KEY": "aBc123FakeTest",
+        "S3_BUCKET": "david-runger-uploads",
+        "S3_REGION": "us-east-1"
+      },
       "scripts": {
         "postdeploy": "bin/rake db:schema:load"
       }

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -12,7 +12,7 @@ production:
 :schedule:
   InvalidRecordsChecker:
     cron: '55 16 * * *' # daily at 4:55pm PT
-  <% if ENV['RAILS_ENV'].in?(%w[production test]) %>
+  <% if %w[production test].include?(ENV['RAILS_ENV']) %>
   SendLogReminderEmails:
     cron: '* * * * *' # every minute
   TruncateTables:


### PR DESCRIPTION
Evidently (based on H10 errors in production when #2744 / 1b86711 deployed), the `Object#in?` monkeypatch provided by ActiveSupport hasn't (necessarily?) yet been applied when Sidekiq needs it to have been while parsing the config file.

```
sidekiq.1 | undefined method `in?' for "production":String
sidekiq.1 | Did you mean?  nil?
sidekiq.1 | (erb):15:in `<main>'
sidekiq.1 | /app/vendor/ruby-2.7.1/lib/ruby/2.7.0/erb.rb:905:in `eval'
sidekiq.1 | /app/vendor/ruby-2.7.1/lib/ruby/2.7.0/erb.rb:905:in `result'
sidekiq.1 | /app/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.0.7/lib/sidekiq/cli.rb:362:in `parse_config'
sidekiq.1 | /app/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.0.7/lib/sidekiq/cli.rb:228:in `setup_options'
sidekiq.1 | /app/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.0.7/lib/sidekiq/cli.rb:24:in `parse'
sidekiq.1 | /app/vendor/bundle/ruby/2.7.0/gems/sidekiq-6.0.7/bin/sidekiq:27:in `<top (required)>'
sidekiq.1 | bin/sidekiq:29:in `load'
sidekiq.1 | bin/sidekiq:29:in `<main>'
sidekiq.1 | exited with code 1
```

It's not clear to me why this error didn't occur when I booted Sidekiq locally but I guess that it has to do with differences in the boot process (e.g. `spring`, maybe?).