### PR TITLE
Increase `process_timeout` from 10 to 20 seconds when prerendering

### DIFF
--- a/bin/prerender
+++ b/bin/prerender
@@ -14,7 +14,7 @@ require 'pry-byebug' if ENV['CI'] != 'true'
 
 class Prerenderer
   def initialize
-    @browser = Ferrum::Browser.new(process_timeout: 10, timeout: 60)
+    @browser = Ferrum::Browser.new(process_timeout: 20, timeout: 60)
   end
 
   def prerender(url:, filename:)


### PR DESCRIPTION
Hopefully this will avoid https://github.com/davidrunger/david_runger/runs/2273115979 :

```
/home/runner/work/david_runger/david_runger/vendor/bundle/ruby/3.0.0/gems/ferrum-0.11/lib/ferrum/browser/process.rb:149:in
`parse_ws_url': Browser did not produce websocket url within 10 seconds,
try to increase `:process_timeout`. See
https://github.com/rubycdp/ferrum#customization
(Ferrum::ProcessTimeoutError)
```