### PR TITLE
Delete Request::recent scope

### DIFF
--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -38,11 +38,4 @@ class Request < ApplicationRecord
 
   validates :url, :handler, :method, :ip, :requested_at, :status, presence: true
   validates :request_id, presence: true
-
-  # rubocop:disable Layout/MultilineMethodArgumentLineBreaks
-  scope :recent, ->(time_period = 1.day) {
-    # convert time_period to integer to avoid DST issues
-    where('requests.requested_at > ?', Time.current - Integer(time_period))
-  }
-  # rubocop:enable Layout/MultilineMethodArgumentLineBreaks
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -1,35 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe Request do
-  describe 'validations' do
-    it { is_expected.not_to validate_presence_of(:format) }
-    it { is_expected.not_to validate_presence_of(:db) }
-    it { is_expected.not_to validate_presence_of(:view) }
-  end
-
-  describe '::recent' do
-    context 'when called without an argument' do
-      subject(:recent_requests) { Request.recent }
-
-      let!(:recent_request) { create(:request, requested_at: 23.hours.ago) }
-      let!(:old_request) { create(:request, requested_at: 25.hours.ago) }
-
-      it 'includes only recent requests within the last day' do
-        expect(recent_requests).to include(recent_request)
-        expect(recent_requests).not_to include(old_request)
-      end
-    end
-
-    context 'when called with an argument' do
-      subject(:requests_in_last_2_days) { Request.recent(2.days) }
-
-      let!(:recent_request) { create(:request, requested_at: 47.hours.ago) }
-      let!(:old_request) { create(:request, requested_at: 49.hours.ago) }
-
-      it 'includes requests within the specified time period' do
-        expect(requests_in_last_2_days).to include(recent_request)
-        expect(requests_in_last_2_days).not_to include(old_request)
-      end
-    end
-  end
+  it { is_expected.not_to validate_presence_of(:format) }
+  it { is_expected.not_to validate_presence_of(:db) }
+  it { is_expected.not_to validate_presence_of(:view) }
 end


### PR DESCRIPTION
I don't think our code ever used this scope; I believe I added it for use in `rails console` -- but I don't use it there, either.