### PR TITLE
Send pretty Reply-To field to Mailgun (not just the actual email)

### DIFF
--- a/lib/email/mailgun_via_http.rb
+++ b/lib/email/mailgun_via_http.rb
@@ -17,9 +17,9 @@ module Email
         body: {
           from: mail['From'].to_s,
           to: mail['To'].to_s,
-          subject: mail.subject,
+          subject: mail['Subject'].to_s,
           html: mail.body.to_s,
-          'h:Reply-To' => mail.reply_to.first,
+          'h:Reply-To' => mail['Reply-To'].to_s,
         }.compact,
       )
     end


### PR DESCRIPTION
This fixes a bug similar to the one that we fixed for `to` and `from` in 70ca1c4 / #2749 .