### PR TITLE
Set up a separate database for each of the 4 RSpec-running test tasks

### DIFF
--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -20,6 +20,7 @@ class Test::RequirementsResolver
         Test::Tasks::CompileJavaScript => Test::Tasks::YarnInstall,
         Test::Tasks::SetupDb => nil,
         Test::Tasks::BuildFixtures => Test::Tasks::SetupDb,
+        Test::Tasks::CreateDbCopies => Test::Tasks::BuildFixtures,
 
         # Checks
         Test::Tasks::RunStylelint => Test::Tasks::YarnInstall,
@@ -30,14 +31,14 @@ class Test::RequirementsResolver
         Test::Tasks::RunDatabaseConsistency => Test::Tasks::SetupDb,
         Test::Tasks::RunImmigrant => Test::Tasks::SetupDb,
         Test::Tasks::RunRubocop => nil,
-        Test::Tasks::RunUnitTests => Test::Tasks::BuildFixtures,
-        Test::Tasks::RunApiControllerTests => Test::Tasks::BuildFixtures,
+        Test::Tasks::RunUnitTests => Test::Tasks::CreateDbCopies,
+        Test::Tasks::RunApiControllerTests => Test::Tasks::CreateDbCopies,
         Test::Tasks::RunHtmlControllerTests => [
-          Test::Tasks::BuildFixtures,
+          Test::Tasks::CreateDbCopies,
           Test::Tasks::CompileJavaScript,
         ],
         Test::Tasks::RunFeatureTests => [
-          Test::Tasks::BuildFixtures,
+          Test::Tasks::CreateDbCopies,
           Test::Tasks::CompileJavaScript,
           Test::Tasks::EnsureLatestChromedriver,
         ],

--- a/bin/test/tasks/create_db_copies.rb
+++ b/bin/test/tasks/create_db_copies.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class Test::Tasks::CreateDbCopies < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    ActiveRecord::Base.remove_connection
+    %w[unit api html feature].each do |db_suffix|
+      db_name = "david_runger_test_#{db_suffix}"
+      # in CI, we know that the database doesn't exist, so don't waste any time dropping it
+      unless ENV.key?('CI')
+        execute_system_command("dropdb --if-exists #{db_name}")
+      end
+      execute_system_command("createdb -T david_runger_test #{db_name}")
+    end
+  end
+end

--- a/bin/test/tasks/run_api_controller_tests.rb
+++ b/bin/test/tasks/run_api_controller_tests.rb
@@ -5,7 +5,10 @@ class Test::Tasks::RunApiControllerTests < Pallets::Task
 
   def run
     execute_system_command(<<~COMMAND)
-      bin/rspec spec/controllers/api/ --format RSpec::Instafail --format progress --force-color
+      DB_SUFFIX=_api
+      bin/rspec
+      spec/controllers/api/
+      --format RSpec::Instafail --format progress --force-color
     COMMAND
   end
 end

--- a/bin/test/tasks/run_feature_tests.rb
+++ b/bin/test/tasks/run_feature_tests.rb
@@ -6,6 +6,7 @@ class Test::Tasks::RunFeatureTests < Pallets::Task
   def run
     # run all tests in `spec/features/` (wrapped by percy, if PERCY_TOKEN is present)
     execute_system_command(<<~COMMAND)
+      DB_SUFFIX=_feature
       #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
       bin/rspec spec/features/
       --format RSpec::Instafail --format progress --force-color

--- a/bin/test/tasks/run_html_controller_tests.rb
+++ b/bin/test/tasks/run_html_controller_tests.rb
@@ -6,6 +6,7 @@ class Test::Tasks::RunHtmlControllerTests < Pallets::Task
   def run
     # run all tests in `spec/controllers/` _except_ those in `spec/controllers/api/`
     execute_system_command(<<~COMMAND)
+      DB_SUFFIX=_html
       bin/rspec
       $(ls -d spec/controllers/*/ | grep -v 'spec/controllers/api/' | tr '\\n' ' ')
       $(ls spec/controllers/*.rb)

--- a/bin/test/tasks/run_unit_tests.rb
+++ b/bin/test/tasks/run_unit_tests.rb
@@ -8,6 +8,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
     # Tests in `spec/controllers/` will be run by RunApiControllerTests and RunHtmlControllerTests.
     # Tests in `spec/features/` will be run by RunFeatureTests.
     execute_system_command(<<~COMMAND)
+      DB_SUFFIX=_unit
       bin/rspec
       $(ls -d spec/*/ | grep --extended-regex -v 'spec/(controllers|features)/' | tr '\\n' ' ')
       --format RSpec::Instafail --format progress --force-color

--- a/config/database.yml
+++ b/config/database.yml
@@ -58,7 +58,7 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: david_runger_test
+  database: david_runger_test<%= ENV['DB_SUFFIX'] %>
 
 # As with config/secrets.yml, you never want to store sensitive information,
 # like your database password, in your source code. If your source code is


### PR DESCRIPTION
When tests are executing in parallel and all using the same database, I think that there is a risk that some of the concurrent attempts to change the database can run afoul of each other. I don't think that I've ever seen this as a problem in any Travis runs, but I do think that I have seen it locally.

I also think that there is somewhat of a risk that the database transactions might block/delay each other, when run concurrently using the same database?

Therefore, by creating a separate DB for each RSpec test-running task (RunFeatureTests, RunApiControllerTests, RunHtmlControllerTests, RunUnitTests), I am hoping that we can:
1. increase parallelism / decrease CI build time
2. eliminate the risk of flakiness caused by concurrent attempts to modify a single database