### PR TITLE
Allow AdminUsers to become(/impersonate/log-in-as) Users

### DIFF
--- a/app/admin/requests.rb
+++ b/app/admin/requests.rb
@@ -6,6 +6,7 @@ ActiveAdmin.register(Request) do
   index do
     id_column
     column :user
+    column :admin_user
     column :auth_token
     column :handler
     column :requested_at

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -3,4 +3,30 @@
 ActiveAdmin.register(User) do
   menu parent: 'Users'
   permit_params :email, :phone, :sms_allowance
+
+  index do
+    id_column
+    column :email
+    column :created_at
+    column :updated_at
+    column :phone
+    column :sms_allowance
+    actions
+    column { |user| link_to('Become', become_admin_user_path(user)) }
+  end
+
+  action_item :become, only: :show do
+    link_to('Become', become_admin_user_path(resource))
+  end
+
+  member_action :become do
+    sign_in(resource)
+    redirect_to(groceries_path)
+  end
+
+  member_action :unbecome do
+    user = current_user
+    sign_out(user)
+    redirect_to(admin_user_path(user))
+  end
 end

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -38,6 +38,7 @@ class Request < ApplicationRecord
   # error class for Rollbar logging
   class CreateRequestError < StandardError ; end
 
+  belongs_to :admin_user, optional: true
   belongs_to :auth_token, optional: true
   belongs_to :user, optional: true
 

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -34,6 +34,10 @@
     = content_for(:extra_javascript)
 
   %body{class: [@body_class, 'sans-serif'].map(&:presence).compact.join(' ')}
+    - if user_signed_in? && admin_user_signed_in? && (current_user.email != current_admin_user.email)
+      .center.p1.bg-aqua
+        = link_to('Unbecome', unbecome_admin_user_path(current_user))
+        = current_user.email
     - if notice.present?
       %p.p2.notice= notice
     - if alert.present?

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+RSpec.describe Admin::UsersController do
+  let(:user) { users(:user) }
+
+  context 'when logged in as an AdminUser' do
+    before { sign_in(admin_users(:admin_user)) }
+
+    describe '#index' do
+      subject(:get_index) { get(:index) }
+
+      it 'responds with 200' do
+        get_index
+        expect(response.status).to eq(200)
+      end
+    end
+
+    describe '#show' do
+      subject(:get_show) { get(:show, params: { id: user.id }) }
+
+      it 'responds with 200' do
+        get_show
+        expect(response.status).to eq(200)
+      end
+    end
+
+    describe '#edit' do
+      subject(:get_edit) { get(:edit, params: { id: user.id }) }
+
+      it 'responds with 200' do
+        get_edit
+        expect(response.status).to eq(200)
+      end
+    end
+
+    describe '#unbecome' do
+      subject(:get_unbecome) { get(:unbecome, params: { id: user.id }) }
+
+      before { sign_in(user) }
+
+      it 'redirects to the admin user show page' do
+        get_unbecome
+        expect(response).to redirect_to(admin_user_path(user))
+      end
+    end
+  end
+
+  describe '#become' do
+    subject(:get_become) { get(:become, params: { id: user.id }) }
+
+    context 'when logged in as an AdminUser' do
+      before { sign_in(admin_users(:admin_user)) }
+
+      it 'redirects to the groceries app' do
+        get_become
+        expect(response).to redirect_to(groceries_path)
+      end
+    end
+
+    context 'when not logged in as an AdminUser (just a User)' do
+      before do
+        controller.sign_out_all_scopes
+        sign_in(users(:user))
+      end
+
+      it 'redirects to the admin login page' do
+        get_become
+        expect(response).to redirect_to(admin_login_path)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There is the [`devise_masquerade`][1] gem that implements this, but it seems simple enough to be worth just doing on our own?

[1]: https://github.com/oivoodoo/devise_masquerade