### PR TITLE
Remove `flamegraph` and `stackprof` gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,6 @@ gem 'draper'
 gem 'email_reply_trimmer', github: 'discourse/email_reply_trimmer'
 gem 'faraday'
 gem 'faraday_middleware'
-gem 'flamegraph'
 gem 'flipper'
 gem 'flipper-redis'
 gem 'flipper-ui'
@@ -45,7 +44,6 @@ gem 'rollbar'
 gem 'sassc' # used by ActiveAdmin asset pipeline
 gem 'sidekiq'
 gem 'sidekiq-scheduler', require: false
-gem 'stackprof'
 gem 'webpacker'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -287,7 +287,6 @@ GEM
       activerecord (>= 2)
       activesupport (>= 2)
       hashdiff
-    flamegraph (0.9.5)
     flipper (0.20.3)
     flipper-redis (0.20.3)
       flipper (~> 0.20.3)
@@ -613,7 +612,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    stackprof (0.2.16)
     super_diff (0.6.1)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -692,7 +690,6 @@ DEPENDENCIES
   faraday_middleware
   ferrum
   fixture_builder
-  flamegraph
   flipper
   flipper-redis
   flipper-ui
@@ -747,7 +744,6 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen!
-  stackprof
   super_diff
   vite_rails
   webmock


### PR DESCRIPTION
I think that we had these for `rack-mini-profiler`, but we removed that in 2338171.