### PR TITLE
Start with needed items unchecked when checking in grocery trip

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -172,7 +172,6 @@ export default {
     },
 
     initializeTripCheckinModal() {
-      this.itemsToZero = this.neededItems;
       this.$store.commit('showModal', { modalName: 'check-in-shopping-trip' });
     },
 


### PR DESCRIPTION
This way, if one has a smartphone, the items can be ticked off while going through the store (rather than ticking them off after getting home, in which case it's better to start with them all checked).