### PR TITLE
Check for EMERGENCY_REDIS_TLS_URL env var

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -17,4 +17,4 @@ production:
   ssl_params:
     verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>
   # We'll check ENV['REDIS_TLS_URL'] for Heroku review apps, which can't decrypt credentials
-  url: <%= Rails.application.credentials.redis&.dig(:tls_url) || ENV['REDIS_TLS_URL'] %>
+  url: <%= RedisOptions.production_redis_url %>

--- a/lib/redis_options.rb
+++ b/lib/redis_options.rb
@@ -5,9 +5,15 @@ module RedisOptions
     url_base =
       case Rails.env
       when 'development', 'test' then 'redis://localhost:6379'
-      # check the ENV var for Heroku review app deployments (since they cannot decode credentials)
-      else Rails.application.credentials.redis&.fetch(:tls_url) || ENV.fetch('REDIS_TLS_URL')
+      else production_redis_url
       end
     { url: "#{url_base}/#{db}", ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
+  end
+
+  def self.production_redis_url
+    ENV.fetch('EMERGENCY_REDIS_TLS_URL', nil) ||
+      Rails.application.credentials.redis&.fetch(:tls_url) ||
+      # check the ENV var for Heroku review app deployments (since they cannot decode credentials)
+      ENV.fetch('REDIS_TLS_URL', nil)
   end
 end


### PR DESCRIPTION
This will be handy in case the Redis TLS URL changes without advance warning and we need to quickly override it.