### PR TITLE
Delete ignored dependency version lists from .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,10 +7,6 @@ updates:
     time: "03:52"
     timezone: America/Chicago
   open-pull-requests-limit: 20
-  ignore:
-  - dependency-name: codecov
-    versions:
-    - 0.5.1
 - package-ecosystem: npm
   directory: "/"
   schedule:
@@ -18,33 +14,3 @@ updates:
     time: "03:52"
     timezone: America/Chicago
   open-pull-requests-limit: 20
-  ignore:
-  - dependency-name: chart.js
-    versions:
-    - 3.0.2
-    - 3.1.0
-    - 3.1.1
-    - 3.2.0
-  - dependency-name: mini-css-extract-plugin
-    versions:
-    - 1.3.5
-    - 1.3.6
-    - 1.3.7
-    - 1.3.8
-    - 1.3.9
-    - 1.4.0
-    - 1.4.1
-    - 1.5.0
-  - dependency-name: "@babel/preset-env"
-    versions:
-    - 7.13.15
-  - dependency-name: vue-router
-    versions:
-    - 4.0.6
-  - dependency-name: postcss
-    versions:
-    - 8.2.6
-    - 8.2.7
-  - dependency-name: caniuse-lite
-    versions:
-    - 1.0.30001181


### PR DESCRIPTION
All of the libraries in question have now been updated past the versions in question, so there's not really any point in listing them out anymore.