### PR TITLE
Remove `turbo-rails` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ gem 'sidekiq'
 gem 'sidekiq-scheduler', require: false
 gem 'stackprof'
 gem 'thread_safe'
-gem 'turbo-rails'
 gem 'webpacker'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -558,8 +558,6 @@ GEM
       e2mmap
     tilt (2.0.10)
     trollop (1.16.2)
-    turbo-rails (0.5.3)
-      rails (>= 6.0.0)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.0.0)
@@ -665,7 +663,6 @@ DEPENDENCIES
   stackprof
   super_diff
   thread_safe
-  turbo-rails
   webmock
   webpacker
 


### PR DESCRIPTION
Although we are still using the `@hotwired/turbo-rails` JavaScript package a little bit, we aren't using any server-side Turbo functionality, and therefore we are removing this gem to keep the app's memory footprint etc as small as possible.