### PR TITLE
Bump `yarn` from 1.22.0 to 1.22.4

### DIFF
--- a/bin/test/tasks/check_versions.rb
+++ b/bin/test/tasks/check_versions.rb
@@ -14,7 +14,7 @@ class Test::Tasks::CheckVersions < Pallets::Task
       node --version && [ "$(node --version)" = 'v12.13.1' ]
     COMMAND
     execute_system_command(<<~COMMAND)
-      yarn --version && [ "$(yarn --version)" = '1.22.0' ]
+      yarn --version && [ "$(yarn --version)" = '1.22.4' ]
     COMMAND
   end
 end

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "engines": {
     "node": "12.13.1",
-    "yarn": "1.22.0"
+    "yarn": "1.22.4"
   },
   "browserslist": [
     ">10%"


### PR DESCRIPTION
Apparently Travis felt the need to update its default yarn version.