### PR TITLE
Allow changing test dependency graph via `.tests.yml` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ spec/fixtures/*.yml
 webpack.config.static.js
 /app/javascript/rails_assets
 coverage/
+.tests.yml

--- a/bin/run-tests.rb
+++ b/bin/run-tests.rb
@@ -24,4 +24,4 @@ Pallets.configure do |c|
   c.middleware << ExitOnFailureMiddleware
 end
 
-Test::Runner.new.run
+Test::Runner.run_once_config_is_confirmed

--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -1,53 +1,151 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/CyclomaticComplexity
 class Test::RequirementsResolver
   extend Memoist
   include DiffHelpers
 
-  DEPENDENCY_MAP = {
-    # Installation / Setup
-    Test::Tasks::CheckVersions => nil,
-    Test::Tasks::EnsureLatestChromedriverIsInstalled => nil,
-    Test::Tasks::YarnInstall => nil,
-    Test::Tasks::CompileJavaScript => Test::Tasks::YarnInstall,
-    Test::Tasks::SetupDb => nil,
-    Test::Tasks::BuildFixtures => Test::Tasks::SetupDb,
+  class << self
+    extend Memoist
 
-    # Checks
-    Test::Tasks::RunStylelint => Test::Tasks::YarnInstall,
-    # RunEslint depends on `CompileJavaScript` to write a `webpack.config.static.js` file
-    Test::Tasks::RunEslint => Test::Tasks::CompileJavaScript,
-    Test::Tasks::RunAnnotate => Test::Tasks::SetupDb,
-    Test::Tasks::RunBrakeman => nil,
-    Test::Tasks::RunDatabaseConsistency => Test::Tasks::SetupDb,
-    Test::Tasks::RunImmigrant => Test::Tasks::SetupDb,
-    Test::Tasks::RunRubocop => nil,
-    Test::Tasks::RunUnitTests => Test::Tasks::BuildFixtures,
-    Test::Tasks::RunHtmlControllerTests => [
-      Test::Tasks::BuildFixtures,
-      Test::Tasks::CompileJavaScript,
-    ].freeze,
-    Test::Tasks::RunFeatureTests => [
-      Test::Tasks::BuildFixtures,
-      Test::Tasks::CompileJavaScript,
-      Test::Tasks::EnsureLatestChromedriverIsInstalled,
-    ].freeze,
+    # rubocop:disable Metrics/MethodLength
+    # rubocop:disable Metrics/PerceivedComplexity
+    memoize \
+    def dependency_map
+      base_dependency_map = {
+        # Installation / Setup
+        Test::Tasks::CheckVersions => nil,
+        Test::Tasks::EnsureLatestChromedriverIsInstalled => nil,
+        Test::Tasks::YarnInstall => nil,
+        Test::Tasks::CompileJavaScript => Test::Tasks::YarnInstall,
+        Test::Tasks::SetupDb => nil,
+        Test::Tasks::BuildFixtures => Test::Tasks::SetupDb,
 
-    # Exit depends on all other tasks completing that are actual checks (as opposed to setup steps)
-    Test::Tasks::Exit => [
-      Test::Tasks::CheckVersions,
-      Test::Tasks::RunAnnotate,
-      Test::Tasks::RunBrakeman,
-      Test::Tasks::RunDatabaseConsistency,
-      Test::Tasks::RunEslint,
-      Test::Tasks::RunFeatureTests,
-      Test::Tasks::RunHtmlControllerTests,
-      Test::Tasks::RunImmigrant,
-      Test::Tasks::RunRubocop,
-      Test::Tasks::RunStylelint,
-      Test::Tasks::RunUnitTests,
-    ].freeze,
-  }.freeze
+        # Checks
+        Test::Tasks::RunStylelint => Test::Tasks::YarnInstall,
+        # RunEslint depends on `CompileJavaScript` to write a `webpack.config.static.js` file
+        Test::Tasks::RunEslint => Test::Tasks::CompileJavaScript,
+        Test::Tasks::RunAnnotate => Test::Tasks::SetupDb,
+        Test::Tasks::RunBrakeman => nil,
+        Test::Tasks::RunDatabaseConsistency => Test::Tasks::SetupDb,
+        Test::Tasks::RunImmigrant => Test::Tasks::SetupDb,
+        Test::Tasks::RunRubocop => nil,
+        Test::Tasks::RunUnitTests => Test::Tasks::BuildFixtures,
+        Test::Tasks::RunHtmlControllerTests => [
+          Test::Tasks::BuildFixtures,
+          Test::Tasks::CompileJavaScript,
+        ],
+        Test::Tasks::RunFeatureTests => [
+          Test::Tasks::BuildFixtures,
+          Test::Tasks::CompileJavaScript,
+          Test::Tasks::EnsureLatestChromedriverIsInstalled,
+        ],
+
+        # Exit depends on all tasks completing that are actual checks (as opposed to setup steps)
+        Test::Tasks::Exit => [
+          Test::Tasks::CheckVersions,
+          Test::Tasks::RunAnnotate,
+          Test::Tasks::RunBrakeman,
+          Test::Tasks::RunDatabaseConsistency,
+          Test::Tasks::RunEslint,
+          Test::Tasks::RunFeatureTests,
+          Test::Tasks::RunHtmlControllerTests,
+          Test::Tasks::RunImmigrant,
+          Test::Tasks::RunRubocop,
+          Test::Tasks::RunStylelint,
+          Test::Tasks::RunUnitTests,
+        ],
+      }
+
+      if run_defaults?
+        # change nothing
+      elsif run_all?
+        all_non_exit_tasks = base_dependency_map.keys.reject { _1 == Test::Tasks::Exit }
+        base_dependency_map[Test::Tasks::Exit] = all_non_exit_tasks
+      else
+        validate_task_config_groups!
+
+        if targets.any?
+          base_dependency_map[Test::Tasks::Exit] += targets
+        end
+
+        forces.each do |force|
+          if !force.in?(base_dependency_map[Test::Tasks::Exit])
+            base_dependency_map[Test::Tasks::Exit] << force
+          end
+        end
+
+        skips.each do |skip|
+          base_dependency_map.reject! { |key, _value| key == skip }
+          base_dependency_map.transform_values! do |value|
+            if value.nil?
+              value
+            elsif Array(value).include?(skip)
+              Array(value).reject { _1 == skip }
+            else
+              value
+            end
+          end
+        end
+      end
+
+      base_dependency_map
+    end
+    # rubocop:enable Metrics/PerceivedComplexity
+    # rubocop:enable Metrics/MethodLength
+
+    def run_defaults?
+      global_config['run_defaults']
+    end
+
+    def run_all?
+      global_config['run_all']
+    end
+
+    memoize \
+    def config
+      YAML.load_file('bin/test/.tests.yml') rescue Hash.new { |hash, key| hash[key] = {} }
+    end
+
+    def forces
+      (task_config_groups['force'] || []).map { "Test::Tasks::#{_1}".constantize }
+    end
+
+    def global_config
+      config['global']
+    end
+
+    def skips
+      (task_config_groups['skip'] || []).map { "Test::Tasks::#{_1}".constantize }
+    end
+
+    def targets
+      (task_config_groups['target'] || []).map { "Test::Tasks::#{_1}".constantize }
+    end
+
+    def task_config
+      config['tasks'].transform_values { _1 || 'default' }
+    end
+
+    memoize \
+    def task_config_groups
+      task_config.group_by { |_key, value| value }.transform_values { _1.map(&:first) }
+    end
+
+    def validate_task_config_groups!
+      task_config_options = %w[
+        default
+        force
+        skip
+        target
+      ]
+
+      unexpected_task_options = task_config_groups.keys - task_config_options
+      if unexpected_task_options.any?
+        raise("Bad task_config! Unexpected options #{unexpected_task_options}.")
+      end
+    end
+  end
 
   CHECK_CAN_BE_SKIPPED_CONDITIONS = {
     Test::Tasks::BuildFixtures => proc { running_locally? },
@@ -75,7 +173,7 @@ class Test::RequirementsResolver
       true_requirements_at_start = true_requirements
 
       tentative_requirements = tasks_and_dependencies(target_tasks)
-      new_tentative_requirements = tentative_requirements
+      new_tentative_requirements = tentative_requirements.dup
       skippable_requirements = []
       tentative_requirements.each do |task|
         if can_skip?(task)
@@ -102,13 +200,22 @@ class Test::RequirementsResolver
   private
 
   def can_skip?(task)
+    return false if self.class.run_all?
+
+    if !self.class.run_defaults?
+      return false if self.class.forces.include?(task)
+      return true if self.class.skips.include?(task)
+      return false if self.class.targets.include?(task)
+    end
+
     instance_eval(&(CHECK_CAN_BE_SKIPPED_CONDITIONS[task] || proc { false }))
   end
 
   def tasks_and_dependencies(target_tasks, known_dependencies: [], skippable_requirements: [])
     new_dependencies =
-      DEPENDENCY_MAP.values_at(*target_tasks).
+      self.class.dependency_map.values_at(*target_tasks).
         flatten.reject(&:nil?) - known_dependencies - skippable_requirements
+    new_dependencies.reject { can_skip?(_1) }
 
     if new_dependencies.empty?
       target_tasks
@@ -127,3 +234,4 @@ class Test::RequirementsResolver
     !ENV.key?('TRAVIS')
   end
 end
+# rubocop:enable Metrics/CyclomaticComplexity

--- a/bin/test/runner.rb
+++ b/bin/test/runner.rb
@@ -6,6 +6,7 @@ module Test::Tasks ; end
 require_relative '../../config/application.rb'
 require 'English'
 require 'benchmark'
+require 'io/console'
 require File.join(File.dirname(__FILE__), 'diff_helpers.rb')
 require File.join(File.dirname(__FILE__), 'task_helpers.rb')
 Dir[File.join(File.dirname(__FILE__), 'tasks', '*.rb')].each { require _1 }
@@ -14,22 +15,84 @@ require File.join(File.dirname(__FILE__), 'requirements_resolver.rb')
 Rails.application.load_tasks
 
 class Test::Runner < Pallets::Workflow
-  required_tasks = Test::RequirementsResolver.new.required_tasks
-  ap('Running these tasks:')
-  ap(required_tasks.map(&:name).sort)
-  ap('NOT running these tasks:')
-  ap((Test::RequirementsResolver::DEPENDENCY_MAP.keys - required_tasks).map(&:name).sort)
-
-  Test::RequirementsResolver::DEPENDENCY_MAP.slice(*required_tasks).each do |task, prerequisites|
-    if Array(prerequisites).reject(&:nil?).empty?
-      task(task)
-    else
-      task(task => Array(prerequisites) & required_tasks)
-    end
-  end
-
   class << self
+    extend Memoist
+
     attr_accessor :exit_code
+
+    def register_tasks_and_run
+      register_tasks
+      new.run
+    end
+
+    def run_once_config_is_confirmed
+      if ENV.key?('TRAVIS')
+        register_tasks_and_run
+      else
+        confirm_config
+      end
+    end
+
+    memoize \
+    def required_tasks
+      Test::RequirementsResolver.new.required_tasks
+    end
+
+    def print_config
+      system('clear') if !ENV.key?('TRAVIS')
+
+      ap('Running these tasks:')
+      ap(required_tasks.map(&:name).sort)
+      ap('NOT running these tasks:')
+      ap((Pallets::Task.descendants - required_tasks).map(&:name).sort)
+    end
+
+    def confirm_config
+      print_config
+      print("\n^ Does that config look good? [y]n")
+      response = STDIN.getch
+
+      if response == "\u0003" # ctrl-c
+        exit(1)
+      elsif response.gsub(/\n|\r/, '').downcase.in?(['', 'y'])
+        puts
+      else
+        system('$EDITOR bin/test/.tests.yml')
+
+        @listener =
+          Listen.to("#{Dir.pwd}/bin/test/", only: /\A.tests.yml\z/) do |_modified, _added, _removed|
+            # reset memoized methods
+            flush_cache
+            Test::RequirementsResolver.flush_cache
+
+            print_config
+
+            puts('What about now? Hit enter to confirm.')
+          end
+        @listener.start
+
+        loop do
+          sleep(0.1)
+          # wait until the user hits enter (which will make `STDIN.ready?` true)
+          if STDIN.ready?
+            STDIN.gets while STDIN.ready? # clear the user's input from STDIN
+            break
+          end
+        end
+      end
+
+      register_tasks_and_run
+    end
+
+    def register_tasks
+      Test::RequirementsResolver.dependency_map.slice(*required_tasks).each do |task, prerequisites|
+        if Array(prerequisites).reject(&:nil?).empty?
+          task(task)
+        else
+          task(task => Array(prerequisites) & required_tasks)
+        end
+      end
+    end
   end
 
   self.exit_code = 0


### PR DESCRIPTION
By creating a file like this in `bin/test/.tests.yml`, this PR makes it very easy to customize which tests are run when executing specs locally:

```yaml
global:
  run_defaults: false
  run_all: false
tasks:
  BuildFixtures:
  CheckVersions: force
  CompileJavaScript: skip
  EnsureLatestChromedriverIsInstalled: force
  Exit:
  RunAnnotate:
  RunBrakeman: skip
  RunDatabaseConsistency: force
  RunEslint: skip
  RunFeatureTests: skip
  RunHtmlControllerTests: skip
  RunImmigrant:
  RunRubocop: force
  RunStylelint:
  RunUnitTests:
  SetupDb: force
  YarnInstall: skip
```

The code is pretty hideous, but the functionality is kind of cool, so I think that I am going to keep it for now. We can always try to clean up the code and/or delete it later.