### PR TITLE
Fix daylight savings time spec flakiness in Log spec

### DIFF
--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -27,12 +27,12 @@ RSpec.describe Log do
         context 'when all log entries were created long enough ago that a reminder is needed' do
           before do
             log.log_entries.find_each do |log_entry|
-              log_entry.update!(created_at: reminder_time_interval.ago - 1.minute)
+              log_entry.update!(created_at: reminder_time_interval.ago - 2.hours)
             end
           end
 
           context 'when the log was created less than the reminder time interval ago' do
-            before { log.update!(created_at: reminder_time_interval.ago + 1.minute) }
+            before { log.update!(created_at: reminder_time_interval.ago + 2.hours) }
 
             it 'does not include the log' do
               expect(needing_reminder).not_to include(log)
@@ -40,7 +40,7 @@ RSpec.describe Log do
           end
 
           context 'when the log was created more than the reminder time interval ago' do
-            before { log.update!(created_at: reminder_time_interval.ago - 1.hour) }
+            before { log.update!(created_at: reminder_time_interval.ago - 2.hours) }
 
             context 'when a reminder email has never been sent' do
               before { log.update!(reminder_last_sent_at: nil) }
@@ -53,7 +53,7 @@ RSpec.describe Log do
             context 'when last reminder was sent prior to the creation of the most recent entry' do
               before do
                 last_log_entry_created_at = log.log_entries.order(:created_at).last!.created_at
-                log.update!(reminder_last_sent_at: last_log_entry_created_at - 1.minute)
+                log.update!(reminder_last_sent_at: last_log_entry_created_at - 2.hours)
               end
 
               it 'includes the log' do
@@ -64,7 +64,7 @@ RSpec.describe Log do
             context 'when last reminder was sent after the creation of the most recent entry' do
               before do
                 last_log_entry_created_at = log.log_entries.order(:created_at).last!.created_at
-                log.update!(reminder_last_sent_at: last_log_entry_created_at + 1.minute)
+                log.update!(reminder_last_sent_at: last_log_entry_created_at + 2.hours)
               end
 
               it 'does not include the log' do
@@ -76,7 +76,7 @@ RSpec.describe Log do
 
         context 'when a log entry was created recently enough that a reminder is not needed' do
           before do
-            log.log_entries.first!.update!(created_at: reminder_time_interval.ago + 1.minute)
+            log.log_entries.first!.update!(created_at: reminder_time_interval.ago + 2.hours)
           end
 
           it 'does not include the log' do
@@ -89,7 +89,7 @@ RSpec.describe Log do
         before { log.log_entries.find_each(&:destroy!) }
 
         context 'when the log was created long enough ago that a reminder is needed' do
-          before { log.update!(created_at: reminder_time_interval.ago - 1.minute) }
+          before { log.update!(created_at: reminder_time_interval.ago - 2.hours) }
 
           context 'when a reminder email has never been sent' do
             before { log.update!(reminder_last_sent_at: nil) }
@@ -100,7 +100,7 @@ RSpec.describe Log do
           end
 
           context 'when a reminder email has been sent' do
-            before { log.update!(reminder_last_sent_at: log.created_at + 1.minute) }
+            before { log.update!(reminder_last_sent_at: log.created_at + 2.hours) }
 
             it 'does not include the log' do
               expect(needing_reminder).not_to include(log)
@@ -109,7 +109,7 @@ RSpec.describe Log do
         end
 
         context 'when the log was created recently enough ago that a reminder is not yet needed' do
-          before { log.update!(created_at: reminder_time_interval.ago + 1.minute) }
+          before { log.update!(created_at: reminder_time_interval.ago + 2.hours) }
 
           it 'does not include the log' do
             expect(needing_reminder).not_to include(log)


### PR DESCRIPTION
I didn't look closely into the spec failures that were occurring here. Changing our adjustments from `1.minute` and `1.hour` to `2.hours` seems to make the 1 hour worth of complication/confusion introduced by daylight saving's time no longer fail the specs.