### PR TITLE
Bump yarn from 1.22.10 to 1.22.11

### DIFF
--- a/bin/test/tasks/check_versions.rb
+++ b/bin/test/tasks/check_versions.rb
@@ -11,7 +11,7 @@ class Test::Tasks::CheckVersions < Pallets::Task
       node --version && [ "$(node --version)" = 'v14.15.0' ]
     COMMAND
     execute_system_command(<<~COMMAND)
-      yarn --version && [ "$(yarn --version)" = '1.22.10' ]
+      yarn --version && [ "$(yarn --version)" = '1.22.11' ]
     COMMAND
   end
 end

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "engines": {
     "node": "14.15.0",
-    "yarn": "1.22.10"
+    "yarn": "1.22.11"
   },
   "browserslist": [
     ">10%"


### PR DESCRIPTION
This is the version that is now on GitHub Actions, so... [shrug]