### PR TITLE
Purge prerendered pages and cache on deploy

### DIFF
--- a/bin/purge-prerendered-pages
+++ b/bin/purge-prerendered-pages
@@ -1,0 +1,10 @@
+#!/usr/bin/env ./bin/rails runner
+# frozen_string_literal: true
+
+%w[home.html].each do |filename|
+  Aws::S3::Resource.new(region: ENV['S3_REGION']).
+    bucket(ENV['S3_BUCKET']).
+    object("prerenders/#{filename}").
+    delete
+  Rails.cache.delete("prerendered-pages:#{filename}")
+end

--- a/bin/release-tasks
+++ b/bin/release-tasks
@@ -5,6 +5,10 @@ migrate() {
   bin/rails db:migrate
 }
 
+echo "Purging prerendered pages..."
+bin/rails runner bin/purge-prerendered-pages
+echo "... done purging prerendered pages."
+
 # run migrations when deploying to production, but not when deploying a review app
 if [ $HEROKU_PR_NUMBER ]
 then


### PR DESCRIPTION
Otherwise, the cached HTML from a previous release might continue to be served after a new release, causing 404s when we try to serve old JS and CSS assets (referenced from the cached prerendered HTML).

In addition to clearing the cache, we also need to delete the prerendered HTML file, so that the cache can't be repopulated by a request that happens to come in between the time of the deploy and the time that a new prerendered page is uploaded to S3.