### PR TITLE
Reorder a few pallets config options

### DIFF
--- a/bin/run-tests.rb
+++ b/bin/run-tests.rb
@@ -7,8 +7,8 @@ require_relative './test/middleware/task_result_tracking_middleware.rb'
 
 Pallets.configure do |c|
   c.concurrency = 3
-  c.backend_args = { url: 'redis://127.0.0.1:6379/8' } # use redis db #8 (to avoid conflicts)
   c.max_failures = 0
+  c.backend_args = { url: 'redis://127.0.0.1:6379/8' } # use redis db #8 (to avoid conflicts)
   c.middleware << Test::Middleware::ExitOnFailureMiddleware
   c.middleware << Test::Middleware::TaskResultTrackingMiddleware
 end


### PR DESCRIPTION
It looks better this way! The length of the options now increases as we move down the list of options. The options that are simple integers are grouped together. The more important options come first.