### PR TITLE
Remove `Content-Transfer-Encoding` header from email body

### DIFF
--- a/app/mailboxes/log_entries_mailbox.rb
+++ b/app/mailboxes/log_entries_mailbox.rb
@@ -21,7 +21,7 @@ class LogEntriesMailbox < ApplicationMailbox
     email_content =
       # call #dup because #trim modifies the string (via at least one `#gsub!` call)
       EmailReplyTrimmer.trim((mail.text_part.presence || mail.body).to_s.dup).
-        sub(/\AContent-Type:.+\n+/, '').
+        sub(/\A[\s\S]*^Content-Transfer-Encoding:.+\n+/, '').
         rstrip
 
     if debug?


### PR DESCRIPTION
The logging in https://github.com/davidrunger/david_runger/pull/2748 revealed this:
```
--- BEGIN mail.text_part.presence.to_s
"Content-Type: text/plain;\r\n charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n180.6\r\n\r\nOn Sat, Jun 6, 2020 at 10:59 PM David Runger <davidjrunger@gmail.com> wrote:\r\n\r\n> 184.2\r\n>\r\n> On Sat, Jun 6, 2020 at 10:58 PM DavidRunger.com <\r\n> log-reminders@davidrunger.com> wrote:\r\n>\r\n>> Submit a new log entry here:\r\n>>\r\n>> https://www.davidrunger.com/logs/weight\r\n>>\r\n>> *Tip:* To create a log entry, you can simply reply to this email with\r\n>> the desired log entry content.\r\n>>\r\n>\r\n"
--- END mail.text_part.presence.to_s
```

That email body/content wasn't being correctly handled by the parsing that we had before; it gave this:
```
--- BEGIN email_content
" charset=UTF-8\nContent-Transfer-Encoding: 7bit\n\n180.6"
--- END email_content
```

The change in this PR should now handle that email body/content correctly. Result from applying the transformation locally:
```
--- BEGIN email_content
"180.6"
--- END email_content
```

✅ 👍 