### PR TITLE
Split api controller tests task from other unit tests

### DIFF
--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -31,6 +31,7 @@ class Test::RequirementsResolver
         Test::Tasks::RunImmigrant => Test::Tasks::SetupDb,
         Test::Tasks::RunRubocop => nil,
         Test::Tasks::RunUnitTests => Test::Tasks::BuildFixtures,
+        Test::Tasks::RunApiControllerTests => Test::Tasks::BuildFixtures,
         Test::Tasks::RunHtmlControllerTests => [
           Test::Tasks::BuildFixtures,
           Test::Tasks::CompileJavaScript,
@@ -49,6 +50,7 @@ class Test::RequirementsResolver
           Test::Tasks::RunDatabaseConsistency,
           Test::Tasks::RunEslint,
           Test::Tasks::RunFeatureTests,
+          Test::Tasks::RunApiControllerTests,
           Test::Tasks::RunHtmlControllerTests,
           Test::Tasks::RunImmigrant,
           Test::Tasks::RunRubocop,

--- a/bin/test/tasks/run_api_controller_tests.rb
+++ b/bin/test/tasks/run_api_controller_tests.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class Test::Tasks::RunApiControllerTests < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    execute_system_command(<<~COMMAND)
+      bin/rspec spec/controllers/api/ --format RSpec::Instafail --format progress --force-color
+    COMMAND
+  end
+end

--- a/bin/test/tasks/run_unit_tests.rb
+++ b/bin/test/tasks/run_unit_tests.rb
@@ -4,12 +4,12 @@ class Test::Tasks::RunUnitTests < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    # run all tests in `spec/` _except_ those in `spec/controllers/` that are _not_ in
-    # `spec/controllers/api/` and those in `spec/features/`
+    # Run all tests in `spec/` _except_ those in `spec/controllers/` and `spec/features/`.
+    # Tests in `spec/controllers/` will be run by RunApiControllerTests and RunHtmlControllerTests.
+    # Tests in `spec/features/` will be run by RunFeatureTests.
     execute_system_command(<<~COMMAND)
       bin/rspec
       $(ls -d spec/*/ | grep --extended-regex -v 'spec/(controllers|features)/' | tr '\\n' ' ')
-      spec/controllers/api/
       --format RSpec::Instafail --format progress --force-color
     COMMAND
   end


### PR DESCRIPTION
Motivations:
1. simpler `bin/rspec` command arguments
2. increased parallelism / decreased test run time (maybe??)