### PR TITLE
Change `Turbo.clearCache()` to `Turbo.cache.clear()`

### DIFF
--- a/app/javascript/packs/quizzes.js
+++ b/app/javascript/packs/quizzes.js
@@ -40,7 +40,7 @@ actionCableConsumer.subscriptions.create(
 );
 
 function refresh() {
-  Turbo.clearCache();
+  Turbo.cache.clear();
   Turbo.visit(window.location.pathname, { action: 'replace' });
 }
 


### PR DESCRIPTION
This addresses a deprecation warning.