### PR TITLE
Memoize Flipper flag state per request via builtin Flipper middleware

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -9,3 +9,5 @@ Flipper.configure do |config|
     Flipper.new(adapter)
   end
 end
+
+Rails.configuration.middleware.use(Flipper::Middleware::Memoizer)


### PR DESCRIPTION
This (unless I'm mistaken) won't have any memoizing impact on Sidekiq, which is probably fine, because I don't think that we do many(/any) repeated Flipper checks in Sidekiq jobs, anyway.