### PR TITLE
Delete `essential` queue from Sidekiq config

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,6 @@ production:
   :concurrency: 2
 
 :queues:
-  - ['essential', 12] # ideally we'd run this queue on a separate process, but that'd cost money :(
   - ['default', 3]
   - ['rollbar', 3]
   - ['action_mailbox_incineration', 1]


### PR DESCRIPTION
We used to use this queue to run jobs that sent metrics to StatsD. However, we no longer have a StatsD server (and so no longer run those jobs on an `essential` queue anymore; see 7d253ea ).