### PR TITLE
Automatically apply `as: :json` option for API controller tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,11 @@ Rails.application.configure do
   # config.action_view.raise_on_missing_translations = true
 
   config.active_storage.service = :local
+
+  extra_load_paths = [
+    Rails.root.join('spec/support'),
+  ].map(&:to_s).map(&:freeze)
+  config.eager_load_paths.concat(extra_load_paths)
 end
+
+Rails.autoloaders.main.do_not_eager_load(Rails.root.join('spec/support/matchers/'))

--- a/spec/actions/sms_records/save_sms_record_spec.rb
+++ b/spec/actions/sms_records/save_sms_record_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe SmsRecords::SaveSmsRecord do
       before do
         expect(response).
           to receive(:parsed_response).
-          and_return(NexmoTestApi.single_message_response)
+          and_return(VendorTestApi::Nexmo.single_message_response)
       end
 
       it 'creates one SmsRecord belonging to the user' do
@@ -72,7 +72,7 @@ RSpec.describe SmsRecords::SaveSmsRecord do
     end
 
     context 'when there is no error' do
-      let(:message_hash) { NexmoTestApi.single_message_response['messages'].first }
+      let(:message_hash) { VendorTestApi::Nexmo.single_message_response['messages'].first }
 
       it 'maps the Nexmo json to attributes of the SmsRecord model' do
         expect(nexmo_message_hash_to_attributes).to eq(

--- a/spec/controllers/api/text_messages_controller_spec.rb
+++ b/spec/controllers/api/text_messages_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Api::TextMessagesController do
   let(:user) { users(:user) }
 
   describe '#create' do
-    subject(:post_create) { post(:create, params: params, as: :json) }
+    subject(:post_create) { post(:create, params: params) }
 
     let(:valid_params) do
       {
@@ -67,13 +67,13 @@ RSpec.describe Api::TextMessagesController do
           end
 
           it 'attempts to send a text message' do
-            NexmoTestApi.stub_post_success
+            VendorTestApi::Nexmo.stub_post_success
             expect(NexmoClient).to receive(:send_text!).and_call_original
             post_create
           end
 
           context 'when sending the message succeeds' do
-            before { NexmoTestApi.stub_post_success }
+            before { VendorTestApi::Nexmo.stub_post_success }
 
             it 'responds with 201 status' do
               post_create
@@ -82,7 +82,7 @@ RSpec.describe Api::TextMessagesController do
           end
 
           context 'when sending the message fails' do
-            before { NexmoTestApi.stub_post_failure }
+            before { VendorTestApi::Nexmo.stub_post_failure }
 
             it 'responds with 400 status' do
               post_create

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,6 +89,7 @@ RSpec.configure do |config|
   config.include(FactoryBot::Syntax::Methods)
   config.include(Devise::Test::ControllerHelpers, type: :controller)
   config.include(Devise::Test::IntegrationHelpers, type: :feature)
+  config.include(Monkeypatches::MakeAllRequestsAsJson, request_format: :json)
 
   config.before(:suite) do
     # Reset FactoryBot sequences to an arbitrarily high number to avoid collisions with

--- a/spec/support/monkeypatches/make_all_requests_as_json.rb
+++ b/spec/support/monkeypatches/make_all_requests_as_json.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Monkeypatches::MakeAllRequestsAsJson
+  private
+
+  # list of verbs taken from here:
+  # https://github.com/rails/rails-controller-testing/blob/a60b3da/lib/rails/controller/testing/integration.rb#L7
+  http_verbs = %w[get post patch put head delete]
+  http_verbs.each do |method|
+    define_method(method) do |action, options|
+      super(action, { as: :json }.merge(options))
+    end
+  end
+end

--- a/spec/support/vendor_test_api/nexmo.rb
+++ b/spec/support/vendor_test_api/nexmo.rb
@@ -2,7 +2,7 @@
 
 # https://developer.nexmo.com/api/sms
 
-module NexmoTestApi
+module VendorTestApi::Nexmo
   def self.stub_post_success
     WebMock.stub_request(:post, 'https://rest.nexmo.com/sms/json').
       to_return(


### PR DESCRIPTION
If `as: :json` is _not_ set, then Rails's testing flow (more specifically, [`rails-controller-testing`](https://github.com/rails/rails-controller-testing), I guess?) will convert number params (e.g. `store_id: 123`) to strings (e.g. `'store_id' => '123'`). This isn't realistic for most/all API requests, since those requests are made with JSON data payloads, which _can_ support actual numbers (unlike non-API requests where e.g. the params are encoded in the path or query params, and therefore are strings and cannot be actual numbers).

Therefore, this PR changes the default behavior for all simulated requests in API controller tests to automatically add the `as: :json` option.