### PR TITLE
Enable `Sidekiq.strict_args!`

### DIFF
--- a/app/controllers/logs/uploads_controller.rb
+++ b/app/controllers/logs/uploads_controller.rb
@@ -21,7 +21,7 @@ class Logs::UploadsController < ApplicationController
 
     if log_entries.all?(&:valid?)
       log_entries.each do |log_entry|
-        CreateLogEntry.perform_async(log_entry.class.name, log_entry.attributes)
+        CreateLogEntry.perform_async(log_entry.class.name, log_entry.attributes.as_json)
       end
       flash[:notice] = 'Data uploaded successfully! Give it a moment to enter the database.'
       redirect_to(log_path(slug: log.slug))

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -2,6 +2,8 @@
 
 require 'sidekiq-scheduler' if Sidekiq.server?
 
+Sidekiq.strict_args!
+
 # We'll give Sidekiq db 1. The app uses db 0 for its direct uses.
 redis_options = RedisOptions.new(db: 1)
 build_sidekiq_redis_connection =


### PR DESCRIPTION
Addresses this warning: "Job arguments to CreateLogEntry do not serialize to JSON safely. This will raise an error in Sidekiq 7.0. See https://github.com/mperham/sidekiq/wiki/Best-Practices or raise an error today by calling `Sidekiq.strict_args!` during Sidekiq initialization."