### PR TITLE
Remove `sleep 60` before prerendering

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -100,8 +100,6 @@ jobs:
           git_remote_url: 'ssh://dokku@198.199.122.6:22/davidrunger'
           ssh_private_key: ${{secrets.SSH_PRIVATE_KEY}}
 
-      - run: sleep 60 # give some time for the new release to boot up
-
       - name: Set up Ruby 3.1.2
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
Since Dokku checks that the new app is ready before swapping it in, this is no longer necessary. 🎉