### PR TITLE
Bump active_actions from 0.3.0 to 0.5.1 ; add shaped as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,6 @@
 source 'https://rubygems.org'
 ruby '2.7.0'
 
-git_source(:github) do |repo_name|
-  repo_name = "#{repo_name}/#{repo_name}" unless repo_name.include?('/')
-  "https://github.com/#{repo_name}.git"
-end
-
 gem 'active_actions', github: 'davidrunger/active_actions'
 gem 'active_model_serializers'
 gem 'administrate'
@@ -40,6 +35,7 @@ gem 'rack-mini-profiler', require: false
 gem 'rails', github: 'rails/rails'
 gem 'redis'
 gem 'rollbar'
+gem 'shaped', github: 'davidrunger/shaped'
 gem 'sidekiq'
 gem 'sidekiq-scheduler', require: false # required manually in config/initializers/sidekiq.rb
 gem 'stackprof' # Provides stack traces for flamegraph for rack-mini-profiler.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,11 @@
 GIT
   remote: https://github.com/davidrunger/active_actions.git
-  revision: 93cabe13d1418f860c72f48530d9037073c0b279
+  revision: d86c801d6e26558efbfc9a289da2883797b18b5d
   specs:
-    active_actions (0.3.0)
+    active_actions (0.5.1)
       memoist (~> 0.16)
       rails (~> 6.0)
+      shaped (~> 0.2)
 
 GIT
   remote: https://github.com/davidrunger/guard-espect.git
@@ -21,6 +22,12 @@ GIT
   specs:
     rspec_performance_summary (0.1.2)
       rspec-core (~> 3.0)
+
+GIT
+  remote: https://github.com/davidrunger/shaped.git
+  revision: 7ae27ac95304602dc960e6e5d398ba4c386c30b0
+  specs:
+    shaped (0.2.1)
 
 GIT
   remote: https://github.com/davidrunger/spring-watcher-listen.git
@@ -606,6 +613,7 @@ DEPENDENCIES
   rubocop-rails
   rubocop-rspec
   selenium-webdriver
+  shaped!
   shoulda-matchers
   sidekiq
   sidekiq-scheduler

--- a/app/actions/sms_records/generate_message.rb
+++ b/app/actions/sms_records/generate_message.rb
@@ -3,7 +3,7 @@
 class SmsRecords::GenerateMessage < ApplicationAction
   class InvalidMessageType < StandardError ; end
 
-  requires :message_params, Hash
+  requires :message_params, Shaped::Hash('store_id' => Integer)
   requires :message_type, String
   requires :user, User
 

--- a/app/actions/sms_records/send_message.rb
+++ b/app/actions/sms_records/send_message.rb
@@ -3,7 +3,7 @@
 class SmsRecords::SendMessage < ApplicationAction
   class SaveSmsRecordError < StandardError ; end
 
-  requires :message_params, Hash
+  requires :message_params, Shaped::Hash('store_id' => Integer)
   requires :message_type, String
   requires :user, User do
     validates :phone, presence: true

--- a/spec/controllers/api/text_messages_controller_spec.rb
+++ b/spec/controllers/api/text_messages_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::TextMessagesController do
   let(:user) { users(:user) }
 
   describe '#create' do
-    subject(:post_create) { post(:create, params: params) }
+    subject(:post_create) { post(:create, params: params, as: :json) }
 
     let(:valid_params) do
       {


### PR DESCRIPTION
(We are installing `shaped` explicitly because it is needed by `active_actions` but cannot be installed automatically by `active_actions` because `shaped` is only released via GitHub.)

Also, define the expected shape of `message_params` hashes using `Shaped::Hash` This is a new feature (provided via `shaped`) that is included in our recent bump of `active_actions` from 0.3.0 to 0.5.1 .