### PR TITLE
Change default Capybara driver to Chrome headless

### DIFF
--- a/spec/features/google_login_spec.rb
+++ b/spec/features/google_login_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Google auth' do
     let(:stubbed_user_email) { user.email }
     let(:user) { users(:user) }
 
-    it 'allows a user to log in with Google', :js do
+    it 'allows a user to log in with Google' do
       visit(login_path)
       expect(page).to have_button('Sign in with Google')
 
@@ -43,7 +43,7 @@ RSpec.describe 'Google auth' do
 
     before { expect(User.where(email: stubbed_user_email)).not_to exist }
 
-    it 'allows a user to sign up (and log in) with Google', :js do
+    it 'allows a user to sign up (and log in) with Google' do
       visit(login_path)
       expect(page).to have_button('Sign in with Google')
 

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Groceries app' do
   context 'when user is signed in' do
     before { sign_in(user) }
 
-    it 'renders expected content', :js do
+    it 'renders expected content' do
       visit groceries_path
 
       expect(page).to have_text(user.email)

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Home page' do
       )
   end
 
-  it 'says "David Runger / Full stack web developer", creates `Request`, fetches IP info', :js do
+  it 'says "David Runger / Full stack web developer", creates `Request`, fetches IP info' do
     spec_start_time = Time.current
 
     expect {
@@ -66,7 +66,8 @@ RSpec.describe 'Home page' do
     expect(ip_info_request_stub).to have_been_requested
   end
 
-  context 'when using an unsupported browser' do
+  # we need to use the :rack_test driver because Chrome doesn't have the page.driver.header method
+  context 'when using an unsupported browser', :rack_test_driver do
     let(:ie_11_user_agent) { 'Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko' }
 
     before do

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Logs app' do
   context 'when user is signed in' do
     before { sign_in(user) }
 
-    it 'renders the logs app', :js do
+    it 'renders the logs app' do
       visit logs_path
 
       expect(page).to have_text(user.email)

--- a/spec/features/workout_spec.rb
+++ b/spec/features/workout_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Workout app' do
   context 'when user is signed in' do
     before { sign_in(user) }
 
-    it 'renders expected content', :js do
+    it 'renders expected content' do
       visit workout_path
 
       # form for new workout

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ Capybara.register_driver(:chrome_headless) do |app|
   options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
   Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 end
-Capybara.default_driver = :rack_test
+Capybara.default_driver = :chrome_headless
 Capybara.javascript_driver = :chrome_headless
 # allow loading JS & CSS assets via `save_and_open_page` when running `rails s`
 Capybara.asset_host = 'http://localhost:3000'
@@ -124,6 +124,12 @@ RSpec.configure do |config|
 
   config.after(:each, type: :controller) do
     Devise.sign_out_all_scopes
+  end
+
+  config.around(:each, :rack_test_driver) do |spec|
+    Capybara.current_driver = :rack_test
+    spec.run
+    Capybara.use_default_driver
   end
 
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
The vast majority of our feature specs (all but one, I think) use Chrome headless (via the `:js` spec metadata/tag), so let's just make it the default and opt out in the rare cases where we don't want to use Chrome.

Specs that need to use the `:rack_test` driver may opt in via the `:rack_test_driver` spec metadata flag that this PR adds support for.