### PR TITLE
Always show all log text entries if there are three or fewer entries

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -30,7 +30,7 @@ export default {
   computed: {
     formattedLogEntries() {
       let logEntriesToShow;
-      if (this.showAllEntries) {
+      if (this.showAllEntries || (this.log_entries.length <= 3)) {
         logEntriesToShow = this.log_entries;
       } else {
         logEntriesToShow = this.log_entries.slice(this.log_entries.length - 3);

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -26,20 +26,33 @@ RSpec.describe 'Logs app' do
       context 'when there are no entries yet for the text log' do
         before { log.log_entries.find_each(&:destroy!) }
 
-        it 'allows the user to submit their first entry for the log' do
+        it 'allows the user to submit their first and second entry for the log' do
           visit(log_path(slug: log.slug))
 
-          new_log_entry_text = 'Some great text log entry content!'
+          first_log_entry_text = 'Some great text log entry content!'
           expect {
-            first(:css, '.new-log-input textarea').native.send_keys(new_log_entry_text)
+            first(:css, '.new-log-input textarea').native.send_keys(first_log_entry_text)
             click_button('Add')
-            expect(page).to have_text(new_log_entry_text) # wait for AJAX request to complete
+            expect(page).to have_text(first_log_entry_text) # wait for AJAX request to complete
           }.to change {
             log.reload.log_entries.count
           }.by(1)
 
           last_log_entry = log.log_entries.reorder(:created_at).last!
-          expect(last_log_entry.data).to eq(new_log_entry_text)
+          expect(last_log_entry.data).to eq(first_log_entry_text)
+
+          second_log_entry_text = 'Even more great content!'
+          expect {
+            first(:css, '.new-log-input textarea').native.send_keys(second_log_entry_text)
+            click_button('Add')
+            expect(page).to have_text(second_log_entry_text) # wait for AJAX request to complete
+            expect(page).to have_text(first_log_entry_text) # confirm first log entry's still there
+          }.to change {
+            log.reload.log_entries.count
+          }.by(1)
+
+          last_log_entry = log.log_entries.reorder(:created_at).last!
+          expect(last_log_entry.data).to eq(second_log_entry_text)
         end
       end
     end


### PR DESCRIPTION
This is a bugfix. Previously, when a user had two text log entries, only the second of them would show, not the first.