### PR TITLE
Extract `CspDisableable` controller concern and add to a controller

### DIFF
--- a/app/controllers/concerns/csp_disableable.rb
+++ b/app/controllers/concerns/csp_disableable.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module CspDisableable
+  extend ActiveSupport::Concern
+
+  included do
+    # (somewhat unsafe) workarounds until https://github.com/hotwired/turbo/issues/ 294 is resolved
+    before_action :dont_set_csp_nonce
+    content_security_policy do |policy|
+      policy.script_src(:self, :https, :unsafe_inline)
+    end
+  end
+
+  private
+
+  def dont_set_csp_nonce
+    request.env['action_dispatch.content_security_policy_nonce_directives'] = []
+  end
+end

--- a/app/controllers/question_uploads_controller.rb
+++ b/app/controllers/question_uploads_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class QuestionUploadsController < ApplicationController
+  include CspDisableable
+
   before_action :set_quiz, only: %i[new create]
 
   self.container_classes = QuizzesController.container_classes

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -2,16 +2,11 @@
 
 class QuizzesController < ApplicationController
   extend Memoist
+  include CspDisableable
 
   self.container_classes = %w[py1 px3]
 
   before_action :set_quiz, only: %i[respondents leaderboard progress]
-
-  # workarounds until https://github.com/hotwired/turbo/issues/ 294 is resolved
-  before_action :dont_set_csp_nonce
-  content_security_policy do |policy|
-    policy.script_src(:self, :https, :unsafe_inline)
-  end
 
   def index
     authorize(Quiz, :index?)
@@ -63,10 +58,6 @@ class QuizzesController < ApplicationController
   end
 
   private
-
-  def dont_set_csp_nonce
-    request.env['action_dispatch.content_security_policy_nonce_directives'] = []
-  end
 
   def set_quiz
     quiz =


### PR DESCRIPTION
This fixes a CSP problem that would occur if the user:
1. went to the add new quiz questions page
2. refreshed the page
3. submitted new question(s) (which goes back to the quiz show page)