### PR TITLE
Stub `Flipper` checks in specs rather than flushing redis

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -124,11 +124,6 @@ RSpec.configure do |config|
     metadata[:request_format] = :json
   end
 
-  config.before(:each) do
-    # flush Flipper state
-    system('redis-cli -n 3 FLUSHDB', exception: true, out: File::NULL)
-  end
-
   config.before(:each, request_format: :json) do
     request.accept = 'application/json'
   end
@@ -301,4 +296,8 @@ end
 
 def json_response
   JSON(response.body)
+end
+
+def activate_feature!(feature_name)
+  allow(Flipper).to receive(:enabled?).with(feature_name).and_return(true)
 end

--- a/spec/workers/run_heat_spec.rb
+++ b/spec/workers/run_heat_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe RunHeat do
     end
 
     context 'when the `disable_run_heat_worker` feature flag is enabled' do
-      before { Flipper.enable(:disable_run_heat_worker) }
+      before { activate_feature!(:disable_run_heat_worker) }
 
       it 'does not execute any system commands' do
         expect(worker).not_to receive(:system)


### PR DESCRIPTION
Flushing Redis is not threadsafe / is not guaranteed to work when specs are running concurrently (as seen here: https://travis-ci.org/github/davidrunger/david_runger/builds/703336598 )

(Stubbing will probably also be slightly more performant than flushing redis, I am guessing?)