### PR TITLE
Run DataMonitors::Launcher hourly rather than every 5 minutes

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -13,7 +13,7 @@
     cron: '23 8 * * *' # daily at 8:23am CT
   <% if %w[production test].include?(ENV['RAILS_ENV']) %>
   DataMonitors::Launcher:
-    cron: '4-59/5 * * * *' # every 5 minutes (offset by 4 minutes)
+    cron: '7 * * * *' # hourly at 7 minutes after
   SendLogReminderEmails:
     cron: '* * * * *' # every minute
   TruncateTables:


### PR DESCRIPTION
This will produce less log clutter while still providing adequately frequent execution of the DataMonitors.