### PR TITLE
Remove `js-yaml` from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "eslint-plugin-vue": "^9.1.1",
     "fuzzyset.js": "^1.0.7",
     "gator": "^1.2.4",
-    "js-yaml": "^4.1.0",
     "keycode": "^2.2.1",
     "lodash": "^4.17.21",
     "marked": "^4.0.17",


### PR DESCRIPTION
It was included via `rails new` for webpacker and we don't need it now.