### PR TITLE
Move from `users.auth_token` column to separate `auth_tokens` table

### DIFF
--- a/app/actions/auth_tokens/create.rb
+++ b/app/actions/auth_tokens/create.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class AuthTokens::Create < ApplicationAction
+  requires :user, User
+
+  def execute
+    user.auth_tokens.create!(secret: SecureRandom.uuid)
+  end
+end

--- a/app/assets/stylesheets/utils/display.scss
+++ b/app/assets/stylesheets/utils/display.scss
@@ -1,0 +1,3 @@
+.inline {
+  display: inline;
+}

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -17,7 +17,7 @@ class ApplicationController < ActionController::Base
   rescue_from(
     Pundit::NotAuthorizedError,
     TokenAuthorizable::BlankToken,
-    TokenAuthorizable::IncorrectToken,
+    TokenAuthorizable::InvalidToken,
     with: :user_not_authorized,
   )
 

--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+class AuthTokensController < ApplicationController
+  using BlankParamsAsNil
+
+  before_action :set_auth_token, only: %i[destroy update]
+
+  def create
+    authorize(AuthToken)
+    AuthTokens::Create.new(user: current_user).run
+    redirect_to(edit_user_path(current_user))
+  end
+
+  def destroy
+    authorize(@auth_token)
+    @auth_token.destroy!
+    redirect_to(edit_user_path(current_user))
+  end
+
+  def update
+    authorize(@auth_token)
+    @auth_token.update!(auth_token_params)
+    redirect_to(edit_user_path(current_user))
+  end
+
+  private
+
+  def auth_token_params
+    params.
+      require(:auth_token).
+      permit(:name, :secret).
+      blank_params_as_nil(%w[name secret])
+  end
+
+  def set_auth_token
+    @auth_token = current_user.auth_tokens.find(params[:id])
+  end
+end

--- a/app/controllers/concerns/token_authorizable.rb
+++ b/app/controllers/concerns/token_authorizable.rb
@@ -4,7 +4,7 @@ module TokenAuthorizable
   extend ActiveSupport::Concern
 
   class BlankToken < StandardError ; end
-  class IncorrectToken < StandardError ; end
+  class InvalidToken < StandardError ; end
 
   private
 
@@ -15,10 +15,12 @@ module TokenAuthorizable
       raise(BlankToken)
     end
 
-    if auth_token_param != current_user.auth_token
-      raise(IncorrectToken)
+    auth_token = current_user.auth_tokens.find_by(secret: auth_token_param)
+    if auth_token.blank?
+      raise(InvalidToken)
     end
 
+    auth_token.update!(last_used_at: Time.current)
     true
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -26,7 +26,7 @@ class UsersController < ApplicationController
   def user_params
     params.
       require(:user).
-      permit(:auth_token, :phone).
+      permit(:phone).
       blank_params_as_nil(%w[phone])
   end
 end

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: auth_tokens
+#
+#  created_at   :datetime         not null
+#  id           :bigint           not null, primary key
+#  last_used_at :datetime
+#  name         :text
+#  secret       :text             not null
+#  updated_at   :datetime         not null
+#  user_id      :bigint           not null
+#
+# Indexes
+#
+#  index_auth_tokens_on_user_id_and_secret  (user_id,secret) UNIQUE
+#
+class AuthToken < ApplicationRecord
+  validates :secret, presence: true, uniqueness: { scope: :user_id }
+
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,6 @@
 #
 # Table name: users
 #
-#  auth_token       :text             not null
 #  created_at       :datetime         not null
 #  email            :string           not null
 #  id               :bigint           not null, primary key
@@ -23,10 +22,10 @@ class User < ApplicationRecord
 
   devise :omniauthable, omniauth_providers: [:google_oauth2]
 
-  validates :auth_token, presence: true
   validates :email, presence: true
   validates :phone, format: { with: /\A1[[:digit:]]{10}\z/ }, allow_nil: true
 
+  has_many :auth_tokens, dependent: :destroy
   has_many :logs, dependent: :destroy
   has_many :log_shares, through: :logs
   has_many :requests, dependent: :destroy
@@ -36,18 +35,12 @@ class User < ApplicationRecord
   has_many :text_log_entries, through: :logs
   has_many :workouts, dependent: :destroy
 
-  before_validation :ensure_auth_token
-
   def admin?
     email.in?(ADMIN_EMAILS)
   end
 
   def may_send_sms?
     sms_usage < sms_allowance
-  end
-
-  def ensure_auth_token
-    self.auth_token = SecureRandom.uuid if auth_token.blank?
   end
 
   def sms_usage

