### PR TITLE
Remove HASHID_SALT from GitHub Actions ENV variables

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -64,7 +64,6 @@ jobs:
         NODE_ENV: test
         DISABLE_SPRING: 1
         SECRET_KEY_BASE: 0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b
-        HASHID_SALT: cdfb96ea-418c-4afd-b607-4960b35d5918
         # The hostname used to communicate with the PostgreSQL service container
         POSTGRES_HOST: 127.0.0.1
         POSTGRES_USER: postgres


### PR DESCRIPTION
We aren't using it anymore.