### PR TITLE
Render Vue apps into `.container` div

### DIFF
--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -15,8 +15,7 @@ export function renderApp(vueApp) {
   app.mixin(titleMixin);
 
   const _renderApp = () => {
-    document.body.appendChild(document.createElement('replaced-container'));
-    app.mount('replaced-container');
+    app.mount('.container');
   };
 
   whenDomReady(() => {


### PR DESCRIPTION
This is also where our HAML views are `yield`ed to (within the `.container` div). This change sets us up to be able to do our prerendering with just the internal content of this `.container` div (rather than the whole HTML page), which will simplify our prerendering system.