### PR TITLE
Recharge spent devicon CSS preload link in prerendered HTML

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -100,7 +100,6 @@ jobs:
           bundler-cache: true
         env:
           BUNDLE_GITHUB__COM: "${{secrets.BUNDLE_GITHUB__COM}}"
-      - run: gem install addressable aws-sdk-s3 ferrum
       - name: Prerender page(s) and upload them to S3
         run: bin/prerender
         env:

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,7 @@ group :development do
 end
 
 group :test do
+  gem 'addressable'
   gem 'brakeman', require: false
   gem 'capybara'
   gem 'climate_control'
@@ -82,10 +83,12 @@ group :test do
   gem 'database_consistency', require: false
   gem 'factory_bot_rails'
   gem 'faker'
+  gem 'ferrum'
   gem 'fixture_builder'
   gem 'guard-espect', require: false, github: 'davidrunger/guard-espect'
   gem 'json-schema'
   gem 'launchy'
+  gem 'nokogiri'
   gem 'pallets'
   gem 'percy-capybara'
   gem 'rails-controller-testing', github: 'rails/rails-controller-testing'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,7 @@ GEM
       activesupport
     childprocess (3.0.0)
     climate_control (0.2.0)
+    cliver (0.3.2)
     cloudflare-rails (1.1.0)
       httparty
       rails (>= 5.0, < 6.2.0)
@@ -235,6 +236,11 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday_middleware (1.0.0)
       faraday (~> 1.0)
+    ferrum (0.9)
+      addressable (~> 2.5)
+      cliver (~> 0.3)
+      concurrent-ruby (~> 1.1)
+      websocket-driver (>= 0.6, < 0.8)
     ffi (1.14.2)
     fixture_builder (0.5.2)
       activerecord (>= 2)
@@ -590,6 +596,7 @@ DEPENDENCIES
   active_actions!
   active_model_serializers
   activeadmin
+  addressable
   amazing_print
   annotate
   aws-sdk-s3
@@ -614,6 +621,7 @@ DEPENDENCIES
   faker
   faraday
   faraday_middleware
+  ferrum
   fixture_builder
   flamegraph
   flipper
@@ -632,6 +640,7 @@ DEPENDENCIES
   lograge
   memoist
   newrelic_rpm
+  nokogiri
   oj
   omniauth-google-oauth2
   omniauth-rails_csrf_protection

--- a/bin/prerender
+++ b/bin/prerender
@@ -1,11 +1,15 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'rubygems'
+require 'bundler'
+Bundler.setup(:default, :test)
+
 require 'addressable'
 require 'aws-sdk-s3'
 require 'dotenv/load' if ENV['CI'] != 'true'
 require 'ferrum'
-require 'fileutils'
+require 'nokogiri'
 
 class Prerenderer
   def initialize
@@ -29,9 +33,21 @@ class Prerenderer
     Aws::S3::Resource.new(region: ENV['S3_REGION']).
       bucket(ENV['S3_BUCKET']).
       object("prerenders/#{filename}").
-      put(body: "<!DOCTYPE html>\n#{html}")
+      put(body: html_for_prerendering(html))
   rescue => error
     puts("Error uploading object: #{error.inspect}")
+  end
+
+  def html_for_prerendering(html)
+    html_doc = Nokogiri::HTML(html)
+    recharge_spent_devicon_css_preloader(html_doc)
+    html_doc.to_s
+  end
+
+  def recharge_spent_devicon_css_preloader(html_doc)
+    spent_css_preloader =
+      html_doc.css(%(head link[rel=stylesheet][onload*="this.rel='stylesheet'"][href*=devicon]))
+    spent_css_preloader.attribute('rel', 'preload')
   end
 end
 


### PR DESCRIPTION
Our prerendered HTML is the evaluated DOM-as-HTML after page load and execution. Via its `onload` handler, our CSS preload link gets converted from `rel="preload"` to `rel="stylesheet"` as part of the page evaluation. We want to convert it back to a `rel="preload"` link before saving the HTML to S3.