### PR TITLE
Allow backdating log entries when creating them

### DIFF
--- a/app/controllers/api/log_entries_controller.rb
+++ b/app/controllers/api/log_entries_controller.rb
@@ -73,6 +73,6 @@ class Api::LogEntriesController < ApplicationController
   private
 
   def log_entry_params
-    params.require(:log_entry).permit(:data, :note)
+    params.require(:log_entry).permit(:created_at, :data, :note)
   end
 end

--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -1,7 +1,7 @@
 <template lang='pug'>
 .flex.justify-center
   .container
-    table
+    table.text-log-table
       EditableTextLogRow(
         v-for='logEntry in formattedLogEntries'
         :key='logEntry.id'
@@ -113,7 +113,7 @@ ol {
   margin-left: 5px;
 }
 
-table {
+table.text-log-table {
   margin: 15px 0;
   color: #aaa;
   font-size: 14px;

--- a/app/javascript/logs/components/new_log_entry_form.vue
+++ b/app/javascript/logs/components/new_log_entry_form.vue
@@ -22,6 +22,11 @@ div
         ref='log-input'
         :type='inputType'
       )
+    el-date-picker.mb1(
+      v-model='newLogEntryCreatedAt'
+      type='datetime'
+      placeholder='Backdate (optional)'
+    )
     el-input.new-log-input.mb1(
       v-if='isCounter || isDuration || isNumber'
       placeholder='Note (optional)'
@@ -91,6 +96,7 @@ export default {
   data() {
     return {
       formstate: {},
+      newLogEntryCreatedAt: null,
       newLogEntryData: null,
       newLogEntryNote: null,
     };
@@ -118,10 +124,12 @@ export default {
         'createLogEntry',
         {
           logId: this.log.id,
+          newLogEntryCreatedAt: this.newLogEntryCreatedAt,
           newLogEntryData,
           newLogEntryNote: this.newLogEntryNote,
         },
       );
+      this.newLogEntryCreatedAt = null;
       this.newLogEntryData = null;
       this.newLogEntryNote = null;
     },

--- a/app/javascript/logs/store.js
+++ b/app/javascript/logs/store.js
@@ -66,9 +66,10 @@ const actions = {
     commit('addLogEntry', { log, newLogEntry });
   },
 
-  createLogEntry({ dispatch }, { logId, newLogEntryData, newLogEntryNote }) {
+  createLogEntry({ dispatch }, { logId, newLogEntryCreatedAt, newLogEntryData, newLogEntryNote }) {
     const payload = {
       log_entry: {
+        created_at: newLogEntryCreatedAt,
         data: newLogEntryData,
         log_id: logId,
         note: newLogEntryNote,

--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -4,6 +4,7 @@ import 'element-ui/lib/theme-chalk/base.css';
 import 'element-ui/lib/theme-chalk/button.css';
 import 'element-ui/lib/theme-chalk/card.css';
 import 'element-ui/lib/theme-chalk/checkbox.css';
+import 'element-ui/lib/theme-chalk/date-picker.css';
 import 'element-ui/lib/theme-chalk/dropdown-item.css';
 import 'element-ui/lib/theme-chalk/icon.css';
 import 'element-ui/lib/theme-chalk/input.css';
@@ -20,6 +21,7 @@ import {
   Checkbox,
   Collapse,
   CollapseItem,
+  DatePicker,
   Icon,
   Input,
   Menu,
@@ -75,6 +77,7 @@ Vue.use(Card);
 Vue.use(Checkbox);
 Vue.use(Collapse);
 Vue.use(CollapseItem);
+Vue.use(DatePicker);
 Vue.use(Icon);
 Vue.use(Input);
 Vue.use(Menu);


### PR DESCRIPTION
This can be useful in order to enter a log entry after a delay has passed since the actual measurement was taken / event occurred.