### PR TITLE
Remove `server.hmr.port: 443` option from Vite config

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,9 +17,4 @@ export default defineConfig({
       'css': path.resolve(__dirname, './app/assets/stylesheets'),
     },
   },
-  server: {
-    hmr: {
-      port: 443,
-    },
-  },
 })


### PR DESCRIPTION
This was previously needed for HMR on an iPhone. With Vite 3, it seems to break things.