### PR TITLE
Simplify branching in test runner `#run_once_config_is_confirmed`

### DIFF
--- a/bin/test/runner.rb
+++ b/bin/test/runner.rb
@@ -31,13 +31,11 @@ class Test::Runner < Pallets::Workflow
     end
 
     def run_once_config_is_confirmed
-      if ENV.key?('TRAVIS')
-        register_tasks_and_run
-      elsif !Test::RequirementsResolver.verify?
+      if Test::RequirementsResolver.verify?
+        confirm_config
+      else
         system('clear')
         register_tasks_and_run
-      else
-        confirm_config
       end
     end
 


### PR DESCRIPTION
(I was looking at this code because no `TRAVIS` env variable is set by GitHub; that made me realize that the first `if` branch being removed here is never entered and is therefore worthless.)