### PR TITLE
Add `extra_sources` to Content Security Policy `connect-src`

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
 
     policy.default_src(:none)
     policy.base_uri(:self)
-    policy.connect_src(:self)
+    policy.connect_src(:self, *extra_sources)
     policy.form_action(:self)
     policy.font_src(:self, :https, :data, *extra_sources)
     policy.img_src(:self, :https, :data, *extra_sources)


### PR DESCRIPTION
Without this, we get errors in development mode with live vite.