### PR TITLE
Remove explicit Flipper memoization initialization

### DIFF
--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -9,5 +9,3 @@ Flipper.configure do |config|
     Flipper.new(adapter)
   end
 end
-
-Rails.configuration.middleware.use(Flipper::Middleware::Memoizer)


### PR DESCRIPTION
I believe that Flipper now memoizes by default and this explicit initialization is no longer required. See https://github.com/jnunemaker/flipper/pull/ 523 .