### PR TITLE
Remove `path-complete-extname` JS package

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lodash": "^4.17.21",
     "marked": "^4.0.17",
     "normalize.css": "^8.0.1",
-    "path-complete-extname": "^1.0.0",
     "pug": "^3.0.2",
     "pug-plain-loader": "^1.1.0",
     "resolve-url-loader": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3593,11 +3593,6 @@ parse-json@^5.0.0:
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
 
-path-complete-extname@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/path-complete-extname/-/path-complete-extname-1.0.0.tgz#f889985dc91000c815515c0bfed06c5acda0752b"
-  integrity sha512-CVjiWcMRdGU8ubs08YQVzhutOR5DEfO97ipRIlOGMK5Bek5nQySknBpuxVAVJ36hseTNs+vdIcv57ZrWxH7zvg==
-
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"


### PR DESCRIPTION
It was added via `rails new` for webpacker, which we no longer use.