### PR TITLE
Initialize ActiveStorage in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -115,7 +115,7 @@ Rails.application.configure do
   require_relative('../../lib/email/mailgun_via_http.rb')
   config.action_mailer.delivery_method = Email::MailgunViaHttp
 
-  if ENV['HEROKU_APP_NAME'].blank?
+  if ENV['HEROKU_APP_NAME'] == 'davidrunger'
     if %w[AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY S3_BUCKET S3_REGION].all? { ENV[_1].present? }
       config.active_storage.service = :amazon
     else


### PR DESCRIPTION
fixes https://rollbar.com/davidjrunger/davidrunger/items/398/

I stupidly/wrongly thought `ENV['HEROKU_APP_NAME']` is `nil` in production, but it's actually `'davidrunger'`.