### PR TITLE
Remove no-longer-used `answered_by_current_user?` method

### DIFF
--- a/app/decorators/quiz_question_decorator.rb
+++ b/app/decorators/quiz_question_decorator.rb
@@ -17,10 +17,6 @@ class QuizQuestionDecorator < Draper::Decorator
     created_at <= quiz.current_question.created_at
   end
 
-  def answered_by_current_user?
-    current_user_answer_selection.present?
-  end
-
   private
 
   def current_user_answer


### PR DESCRIPTION
The last/only usage of this method (added in 7f07d18) was removed in 98401c9.