### PR TITLE
Fix styling issues caused by reset.css => normalize.css switch

### DIFF
--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-li.grocery-item.flex.items-center(
+.grocery-item.flex.items-center(
   :class='{unneeded: item.needed <= 0, "appear-vertically": isJustAdded(item)}'
 )
   Drag(:transferData='item')
@@ -109,7 +109,7 @@ export default {
   -ms-user-select: none;
 }
 
-li.grocery-item {
+.grocery-item {
   background: rgba(255, 255, 255, 0.6);
   margin: 5px 0;
   padding: 0 6px;

--- a/app/javascript/groceries/components/sidebar.vue
+++ b/app/javascript/groceries/components/sidebar.vue
@@ -18,8 +18,8 @@ aside.border-right.border-gray
         :disabled='postingStore || formstate.$invalid'
         size='medium'
       )
-    ul.stores-list
-      li.js-link.stores-list__item.h3.my2.py1.px2(
+    .stores-list
+      .js-link.stores-list__item.h3.my2.py1.px2(
         v-for='store in sortedStores'
         :class='{selected: store === currentStore}'
         @click='$store.dispatch("selectStore", { store })'

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -52,7 +52,7 @@ div.mt1.mb2.ml3.mr2
       :disabled='formstate.$invalid'
     )
 
-  ul.items-list.mt0.mb0
+  .items-list.mt0.mb0
     Item(v-for='item in sortedItems' :item="item" :key="item.id")
 
   Modal(name='check-in-shopping-trip' width='85%' maxWidth='400px')

--- a/app/javascript/logs/components/log_selector.vue
+++ b/app/javascript/logs/components/log_selector.vue
@@ -14,8 +14,8 @@ Modal(
       @keydown.down='incrementHighlightedLogIndex'
       ref='log-search-input'
     )
-    ul
-      li.log-link-container(v-for='(log, index) in orderedMatches')
+    div
+      .log-link-container(v-for='(log, index) in orderedMatches')
         router-link.log-link(
           :to='{ name: "log", params: { slug: log.slug }}'
           :class='{bold: (index === highlightedLogIndex)}'

--- a/app/javascript/logs/components/logs_index.vue
+++ b/app/javascript/logs/components/logs_index.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 section
-  ul
-    li.log-link-container.m1.h2(v-for='log in logs')
+  div
+    .log-link-container.m1.h2(v-for='log in logs')
       router-link.log-link(:to='{ name: "log", params: { slug: log.slug }}') {{log.name}}
   el-collapse(v-model='expandedPanelNames')
     el-collapse-item(title = 'Create new log' name='new-log-form')

--- a/app/javascript/logs/logs.vue
+++ b/app/javascript/logs/logs.vue
@@ -4,8 +4,8 @@ div
     div {{bootstrap.current_user.email}}
     .dropdown
       i.el-icon-more.dropbtn
-      ul.dropdown-content.bg-black.gray
-        li.p1(@click='signOut') Sign out
+      .dropdown-content.bg-black.gray
+        .p1(@click='signOut') Sign out
   .center
     LogSelector
     router-view(:key='$route.fullPath').m3
@@ -83,7 +83,7 @@ body {
   color: #e0e0e0;
 }
 
-li.log-link-container {
+.log-link-container {
   // specify the height so that changing the font on hover size doesn't push other links up/down
   height: 26px;
 }
@@ -139,7 +139,7 @@ textarea.el-textarea__inner {
   display: inline-block;
 }
 
-ul.dropdown-content {
+.dropdown-content {
   display: none;
   position: absolute;
   right: 0;
@@ -149,15 +149,15 @@ ul.dropdown-content {
   z-index: 1;
 }
 
-ul.dropdown-content li {
+.dropdown-content div {
   cursor: pointer;
 }
 
-ul.dropdown-content li:hover {
+.dropdown-content div:hover {
   background-color: white;
 }
 
-.dropdown:hover ul.dropdown-content {
+.dropdown:hover .dropdown-content {
   display: block;
 }
 </style>

--- a/app/javascript/workout/workout_plan.vue
+++ b/app/javascript/workout/workout_plan.vue
@@ -262,6 +262,10 @@ export default {
 </script>
 
 <style scoped>
+table {
+  border-spacing: 0;
+}
+
 tbody tr:last-of-type td:not(:last-of-type) {
   border-top: 1px solid gray;
 }


### PR DESCRIPTION
Basically change a bunch of `li`s to `div`s so that they don't have dots in front of them. (reset.css applied `list-style: none`, but normalize.css doesn't, and I think it makes sense to leave it that way.)