### PR TITLE
Don't send `Aws::S3::Errors::NoSuchKey` errors to Rollbar

### DIFF
--- a/app/controllers/concerns/prerenderable.rb
+++ b/app/controllers/concerns/prerenderable.rb
@@ -34,13 +34,20 @@ module Prerenderable
           else html
           end
         end
+    rescue Aws::S3::Errors::NoSuchKey => error
+      log_warning(error)
+      nil
     rescue => error
       case Rails.env
       when 'production' then Rollbar.error(error, filename: filename)
       when 'test' then raise(error)
-      else Rails.logger.warn("Could not fetch prerendered content: #{error.inspect}")
+      else log_warning(error)
       end
       nil
     end
+  end
+
+  def log_warning(error)
+    Rails.logger.warn("Could not fetch prerendered content: #{error.inspect}")
   end
 end


### PR DESCRIPTION
It's expected that these errors will occur if/when the homepage is requested around the time of a deploy (after the existing prerender has been purged from `Rails.cache` and S3 but before a new prerender has been generated and uploaded to S3). Therefore, to avoid Rollbar noise, we'll just log when this happens via `Rails.logger.warn`.