### PR TITLE
Delete ignored `username` and `password` production DB configs

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -82,5 +82,3 @@ test:
 production:
   <<: *default
   database: david_runger_production
-  username: david_runger
-  password: <%= ENV['DAVID_RUNGER_DATABASE_PASSWORD'] %>


### PR DESCRIPTION
Per https://edgeguides.rubyonrails.org/configuring.html#connection-preference , these settings are overriden by the values in `DATABASE_URL` , anyway:

> If you have both `config/database.yml` and `ENV['DATABASE_URL']` set then Rails will merge the configuration together. [...] When duplicate connection information is provided the environment variable will take precedence: