### PR TITLE
Don't have RunHtmlControllerTests depend on RunFeatureTests

### DIFF
--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -34,7 +34,6 @@ class Test::RequirementsResolver
         Test::Tasks::RunHtmlControllerTests => [
           Test::Tasks::CreateDbCopies,
           Test::Tasks::CompileJavaScript,
-          Test::Tasks::RunFeatureTests, # hack to get feature tests (checked by Percy) to run first
         ],
         Test::Tasks::RunFeatureTests => [
           Test::Tasks::CreateDbCopies,


### PR DESCRIPTION
This hack was stupid. The intent was to get RunFeatureTests to run first. However, in addition to doing that, this hack requires that RunFeatureTests *completes* before we start the HTML tests. This decreases parallelism and probably isn't worth it.