### PR TITLE
Store `BannedPathFragment`s in the database (i.e. no longer in code)

### DIFF
--- a/app/admin/banned_path_fragments.rb
+++ b/app/admin/banned_path_fragments.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+ActiveAdmin.register(BannedPathFragment) do
+  permit_params :value, :notes
+end

--- a/app/models/banned_path_fragment.rb
+++ b/app/models/banned_path_fragment.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: banned_path_fragments
+#
+#  created_at :datetime         not null
+#  id         :bigint           not null, primary key
+#  notes      :text
+#  updated_at :datetime         not null
+#  value      :string           not null
+#
+class BannedPathFragment < ApplicationRecord
+  validates :value, presence: true, format: { without: Rack::Attack::PATH_FRAGMENT_SEPARATOR_REGEX }
+end

--- a/db/datamigrate/populate_banned_path_fragments.rb
+++ b/db/datamigrate/populate_banned_path_fragments.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+def populate_banned_path_fragments
+  %w[
+    administrator
+    env
+    git
+    passwd
+    php
+    phpformbuilder
+    phpmyadmin
+    phpmyadmin
+    phpunit
+    plugins
+    wordpress
+    wp
+    wp1
+    wp2
+  ].each do |path_fragment_string|
+    BannedPathFragment.create!(value: path_fragment_string)
+  end
+end

--- a/db/migrate/20210201082303_create_banned_path_fragments.rb
+++ b/db/migrate/20210201082303_create_banned_path_fragments.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require Rails.root.join('db/datamigrate/populate_banned_path_fragments.rb')
+
+class CreateBannedPathFragments < ActiveRecord::Migration[6.1]
+  def change
+    create_table :banned_path_fragments do |t|
+      t.string :value, null: false
+      t.text :notes
+
+      t.timestamps
+    end
+
+    up_only do
+      populate_banned_path_fragments
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_16_071345) do
+ActiveRecord::Schema.define(version: 2021_02_01_082303) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -82,6 +82,13 @@ ActiveRecord::Schema.define(version: 2021_01_16_071345) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["secret"], name: "index_auth_tokens_on_secret"
     t.index ["user_id", "secret"], name: "index_auth_tokens_on_user_id_and_secret", unique: true
+  end
+
+  create_table "banned_path_fragments", force: :cascade do |t|
+    t.string "value", null: false
+    t.text "notes"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "ip_blocks", force: :cascade do |t|

--- a/spec/factories/banned_path_fragments.rb
+++ b/spec/factories/banned_path_fragments.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# == Schema Information
+#
+# Table name: banned_path_fragments
+#
+#  created_at :datetime         not null
+#  id         :bigint           not null, primary key
+#  notes      :text
+#  updated_at :datetime         not null
+#  value      :string           not null
+#
+
+FactoryBot.define do
+  factory :banned_path_fragment do
+    value { "/#{Faker::Internet.unique.slug}.php" }
+    notes { 'PHP route requested in scanning attack' }
+  end
+end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe 'Home page' do
       Full stack web developer
     HEADLINE
 
+    sleep(2) # allow some extra time for CSS `background-image`s to load and be rendered
     Percy.snapshot(page, { name: 'Homepage' })
 
     expect(ip_info_request_stub).to have_been_requested

--- a/spec/features/rack_attack_spec.rb
+++ b/spec/features/rack_attack_spec.rb
@@ -17,9 +17,12 @@ RSpec.describe 'Rack::Attack', :rack_test_driver do
 
     context 'when -- two times in one day -- a user requests paths with banned segments' do
       subject(:request_two_banned_paths) do
-        visit('/wp')
-        visit('/wordpress')
+        visit(banned_path_1)
+        visit(banned_path_2)
       end
+
+      let(:banned_path_1) { BannedPathFragment.first!.value }
+      let(:banned_path_2) { BannedPathFragment.second!.value }
 
       it 'bans the user from visiting any page', :prerendering_disabled do
         expect {

--- a/spec/models/banned_path_fragment_spec.rb
+++ b/spec/models/banned_path_fragment_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+RSpec.describe BannedPathFragment do
+  subject(:banned_path_fragment) { BannedPathFragment.new }
+
+  it { is_expected.to validate_presence_of(:value) }
+  it { is_expected.to allow_value('wordpress').for(:value) }
+  it { is_expected.not_to allow_value('/wordpress').for(:value) }
+  it { is_expected.not_to allow_value('old-wp').for(:value) }
+end

--- a/spec/models/ip_block_spec.rb
+++ b/spec/models/ip_block_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe IpBlock, type: :model do
+RSpec.describe IpBlock do
   subject(:ip_block) { IpBlock.new }
 
   it { is_expected.to validate_presence_of(:ip) }

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -73,6 +73,10 @@ FixtureBuilder.configure do |fbuilder|
     # IP blocks
     name(:ip_block, create(:ip_block))
 
+    # banned path fragments
+    create(:banned_path_fragment, value: 'wp')
+    create(:banned_path_fragment, value: 'wordpress')
+
     # quizzes
     quiz = create(:quiz, owner: admin)
 


### PR DESCRIPTION
This will make it much easier to add new banned path fragments.