### PR TITLE
Fix new DB integrity checks by adding Rails uniqueness validations

### DIFF
--- a/.database_consistency.yml
+++ b/.database_consistency.yml
@@ -1,29 +1,9 @@
 # do not check ActionMailbox/ActiveStorage models, since they are provided by Rails
 ActionMailbox::InboundEmail:
-  message_id:
-    NullConstraintChecker:
-      enabled: false
-  message_checksum:
-    NullConstraintChecker:
-      enabled: false
+  enabled: false
 ActiveStorage::Blob:
-  key:
-    NullConstraintChecker:
-      enabled: false
-  filename:
-    NullConstraintChecker:
-      enabled: false
-  byte_size:
-    NullConstraintChecker:
-      enabled: false
-  checksum:
-    NullConstraintChecker:
-      enabled: false
+  enabled: false
 ActiveStorage::VariantRecord:
-  variation_digest:
-    NullConstraintChecker:
-      enabled: false
+  enabled: false
 ActiveStorage::Attachment:
-  name:
-    NullConstraintChecker:
-      enabled: false
+  enabled: false

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -42,7 +42,7 @@ class Log < ApplicationRecord
   validates :data_label, presence: true
   validates :data_type, presence: true, inclusion: DATA_TYPES.keys
   validates :name, presence: true, uniqueness: { scope: :user_id }
-  validates :slug, presence: true
+  validates :slug, presence: true, uniqueness: { scope: :user_id }
 
   belongs_to :user
 

--- a/app/models/log_share.rb
+++ b/app/models/log_share.rb
@@ -18,5 +18,5 @@ class LogShare < ApplicationRecord
   belongs_to :log
   has_one :user, through: :log
 
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: { scope: :log_id }
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -40,5 +40,5 @@ class Request < ApplicationRecord
   belongs_to :user, optional: true
 
   validates :url, :handler, :method, :ip, :requested_at, :status, presence: true
-  validates :request_id, presence: true
+  validates :request_id, presence: true, uniqueness: true
 end

--- a/app/models/sms_record.rb
+++ b/app/models/sms_record.rb
@@ -21,7 +21,7 @@
 #
 
 class SmsRecord < ApplicationRecord
-  validates :nexmo_id, presence: true
+  validates :nexmo_id, presence: true, uniqueness: true
   validates :status, presence: true
   validates :to, presence: true
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -22,7 +22,7 @@ class User < ApplicationRecord
 
   devise :omniauthable, omniauth_providers: [:google_oauth2]
 
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: true
   validates :phone, format: { with: /\A1[[:digit:]]{10}\z/ }, allow_nil: true
 
   has_many :auth_tokens, dependent: :destroy


### PR DESCRIPTION
Some of our DB integrity checks are failing. I am guessing that this is because maybe the checks have been added to the `database_consistency` gem since the last time the `RunDatabaseConsistency` test task was run in CI (which it usually isn't; it's only run when `db/schema.rb` has been changed).