### PR TITLE
Change `.container` to `#container` in application layout

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -103,6 +103,7 @@ ol {
 
 .container {
   max-width: 1000px;
+  width: 100%;
 }
 
 .el-button--mini {

--- a/app/javascript/logs/components/new_log_entry_form.vue
+++ b/app/javascript/logs/components/new_log_entry_form.vue
@@ -10,13 +10,15 @@ div
         :key='logEntryValue'
         @click='postNewLogEntry(logEntryValue)'
       ) {{logEntryValue}}
-    el-input.new-log-input.mb1(
-      :placeholder='log.data_label'
-      v-model='newLogEntryData'
-      name='log.data_label'
-      ref='log-input'
-      :type='inputType'
-    )
+    .flex.justify-center
+      .container
+        el-input.new-log-input.mb1(
+          :placeholder='log.data_label'
+          v-model='newLogEntryData'
+          name='log.data_label'
+          ref='log-input'
+          :type='inputType'
+        )
     el-date-picker.mb1.mr1(
       v-model='newLogEntryCreatedAt'
       type='datetime'

--- a/app/javascript/shared/customized_vue.js
+++ b/app/javascript/shared/customized_vue.js
@@ -15,7 +15,7 @@ export function renderApp(vueApp) {
   app.mixin(titleMixin);
 
   const _renderApp = () => {
-    app.mount('.container');
+    app.mount('#container');
   };
 
   whenDomReady(() => {

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -42,5 +42,5 @@
       %p.p2.notice= notice
     - if alert.present?
       %p.p2.alert= alert
-    .container{class: container_classes}
+    #container{class: container_classes}
       = yield


### PR DESCRIPTION
When it was `.container`, it was triggering a style rule in the logs app for text logs for `max-width: 1000px` for `.container`. I also think that `#container` is conceptually more appropriate (since this is intended to be the only one).

Also, some HTML/CSS tweaks to get the text log input rendering with a max width of 1000px etc.