### PR TITLE
Store asset size timeseries in Postgres rather than Redis

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,7 +18,7 @@ GIT
 
 GIT
   remote: https://github.com/davidrunger/runger_style.git
-  revision: 00ff382d60def6ec5e6b53e78476c85fcf59ba8c
+  revision: 90209072b14dfcaf701ec491ce9b3c0d5435454f
   specs:
     runger_style (0.2.22.alpha)
 

--- a/app/admin/asset_sizes.rb
+++ b/app/admin/asset_sizes.rb
@@ -8,7 +8,7 @@ ActiveAdmin.register_page('Asset Sizes') do
 
     TrackAssetSizes.all_globs.each do |glob|
       h2(glob)
-      div(line_chart(RedisTimeseries[glob].to_h))
+      div(line_chart(PostgresTimeseries[glob].to_h))
     end
   end
 end

--- a/app/models/timeseries.rb
+++ b/app/models/timeseries.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Timeseries < ApplicationRecord
+  validates :name, presence: true
+  validates :measurements, presence: true
+end

--- a/db/migrate/20220529020803_create_timeseries.rb
+++ b/db/migrate/20220529020803_create_timeseries.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateTimeseries < ActiveRecord::Migration[6.1]
+  def change
+    create_table :timeseries do |t|
+      t.text :name, null: false
+      t.json :measurements, null: false, default: []
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_22_231420) do
+ActiveRecord::Schema.define(version: 2022_05_29_020803) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -235,6 +235,13 @@ ActiveRecord::Schema.define(version: 2022_04_22_231420) do
     t.datetime "updated_at", null: false
     t.string "note"
     t.index ["log_id"], name: "index_text_log_entries_on_log_id"
+  end
+
+  create_table "timeseries", force: :cascade do |t|
+    t.text "name", null: false
+    t.json "measurements", default: [], null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/postgres_timeseries.rb
+++ b/lib/postgres_timeseries.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class PostgresTimeseries
+  class << self
+    def [](timeseries_name)
+      new(timeseries_name)
+    end
+  end
+
+  def initialize(timeseries_name)
+    @timeseries = Timeseries.find_or_initialize_by(name: timeseries_name)
+  end
+
+  def to_h
+    @timeseries.measurements.
+      to_h do |(time_as_float, value)|
+        [Time.at(time_as_float).in_time_zone, value]
+      end
+  end
+
+  def add(value)
+    measurements = @timeseries.measurements
+    measurements << [Time.current.to_f, value]
+    @timeseries.update!(measurements: measurements)
+  end
+end

--- a/spec/lib/postgres_timeseries_spec.rb
+++ b/spec/lib/postgres_timeseries_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe PostgresTimeseries do
+  subject(:timeseries) { PostgresTimeseries[timeseries_name] }
+
+  let(:timeseries_name) { 'test-timeseries' }
+
+  describe '#to_h' do
+    subject(:to_h) { timeseries.to_h }
+
+    context 'when a measurement has been recorded', :frozen_time do
+      before { timeseries.add(timeseries_sample_value) }
+
+      let(:timeseries_sample_value) { rand(100) }
+
+      it 'returns a hash in the form { Time => value }' do
+        expect(to_h).to eq({ Time.current => timeseries_sample_value })
+      end
+    end
+  end
+end


### PR DESCRIPTION
Storing them in Redis was using too much memory when reading the values
because the timestamps and values were stored as strings. By storing
them in a Postgres JSON array, we can leave them as integers and floats,
saving memory when reading the values. I think inserts will be a bit
slower and use more memory, but that's okay.