### PR TITLE
Set Rails cookie expiry to 1 year

### DIFF
--- a/config/initializers/cookies.rb
+++ b/config/initializers/cookies.rb
@@ -9,3 +9,7 @@ Rails.application.config.action_dispatch.cookies_serializer = :json
 # Specify the SameSite level protection for the cookies
 # Valid options are :none, :lax, and :strict.
 Rails.application.config.action_dispatch.cookies_same_site_protection = :lax
+
+# Specify cookie expiration time (since otherwise defaults to "Session" cookie expiry, which is
+# cleared in Safari after quitting the browser)
+Rails.application.config.session_store(:cookie_store, expire_after: 1.year)


### PR DESCRIPTION
This fixes a bug wherein Safari users would be logged out after closing their browser (since Safari properly implements/respects "Session"-length cookies).