### PR TITLE
Use `rspec-instafail` RSpec formatter in Travis

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -83,6 +83,7 @@ group :test do
   gem 'codecov', require: false
   gem 'database_consistency', require: false
   gem 'fixture_builder'
+  gem 'rspec-instafail', require: false
   # note: to use guard-espect from command line, it will also have to be installed "globally"
   gem 'guard-espect', require: false, github: 'davidrunger/guard-espect'
   gem 'hashdiff'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -414,6 +414,8 @@ GEM
     rspec-expectations (3.9.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
+    rspec-instafail (1.0.0)
+      rspec
     rspec-mocks (3.9.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
@@ -580,6 +582,7 @@ DEPENDENCIES
   rails-controller-testing
   redis
   rollbar
+  rspec-instafail
   rspec-rails
   rubocop
   rubocop-performance

--- a/bin/orchestrate-tests.rb
+++ b/bin/orchestrate-tests.rb
@@ -197,7 +197,7 @@ class RunRubySpecs < Pallets::Task
   def run
     execute_system_command(<<~COMMAND)
       #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
-      bin/rspec --format documentation
+      bin/rspec --format RSpec::Instafail --format progress --color
     COMMAND
   end
 end


### PR DESCRIPTION
We now have 199 tests, which is kind of a lot and generates a lot of output when using the documentation formatter, as we were doing before. The result was a lot of scrolling when looking at the Travis build log, without much upside (since we rarely look at the passed example descriptions (although, on the other hand, I guess it is helpful to be able to known which spec is causing deprecation/log output, but whatever)).

With the rspec-instafail formatter, we'll print the info about any failures as they occur, but we won't print any info about passed examples (except for a (supposed-to-be-)green dot from also including the `--format progress` option, as well).