### PR TITLE
Stop setting `OmniAuth.config.request_validation_phase` manually

### DIFF
--- a/config/initializers/omni_auth.rb
+++ b/config/initializers/omni_auth.rb
@@ -3,9 +3,6 @@
 # avoid OmniAuth output being sent to STDOUT during tests
 OmniAuth.config.logger = Rails.logger
 
-# Can be removed after https://github.com/cookpad/omniauth-rails_csrf_protection/pull/9 is released?
-OmniAuth.config.request_validation_phase = OmniAuth::RailsCsrfProtection::TokenVerifier.new
-
 Rails.application.config.middleware.use(OmniAuth::Builder) do
   provider(
     :google_oauth2,


### PR DESCRIPTION
The mentioned PR (https://github.com/cookpad/omniauth-rails_csrf_protection/pull/9) has been merged and released in `omniauth-rails_csrf_protection` 1.0.0 (which we are using).