### PR TITLE
Move `sign_in` call to within `wait_for` block in quiz feature spec

### DIFF
--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -32,8 +32,8 @@ RSpec.describe 'Quizzes app' do
 
       # a participant joins
       Capybara.using_session('Quiz participant session') do
-        sign_in(participant)
         wait_for do
+          sign_in(participant)
           visit(quiz_path)
           page.has_css?('input#display_name')
         end.to eq(true)


### PR DESCRIPTION
This test is still flaking and the screenshot of the failure shows the login page. Hopefully this will end the flakiness.