### PR TITLE
Remove unnecessary `Shaped::Shape` method calls

### DIFF
--- a/app/actions/log_entries/create_from_param.rb
+++ b/app/actions/log_entries/create_from_param.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class LogEntries::CreateFromParam < ApplicationAction
-  requires :log, Shaped::Shape(Log)
-  requires :param, Shaped::Shape(String)
+  requires :log, Log
+  requires :param, String
 
   def execute
     if log.data_type == 'number' && param.match?(/\s+/)

--- a/app/actions/quiz_question_answer_selections/create.rb
+++ b/app/actions/quiz_question_answer_selections/create.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class QuizQuestionAnswerSelections::Create < ApplicationAction
-  requires :quiz_participation, Shaped::Shape(QuizParticipation)
-  requires :params, Shaped::Shape(ActionController::Parameters)
+  requires :quiz_participation, QuizParticipation
+  requires :params, ActionController::Parameters
 
   returns :selection, QuizQuestionAnswerSelection, presence: true
 

--- a/app/actions/quiz_questions/create_from_list.rb
+++ b/app/actions/quiz_questions/create_from_list.rb
@@ -5,8 +5,8 @@ class QuizQuestions::CreateFromList < ApplicationAction
 
   CORRECT_ANSWER_PREFIX = /\A\s*-\s*/.freeze
 
-  requires :quiz, Shaped::Shape(Quiz)
-  requires :questions_list, Shaped::Shape(String)
+  requires :quiz, Quiz
+  requires :questions_list, String
 
   fails_with :invalid_answers
 

--- a/app/actions/quiz_questions/update.rb
+++ b/app/actions/quiz_questions/update.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class QuizQuestions::Update < ApplicationAction
-  requires :quiz_question, Shaped::Shape(QuizQuestion)
-  requires :params, Shaped::Shape(ActionController::Parameters)
+  requires :quiz_question, QuizQuestion
+  requires :params, ActionController::Parameters
 
   def execute
     quiz_question.update!(params)

--- a/app/actions/quizzes/update.rb
+++ b/app/actions/quizzes/update.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class Quizzes::Update < ApplicationAction
-  requires :quiz, Shaped::Shape(Quiz)
-  requires :params, Shaped::Shape(ActionController::Parameters)
+  requires :quiz, Quiz
+  requires :params, ActionController::Parameters
 
   def execute
     quiz.update!(params)


### PR DESCRIPTION
The `active_actions` gem will automatically turn these shape definitions into `Shaped::Shape`s; we don't need to do so explicitly.