### PR TITLE
Allow users to create log entry via query param in logs#index action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,12 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user
   before_action :enable_rack_mini_profiler_if_admin
 
-  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+  rescue_from(
+    Pundit::NotAuthorizedError,
+    TokenAuthorizable::BlankToken,
+    TokenAuthorizable::IncorrectToken,
+    with: :user_not_authorized,
+  )
 
   private
 

--- a/app/controllers/concerns/token_authorizable.rb
+++ b/app/controllers/concerns/token_authorizable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module TokenAuthorizable
+  extend ActiveSupport::Concern
+
+  class BlankToken < StandardError ; end
+  class IncorrectToken < StandardError ; end
+
+  private
+
+  def verify_valid_auth_token!
+    auth_token_param = params[:auth_token]
+
+    if auth_token_param.blank?
+      raise(BlankToken)
+    end
+
+    if auth_token_param != current_user.auth_token
+      raise(IncorrectToken)
+    end
+
+    true
+  end
+end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class LogsController < ApplicationController
+  include TokenAuthorizable
+
   def index
     user_id_param = params[:user_id]
     if user_id_param && params[:slug]
@@ -10,6 +12,15 @@ class LogsController < ApplicationController
       logs = Log.where(id: shared_log)
     else
       logs = current_user.logs.order(:created_at)
+
+      slug = params[:slug]
+      new_entry = params[:new_entry]
+      if slug && new_entry
+        verify_valid_auth_token!
+        log = current_user.logs.find_by!(slug: slug)
+        log.log_entries.create!(data: new_entry)
+        bootstrap(toast_messages: ['New Log entry created!'])
+      end
     end
 
     @title = 'Logs'

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,8 @@ class UsersController < ApplicationController
   using BlankParamsAsNil
 
   def edit
+    @user = User.find(params[:id])
+    authorize(@user)
     render :edit
   end
 
@@ -24,7 +26,7 @@ class UsersController < ApplicationController
   def user_params
     params.
       require(:user).
-      permit(:phone).
+      permit(:auth_token, :phone).
       blank_params_as_nil(%w[phone])
   end
 end

--- a/app/javascript/logs/logs.vue
+++ b/app/javascript/logs/logs.vue
@@ -13,6 +13,7 @@ div
 
 <script>
 import { mapGetters, mapState } from 'vuex';
+import Toastify from 'toastify-js';
 import 'toastify-js/src/toastify.css';
 
 import signOutMixin from 'lib/mixins/sign_out_mixin';
@@ -50,6 +51,22 @@ export default {
         this.$store.commit('showModal', { modalName: 'log-selector' });
       }
     });
+
+    // display any initial toast messages
+    const toastMessages = this.bootstrap.toast_messages;
+    if (toastMessages) {
+      toastMessages.forEach((message) => {
+        Toastify({
+          text: message,
+          className: 'success',
+          position: 'center',
+          duration: 1800,
+        }).showToast();
+      });
+    }
+
+    // remove any query params that might be present (e.g. `new_entry` and `auth_token`)
+    window.history.replaceState({}, document.title, window.location.pathname);
   },
 
   mixins: [signOutMixin],

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -60,6 +60,10 @@ class Log < ApplicationRecord
 
   before_validation :set_slug, if: -> { name_changed? }
 
+  DATA_TYPES.each_key do |data_type|
+    scope(data_type, -> { where(data_type: data_type) })
+  end
+
   scope :needing_reminder,
     -> {
       left_joins(:number_log_entries).

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,7 +1,12 @@
 # frozen_string_literal: true
 
 class UserPolicy < ApplicationPolicy
-  def update?
+  def edit?
+    # user can only edit themself
     @user == @record
+  end
+
+  def update?
+    edit?
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -4,6 +4,7 @@
 #
 # Table name: users
 #
+#  auth_token       :text             not null
 #  created_at       :datetime         not null
 #  email            :string           not null
 #  id               :bigint           not null, primary key

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -1,4 +1,11 @@
-= form_with model: current_user do |form|
-  = form.label :phone, 'Phone (country code recommended, e.g. 15551239876)'
-  = form.text_field :phone
-  = form.submit
+= form_with model: @user do |form|
+  %div
+    = form.label :phone, 'Phone (country code recommended, e.g. 15551239876)'
+    = form.text_field :phone
+
+  %div
+    = form.label :auth_token, 'Auth token (for advanced features; safe to ignore)'
+    = form.text_field :auth_token
+
+  %div
+    = form.submit

--- a/db/datamigrate/set_auth_token_for_users.rb
+++ b/db/datamigrate/set_auth_token_for_users.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+def set_auth_token_for_users
+  # before_validation hook will set auth_token for the user if they don't have one already
+  User.find_each(&:save!)
+end

--- a/db/migrate/20200610032941_add_auth_token_to_users.rb
+++ b/db/migrate/20200610032941_add_auth_token_to_users.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require Rails.root.join('db/datamigrate/set_auth_token_for_users.rb')
+
+class AddAuthTokenToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :auth_token, :text
+    set_auth_token_for_users
+    change_column_null :users, :auth_token, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_06_140045) do
+ActiveRecord::Schema.define(version: 2020_06_10_032941) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -164,6 +164,7 @@ ActiveRecord::Schema.define(version: 2020_06_06_140045) do
     t.datetime "last_activity_at"
     t.string "phone"
     t.float "sms_allowance", default: 1.0, null: false, comment: "Total cost in EUR of text messages that the user is allowed to accrue."
