### PR TITLE
Don't load `element-plus` unnecessarily for the Home app

### DIFF
--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -26,7 +26,9 @@ div.font-nunito
         a.nav-link(href='#contact')
           span.ptb-1 Contact
     a.down-arrow-container.center.circle.mb3(href='#about')
-      el-icon(name='arrow-down')
+      //- hat tip to https://codepen.io/postor/pen/mskxI for a starting point for this
+      svg(class='arrow')
+        path(d='M0 0 L12 12 L24 0')
 
   .parallax-outer
     .parallax-inner.parallax-inner--macbook-1
@@ -506,5 +508,18 @@ p:first-of-type {
     color: white;
     transition: 0.3s;
   }
+}
+
+.arrow {
+  width: 24px;
+  height: 24px;
+  position: relative;
+  top: 7px;
+}
+
+.arrow path {
+  stroke: #333;
+  fill: transparent;
+  stroke-width: 2px;
 }
 </style>

--- a/app/javascript/packs/groceries_app.js
+++ b/app/javascript/packs/groceries_app.js
@@ -1,5 +1,7 @@
 import { renderApp } from 'shared/customized_vue';
+import { useElementPlus } from 'shared/element_plus';
 import Groceries from 'groceries/groceries.vue';
 import storeDefinition from 'groceries/store';
 
-renderApp(Groceries, { storeDefinition });
+const app = renderApp(Groceries, { storeDefinition });
+useElementPlus(app);

--- a/app/javascript/packs/home_app.js
+++ b/app/javascript/packs/home_app.js
@@ -1,4 +1,7 @@
+import 'element-plus/lib/theme-chalk/el-card.css';
+import { ElCard } from 'element-plus';
 import { renderApp } from 'shared/customized_vue';
 import Home from 'home/home.vue';
 
-renderApp(Home);
+const app = renderApp(Home);
+app.use(ElCard);

--- a/app/javascript/packs/logs_app.js
+++ b/app/javascript/packs/logs_app.js
@@ -1,9 +1,11 @@
 import { renderApp } from 'shared/customized_vue';
+import { useElementPlus } from 'shared/element_plus';
 import LogApp from 'logs/logs.vue';
 import storeDefinition from 'logs/store';
 import router from 'logs/router';
 
-renderApp(LogApp, {
+const app = renderApp(LogApp, {
   router,
   storeDefinition,
 });
+useElementPlus(app);

--- a/app/javascript/packs/workout_app.js
+++ b/app/javascript/packs/workout_app.js
@@ -1,5 +1,7 @@
 import { renderApp } from 'shared/customized_vue';
+import { useElementPlus } from 'shared/element_plus';
 import WorkoutApp from 'workout/workout.vue';
 import storeDefinition from 'workout/store';
 
-renderApp(WorkoutApp, { storeDefinition });
+const app = renderApp(WorkoutApp, { storeDefinition });
+useElementPlus(app);

--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -1,37 +1,4 @@
 import axios from 'axios';
-// don't (explicitly) load element-plus button.css, because it's included in dropdown.css
-import 'element-plus/lib/theme-chalk/base.css';
-import 'element-plus/lib/theme-chalk/el-button.css';
-import 'element-plus/lib/theme-chalk/el-card.css';
-import 'element-plus/lib/theme-chalk/el-checkbox.css';
-import 'element-plus/lib/theme-chalk/el-date-picker.css';
-import 'element-plus/lib/theme-chalk/el-dropdown-item.css';
-import 'element-plus/lib/theme-chalk/el-icon.css';
-import 'element-plus/lib/theme-chalk/el-input.css';
-import 'element-plus/lib/theme-chalk/el-menu.css';
-import 'element-plus/lib/theme-chalk/el-menu-item.css';
-import 'element-plus/lib/theme-chalk/el-option.css';
-import 'element-plus/lib/theme-chalk/el-select.css';
-import 'element-plus/lib/theme-chalk/el-submenu.css';
-import 'element-plus/lib/theme-chalk/el-switch.css';
-import 'element-plus/lib/theme-chalk/el-tag.css';
-import {
-  ElButton,
-  ElCard,
-  ElCheckbox,
-  ElCollapse,
-  ElCollapseItem,
-  ElDatePicker,
-  ElIcon,
-  ElInput,
-  ElMenu,
-  ElMenuItem,
-  ElOption,
-  ElSelect,
-  ElSubmenu,
-  ElSwitch,
-  ElTag,
-} from 'element-plus';
 import { createApp } from 'vue';
 import { createStore, createLogger } from 'vuex';
 import { sync } from 'vuex-router-sync';
@@ -75,22 +42,6 @@ export function renderApp(vueApp, { router, storeDefinition } = {}) {
     }
   }
 
-  app.use(ElButton);
-  app.use(ElCard);
-  app.use(ElCheckbox);
-  app.use(ElCollapse);
-  app.use(ElCollapseItem);
-  app.use(ElDatePicker);
-  app.use(ElIcon);
-  app.use(ElInput);
-  app.use(ElMenu);
-  app.use(ElMenuItem);
-  app.use(ElOption);
-  app.use(ElSelect);
-  app.use(ElSubmenu);
-  app.use(ElSwitch);
-  app.use(ElTag);
-
   app.component('Modal', Modal);
 
   const _renderApp = () => {
@@ -106,4 +57,6 @@ export function renderApp(vueApp, { router, storeDefinition } = {}) {
       _renderApp();
     }
   });
