### PR TITLE
Remove debugging print statements from `LogEntriesMailbox`

### DIFF
--- a/app/mailboxes/log_entries_mailbox.rb
+++ b/app/mailboxes/log_entries_mailbox.rb
@@ -1,19 +1,7 @@
 # frozen_string_literal: true
 
 class LogEntriesMailbox < ApplicationMailbox
-  extend Memoist
-
   def process
-    if debug?
-      puts('--- BEGIN mail.text_part.presence.to_s')
-      p(mail.text_part.presence.to_s)
-      puts('--- END mail.text_part.presence.to_s')
-
-      puts('--- BEGIN mail.body.to_s')
-      p(mail.body.to_s)
-      puts('--- END mail.body.to_s')
-    end
-
     log_id = mail.to.first.presence!.match(ApplicationMailbox::LOG_ENTRIES_ROUTING_REGEX)[:log_id]
     user_email = mail.from.first.presence!
     user = User.find_by!(email: user_email)
@@ -24,19 +12,6 @@ class LogEntriesMailbox < ApplicationMailbox
         sub(/\A[\s\S]*^Content-Transfer-Encoding:.+\n+/, '').
         rstrip
 
-    if debug?
-      puts('--- BEGIN email_content')
-      p(email_content)
-      puts('--- END email_content')
-    end
-
     log.log_entries.create!(data: email_content)
-  end
-
-  private
-
-  memoize \
-  def debug?
-    Flipper.enabled?(:debug_log_entries_mailbox_processing)
   end
 end


### PR DESCRIPTION
We got the information that we needed from these statements ( see #2750 / 6a2ab19 ), so they aren't really needed anymore.