### PR TITLE
Add `debug` gem to development environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,6 +66,7 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
+  gem 'debug', require: false
   gem 'http_logger'
   gem 'letter_opener'
   gem 'listen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,9 @@ GEM
     dalli (3.2.1)
     database_consistency (1.1.15)
       activerecord (>= 3.2)
+    debug (1.5.0)
+      irb (>= 1.3.6)
+      reline (>= 0.2.7)
     debug_inspector (1.1.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -298,6 +301,9 @@ GEM
       has_scope (~> 0.6)
       railties (>= 5.2, < 7.1)
       responders (>= 2, < 4)
+    io-console (0.5.11)
+    irb (1.4.1)
+      reline (>= 0.3.0)
     jmespath (1.6.1)
     jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
@@ -464,6 +470,8 @@ GEM
     redlock (1.2.2)
       redis (>= 3.0.0, < 5.0)
     regexp_parser (2.4.0)
+    reline (0.3.1)
+      io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
     request_store-sidekiq (0.1.0)
@@ -627,6 +635,7 @@ DEPENDENCIES
   connection_pool
   dalli
   database_consistency
+  debug
   devise
   dotenv-rails
   draper


### PR DESCRIPTION
We cannot add the gem to the test environment, because then the gem gets installed and required in CI (GitHub Actions) which causes the specs to hang when running a feature test that uses ActionCable (`spec/features/quizzes_spec.rb`). However, debugging can still be done when running tests locally by requiring the gem manually and setting a breakpoint (`require 'debug'; binding.break`).