### PR TITLE
Re-enable Lint/MixedRegexpCaptureTypes rubocop cop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,9 +48,6 @@ Layout/SpaceBeforeSemicolon:
   Enabled: false
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: space
-Lint/MixedRegexpCaptureTypes:
-  # disable because it raises 2 errors inspecting spec/controllers/api/logs_controller_spec.rb
-  Enabled: false
 Lint/RedundantSplatExpansion:
   Enabled: false
 Metrics/AbcSize:


### PR DESCRIPTION
This rule was previously raising an error, but that issue was resolved by https://github.com/rubocop-hq/rubocop/pull/ 8093 which was brought into our codebase in #2772 .