### PR TITLE
Remove "webp" class from prerendered HTML docs

### DIFF
--- a/bin/prerender
+++ b/bin/prerender
@@ -40,15 +40,20 @@ class Prerenderer
   end
 
   def html_for_prerendering(html)
-    html_doc = Nokogiri::HTML(html)
-    recharge_spent_devicon_css_preloader(html_doc)
-    html_doc.to_s
+    @html_doc = Nokogiri::HTML(html)
+    recharge_spent_devicon_css_preloader
+    remove_webp_class
+    @html_doc.to_s
   end
 
-  def recharge_spent_devicon_css_preloader(html_doc)
+  def recharge_spent_devicon_css_preloader
     spent_css_preloader =
-      html_doc.css(%(head link[rel=stylesheet][onload*="this.rel='stylesheet'"][href*=devicon]))
+      @html_doc.css(%(head link[rel=stylesheet][onload*="this.rel='stylesheet'"][href*=devicon]))
     spent_css_preloader.attribute('rel', 'preload')
+  end
+
+  def remove_webp_class
+    @html_doc.css('html').remove_class('webp')
   end
 end
 


### PR DESCRIPTION
This is added by `%html{class: browser.chrome? ? 'webp' : ''}` in our application layout, since the prerendered page is generated via Chrome. Not everyone viewing the page will use Chrome, though. Therefore, we'll remove the class from our prerendered page(s).