### PR TITLE
Strip extraneous email body content from incoming emails; add Flipper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,11 @@ gem 'browser'
 gem 'connection_pool'
 gem 'dalli'
 gem 'devise'
+gem 'email_reply_trimmer', github: 'discourse/email_reply_trimmer'
 gem 'flamegraph' # Provides flamegraphs for rack-mini-profiler.
+gem 'flipper'
+gem 'flipper-redis'
+gem 'flipper-ui'
 gem 'hamlit'
 gem 'httparty'
 gem 'js-routes', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,12 @@ GIT
       spring (>= 1.2, < 3.0)
 
 GIT
+  remote: https://github.com/discourse/email_reply_trimmer.git
+  revision: fd1f2e82397226391c1d12c0d7fdf69a425e2385
+  specs:
+    email_reply_trimmer (0.1.13)
+
+GIT
   remote: https://github.com/rails/rails.git
   revision: 95af87f0a4b6274a43853ed68b17e17c21f804f3
   specs:
@@ -213,6 +219,15 @@ GEM
       activesupport (>= 2)
       hashdiff
     flamegraph (0.9.5)
+    flipper (0.17.2)
+    flipper-redis (0.17.2)
+      flipper (~> 0.17.2)
+      redis (>= 2.2, < 5)
+    flipper-ui (0.17.2)
+      erubi (>= 1.0.0, < 2.0.0)
+      flipper (~> 0.17.2)
+      rack (>= 1.4, < 3)
+      rack-protection (>= 1.5.3, < 2.1.0)
     formatador (0.2.5)
     fugit (1.3.6)
       et-orbi (~> 1.1, >= 1.1.8)
@@ -515,10 +530,14 @@ DEPENDENCIES
   database_consistency
   devise
   dotenv-rails
+  email_reply_trimmer!
   factory_bot_rails
   faker
   fixture_builder
   flamegraph
+  flipper
+  flipper-redis
+  flipper-ui
   guard-espect!
   hamlit
   hashdiff

--- a/app/mailboxes/log_entries_mailbox.rb
+++ b/app/mailboxes/log_entries_mailbox.rb
@@ -1,11 +1,42 @@
 # frozen_string_literal: true
 
 class LogEntriesMailbox < ApplicationMailbox
+  extend Memoist
+
   def process
+    if debug?
+      puts('--- BEGIN mail.text_part.presence.to_s')
+      p(mail.text_part.presence.to_s)
+      puts('--- END mail.text_part.presence.to_s')
+
+      puts('--- BEGIN mail.body.to_s')
+      p(mail.body.to_s)
+      puts('--- END mail.body.to_s')
+    end
+
     log_id = mail.to.first.presence!.match(ApplicationMailbox::LOG_ENTRIES_ROUTING_REGEX)[:log_id]
     user_email = mail.from.first.presence!
     user = User.find_by!(email: user_email)
     log = user.logs.find(log_id)
-    log.log_entries.create!(data: mail.body.to_s.rstrip)
+    email_content =
+      # call #dup because #trim modifies the string (via at least one `#gsub!` call)
+      EmailReplyTrimmer.trim((mail.text_part.presence || mail.body).to_s.dup).
+        sub(/\AContent-Type:.+\n+/, '').
+        rstrip
+
+    if debug?
+      puts('--- BEGIN email_content')
+      p(email_content)
+      puts('--- END email_content')
+    end
+
+    log.log_entries.create!(data: email_content)
+  end
+
+  private
+
+  memoize \
+  def debug?
+    Flipper.enabled?(:debug_log_entries_mailbox_processing)
   end
 end

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+Flipper.configure do |config|
+  config.default do
+    # See comments in config/initializers/sidekiq.rb for Redis connection distribution logic/details
+    adapter = Flipper::Adapters::Redis.new(Redis.new)
+    Flipper.new(adapter)
+  end
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,10 +9,13 @@ Sidekiq.configure_client do |config|
   # Sidekiq Client Connection Pool size:
   # We have 20 connections total from Heroku Redis Hobby Dev plan
   # ... minus 7 connections used for Sidekiq below ...
-  # ... minus 5 connections for `rails console` and general padding ...
-  # ... leaves us with 8 connections total for the Rails server processes.
-  # We are running 2 processes, so each process gets 4 connections.
-  # We'll use 2 connections for the Sidekiq client pool (the line below) and 2 for the application.
+  # ... minus 3 connections for `rails console` and general padding ...
+  # ... leaves us with 10 connections total for the Rails server processes.
+  # We are running 2 processes, so each process gets 5 connections.
+  # We'll distribute those Redis connections used by each Rails server process like so:
+  # * 2 connections for the Sidekiq client pool (the line below) (per process)
+  # * 2 for the application (per process)
+  # * 1 for Flipper (per process)
   config.redis = ConnectionPool.new(size: 2, &build_sidekiq_redis_connection)
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
 
   authenticate :user, ->(user) { user.admin? } do
     mount Sidekiq::Web => '/sidekiq'
+    mount Flipper::UI.app(Flipper) => '/flipper'
   end
 
   # Google periodically re-verifies this route, so we need to leave it here indefinitely


### PR DESCRIPTION
We're adding Flipper (a feature-flipper / rollout library) so that we can turn on/off the printing of extra debug info about the email body of incoming mails in the LogEntriesMailbox. (Unfortunately, it's more-or-less necessary to debug this in production because we cannot really simulate all of the Mailgun processing / email protocols / DNS configuration etc that culminates in this flow in production.)