### PR TITLE
Split Travis env variables onto separate lines via `global` config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@ addons:
   chrome: stable
   postgresql: "9.6"
 env:
-  - RAILS_ENV=test NODE_ENV=test DISABLE_SPRING=1 SECRET_KEY_BASE=0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b
+  global:
+    - RAILS_ENV=test
+    - NODE_ENV=test
+    - DISABLE_SPRING=1
+    - SECRET_KEY_BASE=0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b
 before_install:
   - . $HOME/.nvm/nvm.sh
   - nvm install 12.13.0


### PR DESCRIPTION
I have tried to do this previously, which -- without the `global` option -- triggered Travis's "build matrix" functionality, which was not what I want. I just want to trigger a single build, which is what (I think) this accomplishes, while also allowing the variables to be split onto separate lines, for better clarity/readability.

I saw that this `global` config option is available when looking at these docs https://docs.travis-ci.com/user/speeding-up-the-build/#rspec-parallelization-example for an unrelated reason.