### PR TITLE
Use non-TLS Redis URL

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -14,4 +14,4 @@ test:
 production:
   <<: *default
   channel_prefix: david_runger_production
-  url: <%= Rails.application.credentials.redis&.dig(:tls_url) %>
+  url: <%= Rails.application.credentials.redis&.dig(:url) %>


### PR DESCRIPTION
The TLS Redis URL is causing errors. (We recently started using it.)