### PR TITLE
Give `.el-button` elements `height: auto` styling in `log.vue`

### DIFF
--- a/app/javascript/logs/components/log.vue
+++ b/app/javascript/logs/components/log.vue
@@ -261,4 +261,8 @@ export default {
 .el-tag + .button-new-tag {
   margin-left: 10px;
 }
+
+.el-button {
+  height: auto;
+}
 </style>


### PR DESCRIPTION
This fixes a visual bug. I don't know what exactly caused the visual bug / when it emerged -- maybe caused by the switch from `element-ui` to `element-plus` in 6e91087 ?

## Before

![image](https://user-images.githubusercontent.com/8197963/106225415-f009d980-6199-11eb-9161-ccb21e21f4b6.png)

## After

![image](https://user-images.githubusercontent.com/8197963/106225425-f304ca00-6199-11eb-9b7e-c60c6abebfcf.png)