### PR TITLE
Use `request.remote_ip` rather than `request.ip`

### DIFF
--- a/app/controllers/lib/request_data_builder.rb
+++ b/app/controllers/lib/request_data_builder.rb
@@ -34,7 +34,7 @@ class RequestDataBuilder
       handler: "#{@params['controller']}##{@params['action']}",
       params: @filtered_params.except(*BORING_PARAMS),
       referer: @request.referer,
-      ip: @request.ip,
+      ip: @request.remote_ip,
       user_agent: raw_user_agent,
       requested_at_as_float: Float(@request_time),
       format: @request.format.symbol,


### PR DESCRIPTION
This difference matters now that we are using Cloudflare as a proxy (and also using the `cloudflare-rails` gem). `remote_ip` will give the IP of the client (which we want) whereas `ip` will give a Cloudflare IP.