### PR TITLE
Remove `data-disable-with` attributes (which don't work with Turbo)

### DIFF
--- a/app/views/quiz_questions/_participant_view.html.haml
+++ b/app/views/quiz_questions/_participant_view.html.haml
@@ -5,6 +5,5 @@
       = form.radio_button :answer_id, answer.id
       = form.label :answer_id, "#{(index + 65).chr}. #{answer.content}", value: answer.id
   - already_answered = @quiz.current_question_current_user_answer_selection.persisted?
-  = form.submit(already_answered ? 'Update' : 'Submit',
-    data: { disable_with: already_answered ? 'Updating...' : 'Submitting...' })
+  = form.submit(already_answered ? 'Update' : 'Submit')
 


### PR DESCRIPTION
As discussed here https://github.com/hotwired/turbo/pull/ 384 , it has been decided not to support `data-disable-with` text in Turbo. Instead (as implemented in https://github.com/hotwired/turbo/pull/ 386 ), the button will automatically be disabled, but its text won't be changed.