### PR TITLE
Whitelist paths starting with `/sidekiq/` in Rack::Attack

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -29,6 +29,7 @@ class Rack::Attack
 
     def blocked_path?(request)
       return true if request.fullpath.include?('%00')
+      return false if request.fullpath.start_with?('/sidekiq/')
 
       fragments = request.path.split(PATH_FRAGMENT_SEPARATOR_REGEX)
       fragments.map!(&:presence)


### PR DESCRIPTION
Since `Rails.application.routes` doesn't know about the Sidekiq routes, some requests for Sidekiq routes/assets that include a BannedPathFragment were being blocked. This stops that.