### PR TITLE
Remove no-longer-used `ApplicationController#without_bullet` method

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -97,23 +97,4 @@ class ApplicationController < ActionController::Base
       end
     end
   end
-
-  helper_method \
-  def without_bullet
-    if defined?(Bullet)
-      begin
-        previous_enable_value = Bullet.enable?
-        previous_counter_cache_enable_value = Bullet.counter_cache_enable?
-        Bullet.enable = false
-        yield
-      ensure
-        Bullet.enable = previous_enable_value
-        Bullet.counter_cache_enable = previous_counter_cache_enable_value
-      end
-    else
-      # :nocov:
-      yield
-      # :nocov:
-    end
-  end
 end


### PR DESCRIPTION
The last/only usage of this method (added in 7f07d18 ) was removed in 98401c9 .