### PR TITLE
Enable distributed_tracing for NewRelic

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -24,6 +24,8 @@ common: &default_settings
   # Logging level for log/newrelic_agent.log
   log_level: info
 
+  distributed_tracing:
+    enabled: true
 
 # Environment-specific settings are in this section.
 # RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.


### PR DESCRIPTION
I don't even know what this does, but, when this is disabled, it prints warnings:
- WARN : Not configured to insert distributed trace headers
- WARN : Not configured to accept distributed trace headers