### PR TITLE
Allow for a `<div>` to follow a word that truly precedes a newline

### DIFF
--- a/lib/refinements/parsed_mail_body.rb
+++ b/lib/refinements/parsed_mail_body.rb
@@ -41,7 +41,7 @@ module ParsedMailBody
               rstrip
           nokogiri_doc = Nokogiri.parse(decoded_html)
           nokogiri_doc.css('.gmail_quote').remove
-          Set.new(nokogiri_doc.to_s.scan(/[^<>\s]+(?=<br|<\/div)/))
+          Set.new(nokogiri_doc.to_s.scan(/[^<>\s]+(?=<br|<\/?div)/))
         end
     end
   end


### PR DESCRIPTION
This accommodates another email-parsing (edge-?)case as illustrated by the spec added in this PR (which fails without this code change).