### PR TITLE
Move gitleaks check from pre-commit to pre-push

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,7 @@
-pre-commit:
+pre-push:
   commands:
     gitleaks:
-      run: gitleaks protect --staged --verbose &> /dev/null
+      run: gitleaks detect --log-opts="master...HEAD" --verbose &> /dev/null
 
 skip_output:
   - meta


### PR DESCRIPTION
This will make committing faster while still protecting our secrets.