### PR TITLE
Bump omniauth-google-oauth2 from 1.1.0 to 1.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,7 +403,7 @@ GEM
       hashie (>= 3.4.6)
       rack (>= 2.2.3)
       rack-protection
-    omniauth-google-oauth2 (1.1.0)
+    omniauth-google-oauth2 (1.1.1)
       jwt (>= 2.0)
       oauth2 (~> 2.0.6)
       omniauth (~> 2.0)


### PR DESCRIPTION
This fixes a bug that is breaking Google OAuth login.