### PR TITLE
Fix comment about number of connections for $redis_pool (4, not 2)

### DIFF
--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
-# See comments in config/initializers/sidekiq.rb for rationale re: pool size of 2.
+# See comments in config/initializers/sidekiq.rb for rationale re: pool size of 4.
 $redis_pool = ConnectionPool.new(size: 4, timeout: 1) { Redis.new }


### PR DESCRIPTION
(The number of connections (per server process) was changed from 2 to 4 in f5e3794 but we failed to also update the comment at that time.)