### PR TITLE
Set `frame-ancestors` to `self` in Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,6 +16,7 @@ Rails.application.configure do
     policy.object_src(:none)
     policy.script_src(:self, *extra_sources)
     policy.style_src(:self, :https, :unsafe_inline, *extra_sources)
+    policy.frame_ancestors(:self)
     # Specify URI for violation reports
     # policy.report_uri "/csp-violation-report-endpoint"
   end


### PR DESCRIPTION
We don't actually even need `self` (could be `none`), but this has the advantage of being consistent with the `X-Frame-Options: SAMEORIGIN` header that is being set (I think) by Rails elsewhere.