### PR TITLE
Include `reply_to` field (if present) in data posted to Mailgun

### DIFF
--- a/lib/email/mailgun_via_http.rb
+++ b/lib/email/mailgun_via_http.rb
@@ -15,11 +15,12 @@ module Email
           password: ENV['MAILGUN_API_KEY'],
         },
         body: {
-          from: mail['From'].to_s,
-          to: mail['To'].to_s,
+          from: mail.from.first,
+          to: mail.to.first,
           subject: mail.subject,
           html: mail.body.to_s,
-        },
+          'h:Reply-To' => mail.reply_to.first,
+        }.compact,
       )
     end
   end

--- a/spec/lib/email/mailgun_via_http_spec.rb
+++ b/spec/lib/email/mailgun_via_http_spec.rb
@@ -11,12 +11,16 @@ RSpec.describe Email::MailgunViaHttp do
         ::Mail::Message,
         subject: subject,
         body: email_body,
+        to: [to_email], # this stub is a bit misleading; this method doesn't return an array
+        from: [from_email], # this stub is a bit misleading; this method doesn't return an array
+        reply_to: [reply_to_email],
       )
     end
     let(:subject) { "There's a new davidrunger.com user! :) Email: davidjrunger@gmail.com." }
     let(:email_body) { 'A new user has been created with email davidjrunger@gmail.com!' }
-    let(:from_email) { 'DavidRunger.com <noreply@davidrunger.com>' }
+    let(:from_email) { '"DavidRunger.com" <reply@davidrunger.com>' }
     let(:to_email) { 'David Runger <davidjrunger@gmail.com>' }
+    let(:reply_to_email) { '"DavidRunger.com" <reply@mg.davidrunger.com>' }
     let(:stubbed_mailgun_api_key) { '2a4d89d1-1984-4453-8ea5-2468d1769a6c' }
     let!(:mailgun_http_request) do
       stub_request(
@@ -28,6 +32,7 @@ RSpec.describe Email::MailgunViaHttp do
           to: to_email,
           subject: subject,
           html: email_body,
+          'h:Reply-To' => reply_to_email,
         ),
         headers: {
           'Accept' => '*/*',
@@ -48,16 +53,6 @@ RSpec.describe Email::MailgunViaHttp do
       expect(ENV).to receive(:[]).at_least(:once).with('MAILGUN_API_KEY').
         and_return(stubbed_mailgun_api_key)
       allow(ENV).to receive(:[]).and_call_original # pass other calls through
-
-      expect(mail).to receive(:[]).at_least(:once) do |key|
-        if key == 'From'
-          from_email
-        elsif key == 'To'
-          to_email
-        else
-          raise('Unexpected key accessed on mail object')
-        end
-      end
     end
 
     it 'makes an HTTP POST request to ENV["MAILGUN_URL"]' do


### PR DESCRIPTION
Relevant documentation: https://documentation.mailgun.com/en/latest/api-sending.html#sending

> **h:X-My-Header** `h:` prefix followed by an arbitrary value allows to append a custom MIME header to the message (`X-My-Header` in this case). For example, `h:Reply-To` to specify Reply-To address.