### PR TITLE
Don't require (but allow) a space after dash when uploading quiz ?'s

### DIFF
--- a/app/actions/quiz_questions/create_from_list.rb
+++ b/app/actions/quiz_questions/create_from_list.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class QuizQuestions::CreateFromList < ApplicationAction
-  CORRECT_ANSWER_PREFIX = '- '
+  CORRECT_ANSWER_PREFIX = /\A- */.freeze
 
   requires :quiz, Shaped::Shape(Quiz)
   requires :questions_list, Shaped::Shape(String)
@@ -29,9 +29,9 @@ class QuizQuestions::CreateFromList < ApplicationAction
   end
 
   def create_answer_from_text!(answer_text:, question:)
-    if answer_text.start_with?(CORRECT_ANSWER_PREFIX)
+    if answer_text.match?(CORRECT_ANSWER_PREFIX)
       is_correct = true
-      answer_text = answer_text.delete_prefix(CORRECT_ANSWER_PREFIX)
+      answer_text = answer_text.sub(CORRECT_ANSWER_PREFIX, '')
     else
       is_correct = false
     end

--- a/app/views/question_uploads/new.html.haml
+++ b/app/views/question_uploads/new.html.haml
@@ -14,7 +14,7 @@
   %ol
     %li Put each question on its own line
     %li Put each answer on a separate line below the question
-    %li Prefix the correct answer with a dash and space ("#{content_tag(:code, '- ')}")
+    %li Prefix the correct answer with a dash ("#{content_tag(:code, '-')}")
     %li Leave a blank line between each set of questions and answers
 
   %h3 Example
@@ -23,15 +23,15 @@
     :preserve
       Which is biggest?
       The earth
-      - The sun
+      -The sun
       The moon
 
       Which is currently farther from the sun?
       Neptune
-      - Pluto
+      -Pluto
 
       Which has the hottest surface temperature?
       Mercury
-      - Venus
+      -Venus
       Earth
       Mars

--- a/spec/actions/quiz_questions/create_from_list_spec.rb
+++ b/spec/actions/quiz_questions/create_from_list_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe QuizQuestions::CreateFromList do
       What's your Hogwarts house?
       Gryffindor
       Hufflepuff
-      - Ravenclaw
+      -Ravenclaw
       Slytherin
 
       Do you think that smarter people are usually capable of deeper love?


### PR DESCRIPTION
Motivation: a Google doc will apply bulletted list formatting(/indentation) after hitting `- ` but not after typing just a dash.