+
+  return app;
 }

--- a/app/javascript/shared/element_plus.js
+++ b/app/javascript/shared/element_plus.js
@@ -1,0 +1,51 @@
+// don't (explicitly) load element-plus button.css, because it's included in dropdown.css
+import 'element-plus/lib/theme-chalk/base.css';
+import 'element-plus/lib/theme-chalk/el-button.css';
+import 'element-plus/lib/theme-chalk/el-card.css';
+import 'element-plus/lib/theme-chalk/el-checkbox.css';
+import 'element-plus/lib/theme-chalk/el-date-picker.css';
+import 'element-plus/lib/theme-chalk/el-dropdown-item.css';
+import 'element-plus/lib/theme-chalk/el-icon.css';
+import 'element-plus/lib/theme-chalk/el-input.css';
+import 'element-plus/lib/theme-chalk/el-menu.css';
+import 'element-plus/lib/theme-chalk/el-menu-item.css';
+import 'element-plus/lib/theme-chalk/el-option.css';
+import 'element-plus/lib/theme-chalk/el-select.css';
+import 'element-plus/lib/theme-chalk/el-submenu.css';
+import 'element-plus/lib/theme-chalk/el-switch.css';
+import 'element-plus/lib/theme-chalk/el-tag.css';
+import {
+  ElButton,
+  ElCard,
+  ElCheckbox,
+  ElCollapse,
+  ElCollapseItem,
+  ElDatePicker,
+  ElIcon,
+  ElInput,
+  ElMenu,
+  ElMenuItem,
+  ElOption,
+  ElSelect,
+  ElSubmenu,
+  ElSwitch,
+  ElTag,
+} from 'element-plus';
+
+export function useElementPlus(app) {
+  app.use(ElButton);
+  app.use(ElCard);
+  app.use(ElCheckbox);
+  app.use(ElCollapse);
+  app.use(ElCollapseItem);
+  app.use(ElDatePicker);
+  app.use(ElIcon);
+  app.use(ElInput);
+  app.use(ElMenu);
+  app.use(ElMenuItem);
+  app.use(ElOption);
+  app.use(ElSelect);
+  app.use(ElSubmenu);
+  app.use(ElSwitch);
+  app.use(ElTag);
+}


### PR DESCRIPTION
Instead, we'll load specifically just `ElCard` and its CSS, since this is the only `element-plus` element that the Home app actually uses.