### PR TITLE
Use `RequestStore` to memoize `RedisConfig` for only one request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,8 @@ gem 'pundit'
 gem 'rack-attack'
 gem 'rails'
 gem 'redis'
+gem 'request_store'
+gem 'request_store-sidekiq'
 gem 'rollbar'
 gem 'sassc' # used by ActiveAdmin asset pipeline
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -460,6 +460,9 @@ GEM
     regexp_parser (2.0.3)
     request_store (1.5.0)
       rack (>= 1.4)
+    request_store-sidekiq (0.1.0)
+      request_store (>= 1.3)
+      sidekiq (>= 3.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -649,6 +652,8 @@ DEPENDENCIES
   rails
   rails-controller-testing!
   redis
+  request_store
+  request_store-sidekiq
   rollbar
   rspec-instafail
   rspec-rails

--- a/lib/redis_config/redis_backed_map.rb
+++ b/lib/redis_config/redis_backed_map.rb
@@ -8,27 +8,27 @@ class RedisConfig::RedisBackedMap
   end
 
   def []=(key, value)
-    $redis_pool.with { |conn| conn.hset(redis_hash_key, key, value) }
-    @memory_store[key] = value
+    $redis_pool.with { |conn| conn.hset(namespace, key, value) }
+    memory_store[key] = value
   end
 
   def delete(key)
-    $redis_pool.with { |conn| conn.hdel(redis_hash_key, key) }
+    $redis_pool.with { |conn| conn.hdel(namespace, key) }
     memory_store.delete(key)
   end
 
   def clear!
-    $redis_pool.with { |conn| conn.del(redis_hash_key) }
-    @memory_store = nil
+    $redis_pool.with { |conn| conn.del(namespace) }
+    RequestStore.store[namespace] = nil
   end
 
   private
 
   def memory_store
-    @memory_store ||= $redis_pool.with { |conn| conn.hgetall(redis_hash_key) }
+    RequestStore.store[namespace] ||= $redis_pool.with { |conn| conn.hgetall(namespace) }
   end
 
-  def redis_hash_key
+  def namespace
     "#{RedisConfig::REDIS_NAMESPACE}:#{@name}-map"
   end
 end


### PR DESCRIPTION
Memoizing indefinitely in a simple Hash was somewhat problematic in that, when a setting was modified in the admin web app, that change wouldn't be picked up by Sidekiq until after a restart (thereby clearing the RedisConfig memory store in Sidekiq and forcing loading from Redis). With this change, it won't be necessary to restart Sidekiq. The downside is a performance decrease, but that should be negligible/worthwhile.