### PR TITLE
Use Redis DB 0 for Flipper

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -3,7 +3,7 @@
 Flipper.configure do |config|
   config.default do
     # See comments in config/initializers/sidekiq.rb for Redis connection distribution logic/details
-    adapter = Flipper::Adapters::Redis.new(Redis.new(db: 3))
+    adapter = Flipper::Adapters::Redis.new(Redis.new)
     Flipper.new(adapter)
   end
 end


### PR DESCRIPTION
Apparently (based on experimentation via production `rails console`) the Redis DB that we have from Heroku gives us only two databases (0 and 1).