### PR TITLE
Add http://localhost:3036 to permitted extra_sources in development

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -13,7 +13,8 @@ Rails.application.configure do
       # :nocov:
       extra_sources << 'https://davidrunger.com' # allow assets from production for local prerenders
       if !ENV.key?('PRODUCTION_ASSET_CONFIG')
-        extra_sources << 'ws:' # for vite live reloading websockets server
+        extra_sources << 'ws://localhost:3036' # vite live reloading websockets server
+        extra_sources << 'http://localhost:3036' # vite asset server
       end
       # :nocov:
     end


### PR DESCRIPTION
This is used by Vite (to check for a connection after the vite dev server has been shut down?).