### PR TITLE
Disable Rollbar JS error tracking unless :rollbar_js flag is enabled

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -59,7 +59,7 @@ Rollbar.configure do |config|
   config.environment = ENV['ROLLBAR_ENV'] || Rails.env
 
   client_token = ENV['POST_CLIENT_ITEM_ACCESS_TOKEN']
-  config.js_enabled = Rails.env.production? || client_token.present?
+  config.js_enabled = Flipper.enabled?(:rollbar_js)
   config.js_options = {
     accessToken: client_token,
     captureUncaught: true,


### PR DESCRIPTION
Rollbar has a few issues:
	1. performance (execution-/render-blocking JavaScript code in the `<head>`)
	2. reports errors from bots using browsers with shitty JS engines
	3. triggers ad blocking
	4. due to the way that `Rollbar::Middleware::Js` works, it's being inserted twice into prerendered pages
	5. It _very_ rarely (once in years?) reports any actually helpful info about JavaScript bugs (mostly because I don't think we have many)

By putting it behind a feature flag instead of disabling it completely, though, we can re-enable it quickly (and then we'd have to restart the server(s)), if desired (e.g. if a bug emerges).