### PR TITLE
Don't look for auth token with a blank secret

### DIFF
--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -11,6 +11,8 @@ module TokenAuthenticatable
 
   memoize \
   def auth_token
+    return nil if auth_token_param.blank?
+
     AuthToken.find_by(secret: auth_token_param)
   end
 


### PR DESCRIPTION
Doing this early `return` saves a database query (that we expect to always return `nil`).