### PR TITLE
Increase delay before prerendering from 30s to 60s

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -92,7 +92,7 @@ jobs:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: davidrunger
           heroku_email: davidjrunger@gmail.com
-      - run: sleep 30 # give some time for the new release to boot up
+      - run: sleep 60 # give some time for the new release to boot up
       - name: Setup Ruby 2.7.2
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
I think that 30s isn't necessarily always quite enough time for the app to boot up fully; hopefully 60s is enough time.