### PR TITLE
Check for `AWS_*` env vars (not `S3_*`) when booting production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -113,9 +113,9 @@ Rails.application.configure do
   require_relative('../../lib/email/mailgun_via_http.rb')
   config.action_mailer.delivery_method = Email::MailgunViaHttp
 
-  if %w[S3_ACCESS_KEY_ID S3_SECRET_ACCESS_KEY S3_BUCKET S3_REGION].all? { ENV[_1].present? }
+  if %w[AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY S3_BUCKET S3_REGION].all? { ENV[_1].present? }
     config.active_storage.service = :amazon
   else
-    puts('Skipping :amazon storage enablement because not all required ENV variables are present.')
+    raise(':amazon storage cannot be enabled because not all required ENV variables are present')
   end
 end


### PR DESCRIPTION
fixes https://rollbar.com/davidjrunger/davidrunger/items/276/

This should have been changed as part of #3092 / 7c6b91c .