### PR TITLE
Configure nginx to forward `$host` for Host header (not `$http_host`)

### DIFF
--- a/nginx.conf.sigil
+++ b/nginx.conf.sigil
@@ -35,7 +35,7 @@ server {
     proxy_busy_buffers_size {{ $.PROXY_BUSY_BUFFERS_SIZE }};
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For {{ $.PROXY_X_FORWARDED_FOR }};
     proxy_set_header X-Forwarded-Port {{ $.PROXY_X_FORWARDED_PORT }};
     proxy_set_header X-Forwarded-Proto {{ $.PROXY_X_FORWARDED_PROTO }};
@@ -101,7 +101,7 @@ server {
     proxy_busy_buffers_size {{ $.PROXY_BUSY_BUFFERS_SIZE }};
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $http_connection;
-    proxy_set_header Host $http_host;
+    proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For {{ $.PROXY_X_FORWARDED_FOR }};
     proxy_set_header X-Forwarded-Port {{ $.PROXY_X_FORWARDED_PORT }};
     proxy_set_header X-Forwarded-Proto {{ $.PROXY_X_FORWARDED_PROTO }};


### PR DESCRIPTION
This should (I think) prevent host spoofing.