### PR TITLE
Stop sending CI build time to log

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -74,9 +74,6 @@ jobs:
         # The hostname used to communicate with the Redis service container
         REDIS_HOST: redis
         REDIS_PORT: 6379
-        BUILD_TIME_LOG_AUTH_TOKEN: "${{secrets.BUILD_TIME_LOG_AUTH_TOKEN}}"
-        BUILD_TIME_LOG_ID: "${{secrets.BUILD_TIME_LOG_ID}}"
-        BUILD_TIME_LOG_URL: "${{secrets.BUILD_TIME_LOG_URL}}"
         BUNDLE_GITHUB__COM: "${{secrets.BUNDLE_GITHUB__COM}}"
         PERCY_TOKEN: "${{secrets.PERCY_TOKEN}}"
         CODECOV_TOKEN: "${{secrets.CODECOV_TOKEN}}"


### PR DESCRIPTION
For some reason, this started erroring out during the first build on GitHub Actions (but then it works after I re-trigger the build?). That's not worth it, since I almost never check said log, and also since I periodically need to delete those log entries, anyway, to save rows in the Postgres database.