--- a/app/policies/auth_token_policy.rb
+++ b/app/policies/auth_token_policy.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class AuthTokenPolicy < ApplicationPolicy
+  def create?
+    true
+  end
+
+  def destroy?
+    @record.user == @user
+  end
+
+  def update?
+    @record.user == @user
+  end
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -4,7 +4,6 @@
 #
 # Table name: users
 #
-#  auth_token       :text             not null
 #  created_at       :datetime         not null
 #  email            :string           not null
 #  id               :bigint           not null, primary key

--- a/app/views/users/edit.haml
+++ b/app/views/users/edit.haml
@@ -1,11 +1,31 @@
-= form_with model: @user do |form|
-  %div
-    = form.label :phone, 'Phone (country code recommended, e.g. 15551239876)'
-    = form.text_field :phone
+.p3
+  = form_with model: @user do |form|
+    %div
+      = form.text_field :phone
+      = form.label :phone, 'Phone (country code recommended, e.g. 15551239876)'
 
-  %div
-    = form.label :auth_token, 'Auth token (for advanced features; safe to ignore)'
-    = form.text_field :auth_token
+    %div
+      = form.submit
 
-  %div
-    = form.submit
+  %hr.mt3
+
+  %div.my3
+    %h2.h3 Auth tokens (advanced feature; safe to ignore)
+    - current_user.auth_tokens.each do |auth_token|
+      %div.mt1
+        = form_with(model: auth_token, class: 'inline') do |form|
+          %span
+            = form.text_field :secret
+            = form.label :secret, 'Secret (required)'
+
+          %span.ml2
+            = form.text_field :name
+            = form.label :name, 'Name (optional)'
+
+          %span.ml2
+            = form.submit
+
+        = button_to('Destroy Auth Token', auth_token_path(auth_token), method: :delete, form_class: 'inline')
+
+    %div.mt2
+      = button_to('Create New Auth Token', auth_tokens_path(method: :post))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
     get 'logs/:slug', to: 'logs#index', as: :shared_log
   end
 
+  resources :auth_tokens, only: %i[create destroy update]
+
   namespace :api, defaults: { format: :json } do
     resources :items, only: %i[update destroy]
     resources :log_entries, only: %i[create destroy index update]

--- a/db/migrate/20200615053049_create_auth_tokens.rb
+++ b/db/migrate/20200615053049_create_auth_tokens.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+class CreateAuthTokens < ActiveRecord::Migration[6.1]
+  def change
+    create_table :auth_tokens do |t|
+      t.references :user, null: false, foreign_key: true, index: false
+      t.text :secret, null: false
+      t.text :name
+      t.datetime :last_used_at
+
+      t.timestamps
+    end
+
+    add_index :auth_tokens, %i[user_id secret], unique: true
+  end
+end

--- a/db/migrate/20200615053455_drop_users_auth_token_column.rb
+++ b/db/migrate/20200615053455_drop_users_auth_token_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class DropUsersAuthTokenColumn < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :auth_token, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_10_032941) do
+ActiveRecord::Schema.define(version: 2020_06_15_053455) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -50,6 +50,16 @@ ActiveRecord::Schema.define(version: 2020_06_10_032941) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "auth_tokens", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.text "secret", null: false
+    t.text "name"
+    t.datetime "last_used_at"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id", "secret"], name: "index_auth_tokens_on_user_id_and_secret", unique: true
   end
 
   create_table "ip_blocks", force: :cascade do |t|
@@ -164,7 +174,6 @@ ActiveRecord::Schema.define(version: 2020_06_10_032941) do
     t.datetime "last_activity_at"
     t.string "phone"
     t.float "sms_allowance", default: 1.0, null: false, comment: "Total cost in EUR of text messages that the user is allowed to accrue."
-    t.text "auth_token", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 
@@ -181,6 +190,7 @@ ActiveRecord::Schema.define(version: 2020_06_10_032941) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "auth_tokens", "users"
   add_foreign_key "items", "stores"
   add_foreign_key "log_shares", "logs"
   add_foreign_key "logs", "users"

