### PR TITLE
Add accounts.google.com to CSP form-action sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,6 +99,7 @@ group :test do
   gem 'rspec-instafail', require: false
   gem 'rspec-rails', '>= 6.0.0.rc1'
   gem 'rspec-wait'
+  gem 'selenium-devtools'
   gem 'selenium-webdriver'
   gem 'shoulda-matchers'
   gem 'super_diff'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -515,6 +515,8 @@ GEM
       nokogiri (>= 1.12.0)
     sassc (2.4.0)
       ffi (~> 1.9)
+    selenium-devtools (0.106.0)
+      selenium-webdriver (~> 4.2)
     selenium-webdriver (4.5.0)
       childprocess (>= 0.5, < 5.0)
       rexml (~> 3.2, >= 3.2.5)
@@ -671,6 +673,7 @@ DEPENDENCIES
   rubocop-rspec
   runger_style!
   sassc
+  selenium-devtools
   selenium-webdriver
   shoulda-matchers
   sidekiq (>= 7.0.0.beta1)

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
     policy.base_uri(:self)
     policy.connect_src(:self, *extra_sources)
     policy.manifest_src(:self, *extra_sources)
-    policy.form_action(:self)
+    policy.form_action(:self, 'https://accounts.google.com')
     policy.font_src(:self, :https, :data, *extra_sources)
     policy.img_src(:self, :https, :data, *extra_sources)
     policy.object_src(:none)

--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -1,37 +1,80 @@
 # frozen_string_literal: true
 
 RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
-  before { MockOmniAuth.google_oauth2(email: stubbed_user_email) }
+  context 'when OmniAuth test mode is enabled and OmniAuth is mocked' do
+    before do
+      expect(OmniAuth.config.test_mode).to eq(true)
+      MockOmniAuth.google_oauth2(email: stubbed_user_email)
+    end
 
-  context 'when the user already exists in the database' do
-    let(:stubbed_user_email) { user.email }
-    let(:user) { users(:user) }
+    context 'when the user already exists in the database' do
+      let(:stubbed_user_email) { user.email }
+      let(:user) { users(:user) }
 
-    it 'allows a user to log in with Google' do
-      visit(login_path)
-      expect(page).to have_css('button.google-login')
+      it 'allows a user to log in with Google' do
+        visit(login_path)
+        expect(page).to have_css('button.google-login')
 
-      expect { click_button(class: 'google-login') }.not_to change { User.count }
+        expect { click_button(class: 'google-login') }.not_to change { User.count }
 
-      visit(groceries_path)
-      expect(page).to have_text(user.email)
+        visit(groceries_path)
+        expect(page).to have_text(user.email)
+      end
+    end
+
+    context 'when there is no user in the databse with the email' do
+      let(:stubbed_user_email) { "#{SecureRandom.uuid}@gmail.com" }
+
+      before { expect(User.where(email: stubbed_user_email)).not_to exist }
+
+      it 'allows a user to sign up (and log in) with Google' do
+        visit(login_path)
+        expect(page).to have_css('button.google-login')
+
+        expect { click_button(class: 'google-login') }.to change { User.count }.by(1)
+        user = User.find_by!(email: stubbed_user_email)
+
+        visit(groceries_path)
+        expect(page).to have_text(user.email)
+      end
     end
   end
 
-  context 'when there is no user in the databse with the email' do
-    let(:stubbed_user_email) { "#{SecureRandom.uuid}@gmail.com" }
+  context 'when OmniAuth test mode is disabled' do
+    around do |spec|
+      original_omni_auth_test_mode = OmniAuth.config.test_mode
+      OmniAuth.config.test_mode = false
 
-    before { expect(User.where(email: stubbed_user_email)).not_to exist }
+      spec.run
 
-    it 'allows a user to sign up (and log in) with Google' do
-      visit(login_path)
-      expect(page).to have_css('button.google-login')
+      OmniAuth.config.test_mode = original_omni_auth_test_mode
+    end
 
-      expect { click_button(class: 'google-login') }.to change { User.count }.by(1)
-      user = User.find_by!(email: stubbed_user_email)
+    context 'when Google responds with "This is Google OAuth."' do
+      before do
+        page.driver.browser.intercept do |request, &continue|
+          if request.url.start_with?('https://accounts.google.com/o/oauth2/auth?')
+            fetch = page.driver.browser.devtools.fetch
+            fetch.enable
+            fetch.fulfill_request(
+              request_id: request.id,
+              response_code: 200,
+              body: Base64.strict_encode64('This is Google OAuth.'),
+            )
+          else
+            continue.call(request)
+          end
+        end
+      end
 
-      visit(groceries_path)
-      expect(page).to have_text(user.email)
+      it "renders Google's response" do
+        visit(login_path)
+        expect(page).to have_css('button.google-login')
+
+        click_button(class: 'google-login')
+
+        expect(page).to have_text('This is Google OAuth.')
+      end
     end
   end
 end


### PR DESCRIPTION
This is necessary for Google OAuth to work on Chrome. (It works on Firefox without this. Browser implementation is inconsistent. See https://github.com/w3c/webappsec-csp/issues/ 8 .)