### PR TITLE
Handle validation error(s) when creating a quiz participation

### DIFF
--- a/app/actions/quiz_participations/create.rb
+++ b/app/actions/quiz_participations/create.rb
@@ -5,9 +5,16 @@ class QuizParticipations::Create < ApplicationAction
   requires :quiz, Quiz
   requires :user, User
 
-  def execute
-    participation = user.quiz_participations.create!(quiz_id: quiz.id, display_name: display_name)
+  fails_with :invalid_participation
 
-    QuizzesChannel.broadcast_to(quiz, new_participant_name: participation.display_name)
+  def execute
+    participation = user.quiz_participations.build(quiz_id: quiz.id, display_name: display_name)
+
+    if participation.valid?
+      participation.save!
+      QuizzesChannel.broadcast_to(quiz, new_participant_name: participation.display_name)
+    else
+      result.invalid_participation!(participation.errors.full_messages.to_sentence)
+    end
   end
 end

--- a/app/controllers/quiz_participations_controller.rb
+++ b/app/controllers/quiz_participations_controller.rb
@@ -5,11 +5,15 @@ class QuizParticipationsController < ApplicationController
     authorize(QuizParticipation, :create?)
 
     quiz = Quiz.find_by_hashid!(params[:quiz_id]) # rubocop:disable Rails/DynamicFindBy
-    QuizParticipations::Create.run!(
+    result = QuizParticipations::Create.new(
       display_name: params[:display_name],
       quiz: quiz,
       user: current_user,
-    )
+    ).run
+
+    if !result.success?
+      flash[:alert] = result.error_message
+    end
 
     redirect_to(quiz)
   end

--- a/spec/controllers/quiz_participations_controller_spec.rb
+++ b/spec/controllers/quiz_participations_controller_spec.rb
@@ -7,13 +7,32 @@ RSpec.describe QuizParticipationsController do
   let(:quiz) { Quiz.first! }
 
   describe '#create' do
-    subject(:post_create) { post(:create, params: { quiz_id: quiz.hashid, display_name: 'Al' }) }
+    subject(:post_create) do
+      post(:create, params: { quiz_id: quiz.hashid, display_name: display_name })
+    end
 
     context 'when the user is not yet participating in the quiz' do
       before { user.quiz_participations.where(quiz: quiz).find_each(&:destroy!) }
 
-      it 'creates a QuizParticipation for the user' do
-        expect { post_create }.to change { user.reload.quiz_participations.size }.by(1)
+      context 'when the user submits a name' do
+        let(:display_name) { 'Al' }
+
+        it 'creates a QuizParticipation for the user' do
+          expect { post_create }.to change { user.reload.quiz_participations.size }.by(1)
+        end
+      end
+
+      context 'when the user does not submit a name' do
+        let(:display_name) { '' }
+
+        it 'does not create a QuizParticipation for the user' do
+          expect { post_create }.not_to change { user.reload.quiz_participations.size }
+        end
+
+        it 'sets a flash message' do
+          post_create
+          expect(flash[:alert]).to eq("Display name can't be blank")
+        end
       end
     end
   end


### PR DESCRIPTION
fixes https://rollbar.com/davidjrunger/davidrunger/items/410/

Previously, I think that the user would see a 500 error and have to refresh the page to see the form again and resubmit.