### PR TITLE
Use `content_tag` (not `tag`) to render `<turbo-frame>`

### DIFF
--- a/app/views/quiz_questions/_open.html.haml
+++ b/app/views/quiz_questions/_open.html.haml
@@ -4,7 +4,7 @@
     = form.hidden_field(:status, value: QuizQuestion::CLOSED)
     = form.submit('Close question')
 - else
-  = tag.turbo_frame(id: 'quiz-question-participant-view') do
+  = content_tag('turbo-frame', id: 'quiz-question-participant-view') do
     = render partial: 'quiz_questions/participant_view', locals: { question: @quiz.current_question }
 
 .pt2


### PR DESCRIPTION
This should avoid the `method_missing` call of `tag.turbo_frame` and should therefore be more performant, I think.