### PR TITLE
Don't reverse ordering of logs after editing one

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -30,7 +30,7 @@ export default {
         logEntriesToShow = this.log_entries.slice(this.log_entries.length - 3);
       }
 
-      return logEntriesToShow.reverse();
+      return logEntriesToShow.slice().reverse();
     },
   },
 


### PR DESCRIPTION
This fixes a bug introduced in 2398cb6 (#1690).