### PR TITLE
Enable branch coverage in specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ if is_ci
   SimpleCov.formatter = SimpleCov::Formatter::Codecov
   SimpleCov.start do
     add_filter(%r{^/spec/})
+    enable_coverage(:branch)
   end
   Codecov.pass_ci_if_error = true
 end


### PR DESCRIPTION
I don't think that Codecov has much/any support for reporting on the branch coverage, but one can see the branch coverage info by running the specs locally and looking at the SimpleCov coverage report.