### PR TITLE
Set `offset: true` for bar graphs

### DIFF
--- a/app/javascript/components/charts/bar_graph.js
+++ b/app/javascript/components/charts/bar_graph.js
@@ -22,6 +22,7 @@ export const optionsDefaults = {
   responsive: true,
   scales: {
     xAxes: [_.merge({}, commonAxisOptions, {
+      offset: true,
       type: 'time',
       time: {
         minUnit: 'day',


### PR DESCRIPTION
This fixes a bug wherein the first and last bar were half width only.

https://github.com/chartjs/Chart.js/issues/ 7564