### PR TITLE
Change WEB_CONCURRENCY default/fallback value to 0 (:cry:)

### DIFF
--- a/Procfile.multi
+++ b/Procfile.multi
@@ -1,2 +1,2 @@
-web: bin/rails server -p $PORT -e $RAILS_ENV
+web: WEB_CONCURRENCY=0 bin/rails server -p $PORT -e $RAILS_ENV
 sidekiq: bin/sidekiq --config config/sidekiq.yml

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 # See comments in config/initializers/sidekiq.rb for rationale re: pool size of 2.
-$redis_pool = ConnectionPool.new(size: 2, timeout: 1) { Redis.new }
+$redis_pool = ConnectionPool.new(size: 4, timeout: 1) { Redis.new }

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -9,14 +9,14 @@ Sidekiq.configure_client do |config|
   # Sidekiq Client Connection Pool size:
   # We have 20 connections total from Heroku Redis Hobby Dev plan
   # ... minus 7 connections used for Sidekiq below ...
-  # ... minus 3 connections for `rails console` and general padding ...
-  # ... leaves us with 10 connections total for the Rails server processes.
-  # We are running 2 processes, so each process gets 5 connections.
-  # We'll distribute those Redis connections used by each Rails server process like so:
-  # * 2 connections for the Sidekiq client pool (the line below) (per process)
-  # * 2 for the application (per process)
-  # * 1 for Flipper (per process)
-  config.redis = ConnectionPool.new(size: 2, &build_sidekiq_redis_connection)
+  # ... minus 5 connections for `rails console` and general padding ...
+  # ... leaves us with 8 connections total for the Rails server process(es).
+  # We are running 1 server process, so that process has 8 connections to work with connections.
+  # We'll distribute those Redis connections like so:
+  # * 3 connections for the Sidekiq client pool (the line below)
+  # * 4 for the application (in config/initializers/redis.rb)
+  # * 1 for Flipper (in config/initializers/flipper.rb)
+  config.redis = ConnectionPool.new(size: 3, &build_sidekiq_redis_connection)
 end
 
 Sidekiq.configure_server do |config|

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,7 +23,7 @@ environment(ENV.fetch('RAILS_ENV', 'development'))
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers(ENV.fetch('WEB_CONCURRENCY', 2))
+workers(ENV.fetch('WEB_CONCURRENCY', 0))
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
Due to the memory increase discussed here https://github.com/davidrunger/david_runger/pull/2744#issuecomment-640219446 , we can no longer afford to run two Puma server processes.

I think that changing to 0 rather than 1 will run Puma with a single process in "single mode" rather than with 1 process in "cluser mode"; I think that "single mode" has better performance when running just 1 process.

I will also change the ENV variable value in Heroku in production to 0 to reflect this change.