### PR TITLE
Check for EMERGENCY_DATABASE_URL env var before credentials

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -86,4 +86,4 @@ production:
   <<: *default
   database: david_runger_production
   # We need to check ENV['DATABASE_URL'] for Heroku review apps, which can't decrypt credentials
-  url: <%= Rails.application.credentials.postgres&.dig(:url) || ENV['DATABASE_URL'] %>
+  url: <%= ENV['EMERGENCY_DATABASE_URL'] || Rails.application.credentials.postgres&.dig(:url) || ENV['DATABASE_URL'] %>


### PR DESCRIPTION
This will be handy if Heroku again suddenly changes the database URL.