### PR TITLE
Remove all remaining references to `TRAVIS` env variable

### DIFF
--- a/bin/test/runner.rb
+++ b/bin/test/runner.rb
@@ -45,7 +45,7 @@ class Test::Runner < Pallets::Workflow
     end
 
     def print_config
-      system('clear') if !ENV.key?('TRAVIS')
+      system('clear')
 
       ap('Running these tasks:')
       ap(required_tasks.map(&:name).map { _1.gsub('Test::Tasks::', '') }.sort)

--- a/config/webpack/test.js
+++ b/config/webpack/test.js
@@ -59,15 +59,6 @@ const testConfig = merge(environment.toWebpackConfig(), shared, {
     new MiniCssExtractPlugin({
       filename: '[name].css',
     }),
-    // from https://github.com/webpack/webpack/issues/708#issuecomment-70869174
-    function () {
-      this.hooks.done.tap('RungerTestEnvErrorLogger', stats => {
-        if (stats.compilation.errors && stats.compilation.errors.length && process.env.TRAVIS) {
-          console.error(stats.compilation.errors);
-          process.exit(1);
-        }
-      });
-    },
   ],
   resolve: {
     modules: [


### PR DESCRIPTION
This env variable is never set, now that we have migrated to GitHub Actions.