### PR TITLE
Move some gems from `:development, :test` to `:test`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,13 +49,8 @@ end
 
 group :development, :test do
   gem 'amazing_print'
-  gem 'annotate'
-  gem 'climate_control'
+  gem 'annotate', require: false
   gem 'dotenv-rails', require: 'dotenv/rails-now'
-  gem 'factory_bot_rails'
-  gem 'faker'
-  gem 'immigrant'
-  gem 'pallets'
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-rails'
@@ -80,12 +75,17 @@ end
 group :test do
   gem 'brakeman', require: false
   gem 'capybara'
+  gem 'climate_control'
   gem 'codecov', require: false
   gem 'database_consistency', require: false
+  gem 'factory_bot_rails'
+  gem 'faker'
   gem 'fixture_builder'
   gem 'guard-espect', require: false, github: 'davidrunger/guard-espect'
+  gem 'immigrant', require: false
   gem 'json-schema'
   gem 'launchy'
+  gem 'pallets'
   gem 'percy-capybara'
   gem 'rails-controller-testing', github: 'rails/rails-controller-testing'
   gem 'rspec-instafail', require: false

--- a/lib/tasks/auto_annotate_models.rake
+++ b/lib/tasks/auto_annotate_models.rake
@@ -32,5 +32,6 @@ if Rails.env.development?
     )
   end
 
-  Annotate.load_tasks
+  # We've commented this out, so that we don't have to require `annotate`.
+  # Annotate.load_tasks
 end


### PR DESCRIPTION
This should make the development environment boot up faster?

Also, add `require: false` to a few gems, also with the goal of facillitating faster bootups.