### PR TITLE
Log "ref" instead of "branch" in build time log entry note

### DIFF
--- a/bin/test/tasks/exit.rb
+++ b/bin/test/tasks/exit.rb
@@ -78,7 +78,7 @@ class Test::Tasks::Exit < Pallets::Task
   end
 
   def log_note
-    "exit_code=#{exit_code} tasks=#{short_job_names.sort.join(',')} branch=#{ENV['TRAVIS_BRANCH']}"
+    "exit_code=#{exit_code} tasks=#{short_job_names.sort.join(',')} ref=#{ENV['GITHUB_REF']}"
   end
 
   def overall_wall_clock_time


### PR DESCRIPTION
GitHub Actions doesn't seem to make a branch name available as an env variable, but it does make a "ref" available (ex: `refs/pull/33/merge`).