### PR TITLE
Retry migrations a few times in release task in the event of failure

### DIFF
--- a/bin/release-tasks
+++ b/bin/release-tasks
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 
+migrate() {
+  echo "Running bin/rails db:migrate"
+  bin/rails db:migrate
+}
+
 # run migrations when deploying to production, but not when deploying a review app
 if [ $HEROKU_PR_NUMBER ]
 then
   echo "Skipping db:migrate because HEROKU_PR_NUMBER is present (value: $HEROKU_PR_NUMBER)"
 else
-  echo "Running bin/rails db:migrate"
-  bin/rails db:migrate
+  # Retry up to 10 times w/ increasing `sleep`. h/t: https://stackoverflow.com/a/12321815/4009384
+  NEXT_WAIT_TIME=1
+  until [ $NEXT_WAIT_TIME -eq 10 ] || migrate; do
+      sleep $(( NEXT_WAIT_TIME++ ))
+  done
+  [ $NEXT_WAIT_TIME -lt 10 ]
 fi


### PR DESCRIPTION
fixes https://rollbar.com/davidjrunger/davidrunger/items/369/

When multiple deploys are going out simultaneously, one of the deploys might fail with a `ActiveRecord::ConcurrentMigrationError` error if the release tasks (which run migrations) execute approximately simultaneously.

This change should swallow any such error and retry the migration a few more times (hopefully allowing enough time for the migrations to complete in the simultaneously executing release taks from another deployment). If the migrations continue to fail, then the release taks script will exit with an error.

A somewhat more robust but more complicated solution would probably be to queue deploys if there is a deploy currently underway, rather than just running a bunch of deploys simultaneously, in the first place, which is the underlying precondition for this problem to occur; that would require building out some sort of more sophisticated deployment infrastructure/process, though. The "quick and dirty" solution implemented in this commit should be good enough for now for our needs.