### PR TITLE
Gracefully handle missing S3 ENV vars; remove them from app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,10 +1,4 @@
 {
-  "env": {
-    "S3_ACCESS_KEY_ID": { "description": "S3 ACCESS KEY ID", "value": "" },
-    "S3_SECRET_ACCESS_KEY": { "description": "S3 SECRET ACCESS KEY", "value": "" },
-    "S3_BUCKET": { "description": "S3 BUCKET", "value": "" },
-    "S3_REGION": { "description": "S3 REGION", "value": "" }
-  },
   "environments": {
     "review": {
       "addons": [
@@ -17,12 +11,6 @@
         { "url": "heroku/ruby" },
         { "url": "https://github.com/weibeld/heroku-buildpack-run" }
       ],
-      "env": {
-        "S3_ACCESS_KEY_ID": "FAKETEST123",
-        "S3_SECRET_ACCESS_KEY": "aBc123FakeTest",
-        "S3_BUCKET": "david-runger-uploads",
-        "S3_REGION": "us-east-1"
-      },
       "scripts": {
         "postdeploy": "bin/rake db:schema:load"
       }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,5 +113,9 @@ Rails.application.configure do
   require_relative('../../lib/email/mailgun_via_http.rb')
   config.action_mailer.delivery_method = Email::MailgunViaHttp
 
-  config.active_storage.service = :amazon
+  if %w[S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_BUCKET S3_REGION].all? { ENV[_1].present? }
+    config.active_storage.service = :amazon
+  else
+    puts('Skipping :amazon storage enablement because not all required ENV variables are present.')
+  end
 end


### PR DESCRIPTION
I think this is a good change because it simplifies `app.json` and booting the app in `production` mode locally. A downside is that, in production, we won't be alerted is one of the necessary S3 ENV variables goes missing, but that seems not too likely and also not super problematic even if it does happen.