### PR TITLE
Allow automatic AdminUser login in development

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,17 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def current_admin_user
+    if Rails.env.development? && Flipper.enabled?(:automatic_admin_login)
+      super ||
+        AdminUser.
+          find_by!(email: 'davidjrunger@gmail.com').
+          tap { |admin_user| sign_in(admin_user) }
+    else
+      super
+    end
+  end
+
   def skip_authorization?
     # ActiveAdmin supports an "Authorization Adapter" that can be implemented separately; skip here.
     return true if params[:controller].match?(%r{\Aactive_admin/|admin/})

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -35,4 +35,28 @@ RSpec.describe ApplicationController, :without_verifying_authorization do
       end
     end
   end
+
+  describe '#current_admin_user' do
+    subject(:current_admin_user) { controller.send(:current_admin_user) }
+
+    context 'when Rails.env is "development"' do
+      before do
+        expect(Rails).
+          to receive(:env).
+          and_return(ActiveSupport::EnvironmentInquirer.new('development'))
+      end
+
+      context 'when the `automatic_admin_login` flag is enabled' do
+        before { activate_feature!(:automatic_admin_login) }
+
+        context 'when no AdminUser is logged in' do
+          before { controller.sign_out_all_scopes }
+
+          it 'returns the AdminUser with email "davidjrunger@gmail.com"' do
+            expect(current_admin_user.email).to eq('davidjrunger@gmail.com')
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -18,7 +18,7 @@ FixtureBuilder.configure do |fbuilder|
     admin = name(:admin, create(:user, :admin)).first
 
     # admin users
-    name(:admin_user, create(:admin_user))
+    name(:admin_user, create(:admin_user, email: 'davidjrunger@gmail.com'))
 
     # groceries
     store = name(:store, create(:store, user: user)).first


### PR DESCRIPTION
To activate: enable the `automatic_admin_login` Flipper flag (only works in the `development` Rails env).

Motivation: this makes it easy to become users via admin in incognito windows, etc. (without needing first to log in to Google to access admin in the incognito window). Being able to do this is useful in order to have User A logged in to a non-incognito window and then to become User B in an incognito window; User A and User B can then interact with the localhost web app simultaneously. Bonus: use the [Firefox Multi-Account Containers](https://addons.mozilla.org/en-US/firefox/addon/multi-account-containers/) add-on so that more than just 2 users can log in simultaneously using a single browser (via using separate "containers").