### PR TITLE
Use `moment-locales-webpack-plugin` to shrink size of logs JS bundle

### DIFF
--- a/config/webpack/shared.js
+++ b/config/webpack/shared.js
@@ -2,8 +2,9 @@ const webpack = require('webpack');
 const { basename, dirname, join, relative, resolve } = require('path');
 const { sync } = require('glob');
 const extname = require('path-complete-extname');
-const { settings } = require('./configuration.js');
 const { VueLoaderPlugin } = require('vue-loader');
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
+const { settings } = require('./configuration.js');
 
 const extensionGlob = `**/*{${settings.extensions.join(',')}}*`;
 const entryPath = join(settings.source_path, settings.source_entry_path);
@@ -61,6 +62,7 @@ module.exports = {
       /element-plus[/\\]lib[/\\]locale[/\\]lang[/\\]zh-CN/,
       'element-plus/lib/locale/lang/en',
     ),
+    new MomentLocalesPlugin(),
   ],
 
   resolve: {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "lodash": "^4.17.20",
     "marked": "^1.2.8",
     "mini-css-extract-plugin": "^0.12.0",
+    "moment-locales-webpack-plugin": "^1.2.0",
     "node-pre-gyp": "^0.17.0",
     "node-sass": "^5.0.0",
     "normalize.css": "^8.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6128,6 +6128,11 @@ lodash.camelcase@^4.3.0:
   resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
   integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
+lodash.difference@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.difference/-/lodash.difference-4.5.0.tgz#9ccb4e505d486b91651345772885a2df27fd017c"
+  integrity sha1-nMtOUF1Ia5FlE0V3KIWi3yf9AXw=
+
 lodash.get@^4.0:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
@@ -6640,6 +6645,13 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
+moment-locales-webpack-plugin@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/moment-locales-webpack-plugin/-/moment-locales-webpack-plugin-1.2.0.tgz#9af83876a44053706b868ceece5119584d10d7aa"
+  integrity sha512-QAi5v0OlPUP7GXviKMtxnpBAo8WmTHrUNN7iciAhNOEAd9evCOvuN0g1N7ThIg3q11GLCkjY1zQ2saRcf/43nQ==
+  dependencies:
+    lodash.difference "^4.5.0"
 
 moment@^2.10.2:
   version "2.25.3"


### PR DESCRIPTION
This shrinks the production `logs_app` bundle from 1.1M (237K w/ brotli compression) to 785K (198K w/ brotli).

# Before

![image](https://user-images.githubusercontent.com/8197963/106581214-7b1b0480-64f7-11eb-820c-144d2a646ef1.png)

# After

![image](https://user-images.githubusercontent.com/8197963/106581247-853d0300-64f7-11eb-90b1-5718f0ac9ef2.png)