### PR TITLE
Delete custom pallets logger config

### DIFF
--- a/bin/run-tests.rb
+++ b/bin/run-tests.rb
@@ -11,7 +11,6 @@ Pallets.configure do |c|
   c.backend_args = { url: 'redis://127.0.0.1:6379/8' } # use redis db #8 (to avoid conflicts)
   c.serializer = :msgpack
   c.max_failures = 0
-  c.logger = Logger.new(STDOUT)
   c.middleware << Test::Middleware::ExitOnFailureMiddleware
   c.middleware << Test::Middleware::TaskResultTrackingMiddleware
 end


### PR DESCRIPTION
This config wasn't actually being respected, anyway. (I'm not sure if this is a bug, or if I am using pallets incorrectly?) We have actually been using the [default logger][1] the whole time, which works well enough for our needs.

[1]: https://github.com/linkyndy/pallets/blob/b93ea47/lib/pallets/configuration.rb#L63-L66