### PR TITLE
Add `git` to fail2ban wordlist

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -3,6 +3,7 @@
 class Rack::Attack
   BANNED_PATH_FRAGMENTS = Set.new(%w[
     env
+    git
     old-wp
     passwd
     php


### PR DESCRIPTION
For example, I have seen a request for `https://www.davidrunger.com/.git/HEAD`.