### PR TITLE
Only import Vue Modal (and, transitively, vuex) when needed

### DIFF
--- a/app/javascript/packs/groceries_app.js
+++ b/app/javascript/packs/groceries_app.js
@@ -2,11 +2,13 @@ import { renderApp } from 'shared/customized_vue';
 import { createStore, createLogger } from 'vuex';
 import { useAxios } from 'shared/axios';
 import { useElementPlus } from 'shared/element_plus';
+import Modal from 'components/modal.vue';
 import Groceries from 'groceries/groceries.vue';
 import storeDefinition from 'groceries/store';
 
 const app = renderApp(Groceries, { storeDefinition });
 
+app.component('Modal', Modal);
 useAxios(app);
 useElementPlus(app);
 

--- a/app/javascript/packs/logs_app.js
+++ b/app/javascript/packs/logs_app.js
@@ -3,6 +3,7 @@ import { createStore, createLogger } from 'vuex';
 import { sync } from 'vuex-router-sync';
 import { useAxios } from 'shared/axios';
 import { useElementPlus } from 'shared/element_plus';
+import Modal from 'components/modal.vue';
 import LogApp from 'logs/logs.vue';
 import storeDefinition from 'logs/store';
 import router from 'logs/router';
@@ -12,6 +13,7 @@ const app = renderApp(LogApp, {
   storeDefinition,
 });
 
+app.component('Modal', Modal);
 useAxios(app);
 useElementPlus(app);
 

--- a/app/javascript/packs/workout_app.js
+++ b/app/javascript/packs/workout_app.js
@@ -2,11 +2,13 @@ import { renderApp } from 'shared/customized_vue';
 import { createStore, createLogger } from 'vuex';
 import { useAxios } from 'shared/axios';
 import { useElementPlus } from 'shared/element_plus';
+import Modal from 'components/modal.vue';
 import WorkoutApp from 'workout/workout.vue';
 import storeDefinition from 'workout/store';
 
 const app = renderApp(WorkoutApp, { storeDefinition });
 
+app.component('Modal', Modal);
 useAxios(app);
 useElementPlus(app);
 

--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -1,7 +1,6 @@
 import { createApp } from 'vue';
 import whenDomReady from 'when-dom-ready';
 
-import Modal from 'components/modal.vue';
 import 'shared/common';
 import titleMixin from 'lib/mixins/title_mixin';
 
@@ -14,8 +13,6 @@ export function renderApp(vueApp) {
   app.config.globalProperties.bootstrap = window.davidrunger && window.davidrunger.bootstrap;
 
   app.mixin(titleMixin);
-
-  app.component('Modal', Modal);
 
   const _renderApp = () => {
     document.body.appendChild(document.createElement('replaced-container'));


### PR DESCRIPTION
This will make the home app JS bundle smaller (since it doesn't use the Modal).