### PR TITLE
Stop using verbose Logger::Formatter to format production Rails logs

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -90,7 +90,7 @@ Rails.application.configure do
   config.active_support.report_deprecations = false
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  # config.log_formatter = ::Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require "syslog/logger"


### PR DESCRIPTION
Production will now use `ActiveSupport::Logger::SimpleFormatter` (which is the default).