### PR TITLE
Lock `redis` to exactly 4.1.4 (down from 4.2.1)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'rack-mini-profiler', require: false
 gem 'rails', github: 'rails/rails'
 # We can probably remove this version constraint once Sidekiq 6.1 has been released.
 # See https://github.com/mperham/sidekiq/issues/4591 .
-gem 'redis', '~> 4.2.1'
+gem 'redis', '4.1.4'
 gem 'rollbar'
 gem 'shaped', github: 'davidrunger/shaped'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,7 +426,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    redis (4.2.1)
+    redis (4.1.4)
     regexp_parser (1.7.1)
     request_store (1.5.0)
       rack (>= 1.4)
@@ -612,7 +612,7 @@ DEPENDENCIES
   rack-mini-profiler
   rails!
   rails-controller-testing!
-  redis (~> 4.2.1)
+  redis (= 4.1.4)
   rollbar
   rspec-instafail
   rspec-rails


### PR DESCRIPTION
Hopefully dependabot will stop updating it now.

Context: https://github.com/davidrunger/david_runger/pull/2941/