### PR TITLE
Delete `node_modules` as part of `assets:clean` rake task in prod

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -24,4 +24,8 @@ end
 
 if Rails.env.production?
   Rake::Task['assets:precompile'].enhance(%w[build_js_routes])
+
+  Rake::Task['assets:clean'].enhance do
+    FileUtils.remove_dir('node_modules', true)
+  end
 end


### PR DESCRIPTION
This will make the Heroku slug size smaller.