### PR TITLE
Include `Pundit::Authorization` (no longer just `Pundit`)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,7 @@ class ApplicationController < ActionController::Base
   include Bootstrappable
   include BrowserSupportCheckable
   include ContainerClassable
-  include Pundit
+  include Pundit::Authorization
   include RequestRecordable
   include TokenAuthenticatable
 


### PR DESCRIPTION
Quote from logs: 'include Pundit' is deprecated. Please use 'include Pundit::Authorization' instead.