### PR TITLE
Log invalid MIME type to Rollbar at `info` level

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -30,7 +30,10 @@ Rollbar.configure do |config|
   # via the rollbar interface.
   # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
   # 'ignore' will cause the exception to not be reported at all.
-  config.exception_level_filters['ActionController::RoutingError'] = 'info'
+  config.exception_level_filters.merge!(
+    'ActionController::RoutingError' => 'info',
+    'ActionDispatch::Http::MimeNegotiation::InvalidType' => 'info',
+  )
   #
   # You can also specify a callable, which will be called with the exception instance.
   # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })


### PR DESCRIPTION
see https://rollbar.com/davidjrunger/davidrunger/items/413/