### PR TITLE
Remove `hashdiff` from `Gemfile`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,7 +80,6 @@ group :test do
   gem 'database_consistency', require: false
   gem 'fixture_builder'
   gem 'guard-espect', require: false, github: 'davidrunger/guard-espect'
-  gem 'hashdiff'
   gem 'json-schema'
   gem 'launchy'
   gem 'percy-capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -616,7 +616,6 @@ DEPENDENCIES
   flipper-ui
   guard-espect!
   hamlit
-  hashdiff
   hashid-rails
   http_logger
   immigrant


### PR DESCRIPTION
See a59eea9 , where it was added to force version 1.0.0.beta1; we no longer need to list it explicitly for this reason.