### PR TITLE
Wait for devicon font to load in home page feature test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,6 +97,7 @@ group :test do
   gem 'rails-controller-testing', github: 'rails/rails-controller-testing'
   gem 'rspec-instafail', require: false
   gem 'rspec-rails'
+  gem 'rspec-wait'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'super_diff'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,6 +508,8 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.11.0)
+    rspec-wait (0.0.9)
+      rspec (>= 3, < 4)
     rubocop (1.29.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -686,6 +688,7 @@ DEPENDENCIES
   rollbar
   rspec-instafail
   rspec-rails
+  rspec-wait
   rubocop
   rubocop-performance
   rubocop-rails

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Home page', :prerendering_disabled do
       Full stack web developer
     HEADLINE
 
+    wait_for { page.execute_script('return document.fonts.check("65px devicon")') }.to eq(true)
+
     page.percy_snapshot('Homepage')
   end
 


### PR DESCRIPTION
Hopefully this will avoid the Percy flakiness that we are seeing caused by the fact that sometimes the font is not loaded.