### PR TITLE
Use Heroku app name as hashid salt for review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -11,9 +11,6 @@
         { "url": "heroku/ruby" },
         { "url": "https://github.com/weibeld/heroku-buildpack-run" }
       ],
-      "env": {
-        "HASHID_SALT": "9611c66b-766d-48b5-a8f4-2b51635db6e9"
-      },
       "scripts": {
         "postdeploy": "bin/rake db:schema:load"
       }

--- a/config/initializers/hashid.rb
+++ b/config/initializers/hashid.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Hashid::Rails.configure do |config|
-  config.salt = ENV.fetch('HASHID_SALT')
+  config.salt = ENV['HEROKU_APP_NAME'].presence || ENV.fetch('HASHID_SALT')
   # we'll only use lowercase letters (default setting is to use capitals, as well)
   config.alphabet = (('a'..'z').to_a + ('0'..'9').to_a).join('').freeze
 end


### PR DESCRIPTION
This eliminates the need to set a HASHID_SALT ENV var for review apps.