### PR TITLE
Update faraday basic auth usage to address deprecation warning

### DIFF
--- a/lib/email/mailgun_via_http.rb
+++ b/lib/email/mailgun_via_http.rb
@@ -32,7 +32,7 @@ module Email
     def connection
       Faraday.new(ENV.fetch('MAILGUN_URL')) do |conn|
         conn.request(:url_encoded)
-        conn.basic_auth('api', ENV.fetch('MAILGUN_API_KEY'))
+        conn.request(:basic_auth, 'api', ENV.fetch('MAILGUN_API_KEY'))
       end
     end
   end


### PR DESCRIPTION
```
WARNING: `Faraday::Connection#basic_auth` is deprecated; it will be
removed in version 2.0. While initializing your connection, use
`#request(:basic_auth, ...)` instead. See
https://lostisland.github.io/faraday/middleware/authentication for more
usage info.
```