### PR TITLE
Allow overriding AWS credentials with ENV variables

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -3,8 +3,10 @@
 # rubocop:disable Rails/SaveBang
 Aws.config.update(
   credentials: Aws::Credentials.new(
-    Rails.application.credentials.aws&.dig(:access_key_id),
-    Rails.application.credentials.aws&.dig(:secret_access_key),
+    ENV['AWS_ACCESS_KEY_ID'].presence ||
+      Rails.application.credentials.aws&.dig(:access_key_id),
+    ENV['AWS_SECRET_ACCESS_KEY'].presence ||
+      Rails.application.credentials.aws&.dig(:secret_access_key),
   ),
 )
 # rubocop:enable Rails/SaveBang


### PR DESCRIPTION
This makes it easy temporarilly to use AWS credentials locally via `.env` file.