### PR TITLE
Don't create a `QuizQuestion::open` scope

### DIFF
--- a/app/models/quiz_question.rb
+++ b/app/models/quiz_question.rb
@@ -35,7 +35,9 @@ class QuizQuestion < ApplicationRecord
   has_many(:answer_selections, through: :answers, source: :selections)
 
   STATUSES.each do |status|
-    scope status, -> { where(status: status) }
+    unless status == 'open' # there is a QuizQuestion::open class method we don't want to overwrite
+      scope status, -> { where(status: status) }
+    end
 
     define_method("#{status}?") do
       self.status == status


### PR DESCRIPTION
We don't actually use any such scope, and it was generating a warning: `Creating scope :open. Overwriting existing method QuizQuestion.open.`