### PR TITLE
Change "open" quiz status to "active"

### DIFF
--- a/app/models/quiz.rb
+++ b/app/models/quiz.rb
@@ -18,7 +18,7 @@
 class Quiz < ApplicationRecord
   include Hashid::Rails
 
-  validates :status, presence: true, inclusion: %w[unstarted open closed].map(&:freeze).freeze
+  validates :status, presence: true, inclusion: %w[unstarted active closed].map(&:freeze).freeze
 
   belongs_to :owner, class_name: 'User'
 


### PR DESCRIPTION
I think "active" better captures the concept of a quiz that has been started and is currently in progress.