### PR TITLE
Split URL fragment on dashes for blacklisting

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -13,9 +13,6 @@ class Rack::Attack
     plugins
     wordpress
     wp
-    wp-admin
-    wp-includes
-    wp-login
     wp1
     wp2
   ].map(&:freeze)).freeze
@@ -39,7 +36,7 @@ class Rack::Attack
     end
 
     def blocked_path?(request)
-      fragments = request.path.split(%r{/|\.|\?})
+      fragments = request.path.split(%r{/|\.|\?|-})
       fragments.map!(&:presence)
       fragments.compact!
       fragments.any? do |fragment|


### PR DESCRIPTION
This way I don't need to add `wp-json` and I can remove some existing variants.