### PR TITLE
Lock `js-routes` at 2.0.8 (down from 2.1.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,7 @@ gem 'flipper-ui'
 gem 'hamlit'
 gem 'hashid-rails'
 gem 'heat', git: 'https://github.com/davidrunger/heat.git', require: false
-gem 'js-routes', require: false
+gem 'js-routes', '2.0.8', require: false
 gem 'lograge'
 gem 'memoist'
 gem 'newrelic_rpm'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -359,7 +359,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    js-routes (2.1.0)
+    js-routes (2.0.8)
       railties (>= 4)
     json-schema (2.8.1)
       addressable (>= 2.4)
@@ -698,7 +698,7 @@ DEPENDENCIES
   heat!
   http_logger
   immigrant
-  js-routes
+  js-routes (= 2.0.8)
   json-schema
   launchy
   letter_opener

--- a/lib/tasks/rails_assets.rake
+++ b/lib/tasks/rails_assets.rake
@@ -10,7 +10,7 @@ task build_js_routes: :environment do
   puts 'Writing app/javascript/rails_assets/routes.js ...'
   rails_assets_directory_name = 'app/javascript/rails_assets'
   FileUtils.mkdir(rails_assets_directory_name) unless File.exist?(rails_assets_directory_name)
-  routes_path = 'rails_assets/routes.js'
+  routes_path = 'app/javascript/rails_assets/routes.js'
   JsRoutes.generate!(routes_path, exclude: /admin|google|login|rails|sidekiq/)
   # HACK: fix a weird bug where `this` is somehow undefined when switching to Vite
   File.write(


### PR DESCRIPTION
`js-routes` 2.1.0 is causing deploy issues; I'm going to revert and then look into fixing that.