### PR TITLE
Redirect from `/workouts` to `/workout`

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
 
   get 'groceries', to: 'groceries#index'
   get 'workout', to: 'workouts#index'
+  get 'workouts', to: redirect('workout')
   get 'logs', to: 'logs#index'
   namespace :logs do
     resources :uploads, only: %i[index create]


### PR DESCRIPTION
This is just a convenience so that one needn't remember whether `/workouts` or `/workout` is the canonical route; either will work.