### PR TITLE
Only serve prerender if it has expected content

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -8,7 +8,12 @@ class HomeController < ApplicationController
   def index
     skip_authorization
     @description = 'The personal website of web developer David Runger'
-    serve_prerender_with_fallback(filename: 'home.html') { render :index }
+    serve_prerender_with_fallback(
+      filename: 'home.html',
+      expected_content: 'Full stack web developer',
+    ) do
+      render :index
+    end
   end
 
   def upgrade_browser


### PR DESCRIPTION
We don't want to serve a prerender of an error page, which might be the prerendered HTML content if something goes wrong when generating the prerender (e.g. a Heroku timeout error due to many deploys going out around the same time).

We could to this checking instead (or also) at the time that we generate the prerender, but I chose to do it here because:
1. checking at the last minute before rendering is more robust (e.g. if the S3 prerender were initially correct but then was corrupted somehow)
2. this makes it easier/possible to use `Rails.logger` to write to our production logs (and/or to Rollbar)