### PR TITLE
Give `.anchor-target`s `bottom: 0` on small devices

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,3 +1,4 @@
 @import "variables/colors";
 
 $header-height: 56px;
+$small-screen-breakpoint: 600px;

--- a/app/javascript/home/components/home_section.vue
+++ b/app/javascript/home/components/home_section.vue
@@ -48,5 +48,9 @@ section {
 .anchor-target {
   position: relative;
   bottom: $header-height;
+
+  @media screen and (max-width: $small-screen-breakpoint) {
+    bottom: 0;
+  }
 }
 </style>

--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -409,7 +409,7 @@ p:first-of-type {
 #headline-name {
   font-size: 80px;
 
-  @media screen and (max-width: 600px) {
+  @media screen and (max-width: $small-screen-breakpoint) {
     font-size: 40px;
   }
 }
@@ -432,7 +432,7 @@ p:first-of-type {
     width: 500px;
     right: 0;
 
-    @media screen and (max-width: 600px) {
+    @media screen and (max-width: $small-screen-breakpoint) {
       display: none;
     }
 


### PR DESCRIPTION
(since the header has `display: none` so we don't need the anchor target offset then)