### PR TITLE
Change `ip_blocks.ip` from `text` to `string`

### DIFF
--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -6,7 +6,7 @@
 #
 #  created_at :datetime         not null
 #  id         :bigint           not null, primary key
-#  ip         :text             not null
+#  ip         :string           not null
 #  reason     :text
 #  updated_at :datetime         not null
 #

--- a/db/migrate/20210106065110_change_ip_block_ip_from_text_to_string.rb
+++ b/db/migrate/20210106065110_change_ip_block_ip_from_text_to_string.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ChangeIpBlockIpFromTextToString < ActiveRecord::Migration[6.1]
+  def change
+    reversible do |direction|
+      change_table :ip_blocks do |t|
+        direction.up { t.change :ip, :string }
+        direction.down { t.change :ip, :text }
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_03_111241) do
+ActiveRecord::Schema.define(version: 2021_01_06_065110) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 2021_01_03_111241) do
   end
 
   create_table "ip_blocks", force: :cascade do |t|
-    t.text "ip", null: false
+    t.string "ip", null: false
     t.text "reason"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/spec/factories/ip_blocks.rb
+++ b/spec/factories/ip_blocks.rb
@@ -6,7 +6,7 @@
 #
 #  created_at :datetime         not null
 #  id         :bigint           not null, primary key
-#  ip         :text             not null
+#  ip         :string           not null
 #  reason     :text
 #  updated_at :datetime         not null
 #


### PR DESCRIPTION
This results in a text `input` in ActiveAdmin when creating/editing an `IpBlock`; the text `input` is smaller and more appropriate than the `textarea` that is used when the column is of type `text`.