### PR TITLE
Color rails server log lines red and append 2 newlines in development

### DIFF
--- a/lib/david_runger/log_formatter.rb
+++ b/lib/david_runger/log_formatter.rb
@@ -14,6 +14,7 @@ class DavidRunger::LogFormatter < Lograge::Formatters::KeyValue
   end
 
   def call
-    super(@data) # use the Lograge::Formatters::KeyValue#call method
+    log_message = super(@data)
+    Rails.env.development? ? "#{log_message.red}\n\n" : log_message
   end
 end


### PR DESCRIPTION
This makes it way easier to see each request separately, rather than the requests all bleeding together in a continuous stream of log lines without any separation between them.

# Before

![image](https://user-images.githubusercontent.com/8197963/84107448-80f53000-a9d2-11ea-83b4-01396d7af4b5.png)

# After

![image](https://user-images.githubusercontent.com/8197963/84107727-4770f480-a9d3-11ea-9692-9765a168a9b4.png)

**_I know which one I prefer_!** 👍 😄 IMO the latter format makes it _way_ easier to distinguish each separate request, at a glance.