### PR TITLE
Increase timeout when posting CI build time to 120 seconds

### DIFF
--- a/bin/test/tasks/exit.rb
+++ b/bin/test/tasks/exit.rb
@@ -55,7 +55,7 @@ class Test::Tasks::Exit < Pallets::Task
     print("\nPosting data to log... ")
     begin
       response =
-        Faraday.json_connection.post(
+        Faraday.json_connection(timeout: 120).post(
           ENV['BUILD_TIME_LOG_URL'],
           {
             auth_token: ENV['BUILD_TIME_LOG_AUTH_TOKEN'],

--- a/config/initializers/monkeypatches/faraday.rb
+++ b/config/initializers/monkeypatches/faraday.rb
@@ -2,8 +2,9 @@
 
 module Faraday
   class << self
-    def json_connection(&blk)
+    def json_connection(timeout: 60, &blk)
       new do |conn|
+        conn.options.timeout = timeout
         conn.request(:json)
         conn.response(:json)
         blk&.call(conn)


### PR DESCRIPTION
I think that the previous default was 60 seconds.

This should avoid some errors that we have been getting in CI builds caused by timeouts when a previous build has recently been released and so the new production servers are booting up.