### PR TITLE
Bump active_actions from 0.2.2 to 0.3.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GIT
   remote: https://github.com/davidrunger/active_actions.git
-  revision: 06bda356694057b8fa722519d0b09a869c5257ec
+  revision: 93cabe13d1418f860c72f48530d9037073c0b279
   specs:
-    active_actions (0.2.2)
+    active_actions (0.3.0)
       memoist (~> 0.16)
       rails (~> 6.0)
 

--- a/app/actions/sms_records/send_message.rb
+++ b/app/actions/sms_records/send_message.rb
@@ -17,19 +17,19 @@ class SmsRecords::SendMessage < ApplicationAction
         message_params: message_params,
         message_type: message_type,
         user: user,
-      ).run.message_body
+      ).run!.message_body
 
     nexmo_response =
       SmsRecords::PostToNexmo.new(
         message_body: message_body,
         phone_number: user.phone,
-      ).run.nexmo_response
+      ).run!.nexmo_response
 
     if nexmo_response.success?
       SmsRecords::SaveSmsRecord.new(
         nexmo_response: nexmo_response,
         user: user,
-      ).run
+      ).run!
     else
       result.nexmo_request_failed!
     end

--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -7,7 +7,7 @@ class AuthTokensController < ApplicationController
 
   def create
     authorize(AuthToken)
-    AuthTokens::Create.new(user: current_user).run
+    AuthTokens::Create.new(user: current_user).run!
     redirect_to(edit_user_path(current_user))
   end
 


### PR DESCRIPTION
... and use the new ActiveActions `#run!` method where we don't explicitly validate the action being invoked. This will automatically check that any ActiveRecord params provided to the action meet any validations specified for that ActiveRecord param; if not, an error will be raised.