### PR TITLE
Add `request_id` to headers in controller tests

### DIFF
--- a/spec/config/initializers/request_logging_spec.rb
+++ b/spec/config/initializers/request_logging_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+RSpec.describe 'request logging', type: :controller do
+  describe HomeController do
+    context 'when request_id somehow is not set' do
+      before do
+        # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(ActionController::TestRequest).
+          to receive(:headers).
+          and_wrap_original do |request|
+            headers = request.call
+            headers['action_dispatch.request_id'] = nil
+            headers
+          end
+        # rubocop:enable RSpec/AnyInstance
+      end
+
+      it 'sends a warning to Rollbar' do
+        expect(Rollbar).
+          to receive(:warn).
+          with(Request::CreateRequestError, { request_id: nil }).
+          and_call_original
+
+        get(:upgrade_browser)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -224,6 +224,14 @@ RSpec.configure do |config|
     allow_any_instance_of(ActionController::TestRequest).
       to receive(:request_id).
       and_return(SecureRandom.uuid)
+
+    allow_any_instance_of(ActionController::TestRequest).
+      to receive(:headers).
+      and_wrap_original do |request|
+        headers = request.call
+        headers['action_dispatch.request_id'] ||= SecureRandom.uuid
+        headers
+      end
     # rubocop:enable RSpec/AnyInstance
   end
 


### PR DESCRIPTION
This saves "Request UUID for request logging was blank" from being logged when running specs.