### PR TITLE
Run helper specs in `RunHtmlControllerTests` group

### DIFF
--- a/bin/test/tasks/run_html_controller_tests.rb
+++ b/bin/test/tasks/run_html_controller_tests.rb
@@ -10,6 +10,7 @@ class Test::Tasks::RunHtmlControllerTests < Pallets::Task
       bin/rspec
       $(ls -d spec/controllers/*/ | grep -v 'spec/controllers/api/' | tr '\\n' ' ')
       $(ls spec/controllers/*.rb)
+      $(ls spec/helpers/*.rb)
       --format RSpec::Instafail --format progress --force-color
     COMMAND
   end

--- a/bin/test/tasks/run_unit_tests.rb
+++ b/bin/test/tasks/run_unit_tests.rb
@@ -10,7 +10,9 @@ class Test::Tasks::RunUnitTests < Pallets::Task
     execute_system_command(<<~COMMAND)
       DB_SUFFIX=_unit
       bin/rspec
-      $(ls -d spec/*/ | grep --extended-regex -v 'spec/(controllers|features)/' | tr '\\n' ' ')
+      $(ls -d spec/*/ |
+        grep --extended-regex -v 'spec/(controllers|features|helpers)/' |
+        tr '\\n' ' ')
       --format RSpec::Instafail --format progress --force-color
     COMMAND
   end


### PR DESCRIPTION
This is because we need to wait for the webpack assets to finish compiling before we execute the helper specs.