### PR TITLE
Use :back link_to helper and only show if referrer is present

### DIFF
--- a/app/views/emotional_needs/history.html.haml
+++ b/app/views/emotional_needs/history.html.haml
@@ -1,7 +1,8 @@
 - content_for(:page_assets) do
   = js_tag('charts')
 
-%a{href: 'javascript:history.back()'} Go back
+- if request.referrer.present?
+  = link_to 'Go back', :back
 
 %h1.center= @emotional_need.name
 

--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -112,12 +112,16 @@ RSpec.describe 'Check-Ins app' do
             /Their answers #{first_emotional_need.name}igraph -3😞-10123/,
           )
 
-          # links to graph of ratings of partner
+          # check for link(s) to graph of ratings of partner
           expect(page).to have_link(
             'graph',
             href: history_emotional_need_path(first_emotional_need, rated_user: 'partner'),
           )
-          # links to graph of partner's ratings of user
+          # view a graph
+          first('a', text: 'graph').click
+          # go back
+          click_link('Go back')
+          # check for link(s) to graph of partner's ratings of user
           expect(page).to have_link(
             'graph',
             href: history_emotional_need_path(first_emotional_need, rated_user: 'self'),


### PR DESCRIPTION
`javascript:history.back()` stopped working because it's inline JavaScript, which violates our Content Security Policy (CSP). The `:back` `link_to` helper uses the referrer as the link content if a referrer is present, thus avoiding this CSP issue.