### PR TITLE
Only import used `element-plus` components/CSS

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -13,5 +13,6 @@ module.exports = {
     '@babel/syntax-dynamic-import',
     '@babel/proposal-object-rest-spread',
     ['@babel/proposal-class-properties', { spec: true }],
+    ['component', { libraryName: 'element-plus', styleLibraryName: 'theme-chalk' }],
   ],
 };

--- a/app/javascript/home/components/project.vue
+++ b/app/javascript/home/components/project.vue
@@ -1,18 +1,36 @@
 <template lang='pug'>
-el-card.box-card.mt2
-  .project.py1.px3
-    h2.h2.center.mb1
-      slot(name='title')
-    .center.gray.mb1
-      slot(name='technologies')
-    .center.mb2
-      slot(name='links')
+.mt2
+  .card
+    .card__body
+      .project.py1.px3
+        h2.h2.center.mb1
+          slot(name='title')
+        .center.gray.mb1
+          slot(name='technologies')
+        .center.mb2
+          slot(name='links')
 
-    .mb3.center
-      slot(name='image')
+        .mb3.center
+          slot(name='image')
 
-    slot(name='overview')
+        slot(name='overview')
 
-    h3.h3.bold.mb1(v-if='this.$slots["tech-list"]') Tech
-    slot(name='tech-list')
+        h3.h3.bold.mb1(v-if='this.$slots["tech-list"]') Tech
+        slot(name='tech-list')
 </template>
+
+<style>
+.card {
+  border-radius: 4px;
+  border: 1px solid #ebeef5;
+  background-color: #fff;
+  overflow: hidden;
+  color: #303133;
+  transition: 0.3s;
+  box-shadow: 0 2px 12px 0 rgba(0, 0, 0, 0.1);
+}
+
+.card__body {
+  padding: 20px;
+}
+</style>

--- a/app/javascript/logs/components/logs_index.vue
+++ b/app/javascript/logs/components/logs_index.vue
@@ -35,3 +35,12 @@ export default {
   },
 };
 </script>
+
+<style>
+.el-collapse,
+.el-collapse-item__header,
+.el-collapse-item__wrap {
+  background: initial;
+  border: none;
+}
+</style>

--- a/app/javascript/packs/home_app.js
+++ b/app/javascript/packs/home_app.js
@@ -1,7 +1,4 @@
-import 'element-plus/lib/theme-chalk/el-card.css';
-import { ElCard } from 'element-plus';
 import { renderApp } from 'shared/customized_vue';
 import Home from 'home/home.vue';
 
-const app = renderApp(Home);
-app.use(ElCard);
+renderApp(Home);

--- a/app/javascript/shared/element_plus.js
+++ b/app/javascript/shared/element_plus.js
@@ -1,19 +1,4 @@
-// don't (explicitly) load element-plus button.css, because it's included in dropdown.css
 import 'element-plus/lib/theme-chalk/base.css';
-import 'element-plus/lib/theme-chalk/el-button.css';
-import 'element-plus/lib/theme-chalk/el-card.css';
-import 'element-plus/lib/theme-chalk/el-checkbox.css';
-import 'element-plus/lib/theme-chalk/el-date-picker.css';
-import 'element-plus/lib/theme-chalk/el-dropdown-item.css';
-import 'element-plus/lib/theme-chalk/el-icon.css';
-import 'element-plus/lib/theme-chalk/el-input.css';
-import 'element-plus/lib/theme-chalk/el-menu.css';
-import 'element-plus/lib/theme-chalk/el-menu-item.css';
-import 'element-plus/lib/theme-chalk/el-option.css';
-import 'element-plus/lib/theme-chalk/el-select.css';
-import 'element-plus/lib/theme-chalk/el-submenu.css';
-import 'element-plus/lib/theme-chalk/el-switch.css';
-import 'element-plus/lib/theme-chalk/el-tag.css';
 import {
   ElButton,
   ElCard,

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "autoprefixer": "^10.2.3",
     "axios": "^0.21.1",
     "babel-loader": "^8.2.2",
+    "babel-plugin-component": "^1.1.1",
     "babel-polyfill": "^6.23.0",
     "basscss": "^8.1.0",
     "basscss-background-colors": "^2.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,14 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
+"@babel/helper-module-imports@7.0.0-beta.35":
+  version "7.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.0.0-beta.35.tgz#308e350e731752cdb4d0f058df1d704925c64e0a"
+  integrity sha512-vaC1KyIZSuyWb3Lj277fX0pxivyHwuDU4xZsofqgYAbkDxNieMg2vuhzP5AgMweMY7fCQUMTi+BgPqTLjkxXFg==
+  dependencies:
+    "@babel/types" "7.0.0-beta.35"
+    lodash "^4.2.0"
+
 "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
@@ -840,6 +848,15 @@
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.19"
+
+"@babel/types@7.0.0-beta.35":
+  version "7.0.0-beta.35"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.35.tgz#cf933a9a9a38484ca724b335b88d83726d5ab960"
+  integrity sha512-y9XT11CozHDgjWcTdxmhSj13rJVXpa5ZXwjjOiTedjaM0ba5ItqdS02t31EhPl7HtOWxsZkYCCUNrSfrOisA6w==
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
 
 "@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.12.1", "@babel/types@^7.12.10", "@babel/types@^7.12.11", "@babel/types@^7.12.5", "@babel/types@^7.12.7", "@babel/types@^7.4.4", "@babel/types@^7.6.1", "@babel/types@^7.9.6":
   version "7.12.11"
@@ -1877,6 +1894,13 @@ babel-loader@^8.1.0, babel-loader@^8.2.2:
     loader-utils "^1.4.0"
     make-dir "^3.1.0"
     schema-utils "^2.6.5"
+
+babel-plugin-component@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-component/-/babel-plugin-component-1.1.1.tgz#9b023a23ff5c9aae0fd56c5a18b9cab8c4d45eea"
+  integrity sha512-WUw887kJf2GH80Ng/ZMctKZ511iamHNqPhd9uKo14yzisvV7Wt1EckIrb8oq/uCz3B3PpAW7Xfl7AkTLDYT6ag==
+  dependencies:
+    "@babel/helper-module-imports" "7.0.0-beta.35"
 
 babel-plugin-dynamic-import-node@^2.3.3:
   version "2.3.3"
@@ -6064,7 +6088,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@~4.17.12:
+lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.5, lodash@^4.2.0, lodash@~4.17.12:
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==


### PR DESCRIPTION
This is accomplished via `babel-plugin-component` as described [here][1] and [here][2].

[1]: https://element-plus.org/#/en-US/component/quickstart
[2]: https://github.com/ElementUI/babel-plugin-component