### PR TITLE
Explicitly add `postcss-html` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
   "devDependencies": {
     "@percy/agent": "^0.28.4",
     "postcss": "^8.1.4",
+    "postcss-html": "^0.36.0",
     "postcss-safe-parser": "^5.0.2",
     "postcss-scss": "^3.0.4",
     "postcss-syntax": "^0.36.2",


### PR DESCRIPTION
This essentially reverts fd38c0c .

I'm unsure why this is necessary, since `postcss-html` is a dependency of `stylelint` (and, for this reason, `postcss-html` is already listed in `yarn.lock`), but it is; without having `postcss-html` as an explicit dependency in `package.json`, it isn't in `node_modules/` after running `yarn install --check-files`, which causes the error seen [here](https://github.com/davidrunger/david_runger/pull/3759). 🤷‍♂️