### PR TITLE
Handle `current_user` being `nil` when unbecoming

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -25,8 +25,7 @@ ActiveAdmin.register(User) do
   end
 
   member_action :unbecome do
-    user = current_user
-    sign_out(user)
-    redirect_to(admin_user_path(user))
+    sign_out(:user)
+    redirect_to(admin_user_path(params[:id]))
   end
 end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -36,11 +36,23 @@ RSpec.describe Admin::UsersController do
     describe '#unbecome' do
       subject(:get_unbecome) { get(:unbecome, params: { id: user.id }) }
 
-      before { sign_in(user) }
+      context 'when a user is signed in' do
+        before { sign_in(user) }
 
-      it 'redirects to the admin user show page' do
-        get_unbecome
-        expect(response).to redirect_to(admin_user_path(user))
+        it 'redirects to the admin user show page' do
+          get_unbecome
+          expect(response).to redirect_to(admin_user_path(user))
+        end
+      end
+
+      # this can happen if an AdminUser double clicks the "Unbecome" link, for example
+      context 'when a user is not signed in' do
+        before { sign_out(:user) }
+
+        it 'redirects to the admin user show page' do
+          get_unbecome
+          expect(response).to redirect_to(admin_user_path(user))
+        end
       end
     end
   end


### PR DESCRIPTION
fixes https://rollbar.com/davidjrunger/davidrunger/items/377/

This fixes a bug wherein a 500 error could/would occur if an AdminUser were to double click the "Unbecome" link when impersonating a user.