### PR TITLE
Give the homepage a monospace font

### DIFF
--- a/app/javascript/home/home.vue
+++ b/app/javascript/home/home.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-div.font-nunito
+.monospace
   #home.flex.flex-column.relative.vh-100.items-center.justify-around.font-white-dark.p4.bg-black
     .spacer.flex-grow-1
     //- HACK: add `data-section=''` so that we will clear the selected nav element when scrolled to
@@ -380,12 +380,7 @@ export default {
 </script>
 
 <style lang='scss' scoped>
-@import url('https://fonts.googleapis.com/css?family=Nunito:400,700');
 @import '~css/variables';
-
-.font-nunito {
-  font-family: 'Nunito', sans-serif;
-}
 
 p,
 ul {


### PR DESCRIPTION
It gives the page actually a somewhat interesting look and saves us from loading an external stylesheet from Google and then loading the webfont required by that stylesheet.