### PR TITLE
Remove rspec_performance_summary gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -98,7 +98,6 @@ group :test do
   gem 'percy-capybara'
   gem 'rails-controller-testing', github: 'rails/rails-controller-testing'
   gem 'rspec-instafail', require: false
-  gem 'rspec_performance_summary', require: false, github: 'davidrunger/rspec_performance_summary'
   gem 'rspec-rails'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,13 +40,6 @@ GIT
       lazy_lazer (~> 0.8.1)
 
 GIT
-  remote: https://github.com/davidrunger/rspec_performance_summary.git
-  revision: 664f0bca9d78cb89552007836bc8816b5d1c0a29
-  specs:
-    rspec_performance_summary (0.1.8.alpha)
-      rspec-core (~> 3.0)
-
-GIT
   remote: https://github.com/davidrunger/runger_style.git
   revision: c7074afc0032f8ad29f09cbe298d1540f0673ad2
   specs:
@@ -736,7 +729,6 @@ DEPENDENCIES
   rollbar
   rspec-instafail
   rspec-rails
-  rspec_performance_summary!
   rubocop
   rubocop-performance
   rubocop-rails

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,7 +30,6 @@ require 'active_support/cache/mem_cache_store'
 require 'sidekiq/testing'
 require 'mail'
 require 'percy/capybara'
-require 'rspec_performance_summary'
 require 'super_diff/rspec-rails'
 
 # w/o this, Sidekiq's `logger` prints to STDOUT (bad); with this, it prints to `log/test.log` (good)


### PR DESCRIPTION
It's not worth the weekly updates; I never look at the spec run times.