### PR TITLE
Log full request path, including query string

### DIFF
--- a/lib/david_runger/log_builder.rb
+++ b/lib/david_runger/log_builder.rb
@@ -10,6 +10,7 @@ class DavidRunger::LogBuilder
 
   def extra_logged_data
     {
+      path: request.fullpath,
       exception: exception_log,
       params: params_log,
       status: status_code_log,
@@ -19,6 +20,10 @@ class DavidRunger::LogBuilder
   end
 
   private
+
+  def request
+    payload[:request]
+  end
 
   def payload
     @event.payload


### PR DESCRIPTION
For whatever reason, `lograge` [removes][1] the query string from the logged data. I prefer to see the query string as part of the path. (The query string params do show up in the `params` that are all logged, but I we don't know, for example, if a param came from a query string or from a POST request body, which might be worth knowing.)

[1]: https://github.com/roidrage/lograge/blob/1729eab/lib/lograge/log_subscribers/action_controller.rb#L31