### PR TITLE
Bump yarn from 1.22.17 to 1.22.18

### DIFF
--- a/bin/test/tasks/check_versions.rb
+++ b/bin/test/tasks/check_versions.rb
@@ -11,7 +11,7 @@ class Test::Tasks::CheckVersions < Pallets::Task
       node --version && [ "$(node --version)" = 'v16.13.0' ]
     COMMAND
     execute_system_command(<<~COMMAND)
-      yarn --version && [ "$(yarn --version)" = '1.22.17' ]
+      yarn --version && [ "$(yarn --version)" = '1.22.18' ]
     COMMAND
   end
 end

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "engines": {
     "node": "16.13.0",
-    "yarn": "1.22.17"
+    "yarn": "1.22.18"
   },
   "browserslist": [
     ">10%"


### PR DESCRIPTION
GitHub actions updated its yarn version, so we need to.