### PR TITLE
Make omniauth `callback_path` regex more strict

### DIFF
--- a/config/initializers/omni_auth.rb
+++ b/config/initializers/omni_auth.rb
@@ -11,7 +11,7 @@ Rails.application.config.middleware.use(OmniAuth::Builder) do
     scope: 'email',
     # a better name would be `is_callback_path' (https://github.com/omniauth/omniauth/issues/630)
     callback_path: ->(env) do
-      env['REQUEST_PATH'].to_s.start_with?(%r{/(admin_)?users/auth/google_oauth2/callback})
+      env['REQUEST_PATH'].to_s.start_with?(%r{/(admin_)?users/auth/google_oauth2/callback(/|\?|\z)})
     end,
   )
 end


### PR DESCRIPTION
As desired, the regex now will not match a path like `/users/auth/google_oauth2/callbackzzzz`; previously it would.