### PR TITLE
Delete custom pallets backend config

### DIFF
--- a/bin/run-tests.rb
+++ b/bin/run-tests.rb
@@ -7,7 +7,6 @@ require_relative './test/middleware/task_result_tracking_middleware.rb'
 
 Pallets.configure do |c|
   c.concurrency = 3
-  c.backend = :redis
   c.backend_args = { url: 'redis://127.0.0.1:6379/8' } # use redis db #8 (to avoid conflicts)
   c.serializer = :msgpack
   c.max_failures = 0


### PR DESCRIPTION
The [default is `:redis`][1], so let's just lean on that.

[1]: https://github.com/linkyndy/pallets/blob/b93ea47/lib/pallets/configuration.rb#L50