### PR TITLE
Require opting in to Turbo JavaScript (i.e. disable Turbo by default)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,6 +8,7 @@ class ApplicationController < ActionController::Base
   include Redirectable
   include RequestRecordable
   include TokenAuthenticatable
+  include TurboEnableable
 
   protect_from_forgery with: :exception
 

--- a/app/controllers/concerns/turbo_enableable.rb
+++ b/app/controllers/concerns/turbo_enableable.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module TurboEnableable
+  extend ActiveSupport::Concern
+
+  private
+
+  def enable_turbo
+    @turbo_enabled = true
+  end
+end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class QuizzesController < ApplicationController
+  before_action :enable_turbo
+
   def show
     @quiz = policy_scope(Quiz).find(params[:id]).decorate
     authorize(@quiz, :show?)

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -26,8 +26,9 @@
       window.davidrunger = {env: '#{Rails.env}'};
       window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript((@bootstrap_data || {}).to_json))}");
 
-    = stimulus_include_tags
-    = turbo_include_tags
+    - if @turbo_enabled
+      = stimulus_include_tags
+      = turbo_include_tags
     - if Rails.env.development? && !ENV['PRODUCTION_ASSET_CONFIG'].present?
       = javascript_pack_tag('styles', defer: true)
     - else


### PR DESCRIPTION
Turbo was breaking lots of stuff in the parts of the application that weren't built with Turbo awareness in mind. (For example, links from the home page to the groceries app were doing nothing.)