### PR TITLE
Increase Ferrum timeout from 10s to 60s when prerendering

### DIFF
--- a/bin/prerender
+++ b/bin/prerender
@@ -14,7 +14,7 @@ require 'pry-byebug' if ENV['CI'] != 'true'
 
 class Prerenderer
   def initialize
-    @browser = Ferrum::Browser.new(process_timeout: 10, timeout: 10)
+    @browser = Ferrum::Browser.new(process_timeout: 10, timeout: 60)
   end
 
   def prerender(url:, filename:)


### PR DESCRIPTION
When a bunch of deploys are going out ~simultaneously, and thus triggering dyno restarts, it can happen that a request won't be served within 10 seconds. Our web dynos seem to take almost ~40 seconds to boot up. Therefore, this change increases the Ferrum timeout to 60 seconds (giving ~20+ seconds of "padding", even if a prerender request is initiated at the same time as a dyno restart).