### PR TITLE
Remove debugging gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,9 +56,6 @@ group :development, :test do
   gem 'bullet'
   gem 'dotenv-rails', require: 'dotenv/rails-now'
   gem 'immigrant'
-  gem 'pry'
-  gem 'pry-byebug'
-  gem 'pry-rails'
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,7 +167,6 @@ GEM
     bullet (7.0.1)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (11.1.3)
     capybara (3.37.0)
       addressable
       matrix
@@ -432,11 +431,6 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    pry-byebug (3.8.0)
-      byebug (~> 11.0)
-      pry (~> 0.10)
-    pry-rails (0.3.9)
-      pry (>= 0.10.4)
     public_suffix (4.0.7)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -690,9 +684,6 @@ DEPENDENCIES
   pallets
   percy-capybara
   pg
-  pry
-  pry-byebug
-  pry-rails
   puma
   pundit
   rack-attack


### PR DESCRIPTION
This should remove a deprecation warning:

```
/Users/david/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/pry-byebug-3.8.0/lib/pry-byebug/control_d_handler.rb:5:
warning: control_d_handler's arity of 2 parameters was deprecated
(eval_string, pry_instance). Now it gets passed just 1 parameter
(pry_instance)
```

I don't know that it's possible to avoid that deprecation warning with currently available releases of the debugging gems being removed in this PR while using Ruby 3.

I believe that debugging capabilities have now been added to Ruby 3 (though maybe I'll have to add a gem to achieve that).