### PR TITLE
Remove `defer: true` option from chartkick charts for asset sizes

### DIFF
--- a/app/admin/asset_sizes.rb
+++ b/app/admin/asset_sizes.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register_page('Asset Sizes') do
 
     TrackAssetSizes.all_globs.each do |glob|
       h2(glob)
-      div(line_chart(RedisTimeseries[glob].to_h, defer: true))
+      div(line_chart(RedisTimeseries[glob].to_h))
     end
   end
 end


### PR DESCRIPTION
Fixes a deprecation warning:
```
[chartkick] The defer option is no longer needed and can be removed
```