### PR TITLE
Clear `Turbo` cache before "refreshing"

### DIFF
--- a/app/javascript/packs/quizzes.js
+++ b/app/javascript/packs/quizzes.js
@@ -11,6 +11,7 @@ actionCableConsumer.subscriptions.create(
       if (!data) return;
 
       if (data.command === 'refresh') {
+        Turbo.clearCache();
         Turbo.visit(window.location.pathname, { action: 'replace' });
       } else if (data.new_answerer_name) {
         [...document.getElementById('quiz_question_answer_selections').querySelectorAll('li')].


### PR DESCRIPTION
If we don't clear the cache, then -- since we are just reloading the same URL -- when we "reload" the page, while we're waiting for the response from the server an old version of the page will be displayed, which creates a confusing and "jumpy" user experience.