### PR TITLE
Delete `chromedriver` executable if one is already installed

### DIFF
--- a/bin/test/tasks/ensure_latest_chromedriver.rb
+++ b/bin/test/tasks/ensure_latest_chromedriver.rb
@@ -14,6 +14,7 @@ class Test::Tasks::EnsureLatestChromedriver < Pallets::Task
         curl -o $(pwd)/tmp/chromedriver.zip
         https://chromedriver.storage.googleapis.com/#{latest_release}/#{filename}
       COMMAND
+      execute_system_command('rm -f $HOME/bin/chromedriver')
       execute_system_command('unzip -d "$HOME/bin/" $(pwd)/tmp/chromedriver.zip')
     end
 


### PR DESCRIPTION
Without this, the `unzip` command below can/will hang if `chromedriver` already exists, waiting for manual confirmation about whether or not we want to overwrite the existing file.