### PR TITLE
Fix event name (groceries:route-changed => logs:route-changed)

### DIFF
--- a/app/javascript/logs/components/log_selector.vue
+++ b/app/javascript/logs/components/log_selector.vue
@@ -61,7 +61,7 @@ export default {
     this.logNames.forEach(logName => {
       this.fuzzySet.add(logName);
     });
-    this.unsubscribeFromRouteChanges = on('groceries:route-changed', this.resetQuickSelector);
+    this.unsubscribeFromRouteChanges = on('logs:route-changed', this.resetQuickSelector);
   },
 
   destroyed() {

--- a/app/javascript/logs/router.js
+++ b/app/javascript/logs/router.js
@@ -16,7 +16,7 @@ const router = new VueRouter({
 });
 
 router.beforeEach((to, from, next) => {
-  emit('groceries:route-changed');
+  emit('logs:route-changed');
   next();
 });
 


### PR DESCRIPTION
This happens in the logs app; it appears that this is a typo that has existed since this code was introduced in 4c9d198 .