### PR TITLE
Print colorized RSpec output in Travis

### DIFF
--- a/bin/orchestrate-tests.rb
+++ b/bin/orchestrate-tests.rb
@@ -200,7 +200,7 @@ class RunHtmlControllerTests < Pallets::Task
       bin/rspec
       $(ls -d spec/controllers/*/ | grep -v 'spec/controllers/api/' | tr '\\n' ' ')
       $(ls spec/controllers/*.rb)
-      --format RSpec::Instafail --format progress --color
+      --format RSpec::Instafail --format progress --force-color
     COMMAND
   end
 end
@@ -211,7 +211,7 @@ class RunFeatureTests < Pallets::Task
     execute_system_command(<<~COMMAND)
       #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
       bin/rspec spec/features/
-      --format RSpec::Instafail --format progress --color
+      --format RSpec::Instafail --format progress --force-color
     COMMAND
   end
 end
@@ -224,7 +224,7 @@ class RunUnitTests < Pallets::Task
       bin/rspec
       $(ls -d spec/*/ | grep --extended-regex -v 'spec/(controllers|features)/' | tr '\\n' ' ')
       spec/controllers/api/
-      --format RSpec::Instafail --format progress --color
+      --format RSpec::Instafail --format progress --force-color
     COMMAND
   end
 end


### PR DESCRIPTION
This is a bug in Travis ( https://github.com/travis-ci/travis-ci/issues/ 7967 ) but fortunately it's easy to fix via the `--force-color` RSpec option/flag. 🙌 This solution is better than the `expect-dev` / `unbuffer` solution mentioned in that thread because installing `expect-dev` takes a little while (~15 seconds, I think) which we'd rather not have to wait for just to get colorized output.