### PR TITLE
Don't run `git checkout config/webpacker.yml` after running tests

### DIFF
--- a/bin/orchestrate-tests.rb
+++ b/bin/orchestrate-tests.rb
@@ -199,8 +199,6 @@ class RunRubySpecs < Pallets::Task
       #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
       bin/rspec --format documentation
     COMMAND
-  ensure
-    execute_system_command('git checkout config/webpacker.yml')
   end
 end
 


### PR DESCRIPTION
This is no longer necessary since we deleted JaavaScript tests in #2835 / 5ba0c9f ; in that PR we updated the default settings in `config/webpacker.yml` to be appropriate for our Ruby tests (and so we stopped changing `config/webpacker.yml` before running Ruby tests (and so there's no longer any point in checking out `config/webpacker.yml` after Ruby tests)).