### PR TITLE
Fix `vue/no-mutating-props` eslint violations

### DIFF
--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -66,11 +66,10 @@ export default {
 
     stopEditingAndUpdateItemName() {
       this.editingName = false;
-      this.item.name = this.$refs['item-name-input'].value;
       this.$store.dispatch('updateItem', {
-        id: this.item.id,
+        item: this.item,
         attributes: {
-          name: this.item.name,
+          name: this.$refs['item-name-input'].value,
         },
       });
     },

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -236,16 +236,13 @@ export default {
       if (this.formstate.$invalid) return;
 
       this.$store.commit('incrementPendingRequests');
-      const payload = {
-        item: {
+      this.$store.dispatch('createItem', {
+        store: this.store,
+        itemAttributes: {
           name: this.newItemName,
         },
-      };
-      this.$http.post(this.$routes.api_store_items_path(this.store.id), payload).then(response => {
-        this.newItemName = '';
-        this.$store.commit('decrementPendingRequests');
-        this.store.items.unshift({ createdAt: (new Date()).valueOf(), ...response.data });
       });
+      this.newItemName = '';
     },
 
     sortItems(items) {


### PR DESCRIPTION
I think that we've had these eslint violations for quite a while, but just haven't noticed them, exactly, because eslint hasn't been triggered in CI for a long time (due to no JavaScript changes having been made for a long time).

These changes slightly degrade the user experience, I think (basically by changing to a "non-optimistic UI" vs the "optimistic UI" that we had before), but it's not the end of the world.