### PR TITLE
Remove N+1 query for `Timeseries` when viewing asset sizes in admin

### DIFF
--- a/app/admin/asset_sizes.rb
+++ b/app/admin/asset_sizes.rb
@@ -6,9 +6,9 @@ ActiveAdmin.register_page('Asset Sizes') do
   content do
     div(js_tag('charts'))
 
-    TrackAssetSizes.all_globs.each do |glob|
-      h2(glob)
-      div(line_chart(Timeseries[glob].to_h))
+    Timeseries.where(name: TrackAssetSizes.all_globs).each do |timeseries|
+      h2(timeseries.name)
+      div(line_chart(timeseries.to_h))
     end
   end
 end


### PR DESCRIPTION
It's not technically an "N+1" query, but whatever, you get the idea.