### PR TITLE
Add (and use) bootsnap (for boot time speedup)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ end
 gem 'active_model_serializers'
 gem 'administrate'
 gem 'aws-sdk-s3', require: false
+gem 'bootsnap', require: false
 gem 'browser'
 gem 'connection_pool'
 gem 'dalli'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -156,6 +156,8 @@ GEM
       rack (>= 0.9.0)
     binding_of_caller (0.8.0)
       debug_inspector (>= 0.0.1)
+    bootsnap (1.4.6)
+      msgpack (~> 1.0)
     brakeman (4.8.2)
     browser (4.2.0)
     builder (3.2.4)
@@ -314,6 +316,7 @@ GEM
     minitest (5.14.1)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
+    msgpack (1.3.3)
     multi_json (1.14.1)
     multi_xml (0.6.0)
     multipart-post (2.1.1)
@@ -521,6 +524,7 @@ DEPENDENCIES
   aws-sdk-s3
   better_errors
   binding_of_caller
+  bootsnap
   brakeman
   browser
   capybara

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -3,3 +3,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+require 'bootsnap/setup'


### PR DESCRIPTION
# Performance testing

_Spec: spec/lib/email/mailgun_via_http_spec.rb_

~Time for 30 runs with `spring`, without `bootsnap`: 72 seconds ("baseline" time)

~Time for 15 runs without `spring`, without `bootsnap`: 190 seconds
Estimated time for 30 runs without `spring`: 380 seconds (5.28x as long as baseline)

~Time for 10 runs without `spring`, with `bootsnap`: 71 seconds
Estimated time for 30 runs without `spring`, with `bootsnap`: 213 seconds (2.96x as long as baseline)

~Time for 30 runs with `spring` _and_ `bootsnap`: 58 seconds (0.81x as long as baseline)

---------------

Time to boot `DISABLE_SPRING=1 bin/rails console` without bootsnap: ~12 seconds

Time to boot `DISABLE_SPRING=1 bin/rails console` with bootsnap: ~6 seconds