### PR TITLE
Add error handling for reading email bodies

### DIFF
--- a/app/mailboxes/replies_mailbox.rb
+++ b/app/mailboxes/replies_mailbox.rb
@@ -6,7 +6,18 @@ class RepliesMailbox < ApplicationMailbox
   def process
     from_email = mail['From'].to_s.presence!
     subject = mail.subject.presence || '[no subject]'
-    body = mail.parsed_body || '[no body]'
+    body =
+      begin
+        mail.parsed_body || '[no body]'
+      rescue => error
+        Rollbar.error(
+          error,
+          from_email:,
+          subject:,
+          body: ((mail.text_part.presence || mail.body).to_s.dup rescue '[error reading raw body]'),
+        )
+        '[error reading parsed body]'
+      end
 
     ReplyForwardingMailer.reply_received(from_email, subject, body).deliver_later
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,7 +68,7 @@ class DavidRunger::Application < Rails::Application
   ENV['FIXTURES_PATH'] = 'spec/fixtures'
 
   # Time until incoming mail incineration. Default is 30 days, but we don't need that long.
-  config.action_mailbox.incinerate_after = 1.minute
+  config.action_mailbox.incinerate_after = 1.week
 
   # https://github.com/hotwired/turbo-rails/blob/9d53529/README.md#compatibility-with-rails-ujs
   config.action_view.form_with_generates_remote_forms = false

--- a/spec/mailboxes/replies_mailbox_spec.rb
+++ b/spec/mailboxes/replies_mailbox_spec.rb
@@ -28,5 +28,29 @@ RSpec.describe RepliesMailbox do
       expect { processed_mail }.to enqueue_mail(ReplyForwardingMailer, :reply_received).
         with(from_email, email_subject, email_body)
     end
+
+    context 'when an error is raised while parsing the email body' do
+      before do
+        expect(EmailReplyTrimmer).
+          to receive(:trim).
+          and_raise(ArgumentError, 'invalid byte sequence in UTF-8')
+      end
+
+      it 'sends an error to Rollbar' do
+        expect(Rollbar).to receive(:error).with(
+          instance_of(ArgumentError),
+          from_email:,
+          subject: email_subject,
+          body: email_body,
+        ).and_call_original
+
+        processed_mail
+      end
+
+      it 'sends the email with a body indicating an error occurred', queue_adapter: :test do
+        expect { processed_mail }.to enqueue_mail(ReplyForwardingMailer, :reply_received).
+          with(from_email, email_subject, '[error reading parsed body]')
+      end
+    end
   end
 end


### PR DESCRIPTION
This should help us to understand errors like https://rollbar.com/davidjrunger/davidrunger/items/491/ .

Also, increase mail incinerate_after time to help with debugging.