### PR TITLE
Add back postcss as a development dependency

### DIFF
--- a/bin/test/tasks/run_stylelint.rb
+++ b/bin/test/tasks/run_stylelint.rb
@@ -4,6 +4,8 @@ class Test::Tasks::RunStylelint < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    execute_system_command('./node_modules/.bin/stylelint app/**/*.{css,scss,vue} --max-warnings 0')
+    execute_system_command(
+      './node_modules/.bin/stylelint "app/**/*.{css,scss,vue}" --max-warnings 0',
+    )
   end
 end

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   },
   "devDependencies": {
     "@percy/cli": "^1.2.1",
+    "postcss": "^8.4.14",
     "postcss-html": "^1.4.1",
     "sass": "^1.52.3",
     "stylelint": "^14.8.5",


### PR DESCRIPTION
This fixes the stylelint check, which has been broken.