### PR TITLE
Delete `config/skylight.yml`

### DIFF
--- a/config/skylight.yml
+++ b/config/skylight.yml
@@ -1,2 +1,0 @@
----
-enable_sidekiq: true


### PR DESCRIPTION
We removed `skylight` in 6b59238 . We should have deleted this file then.