### PR TITLE
Only retry RunHeat job twice

### DIFF
--- a/app/workers/run_heat.rb
+++ b/app/workers/run_heat.rb
@@ -5,6 +5,8 @@ require 'aws-sdk-s3'
 class RunHeat
   include Sidekiq::Worker
 
+  sidekiq_options(retry: 2)
+
   def perform
     if Flipper.enabled?(:disable_run_heat_worker)
       puts('Skipping RunHeat job because the `disable_run_heat_worker` flag is enabled.')


### PR DESCRIPTION
The job is scheduled to run hourly, so retrying more than a few times will generally be unnecessary/counterproductive.