### PR TITLE
Use `AWS_*` rather than `S3_*` env vars for Active Storage config

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -4,7 +4,7 @@ local:
 
 amazon:
   service: S3
-  access_key_id: <%= ENV['S3_ACCESS_KEY_ID'] %>
-  secret_access_key: <%= ENV['S3_SECRET_ACCESS_KEY'] %>
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   bucket: <%= ENV['S3_BUCKET'] %>
   region: <%= ENV['S3_REGION'] %>


### PR DESCRIPTION
Currently, in production, we have both `S3_*` and `AWS_*` env vars set to the same values. We need the `AWS_` env vars so that they can be picked up by the `aws-sdk-s3` gem (used in the `RunHeat` worker). Let's also use those env vars in our Active Storage config, so we can delete the `S3_*` env vars and thereby eliminate that duplication.