### PR TITLE
Remove "www" subdomain from production host name

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,7 +30,7 @@ class DavidRunger::Application < Rails::Application
     case Rails.env
     when 'production'
       # :nocov:
-      { host: 'www.davidrunger.com', protocol: 'https' }
+      { host: 'davidrunger.com', protocol: 'https' }
       # :nocov:
     else
       { host: 'localhost:3000', protocol: 'http' }


### PR DESCRIPTION
We have now switched to CloudFlare and are using their ["CNAME flattening"][1] feature, which allows us to default to using a naked/root/non-www domain.

[1]: https://blog.cloudflare.com/introducing-cname-flattening-rfc-compliant-cnames-at-a-domains-root/