### PR TITLE
Remove no longer needed explicit Turbo disablement for Google login

### DIFF
--- a/app/views/admin/sessions/new.haml
+++ b/app/views/admin/sessions/new.haml
@@ -11,5 +11,5 @@
     }
 
 %div.py4.center
-  = form_tag("/auth/google_oauth2?redirect_uri=#{url_base}/admin_users/auth/google_oauth2/callback", method: :post, data: { turbo: false }) do
+  = form_tag("/auth/google_oauth2?redirect_uri=#{url_base}/admin_users/auth/google_oauth2/callback", method: :post) do
     = button_tag(image_tag('google-login.png'), type: :submit, class: 'google-login')

--- a/app/views/sessions/new.haml
+++ b/app/views/sessions/new.haml
@@ -11,5 +11,5 @@
     }
 
 %div.py4.center
-  = form_tag("/auth/google_oauth2?redirect_uri=#{url_base}/users/auth/google_oauth2/callback", method: :post, data: { turbo: false }) do
+  = form_tag("/auth/google_oauth2?redirect_uri=#{url_base}/users/auth/google_oauth2/callback", method: :post) do
     = button_tag(image_tag('google-login.png'), type: :submit, class: 'google-login')


### PR DESCRIPTION
Since ae7147e, we now disable Turbo by default, so these specific/manual disablements are no longer necessary.