### PR TITLE
Generate each phone number digit randomly in tests

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe UsersController do
       before { expect(user).to be_valid }
 
       context 'when the submitted params are valid' do
-        let(:new_phone_number) { "1555#{rand(10_000_000).to_s.rjust(7, '9')}" }
+        let(:new_phone_number) { "1555#{Array.new(7) { rand(10).to_s }.join('')}" }
 
         it 'updates the user' do
           expect { patch_update }.

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     last_activity_at { 2.months.ago }
-    phone { "1630#{rand(10_000_000).to_s.rjust(7, '5')}" }
+    phone { "1630#{Array.new(7) { rand(10).to_s }.join('')}" }
     sms_allowance { 1.0 }
 
     trait :admin do


### PR DESCRIPTION
This new pattern has the advantage of being fully pseudo-random for all of the phone digits, and it is also more clear / easier to read, IMO.