### PR TITLE
Remove all `required` attributes from inputs in Vue templates

### DIFF
--- a/app/javascript/groceries/components/sidebar.vue
+++ b/app/javascript/groceries/components/sidebar.vue
@@ -8,7 +8,6 @@ aside.border-right.border-gray
           type='text'
           v-model='newStoreName'
           name='newStoreName'
-          required
           placeholder='Add a store'
           size='medium'
         )

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -42,7 +42,6 @@ div.mt1.mb2.ml3.mr2
         type='text'
         v-model='newItemName'
         name='newItemName'
-        required
         size='medium'
       )
     .ml1

--- a/app/javascript/logs/components/new_log_entry_form.vue
+++ b/app/javascript/logs/components/new_log_entry_form.vue
@@ -14,7 +14,6 @@ div
       :placeholder='log.data_label'
       v-model='newLogEntryData'
       name='log.data_label'
-      required
       ref='log-input'
       :type='inputType'
     )

--- a/app/javascript/logs/components/new_log_form.vue
+++ b/app/javascript/logs/components/new_log_form.vue
@@ -9,7 +9,6 @@ div
             placeholder='Name'
             v-model='newLog.name'
             name='newLog.name'
-            required
           )
         el-input.mb1(
           type='textarea'
@@ -22,14 +21,12 @@ div
             placeholder='Label'
             v-model='newLog.data_label'
             name='newLog.data_label'
-            required
           )
         .mb1
           el-select(
             placeholder='Type'
             v-model='newLog.data_type'
             name='newLog.data_type'
-            required
           )
             el-option(
               v-for='dataType in bootstrap.log_input_types'

--- a/app/javascript/workout/new_workout_form.vue
+++ b/app/javascript/workout/new_workout_form.vue
@@ -8,7 +8,6 @@ div.m2
         el-input(
           v-model.number='minutes'
           name='minutes'
-          required
           type='number'
         )
     .my1
@@ -17,7 +16,6 @@ div.m2
         el-input(
           v-model.number='numberOfSets'
           name='numberOfSets'
-          required
           type='number'
         )
     .my1.clearfix(v-for='(exercise, index) in exercises')
@@ -27,7 +25,6 @@ div.m2
           el-input(
             v-model='exercise.name'
             :name='`exercise-${index}-name`'
-            required
             type='text'
           )
       .col.col-6
@@ -36,7 +33,6 @@ div.m2
           el-input(
             v-model.number='exercise.reps'
             :name='`exercise-${index}-reps`'
-            required
             type='number'
           )
     .my1.center


### PR DESCRIPTION
Previously, this `required` attribute was handled by `vue-form` in a good way. Now (after the removal of `vue-form` in 6e91087), it seems to be handled by the browser in a bad way. Therefore, we're removing it.