### PR TITLE
Bump `active_actions` from 0.8.0 to 0.10.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,11 @@
 GIT
   remote: https://github.com/davidrunger/active_actions.git
-  revision: 5b3c1b251cba2eaec947cda6435ab53c3d5ab3b7
+  revision: ebca5e87a7b9d0983f3e860fbd17ab35b558d274
   specs:
-    active_actions (0.8.0)
+    active_actions (0.10.0)
       memoist (~> 0.16)
       rails (~> 6.0)
-      shaped (~> 0.5.0)
+      shaped (~> 0.6.0)
 
 GIT
   remote: https://github.com/davidrunger/guard-espect.git
@@ -25,9 +25,9 @@ GIT
 
 GIT
   remote: https://github.com/davidrunger/shaped.git
-  revision: db3762a9b8e1a2170c5f0cac137a44cd0dc42aec
+  revision: b0fa51904bd01377a057c60aedbc3a329f0ab4d7
   specs:
-    shaped (0.5.4)
+    shaped (0.6.0)
       activemodel (~> 6.0)
       activesupport (~> 6.0)
 
@@ -56,7 +56,7 @@ GIT
 
 GIT
   remote: https://github.com/rails/rails.git
-  revision: c2441b00db3e5bdea74ace25388795f9e6a7f67d
+  revision: 596d4dbb336d29d9b13487624b99657cd4161c6c
   specs:
     actioncable (6.1.0.alpha)
       actionpack (= 6.1.0.alpha)

--- a/app/actions/sms_records/generate_message.rb
+++ b/app/actions/sms_records/generate_message.rb
@@ -11,7 +11,7 @@ class SmsRecords::GenerateMessage < ApplicationAction
   requires :message_type, String, inclusion: MESSAGE_TEMPLATES
   requires :user, User
 
-  returns :message_body, String
+  returns :message_body, String, presence: true
 
   def execute
     result.message_body = message_body


### PR DESCRIPTION
(and bump `shaped` from 0.5.4 to 0.6.0 and `rails` from c2441b0 to 596d4db)

Also, validate presence of message_body returned by GenerateMessage action (using new functionality made available in `active_actions` 0.10.0).