### PR TITLE
Prevent duplicate quiz participant listings

### DIFF
--- a/app/views/quiz_participations/_quiz_participation.haml
+++ b/app/views/quiz_participations/_quiz_participation.haml
@@ -1,1 +1,3 @@
-%li= quiz_participation.display_name
+= turbo_stream.remove(quiz_participation)
+= turbo_stream.append('quiz_participations') do
+  %li{id: dom_id(quiz_participation)}= quiz_participation.display_name


### PR DESCRIPTION
Ideally, there'd be a `replace_or_append` (and `replace_or_prepend`) Turbo Stream action(s) (in addition to the `replace`, `append`, and `prepend` actions that currently exist). This proposed solution is complicated, however, by the fact that the `target` DOM ID will be different in the `replace` vs `append` cases (e.g. `message_1` vs `messages`).

Given this lack of a framework solution, I've come up with this very hacky solution -- but is seems to mostly work, so we'll go with this for now. Per https://github.com/hotwired/turbo/issues/ 25 (somewhat related, but maybe not exactly the same issue), there doesn't seem to be much appetite for solving this sort of problem at the framework level right now.

One deficiency of this hack (`remove` then `append`) relative to a framework-level `replace_or_append` is that this hack solution might cause a reordering of elements in the list, whereas `replace_or_append` would not.

The hack seems to be modelled here?: https://github.com/hotwired/turbo-rails/blob/969d899/app/models/turbo/streams/tag_builder.rb#L9-L17