### PR TITLE
Make workout callouts work on iOS Safari

### DIFF
--- a/app/javascript/workout/workout_plan.vue
+++ b/app/javascript/workout/workout_plan.vue
@@ -205,10 +205,12 @@ export default {
       this.$store.commit('showModal', { modalName: 'confirm-workout' });
     },
 
-    say(message) {
+    say(message, volume = 1) {
       if (!this.soundEnabled) return;
 
-      window.speechSynthesis.speak(new SpeechSynthesisUtterance(message));
+      const utterance = new SpeechSynthesisUtterance(message);
+      utterance.volume = volume;
+      window.speechSynthesis.speak(utterance);
     },
 
     secondsAsTime(seconds) {
@@ -225,6 +227,7 @@ export default {
       this.currentRoundIndex = 0;
 
       this.timer.start();
+      this.say('Starting workout', 0); // "say" it silently to enable speech synthesis on iOS
       this.timer.addEventListener('secondsUpdated', () => {
         this.secondsElapsed = this.timer.getTotalTimeValues().seconds;
         this.handleSecondElapsed();

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -67,4 +67,9 @@ Rails.application.configure do
   config.action_mailer.delivery_method = :letter_opener
 
   config.active_storage.service = :local
+
+  local_hostname = ENV.fetch('LOCAL_HOSTNAME', nil)
+  if local_hostname && !local_hostname.empty? # rubocop:disable Rails/Present
+    config.hosts << local_hostname
+  end
 end


### PR DESCRIPTION
It seems that, before speechSynthesis will work on iOS Safari, a user interaction must trigger a speech synthesis (and thereafter speech synthesis is then allowed, even without further user interaction).