### PR TITLE
Delete unnecessary let in admin users controller test

### DIFF
--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -28,8 +28,6 @@ RSpec.describe Admin::UsersController do
   describe '#show' do
     subject(:get_show) { get(:show, params: { id: user.id }) }
 
-    let(:user) { User.first! }
-
     it 'renders the email of the user' do
       get_show
 


### PR DESCRIPTION
There's already a `let(:user)` declared in the outer `describe` scope, and it's arguably better since it finds a non-admin user to view (`let(:user) { User.where.not(id: admin_user).first! }`).