--- a/spec/controllers/auth_tokens_controller_spec.rb
+++ b/spec/controllers/auth_tokens_controller_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+RSpec.describe AuthTokensController do
+  before { sign_in(user) }
+
+  let(:user) { users(:user) }
+
+  describe '#create' do
+    subject(:post_create) { post(:create) }
+
+    it 'creates an auth token for the user' do
+      expect { post_create }.to change { user.reload.auth_tokens.size }.by(1)
+    end
+  end
+
+  describe '#destroy' do
+    subject(:delete_destroy) { delete(:destroy, params: { id: auth_token.id }) }
+
+    let(:auth_token) { user.auth_tokens.first! }
+
+    it 'destroys the specified auth token' do
+      expect { delete_destroy }.
+        to change { user.reload.auth_tokens.where(id: auth_token).size }.
+        by(-1)
+    end
+  end
+
+  describe '#update' do
+    subject(:patch_update) do
+      patch(
+        :update,
+        params: {
+          id: auth_token.id,
+          auth_token: {
+            name: new_auth_token_name,
+            secret: new_auth_token_secret,
+          },
+        },
+      )
+    end
+
+    let(:auth_token) { user.auth_tokens.first! }
+    let(:new_auth_token_name) { 'Travis CI run times' }
+    let(:new_auth_token_secret) { SecureRandom.uuid }
+
+    it 'updates the specified auth token' do
+      expect {
+        patch_update
+      }.to change {
+        auth_token.reload.attributes.values_at(*%w[name secret])
+      }.to([new_auth_token_name, new_auth_token_secret])
+    end
+  end
+end

--- a/spec/controllers/logs_controller_spec.rb
+++ b/spec/controllers/logs_controller_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe LogsController do
       context 'when there is a non-blank `new_entry` query param' do
         let(:params) { super().merge(new_entry: '199.8') }
 
-        context "when there is an `auth_token` param that is the user's `auth_token`" do
-          let(:params) { super().merge(auth_token: user.auth_token) }
+        context 'when the user has an auth_token whose secret is the submitted auth token param' do
+          let(:params) { super().merge(auth_token: user.auth_tokens.first!.secret) }
 
           it 'creates a log entry with the value of the `new_entry` query param' do
             expect { get_index }.to change { log.log_entries.size }.by(1)
@@ -81,8 +81,8 @@ RSpec.describe LogsController do
       context 'when there is a blank string `new_entry` param' do
         let(:params) { super().merge(new_entry: '') }
 
-        context "when there is an `auth_token` param that is the user's `auth_token`" do
-          let(:params) { super().merge(auth_token: user.auth_token) }
+        context "when there is an auth_token param that is one of the user's auth_token secrets" do
+          let(:params) { super().merge(auth_token: user.auth_tokens.first!.secret) }
 
           it 'does not create a log_entry' do
             expect { get_index }.not_to change { log.reload.log_entries.size }

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -65,14 +65,5 @@ RSpec.describe UsersController do
         end
       end
     end
-
-    context 'when params include an `auth_token`' do
-      let(:user_params) { { auth_token: new_auth_token } }
-      let(:new_auth_token) { SecureRandom.uuid }
-
-      it "updates the user's `auth_token` to the new value" do
-        expect { patch_update }.to change { user.reload.auth_token }.to(new_auth_token)
-      end
-    end
   end
 end

--- a/spec/factories/auth_tokens.rb
+++ b/spec/factories/auth_tokens.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: auth_tokens
+#
+#  created_at   :datetime         not null
+#  id           :bigint           not null, primary key
+#  last_used_at :datetime
+#  name         :text
+#  secret       :text             not null
+#  updated_at   :datetime         not null
+#  user_id      :bigint           not null
+#
+# Indexes
+#
+#  index_auth_tokens_on_user_id_and_secret  (user_id,secret) UNIQUE
+#
+FactoryBot.define do
+  factory :auth_token do
+    association :user
+    secret { SecureRandom.uuid }
+    name { 'browser shortcut' }
+    last_used_at { 2.days.ago }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,7 +4,6 @@
 #
 # Table name: users
 #
-#  auth_token       :text             not null
 #  created_at       :datetime         not null
 #  email            :string           not null
 #  id               :bigint           not null, primary key

--- a/spec/models/auth_token_spec.rb
+++ b/spec/models/auth_token_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+RSpec.describe AuthToken do
+  subject(:auth_token) { AuthToken.first! }
+
+  it { is_expected.to validate_uniqueness_of(:secret).scoped_to(:user_id) }
+
+  it { is_expected.to belong_to(:user) }
+end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -55,5 +55,8 @@ FixtureBuilder.configure do |fbuilder|
 
     # workouts
     name(:workout, create(:workout, user: user))
+
+    # auth_tokens
+    create(:auth_token, user: user)
   end
 end


### PR DESCRIPTION
This allows a user to create different auth tokens for various different purposes, gives us tracking of when each token was last used, and allows a user to revoke (i.e. delete) an individual token if it has been compromised.