### PR TITLE
Don't specify Sidekiq config file

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
 web: bin/rails server -p $PORT -e $RAILS_ENV
-worker: bin/sidekiq --config config/sidekiq.yml
+worker: bin/sidekiq
 release: bin/release-tasks


### PR DESCRIPTION
Sidekiq should default to reading the config file at `config/sidekiq.yml.`
