### PR TITLE
Remove an unnecessary eslint `max-len` disablement

### DIFF
--- a/app/javascript/check_in_ratings/app.vue
+++ b/app/javascript/check_in_ratings/app.vue
@@ -1,4 +1,3 @@
-<!-- eslint-disable max-len -->
 <template lang='pug'>
 h2 Your answers
 Ratings(


### PR DESCRIPTION
The problematic long line has been moved to `ratings.vue`.