### PR TITLE
Require use of `hashid` as quiz `id` param (don't allow integer id)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@
 # We are getting some ignorable warnings about :reek:InstanceVariableAssumption
 class ApplicationController < ActionController::Base
   include Bootstrappable
+  include HashidRequireable
   include Pundit
   include Redirectable
   include RequestRecordable

--- a/app/controllers/concerns/hashid_requireable.rb
+++ b/app/controllers/concerns/hashid_requireable.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module HashidRequireable
+  class HashidNotProvided < StandardError ; end
+
+  extend ActiveSupport::Concern
+
+  included do
+    rescue_from HashidNotProvided, with: :render_404
+  end
+
+  private
+
+  def require_hashid_param!(resource)
+    # require use of `hashid` as `:id` param; don't allow use of raw integer id
+    if params[:id] != resource.hashid
+      raise(HashidNotProvided)
+    end
+  end
+
+  def render_404
+    render file: 'public/404.html', status: :not_found, layout: false
+  end
+end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -5,6 +5,8 @@ class QuizzesController < ApplicationController
     # don't use `policy_scope` here, because we want anyone to be able to view any quiz
     @quiz = Quiz.find(params[:id]).decorate
     authorize(@quiz, :show?)
+    require_hashid_param!(@quiz)
+
     @title = @quiz.name
     bootstrap(
       current_user: UserSerializer.new(current_user),

--- a/spec/controllers/quizzes_controller_spec.rb
+++ b/spec/controllers/quizzes_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe QuizzesController do
   let(:user) { users(:admin) }
 
   describe '#show' do
-    subject(:get_show) { get(:show, params: { id: quiz.id }) }
+    subject(:get_show) { get(:show, params: { id: quiz.hashid }) }
 
     let(:quiz) { Quiz.first! }
 
@@ -23,6 +23,15 @@ RSpec.describe QuizzesController do
       before { expect(controller.current_user).not_to eq(quiz.owner) }
 
       let(:user) { User.where.not(id: quiz.owner).first! }
+
+      context 'when using plain, integer id rather than hashid URL param' do
+        subject(:get_show) { get(:show, params: { id: quiz.id }) }
+
+        it 'responds with 404' do
+          get_show
+          expect(response.status).to eq(404)
+        end
+      end
 
       context 'when the user is not yet a quiz participant' do
         before { quiz.participations.where(participant: user).find_each(&:destroy!) }


### PR DESCRIPTION
This is a security measure to prevent accessing quizzes just by guessing/entering an integer id (since quizzes are accessible to any user who knows / can guess the quiz URL).