### PR TITLE
Delete never-entered on_load(:active_model_serializers) block

### DIFF
--- a/config/initializers/active_model_serializers.rb
+++ b/config/initializers/active_model_serializers.rb
@@ -1,12 +1,4 @@
 # frozen_string_literal: true
 
-ActiveSupport.on_load(:active_model_serializers) do
-  # Disable for all serializers (except ArraySerializer)
-  ActiveModel::Serializer.root = false
-
-  # Disable for ArraySerializer
-  ActiveModel::ArraySerializer.root = false
-end
-
 # disable ActiveModelSerializers logging
 ActiveSupport::Notifications.unsubscribe(ActiveModelSerializers::Logging::RENDER_EVENT)


### PR DESCRIPTION
I think that maybe ever since https://github.com/rails-api/active_model_serializers/pull/1352/files#diff-dd5a350c0bb52bd290e389761539fd70L27 we don't enter this block anymore? At least, in my testing we don't seem to enter it now.