### PR TITLE
Use ENV vars (not encrypted credentials) for Redis and Postgres

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -16,5 +16,4 @@ production:
   channel_prefix: david_runger_production
   ssl_params:
     verify_mode: <%= OpenSSL::SSL::VERIFY_NONE %>
-  # We'll check ENV['REDIS_TLS_URL'] for Heroku review apps, which can't decrypt credentials
-  url: <%= RedisOptions.production_redis_url %>
+  url: <%= ENV.fetch('REDIS_TLS_URL', nil) %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -85,5 +85,4 @@ test:
 production:
   <<: *default
   database: david_runger_production
-  # We need to check ENV['DATABASE_URL'] for Heroku review apps, which can't decrypt credentials
-  url: <%= ENV['EMERGENCY_DATABASE_URL'] || Rails.application.credentials.postgres&.dig(:url) || ENV['DATABASE_URL'] %>
+  url: <%= ENV.fetch('DATABASE_URL', nil) %>

--- a/lib/redis_options.rb
+++ b/lib/redis_options.rb
@@ -5,15 +5,8 @@ module RedisOptions
     url_base =
       case Rails.env
       when 'development', 'test' then 'redis://localhost:6379'
-      else production_redis_url
+      else ENV.fetch('REDIS_TLS_URL')
       end
     { url: "#{url_base}/#{db}", ssl_params: { verify_mode: OpenSSL::SSL::VERIFY_NONE } }
-  end
-
-  def self.production_redis_url
-    ENV.fetch('EMERGENCY_REDIS_TLS_URL', nil) ||
-      Rails.application.credentials.redis&.fetch(:tls_url) ||
-      # check the ENV var for Heroku review app deployments (since they cannot decode credentials)
-      ENV.fetch('REDIS_TLS_URL', nil)
   end
 end

--- a/spec/lib/redis_options_spec.rb
+++ b/spec/lib/redis_options_spec.rb
@@ -20,11 +20,9 @@ RSpec.describe RedisOptions do
       context 'when Redis credentials are present' do
         let(:tls_url) { 'rediss://:p4ssw0rd@10.0.1.1:6380' }
 
-        before do
-          expect(Rails.application.credentials).to receive(:redis).and_return(tls_url: tls_url)
-        end
+        around { |spec| ClimateControl.modify(REDIS_TLS_URL: tls_url) { spec.run } }
 
-        it 'returns the redis.tls_url from the Rails credentials' do
+        it 'uses the Redis TLS url' do
           expect(options[:url]).to eq("#{tls_url}/#{db_number}")
         end
       end


### PR DESCRIPTION
Heroku changes the values of these ENV vars sometimes. We need our app to be able to pick up those changes immediately.