### PR TITLE
Run rubocop in tests if the diff text mentions rubocop anywhere

### DIFF
--- a/bin/orchestrate-tests.rb
+++ b/bin/orchestrate-tests.rb
@@ -311,6 +311,20 @@ class OrchestrateTests < Pallets::Workflow
     end
 
     memoize \
+    def diff
+      command = <<~COMMAND.squish
+        git log master..HEAD --full-diff --source --format="" --unified=0 -p .
+          | grep -Ev "^(diff |index |--- a/|\\+\\+\\+ b/|@@ )"
+      COMMAND
+      `#{command}`
+    end
+
+    memoize \
+    def diff_mentions_rubocop?
+      diff.match?(%r{rubocop}i)
+    end
+
+    memoize \
     def files_changed
       if !system('git log -1 --pretty="%H" master > /dev/null 2>&1')
         puts('`master` branch is not present; fetching it now...')


### PR DESCRIPTION
For example, adding or removing a `# rubocop:disable` comment would mean that it's probably a good idea to run rubocop.