### PR TITLE
Move `stylelint-config-standard-scss` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "normalize.css": "^8.0.1",
     "pug": "^3.0.2",
     "strftime": "^0.10.1",
-    "stylelint-config-standard-scss": "^4.0.0",
     "toastify-js": "^1.11.2",
     "unplugin-element-plus": "^0.4.0",
     "vite": "^2.9.12",
@@ -69,6 +68,7 @@
     "sass": "^1.52.3",
     "stylelint": "^14.9.1",
     "stylelint-config-standard": "^25.0.0",
+    "stylelint-config-standard-scss": "^4.0.0",
     "stylelint-scss": "^4.2.0"
   }
 }


### PR DESCRIPTION
It probably should have been there all along.