### PR TITLE
Allow yarn version 1.22.18 or 1.22.19

### DIFF
--- a/bin/test/tasks/check_versions.rb
+++ b/bin/test/tasks/check_versions.rb
@@ -11,7 +11,7 @@ class Test::Tasks::CheckVersions < Pallets::Task
       node --version && [ "$(node --version)" = 'v16.13.0' ]
     COMMAND
     execute_system_command(<<~COMMAND)
-      yarn --version && [ "$(yarn --version)" = '1.22.19' ]
+      yarn --version && ([ "$(yarn --version)" = '1.22.18' ] || [ "$(yarn --version)" = '1.22.19' ])
     COMMAND
   end
 end

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "engines": {
     "node": "16.13.0",
-    "yarn": "1.22.19"
+    "yarn": "1.22.x"
   },
   "browserslist": [
     ">10%"


### PR DESCRIPTION
GitHub Actions sometimes runs with one or the other. Heroku doesn't offer 1.22.19 yet but probably will soon.