### PR TITLE
Improve reliability of list of quizees who have answered question

### DIFF
--- a/app/actions/quiz_question_answer_selections/create.rb
+++ b/app/actions/quiz_question_answer_selections/create.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class QuizQuestionAnswerSelections::Create < ApplicationAction
+  requires :quiz_participation, Shaped::Shape(QuizParticipation)
+  requires :params, Shaped::Shape(ActionController::Parameters)
+
+  returns :selection, QuizQuestionAnswerSelection, presence: true
+
+  def execute
+    result.selection = quiz_participation.quiz_question_answer_selections.create!(params)
+
+    QuizzesChannel.broadcast_to(
+      quiz_participation.quiz,
+      new_answerer_name: quiz_participation.display_name,
+    )
+  end
+end

--- a/app/controllers/quiz_question_answer_selections_controller.rb
+++ b/app/controllers/quiz_question_answer_selections_controller.rb
@@ -3,12 +3,17 @@
 class QuizQuestionAnswerSelectionsController < ApplicationController
   def create
     authorize(QuizQuestionAnswerSelection, :create?)
-    selection =
+
+    quiz_participation =
       current_user.
         quiz_participations.
-        find_by!(quiz_id: Quiz.find(params[:quiz_id]).id).
-        quiz_question_answer_selections.
-        create!(quiz_question_answer_selection_params)
+        find_by!(quiz_id: Quiz.find(params[:quiz_id]).id)
+    selection =
+      QuizQuestionAnswerSelections::Create.new(
+        params: quiz_question_answer_selection_params,
+        quiz_participation: quiz_participation,
+      ).run!.selection
+
     redirect_to(selection.quiz)
   end
 

--- a/app/javascript/packs/quizzes.js
+++ b/app/javascript/packs/quizzes.js
@@ -8,8 +8,14 @@ actionCableConsumer.subscriptions.create(
   },
   {
     received(data) {
-      if (data && data.command === 'refresh') {
+      if (!data) return;
+
+      if (data.command === 'refresh') {
         Turbo.visit(window.location.pathname, { action: 'replace' });
+      } else if (data.new_answerer_name) {
+        [...document.getElementById('quiz_question_answer_selections').querySelectorAll('li')].
+          find(el => el.innerText === data.new_answerer_name).
+          classList.add('bold');
       }
     },
   },

--- a/app/models/quiz_question_answer_selection.rb
+++ b/app/models/quiz_question_answer_selection.rb
@@ -21,6 +21,4 @@ class QuizQuestionAnswerSelection < ApplicationRecord
 
   has_one :question, through: :answer
   has_one :quiz, through: :question
-
-  broadcasts_to :quiz
 end


### PR DESCRIPTION
The turbostreaming was not reliable for some reason, i.e. sometimes a participant would answer a quiz question but that wouldn't be displayed via websockets for other users (I suspect probably too much connecting/disconnecting to the stream as we did "refreshes" via TurboLinks when moving from one question to another, etc), and this new approach seems more reliable.