### PR TITLE
Bump `heroku-deploy` from 3.6.8 to 3.12.12

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Deploy To Heroku
-        uses: akhileshns/heroku-deploy@v3.6.8
+        uses: akhileshns/heroku-deploy@v3.12.12
         with:
           heroku_api_key: ${{secrets.HEROKU_API_KEY}}
           heroku_app_name: davidrunger


### PR DESCRIPTION
We are getting an error (see below) when the workflow attempts to deploy to Heroku, so hopefully this will fix it. :shrug:

```
Error: Command failed: git push heroku HEAD:refs/heads/master --force
fatal: 'heroku' does not appear to be a git repository
fatal: Could not read from remote repository.
```