### PR TITLE
Display textarea for new text log entry when log has no entries yet

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -1,7 +1,6 @@
 <template lang='pug'>
 .flex.justify-center
   .container
-    NewLogEntryForm(:log='log')
     table
       EditableTextLogRow(
         v-for='logEntry in formattedLogEntries'

--- a/app/javascript/logs/components/log.vue
+++ b/app/javascript/logs/components/log.vue
@@ -3,6 +3,7 @@ div
   h1.h2.mt3.mb1 {{log.name}}
   h2.h5.gray(v-if='!isOwnLog') shared by {{log.user.email}}
   p.h5.mb2.description {{log.description}}
+  NewLogEntryForm(:log='log' v-if='renderInputAtTop')
   div.mb2(v-if='log.log_entries === undefined').
     Loading...
   LogDataDisplay(


### PR DESCRIPTION
This is a bugfix. From an unknown time until this change, no textarea was being shown for a user to submit a new entry for their text log if the log didn't have any existing entries already.