### PR TITLE
Change label text when creating quiz from "Name" to "Quiz name"

### DIFF
--- a/app/views/quizzes/new.html.haml
+++ b/app/views/quizzes/new.html.haml
@@ -1,6 +1,6 @@
 %h1 New Quiz
 
 = form_with model: @quiz do |form|
-  = form.label :name
+  = form.label :name, 'Quiz name'
   = form.text_field :name
   = form.submit('Create quiz')


### PR DESCRIPTION
When it's just "Name", some users will enter their name rather than the quiz name.