### PR TITLE
Have a participant join the new quiz in feature spec

### DIFF
--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Quizzes app' do
-  let(:user) { users(:user) }
+  let(:quiz_owner) { users(:admin) }
+  let(:participant) { users(:user) }
 
   context 'when user is signed in' do
-    before { sign_in(user) }
+    before { sign_in(quiz_owner) }
 
     it 'allows creating a new quiz and then shows that quiz' do
       visit(new_quiz_path)
@@ -17,6 +18,20 @@ RSpec.describe 'Quizzes app' do
       click_button('Create quiz')
 
       expect(page).to have_css('h1', text: new_quiz_name)
+      new_quiz = Quiz.order(:created_at).last!
+      quiz_path = quiz_path(new_quiz)
+      expect(page).to have_current_path(quiz_path)
+
+      participant_name = 'Jessica'
+      expect(page).not_to have_text(participant_name)
+      Capybara.using_session('Quiz participant session') do
+        sign_in(participant)
+        visit(quiz_path)
+        fill_in('display_name', with: participant_name)
+        click_button('Join the quiz!')
+      end
+
+      expect(page).to have_text(participant_name)
     end
   end
 end


### PR DESCRIPTION
Part of the motivation for this change is to ensure that the websocket/cable connection to QuizzesChannel completes before the spec ends. Prior to this change, it wouldn't always do so, causing `QuizzesChannel#subscribed` to appear to fall in and out of being covered by tests (as monitored by Codecov).