### PR TITLE
Drop chartkick gem from 4.0.0 to 3.4.2 and add back `defer: true` option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,7 +211,7 @@ GEM
       launchy
     case_transform (0.2)
       activesupport
-    chartkick (4.0.0)
+    chartkick (3.4.2)
     childprocess (3.0.0)
     climate_control (1.0.0)
     cliver (0.3.2)

--- a/app/admin/asset_sizes.rb
+++ b/app/admin/asset_sizes.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register_page('Asset Sizes') do
 
     TrackAssetSizes.all_globs.each do |glob|
       h2(glob)
-      div(line_chart(RedisTimeseries[glob].to_h))
+      div(line_chart(RedisTimeseries[glob].to_h, defer: true))
     end
   end
 end


### PR DESCRIPTION
We cannot yet upgrade the chartkick JS library (see https://github.com/davidrunger/david_runger/pull/491) and so we can't bump the Ruby chartkick library yet, either.