### PR TITLE
Run feature tests before HTML tests (by listing feature tests first)

### DIFF
--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -31,14 +31,14 @@ class Test::RequirementsResolver
         Test::Tasks::RunRubocop => nil,
         Test::Tasks::RunUnitTests => Test::Tasks::CreateDbCopies,
         Test::Tasks::RunApiControllerTests => Test::Tasks::CreateDbCopies,
-        Test::Tasks::RunHtmlControllerTests => [
-          Test::Tasks::CreateDbCopies,
-          Test::Tasks::CompileJavaScript,
-        ],
         Test::Tasks::RunFeatureTests => [
           Test::Tasks::CreateDbCopies,
           Test::Tasks::CompileJavaScript,
           Test::Tasks::EnsureLatestChromedriver,
+        ],
+        Test::Tasks::RunHtmlControllerTests => [
+          Test::Tasks::CreateDbCopies,
+          Test::Tasks::CompileJavaScript,
         ],
 
         # Exit depends on all tasks completing that are actual checks (as opposed to setup steps)


### PR DESCRIPTION
This is desirable because we want the Percy screenshot check(s), which are based off of the feature tests, to run as early as possible.

I'm not sure if this works, but, based on a couple of experiments, it seems that it might.