### PR TITLE
Have HTML controller tests depend on (wait for) feature tests

### DIFF
--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -34,6 +34,7 @@ class Test::RequirementsResolver
         Test::Tasks::RunHtmlControllerTests => [
           Test::Tasks::CreateDbCopies,
           Test::Tasks::CompileJavaScript,
+          Test::Tasks::RunFeatureTests, # hack to get feature tests (checked by Percy) to run first
         ],
         Test::Tasks::RunFeatureTests => [
           Test::Tasks::CreateDbCopies,


### PR DESCRIPTION
The HTML controller tests don't actually need the feature tests to run first. We are doing this simply so that the feature tests will run first. This is desirable because the feature tests include Percy checks, which take time, so it's better to start the feature tests sooner rather than later.