### PR TITLE
Decrease fallback value for `RAILS_MAX_THREADS` from 5 to 3

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,7 +6,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
+threads_count = ENV.fetch('RAILS_MAX_THREADS', 3)
 threads(threads_count, threads_count)
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.


### PR DESCRIPTION
We have been getting R14 errors on Heroku.