### PR TITLE
Speficy `os` and `dist` options in `.travis.yml`; remove `sudo`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
-sudo: false
+os: linux
+dist: bionic
 cache:
   bundler: true
   directories:
@@ -9,7 +10,7 @@ rvm:
 services:
   - memcached
   - postgresql
-  - redis-server
+  - redis
 addons:
   chrome: stable
   postgresql: "9.6"


### PR DESCRIPTION
Also: change `redis-server` to `redis`.

I am making these changes per the recommendations/warnings of Travis: https://travis-ci.org/github/davidrunger/david_runger/jobs/697123151/config

![image](https://user-images.githubusercontent.com/8197963/84355205-0addfe00-ab77-11ea-82e0-21e755910aa7.png)

I am specifying the `bionic` Ubuntu version (version 18) because that's the Heroku stack that we are currently on.