### PR TITLE
Remove unnecessary Pundit policy action specification

### DIFF
--- a/app/controllers/api/users_controller.rb
+++ b/app/controllers/api/users_controller.rb
@@ -3,7 +3,7 @@
 class Api::UsersController < ApplicationController
   def update
     @user = User.find(params[:id])
-    authorize(@user, :update?)
+    authorize(@user)
     @user.update!(user_params)
     render json: @user
   end


### PR DESCRIPTION
The fact that we are in the `#update` controller action means that Pundit already knows to automatically check the `#update?` Pundit policy by default; specifying that policy name is not necessary.