### PR TITLE
Run `bin/vite build` after `assets:precompile` rake task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,11 +6,3 @@
 require_relative 'config/application'
 
 Rails.application.load_tasks
-
-if Rails.env.production?
-  # https://github.com/heroku/heroku-buildpack-ruby/pull/892#issuecomment-548897899
-  assets_precompile_task = Rake.application.tasks.find { |task| task.name == 'assets:precompile' }
-  if assets_precompile_task.present?
-    assets_precompile_task.prerequisites.delete('yarn:install')
-  end
-end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -24,17 +24,18 @@ namespace :assets do
   end
 end
 
-if Rails.env.production?
-  Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
-    system(
-      {
-        'VITE_RUBY_ENTRYPOINTS_DIR' => 'admin_packs',
-        'VITE_RUBY_PUBLIC_OUTPUT_DIR' => 'vite-admin',
-      },
-      'bin/vite build --force',
-    )
-  end
+Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
+  system('bin/vite build --force')
+  system(
+    {
+      'VITE_RUBY_ENTRYPOINTS_DIR' => 'admin_packs',
+      'VITE_RUBY_PUBLIC_OUTPUT_DIR' => 'vite-admin',
+    },
+    'bin/vite build --force',
+  )
+end
 
+if Rails.env.production?
   Rake::Task['assets:clean'].enhance do
     FileUtils.remove_dir('node_modules', true)
   end


### PR DESCRIPTION
Having just set `VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true` on dokku, we now need to ourselves enhance the `assets:precompile` rake task to build our JavaScript bundles (now including the main app bundles in addition to the admin bundles).