### PR TITLE
Delete extra word "connections" from comment about Redis connections

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -8,10 +8,10 @@ build_sidekiq_redis_connection = proc { Redis.new(db: 1) }
 Sidekiq.configure_client do |config|
   # Sidekiq Client Connection Pool size:
   # We have 20 connections total from Heroku Redis Hobby Dev plan
-  # ... minus 7 connections used for Sidekiq below ...
+  # ... minus 7 connections used for the Sidekiq server below ...
   # ... minus 5 connections for `rails console` and general padding ...
   # ... leaves us with 8 connections total for the Rails server process(es).
-  # We are running 1 server process, so that process has 8 connections to work with connections.
+  # We are running 1 server process, so that process has 8 connections to work with.
   # We'll distribute those Redis connections like so:
   # * 3 connections for the Sidekiq client pool (the line below)
   # * 4 for the application (in config/initializers/redis.rb)


### PR DESCRIPTION
This is a typo resulting from some careless changes to this comment in f5e3794 .