### PR TITLE
Don't use async partials for quiz#show after submitting an answer

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,4 +97,23 @@ class ApplicationController < ActionController::Base
       end
     end
   end
+
+  helper_method \
+  def without_bullet
+    if defined?(Bullet)
+      begin
+        previous_enable_value = Bullet.enable?
+        previous_counter_cache_enable_value = Bullet.counter_cache_enable?
+        Bullet.enable = false
+        yield
+      ensure
+        Bullet.enable = previous_enable_value
+        Bullet.counter_cache_enable = previous_counter_cache_enable_value
+      end
+    else
+      # :nocov:
+      yield
+      # :nocov:
+    end
+  end
 end

--- a/app/decorators/quiz_question_decorator.rb
+++ b/app/decorators/quiz_question_decorator.rb
@@ -17,11 +17,19 @@ class QuizQuestionDecorator < Draper::Decorator
     created_at <= quiz.current_question.created_at
   end
 
+  def answered_by_current_user?
+    current_user_answer_selection.present?
+  end
+
   private
 
   def current_user_answer
+    current_user_answer_selection&.answer
+  end
+
+  def current_user_answer_selection
     answer_selections.find do |selection|
       selection.participation_id == h.current_user_participation.id
-    end&.answer
+    end
   end
 end

--- a/app/views/quiz_questions/_open.html.haml
+++ b/app/views/quiz_questions/_open.html.haml
@@ -6,17 +6,28 @@
 - else
   = render partial: 'quiz_questions/participant_view', locals: { question: @quiz.current_question }
 
+- already_answered = !@quiz.owned_by_current_user? && without_bullet { @quiz.current_question.decorate.answered_by_current_user? }
 .pt2
   %hr
   %h3 Respondents
-  .mb2{data: { async_partial_src: respondents_quiz_path(@quiz), delay: 750 }}
-    [ ... loading respondents ... ]
+  - if already_answered
+    - @quiz = Quiz.includes(:participations).find(@quiz.id).decorate
+    = render partial: 'quiz_questions/respondents', locals: { question: @quiz.current_question }
+  - else
+    .mb2{data: { async_partial_src: respondents_quiz_path(@quiz), delay: 750 }}
+      [ ... loading respondents ... ]
   %hr
   %h3 Leaderboard
-  .mb2{data: { async_partial_src: leaderboard_quiz_path(@quiz), delay: 1000 }}
-    [ ... loading leaderboard ... ]
+  - if already_answered
+    = render partial: 'quiz/leaderboard', locals: { quiz: @quiz }
+  - else
+    .mb2{data: { async_partial_src: leaderboard_quiz_path(@quiz), delay: 1000 }}
+      [ ... loading leaderboard ... ]
   - if !@quiz.owned_by_current_user?
     %hr
     %h3 Progress
-    %div{data: { async_partial_src: progress_quiz_path(@quiz), delay: 1250 }}
-      [ ... loading progress ... ]
+    - if already_answered
+      = render partial: 'quiz/progress', locals: { quiz: @quiz }
+    - else
+      %div{data: { async_partial_src: progress_quiz_path(@quiz), delay: 1250 }}
+        [ ... loading progress ... ]


### PR DESCRIPTION
The async partials are mostly useful when advancing to the next question, because then everyone needs to load the quiz question at once. When a user submits their answer, though, they are probably the only person submitting at that time, so there's less need for the async partials, and not using the async partials provides a better user experience (by not rendering the loading placeholders for a while).