### PR TITLE
Upgrade from heroku-20 to heroku-22 stack

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,5 +1,5 @@
 {
-  "stack": "heroku-20",
+  "stack": "heroku-22",
   "environments": {
     "review": {
       "addons": [


### PR DESCRIPTION
Specify heroku-22 stack in app.json for review apps and trigger a build that will bump production to heroku-22 (after `heroku stack:set heroku-22 -a davidrunger`).