### PR TITLE
Drop last 2 words from EnsureLatestChromedriverIsInstalled task name

### DIFF
--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -15,7 +15,7 @@ class Test::RequirementsResolver
       base_dependency_map = {
         # Installation / Setup
         Test::Tasks::CheckVersions => nil,
-        Test::Tasks::EnsureLatestChromedriverIsInstalled => nil,
+        Test::Tasks::EnsureLatestChromedriver => nil,
         Test::Tasks::YarnInstall => nil,
         Test::Tasks::CompileJavaScript => Test::Tasks::YarnInstall,
         Test::Tasks::SetupDb => nil,
@@ -38,7 +38,7 @@ class Test::RequirementsResolver
         Test::Tasks::RunFeatureTests => [
           Test::Tasks::BuildFixtures,
           Test::Tasks::CompileJavaScript,
-          Test::Tasks::EnsureLatestChromedriverIsInstalled,
+          Test::Tasks::EnsureLatestChromedriver,
         ],
 
         # Exit depends on all tasks completing that are actual checks (as opposed to setup steps)

--- a/bin/test/tasks/ensure_latest_chromedriver.rb
+++ b/bin/test/tasks/ensure_latest_chromedriver.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Test::Tasks::EnsureLatestChromedriverIsInstalled < Pallets::Task
+class Test::Tasks::EnsureLatestChromedriver < Pallets::Task
   include Test::TaskHelpers
 
   def run


### PR DESCRIPTION
The task name was too long before! It was by far our longest task name.