### PR TITLE
Fetch 100 commits for GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -38,6 +38,8 @@ jobs:
           - 6379:6379 # Maps port 6379 on service container to the host
     steps:
     - uses: actions/checkout@v2
+      with:
+        fetch-depth: 100 # this might cause issues if there are more than 100 commits in a PR (?)
     - name: Setup Ruby 2.7.2
       uses: ruby/setup-ruby@v1
       with:

--- a/bin/test/diff_helpers.rb
+++ b/bin/test/diff_helpers.rb
@@ -25,7 +25,7 @@ module DiffHelpers
   def files_changed
     if !system('git log -1 --pretty="%H" master > /dev/null 2>&1')
       puts('`master` branch is not present; fetching it now...')
-      `git fetch origin master:master --depth=1`
+      system('git fetch origin master:master --depth=1', exception: true)
       puts('Done fetching origin master branch.')
     end
 


### PR DESCRIPTION
Without this, everything is fetched as a single commit, which was then breaking our ability to determine which files have been changed since `master` (which, in turn, we use to determine which tests/linters should be run).