### PR TITLE
Increase TruncateTables::max_allowed_rows from 800 to 10,000

### DIFF
--- a/app/workers/truncate_tables.rb
+++ b/app/workers/truncate_tables.rb
@@ -10,7 +10,7 @@ class TruncateTables
   SQL
 
   def self.max_allowed_rows
-    Integer(ENV.fetch('MAX_TABLE_ROWS', 800))
+    Integer(ENV.fetch('MAX_TABLE_ROWS', 10_000))
   end
 
   def self.print_row_counts

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -10,12 +10,12 @@
 
 :schedule:
   InvalidRecordsCheck::Launcher:
-    cron: '23 8 * * *' # daily at 8:23am PT
+    cron: '23 8 * * *' # daily at 8:23am CT
   <% if %w[production test].include?(ENV['RAILS_ENV']) %>
   DataMonitors::Launcher:
     cron: '4-59/5 * * * *' # every 5 minutes (offset by 4 minutes)
   SendLogReminderEmails:
     cron: '* * * * *' # every minute
   TruncateTables:
-    cron: '33 * * * *' # hourly at 33 minutes after
+    cron: '58 4 * * *' # daily at 4:58am CT
   <% end %>


### PR DESCRIPTION
Now that we are on DigitalOcean/Dokku, we don't have to worry about limiting the number of rows in our DB nearly as much.