### PR TITLE
Specify to use webpack locally via env variable (not Flipper)

### DIFF
--- a/app/helpers/javascript_helper.rb
+++ b/app/helpers/javascript_helper.rb
@@ -10,6 +10,6 @@ module JavascriptHelper
   end
 
   def use_vite?
-    Rails.env.development? && !Flipper.enabled?(:use_webpack)
+    Rails.env.development? && !ENV.key?('USE_WEBPACK')
   end
 end


### PR DESCRIPTION
Using an ENV variable is easier (`USE_WEBPACK=1 bin/rails server`) than launching a `rails console` or web server to toggle the Flipper feature.