### PR TITLE
Delete custom pallets serializer config

### DIFF
--- a/bin/run-tests.rb
+++ b/bin/run-tests.rb
@@ -8,7 +8,6 @@ require_relative './test/middleware/task_result_tracking_middleware.rb'
 Pallets.configure do |c|
   c.concurrency = 3
   c.backend_args = { url: 'redis://127.0.0.1:6379/8' } # use redis db #8 (to avoid conflicts)
-  c.serializer = :msgpack
   c.max_failures = 0
   c.middleware << Test::Middleware::ExitOnFailureMiddleware
   c.middleware << Test::Middleware::TaskResultTrackingMiddleware


### PR DESCRIPTION
This will change the pallets serializer from `:msgpack` to [`:json`][1]. This will probably slow down pallets by the teeniest, tiniest bit. That slowdown is worth the upside of not having this custom configuration option.

[1]: https://github.com/linkyndy/pallets/blob/b93ea47/lib/pallets/configuration.rb#L58

(More broadly, I question whether it's even worthwhile for `pallets` to support `msgpack` serialization and have `msgpack` as a dependency? It doesn't really seem worth it?, unless there are some workflows that run through a lot of jobs / do a lot of serialization -- which I guess that there might indeed be in the world. But our workflow is not one of them.)