### PR TITLE
Use Redis db 3 for Flipper in tests

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -3,7 +3,9 @@
 Flipper.configure do |config|
   config.default do
     # See comments in config/initializers/sidekiq.rb for Redis connection distribution logic/details
-    adapter = Flipper::Adapters::Redis.new(Redis.new)
+    # Use a separate redis DB in test so settings don't mix with development config.
+    db_number = Rails.env.test? ? 3 : 0
+    adapter = Flipper::Adapters::Redis.new(Redis.new(db: db_number))
     Flipper.new(adapter)
   end
 end


### PR DESCRIPTION
This is so that development config for Flipper features doesn't affect tests / so that the test Redis db (#3) can easily be cleared before running tests.