### PR TITLE
Remove `script-loader` JS packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "marked": "^4.0.17",
     "normalize.css": "^8.0.1",
     "pug": "^3.0.2",
-    "script-loader": "^0.7.2",
     "strftime": "^0.10.1",
     "stylelint-config-standard-scss": "^4.0.0",
     "toastify-js": "^1.11.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3808,11 +3808,6 @@ quick-lru@^4.0.1:
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
-raw-loader@~0.5.1:
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-0.5.1.tgz#0c3d0beaed8a01c966d9787bf778281252a979aa"
-  integrity sha1-DD0L6u2KAclm2Xh793goElKpeao=
-
 read-pkg-up@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-7.0.1.tgz#f3a6135758459733ae2b95638056e1854e7ef507"
@@ -4012,13 +4007,6 @@ sass@^1.52.3:
     chokidar ">=3.0.0 <4.0.0"
     immutable "^4.0.0"
     source-map-js ">=0.6.2 <2.0.0"
-
-script-loader@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/script-loader/-/script-loader-0.7.2.tgz#2016db6f86f25f5cf56da38915d83378bb166ba7"
-  integrity sha512-UMNLEvgOAQuzK8ji8qIscM3GIrRCWN6MmMXGD4SD5l6cSycgGsCo0tX5xRnfQcoghqct0tjHjcykgI1PyBE2aA==
-  dependencies:
-    raw-loader "~0.5.1"
 
 select@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
`script-loader` was added in "Get js-routes working with tests" (15f65d7) and is no longer needed now that we aren't running JS tests anymore and aren't using webpack(er) anymore.