### PR TITLE
Raise errors that occur when executing system commands in `RunHeat`

### DIFF
--- a/app/workers/run_heat.rb
+++ b/app/workers/run_heat.rb
@@ -14,11 +14,11 @@ class RunHeat
     end
 
     # download
-    system('bin/heat')
+    system('bin/heat', exception: true)
 
     # zip
     zip_file_name = "#{Time.current.iso8601.tr(':', '-')}.zip"
-    system(<<~COMMANDS.squish)
+    system(<<~COMMANDS.squish, exception: true)
       cd tmp/heat/images/ &&
         zip -r #{zip_file_name} ./ &&
         mv #{zip_file_name} ../ &&

--- a/spec/workers/run_heat_spec.rb
+++ b/spec/workers/run_heat_spec.rb
@@ -22,8 +22,9 @@ RSpec.describe RunHeat do
       end
 
       it 'downloads, zips, and uploads' do
-        expect(worker).to receive(:system).with('bin/heat')
-        expect(worker).to receive(:system).with(%r{\Acd tmp/heat/images/ && zip -r \w+})
+        expect(worker).to receive(:system).with('bin/heat', exception: true)
+        expect(worker).
+          to receive(:system).with(%r{\Acd tmp/heat/images/ && zip -r \w+}, exception: true)
         # rubocop:disable RSpec/AnyInstance
         expect_any_instance_of(Aws::S3::Object).to receive(:upload_file)
         # rubocop:enable RSpec/AnyInstance


### PR DESCRIPTION
This will make debugging easier by surfacing problems earlier rather than waiting for downstream problems to occur and raise errors of their own.