### PR TITLE
Disable NewRelic JavaScript tracking

### DIFF
--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -27,6 +27,10 @@ common: &default_settings
   distributed_tracing:
     enabled: true
 
+  # https://docs.newrelic.com/docs/agents/ruby-agent/configuration/ruby-agent-configuration#browser_monitoring
+  browser_monitoring:
+    auto_instrument: false
+
 # Environment-specific settings are in this section.
 # RAILS_ENV or RACK_ENV (as appropriate) is used to determine the environment.
 # If your application has other named environments, configure them here.


### PR DESCRIPTION
It doesn't seem to be providing any useful data, and I think it throws some errors in the console and makes Firefox warn about privacy.

![image](https://user-images.githubusercontent.com/8197963/85217911-1933d300-b34a-11ea-98f6-a4808d2e577e.png)
