### PR TITLE
Add policy scope for logs

### DIFF
--- a/app/policies/log_policy.rb
+++ b/app/policies/log_policy.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class LogPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      @user.logs
+    end
+  end
+
   def show?
     own_record? || log.publicly_viewable? || LogShare.exists?(log: log, email: @user.email)
   end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe ApplicationPolicy do
 
   describe '#show?' do
     subject(:show?) { policy.show? }
-    specify { expect(show?).to eq(false) }
+    specify { expect(show?).to eq(true) }
   end
 
   describe '#create?' do
@@ -46,8 +46,8 @@ RSpec.describe ApplicationPolicy do
   describe '#scope' do
     subject(:scope) { policy.scope }
 
-    it 'returns an empty set of records' do
-      expect(scope).not_to exist
+    it 'returns the set of records that the user may access' do
+      expect(scope.order(:id)).to eq(user.logs.order(:id))
     end
   end
 end


### PR DESCRIPTION
This isn't actually used in the application code at this time, but I think it's a good idea to be consistent having a `Scope` for all policies and it makes the `ApplicationPolicy` spec read better.