### PR TITLE
Update devicon URL

### DIFF
--- a/app/views/home/index.haml
+++ b/app/views/home/index.haml
@@ -1,6 +1,6 @@
 - content_for(:extra_css) do
   -# always load `devicons` (in a nonblocking way (https://web.dev/defer-non-critical-css/))
-  - devicon_href = 'https://cdn.rawgit.com/konpa/devicon/df6431e323547add1b4cf45992913f15286456d3/devicon.min.css'
+  - devicon_href = 'https://cdn.jsdelivr.net/gh/konpa/devicon@df6431e323547add1b4cf45992913f15286456d3/devicon.min.css'
   %link{rel: "preload", href: devicon_href, as: "style", onload: "this.onload=null;this.rel='stylesheet'"}
   %noscript
     %link{rel: "stylesheet", href: devicon_href}


### PR DESCRIPTION
The old cdn.rawgit.com URL redirects to cdn.jsdelivr.net, so let's just go there directly instead (faster).