### PR TITLE
Delete `verify` alias for `before` in specs

### DIFF
--- a/spec/controllers/api/text_messages_controller_spec.rb
+++ b/spec/controllers/api/text_messages_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Api::TextMessagesController do
     end
 
     context 'when the user may send SMS messages' do
-      verify { expect(user.may_send_sms?).to eq(true) }
+      before { expect(user.may_send_sms?).to eq(true) }
 
       context 'when the user does not have a phone number' do
         before { user.update!(phone: nil) }
@@ -104,9 +104,10 @@ RSpec.describe Api::TextMessagesController do
     end
 
     context 'when the user may not send SMS messages' do
-      before { user.update!(sms_allowance: 0) }
-
-      verify { expect(user.may_send_sms?).to eq(false) }
+      before do
+        user.update!(sms_allowance: 0)
+        expect(user.may_send_sms?).to eq(false)
+      end
 
       context 'when the message params are valid' do
         let(:params) { valid_params }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -290,10 +290,6 @@ Shoulda::Matchers.configure do |config|
   end
 end
 
-def verify(&blk)
-  before(&blk)
-end
-
 def json_response
   JSON(response.body)
 end


### PR DESCRIPTION
The idea had been to be explicit about distinguishing test setup (`before`) from test precondition verification (`verify`), but it's not worth it.