### PR TITLE
Only run eslint if files with JavaScript were changed

### DIFF
--- a/bin/orchestrate-tests.rb
+++ b/bin/orchestrate-tests.rb
@@ -230,6 +230,7 @@ class OrchestrateTests < Pallets::Workflow
   TRIMMABLE_CHECKS = {
     RunAnnotate => proc { OrchestrateTests.skip_database_checks? },
     RunDatabaseConsistency => proc { OrchestrateTests.skip_database_checks? },
+    RunEslint => proc { !OrchestrateTests.files_with_js_changed? },
     RunImmigrant => proc { OrchestrateTests.skip_database_checks? },
     RunStylelint => proc { OrchestrateTests.skip_css_checks? },
     SetupJs => proc do |tentative_list|
@@ -245,6 +246,13 @@ class OrchestrateTests < Pallets::Workflow
 
     def db_schema_changed?
       files_changed.include?('db/schema.rb')
+    end
+
+    def files_with_js_changed?
+      (
+        (Dir['app/javascript/**/*.{js,vue}'] + Dir['spec/javascript/**/*.{js,vue}']) &
+          files_changed
+      ).any?
     end
 
     def files_changed


### PR DESCRIPTION
Based on some recent `master` builds ( https://travis-ci.org/github/davidrunger/david_runger/builds/697080710 , https://travis-ci.org/github/davidrunger/david_runger/builds/697087477 ), it seems like we can expect this to save us about 6 to 7 seconds per build that doesn't change any `.js` or `.vue` files in `app/javascript/` or `spec/javascript/`.