### PR TITLE
Remove `thread_safe` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,7 +41,6 @@ gem 'sassc' # used by ActiveAdmin asset pipeline
 gem 'sidekiq'
 gem 'sidekiq-scheduler', require: false
 gem 'stackprof'
-gem 'thread_safe'
 gem 'webpacker'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -556,7 +556,6 @@ GEM
     stackprof (0.2.16)
     temple (0.8.2)
     thor (1.1.0)
-    thread_safe (0.3.6)
     thwait (0.2.0)
       e2mmap
     tilt (2.0.10)
@@ -668,7 +667,6 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen!
   stackprof
-  thread_safe
   webmock
   webpacker
 


### PR DESCRIPTION
It used to be necessary to have this gem in our `Gemfile` because `active_model_serializers` depended on it, but didn't list it in its gemspec. `active_model_serializers` seems to no longer depend on `thread_safe`, so let's remove it.

Credit to https://github.com/BigBigDoudou/gems_bond for helping to bring this to my attention.