+    t.text "auth_token", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/controllers/api/log_entries_controller_spec.rb
+++ b/spec/controllers/api/log_entries_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Api::LogEntriesController do
     end
 
     context 'when the log entry params are valid' do
-      let(:log) { user.logs.where(data_type: 'number').first! }
+      let(:log) { user.logs.number.first! }
       let(:valid_params) { { log_entry: { data: 122, log_id: log.id } } }
       let(:params) { valid_params }
 

--- a/spec/controllers/logs/uploads_controller_spec.rb
+++ b/spec/controllers/logs/uploads_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Logs::UploadsController do
 
     after { tempfile.close }
 
-    let(:log) { user.logs.where(data_type: 'number').first! }
+    let(:log) { user.logs.number.first! }
     let(:tempfile) { Tempfile.new('log_data.csv') }
     let(:csv_file) do
       # https://rubyquicktips.com/post/27753730620/testing-csv-file-uploads

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -20,47 +20,58 @@ RSpec.describe UsersController do
   describe '#update' do
     subject(:patch_update) { patch(:update, params: { id: user.id, user: user_params }) }
 
-    let(:user_params) { { phone: new_phone_number } }
+    context "when updating the user's phone number" do
+      let(:user_params) { { phone: new_phone_number } }
 
-    before { user.update!(phone: '11231231234') }
+      before { user.update!(phone: '11231231234') }
 
-    context 'when the user is valid (i.e. can be updated successfully)' do
-      before { expect(user).to be_valid }
+      context 'when the user is valid (i.e. can be updated successfully)' do
+        before { expect(user).to be_valid }
 
-      context 'when the submitted params are valid' do
-        let(:new_phone_number) { "1555#{Array.new(7) { rand(10).to_s }.join('')}" }
+        context 'when the submitted params are valid' do
+          let(:new_phone_number) { "1555#{Array.new(7) { rand(10).to_s }.join('')}" }
 
-        it 'updates the user' do
-          expect { patch_update }.
-            to change { user.reload.phone }.
-            to(new_phone_number)
+          it 'updates the user' do
+            expect { patch_update }.
+              to change { user.reload.phone }.
+              to(new_phone_number)
+          end
+
+          it 'sets a flash message' do
+            patch_update
+
+            expect(flash[:notice]).to eq('Updated successfully!')
+          end
         end
 
-        it 'sets a flash message' do
-          patch_update
+        context 'when the submitted params are not valid' do
+          let(:new_phone_number) { 'this is not a phone number' }
 
-          expect(flash[:notice]).to eq('Updated successfully!')
+          it 'does not update the user' do
+            expect { patch_update }.not_to change { user.reload.phone }
+          end
+
+          it 're-renders the edit page' do
+            patch_update
+
+            expect(patch_update).to render_template('users/edit')
+          end
+
+          it 'sets a flash message' do
+            patch_update
+
+            expect(flash[:alert]).to eq('Please fix these problems: Phone is invalid')
+          end
         end
       end
+    end
 
-      context 'when the submitted params are not valid' do
-        let(:new_phone_number) { 'this is not a phone number' }
+    context 'when params include an `auth_token`' do
+      let(:user_params) { { auth_token: new_auth_token } }
+      let(:new_auth_token) { SecureRandom.uuid }
 
-        it 'does not update the user' do
-          expect { patch_update }.not_to change { user.reload.phone }
-        end
-
-        it 're-renders the edit page' do
-          patch_update
-
-          expect(patch_update).to render_template('users/edit')
-        end
-
-        it 'sets a flash message' do
-          patch_update
-
-          expect(flash[:alert]).to eq('Please fix these problems: Phone is invalid')
-        end
+      it "updates the user's `auth_token` to the new value" do
+        expect { patch_update }.to change { user.reload.auth_token }.to(new_auth_token)
       end
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,7 @@
 #
 # Table name: users
 #
+#  auth_token       :text             not null
 #  created_at       :datetime         not null
 #  email            :string           not null
 #  id               :bigint           not null, primary key


### PR DESCRIPTION
In order for this to be somewhat secure / prevent CSRF-like attacks, we also need the user to incude an authorization token as a query param, as well.

For example, a user might make a request like this:
```
GET /logs/weight?new_entry=120.4&auth_token=123ThisShouldBeTheUsersToken
```

and that will create a new log entry with the value `120.4` for the user's `weight` log.

The motivation for this feature is that one can then set up a bookmark/"search" in their browser like this (note the `%s` part):
```
https://www.davidrunger.com/logs/weight?new_entry=%s&auth_token=abc123
```

and set that up with a keyword of `w`, which makes submitting a log entry for that log as simple as entering `w 120.4` or whatever in the user's browser URL bar.

(In order to set up that sort of browser bookmark/"search", the user will need to get their `auth_token`, which, as of this PR, they can do via the user edit page.)