### PR TITLE
Remove extra postcss listing from `yarn.lock`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8839,7 +8839,7 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postcss@^8.1.10, postcss@^8.2.1, postcss@^8.2.14, postcss@^8.2.15, postcss@^8.4.0, postcss@^8.4.12, postcss@^8.4.13:
+postcss@^8.1.10, postcss@^8.2.1, postcss@^8.2.14, postcss@^8.2.15, postcss@^8.4.0, postcss@^8.4.13:
   version "8.4.13"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.13.tgz#7c87bc268e79f7f86524235821dfdf9f73e5d575"
   integrity sha512-jtL6eTBrza5MPzy8oJLFuUscHDXTV5KcLlqAWHl5q5WYRfnNRGSmOZmOZ1T6Gy7A99mOZfqungmZMpMmCVJ8ZA==


### PR DESCRIPTION
Running `yarn install --check-files` generates this diff, so I'm committing it.