### PR TITLE
Add back `pry-byebug` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,6 +58,7 @@ group :development, :test do
   gem 'debug', require: false
   gem 'dotenv-rails', require: 'dotenv/rails-now'
   gem 'immigrant'
+  gem 'pry-byebug', require: false
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -149,6 +149,7 @@ GEM
     bullet (7.0.3)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
+    byebug (11.1.3)
     capybara (3.37.1)
       addressable
       matrix
@@ -382,6 +383,12 @@ GEM
     percy-capybara (5.0.0)
       capybara (>= 3)
     pg (1.4.3)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     public_suffix (5.0.0)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -643,6 +650,7 @@ DEPENDENCIES
   pallets
   percy-capybara
   pg
+  pry-byebug
   puma
   pundit
   rack-attack


### PR DESCRIPTION
We removed this gem in f8f3037 / #1232 because it was printing a deprecation warning. I think that has since been fixed. I'm adding this gem back to the development and test bundle groups because I think it has different/better debugging behaviour sometimes in multi-threaded environments (e.g. in capybara specs when we need the server thread to be executed so we can navigate to new pages and make API requests, see https://github.com/deivid-rodriguez/pry-byebug/pull/ 142 ).