### PR TITLE
Delete `job_timeout` pallets setting

### DIFF
--- a/bin/run-tests.rb
+++ b/bin/run-tests.rb
@@ -10,7 +10,6 @@ Pallets.configure do |c|
   c.backend = :redis
   c.backend_args = { url: 'redis://127.0.0.1:6379/8' } # use redis db #8 (to avoid conflicts)
   c.serializer = :msgpack
-  c.job_timeout = 120 # allow 2 minutes for each task to complete
   c.max_failures = 0
   c.logger = Logger.new(STDOUT)
   c.middleware << Test::Middleware::ExitOnFailureMiddleware


### PR DESCRIPTION
It seems that a job doesn't get _aborted_ if it reaches the timeout limit; the job is _retried_ (see documentation comment here: https://github.com/linkyndy/pallets/blob/b93ea47/lib/pallets/configuration.rb#L23-L25 ). (Also, see Travis build log for a different branch for evidence of this: https://travis-ci.org/github/davidrunger/david_runger/builds/699170675 .)

This is not really the behavior that we want; we'd want a job to be aborted if it reached the timeout.

Since aborting a job if it reaches the timeout doesn't seem to be an option, I guess that I'll just delete this config, then, and leave the default job timeout period of [30 minutes](https://github.com/linkyndy/pallets/blob/b93ea47/lib/pallets/configuration.rb#L56).