### PR TITLE
Add `scoped` for `workout_plan.vue` CSS

### DIFF
--- a/app/javascript/workout/workout.vue
+++ b/app/javascript/workout/workout.vue
@@ -30,3 +30,10 @@ export default {
   },
 };
 </script>
+
+<style>
+th,
+td {
+  padding: 5px 10px;
+}
+</style>

--- a/app/javascript/workout/workout_plan.vue
+++ b/app/javascript/workout/workout_plan.vue
@@ -261,12 +261,7 @@ export default {
 };
 </script>
 
-<style>
-th,
-td {
-  padding: 5px 10px;
-}
-
+<style scoped>
 tbody tr:last-of-type td:not(:last-of-type) {
   border-top: 1px solid gray;
 }


### PR DESCRIPTION
This fixes a bug wherein there was a border above the last row of a user's previous workouts and/or others' shared workouts at `/workouts` before initializing a workout.