### PR TITLE
Set cookies to `SameSite=Lax`

### DIFF
--- a/config/initializers/cookies.rb
+++ b/config/initializers/cookies.rb
@@ -5,3 +5,7 @@
 # Specify a serializer for the signed and encrypted cookie jars.
 # Valid options are :json, :marshal, and :hybrid.
 Rails.application.config.action_dispatch.cookies_serializer = :json
+
+# Specify the SameSite level protection for the cookies
+# Valid options are :none, :lax, and :strict.
+Rails.application.config.action_dispatch.cookies_same_site_protection = :lax

--- a/yarn.lock
+++ b/yarn.lock
@@ -2375,7 +2375,7 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001179:
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001173, caniuse-lite@^1.0.30001178, caniuse-lite@^1.0.30001179:
   version "1.0.30001179"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz#b0803883b4471a6c62066fb1752756f8afc699c8"
   integrity sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==


### PR DESCRIPTION
This fixes a warning that otherwise appears in the Firefox development console locally. ("Cookie "_david_runger_session" will be soon rejected because it has the "SameSite" attribute set to "None" or an invalid value, without the "secure" attribute. To know more about the "SameSite" attribute, read https://developer.mozilla.org/docs/Web/HTTP/Headers/Set-Cookie/SameSite")

(Also, unrelated change re: `caniuse-lite` in `yarn.lock`. :shrug:)