### PR TITLE
Bump `active_actions` (0.6.1 => 0.7.0) and `shaped` (0.3.0 => 0.4.0)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/davidrunger/active_actions.git
-  revision: 36d2b3d1de4065a679ddae7793ae3ffca65910a6
+  revision: 62f170edc21b7c0ef96406ea1f96b33da3245e8c
   specs:
-    active_actions (0.6.1)
+    active_actions (0.7.0)
       memoist (~> 0.16)
       rails (~> 6.0)
-      shaped (~> 0.3.0)
+      shaped (~> 0.4.0)
 
 GIT
   remote: https://github.com/davidrunger/guard-espect.git
@@ -25,9 +25,10 @@ GIT
 
 GIT
   remote: https://github.com/davidrunger/shaped.git
-  revision: c06e6f2a64787b15af174877686d61cd067bdbde
+  revision: 9ef4b187ce4b31fc6938e76d83d25a1affb2ce27
   specs:
-    shaped (0.3.0)
+    shaped (0.4.0)
+      activemodel (~> 6.0)
       activesupport (~> 6.0)
 
 GIT
@@ -55,7 +56,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 664e94989e00b81d61b0dba5ecf476213759adf7
+  revision: 4fb2a5ec12cab308dd57caf704c3e084dc4f472b
   specs:
     actioncable (6.1.0.alpha)
       actionpack (= 6.1.0.alpha)

--- a/app/actions/ip_blocks/store_request_block_in_redis.rb
+++ b/app/actions/ip_blocks/store_request_block_in_redis.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class IpBlocks::StoreRequestBlockInRedis < ApplicationAction
-  requires :ip, String
-  requires :path, String
+  requires :ip, String, format: { with: /[.0-9]{7,15}/ }
+  requires :path, String, format: { with: %r{\A/} }
 
   def execute
     $redis_pool.with do |conn|

--- a/app/actions/sms_records/generate_message.rb
+++ b/app/actions/sms_records/generate_message.rb
@@ -3,8 +3,12 @@
 class SmsRecords::GenerateMessage < ApplicationAction
   class InvalidMessageType < StandardError ; end
 
+  MESSAGE_TEMPLATES = %w[
+    grocery_store_items_needed
+  ].map(&:freeze).freeze
+
   requires :message_params, 'store_id' => Integer
-  requires :message_type, String
+  requires :message_type, String, inclusion: MESSAGE_TEMPLATES
   requires :user, User
 
   returns :message_body, String
@@ -18,7 +22,6 @@ class SmsRecords::GenerateMessage < ApplicationAction
   def message_body
     case message_type
     when 'grocery_store_items_needed' then grocery_store_items_needed_message_body
-    else fail InvalidMessageType, "`#{message_type}` is not a valid message type"
     end
   end
 

--- a/app/actions/sms_records/post_to_nexmo.rb
+++ b/app/actions/sms_records/post_to_nexmo.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class SmsRecords::PostToNexmo < ApplicationAction
-  requires :message_body, String
-  requires :phone_number, String
+  requires :message_body, String, presence: true
+  requires :phone_number, String, presence: true
 
   returns :nexmo_response, HTTParty::Response
 

--- a/spec/actions/ip_blocks/store_request_block_in_redis_spec.rb
+++ b/spec/actions/ip_blocks/store_request_block_in_redis_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+RSpec.describe IpBlocks::StoreRequestBlockInRedis do
+  subject(:store_request_block_action) do
+    IpBlocks::StoreRequestBlockInRedis.new(store_request_block_params)
+  end
+
+  let(:store_request_block_params) do
+    {
+      ip: '123.456.987.12',
+      path: '/wordpress/themes?admin=true',
+    }
+  end
+
+  describe 'initializing the action' do
+    context 'when the inputs are valid' do
+      it 'does not raise an error' do
+        expect { store_request_block_action }.not_to raise_error
+      end
+    end
+
+    context 'when the inputs are not valid' do
+      let(:store_request_block_params) do
+        {
+          ip: 'this is not an IP',
+          path: 'this is not a path',
+        }
+      end
+
+      it 'raises an error' do
+        expect { store_request_block_action }.to raise_error(
+          ActiveActions::TypeMismatch,
+          <<~ERROR.squish)
+            One or more required params are of the wrong type: `ip` is expected to be shaped like
+            String validating {:format=>{:with=>/[.0-9]{7,15}/}}, but was `"this is not an IP"` ;
+            `path` is expected to be shaped like String validating {:format=>{:with=>/\\A\\//}}, but
+            was `"this is not a path"`.
+          ERROR
+      end
+    end
+  end
+end

--- a/spec/actions/sms_records/post_to_nexmo_spec.rb
+++ b/spec/actions/sms_records/post_to_nexmo_spec.rb
@@ -11,6 +11,34 @@ RSpec.describe SmsRecords::PostToNexmo do
   end
   let(:message_body) { 'Hi there!' }
 
+  describe 'initializing the action' do
+    context 'when the message_body is a blank string' do
+      let(:post_to_nexmo_params) { super().merge(message_body: '') }
+
+      it 'raises an error' do
+        expect { post_to_nexmo_action }.to raise_error(
+          ActiveActions::TypeMismatch,
+          <<~ERROR.squish)
+            One or more required params are of the wrong type: `message_body` is expected to be
+            shaped like String validating {:presence=>true}, but was `""`.
+          ERROR
+      end
+    end
+
+    context 'when the phone_number is a blank string' do
+      let(:post_to_nexmo_params) { super().merge(phone_number: '') }
+
+      it 'raises an error' do
+        expect { post_to_nexmo_action }.to raise_error(
+          ActiveActions::TypeMismatch,
+          <<~ERROR.squish)
+            One or more required params are of the wrong type: `phone_number` is expected to be
+            shaped like String validating {:presence=>true}, but was `""`.
+          ERROR
+      end
+    end
+  end
+
   describe '#execute' do
     subject(:execute) { post_to_nexmo_action.execute }
 

--- a/spec/controllers/api/text_messages_controller_spec.rb
+++ b/spec/controllers/api/text_messages_controller_spec.rb
@@ -53,7 +53,13 @@ RSpec.describe Api::TextMessagesController do
 
         it 'does not attempt to send a text message and raises an error' do
           expect(NexmoClient).not_to receive(:send_text!)
-          expect { post_create }.to raise_error(SmsRecords::GenerateMessage::InvalidMessageType)
+          expect { post_create }.to raise_error(
+            ActiveActions::TypeMismatch,
+            <<~ERROR.squish)
+              One or more required params are of the wrong type: `message_type` is expected to be
+              shaped like String validating {:inclusion=>["grocery_store_items_needed"]}, but was
+              `"an_unknown_message_type"`.
+            ERROR
         end
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -104,6 +104,11 @@ RSpec.configure do |config|
     FactoryBot::Internal.inline_sequences.each do |sequence|
       sequence.instance_variable_set(:@value, FactoryBot::Sequence::EnumeratorAdapter.new(10_000))
     end
+
+    # Some of the specs involve somewhat lengthy strings; increase the size of the printed output
+    # for easier comparison of expected vs actual strings, in the event of a failure.
+    # https://github.com/rspec/rspec-expectations/issues/ 991#issuecomment-302863645
+    RSpec::Support::ObjectFormatter.default_instance.max_formatted_output_length = 2_000
   end
 
   config.around(:each, :cache) do |spec|


### PR DESCRIPTION
This `active_actions` release (via shaped 0.4.0) gives us the ability to add ActiveModel-style validations for action inputs (`requires`), which, in this PR, we've utilized in a few of the existing actions to add validations for the inputs.