### PR TITLE
Add `export` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ spec/fixtures/*.yml
 coverage/
 .tests.yml
 *.dump*
+export
 /public/vite
 /public/vite-admin
 /config/credentials/development.key


### PR DESCRIPTION
This is the name of our database dumps. We want to never commit them.
