### PR TITLE
Use `lodash-es` (not `lodash`) in check-ins app; add eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,12 @@ module.exports = {
     'no-new': 'off',
     'no-param-reassign': 'off',
     'no-plusplus': 'off',
+    'no-restricted-imports': ['error', {
+      paths: [{
+        name: 'lodash',
+        message: 'Use lodash-es.',
+      }],
+    }],
     'no-underscore-dangle': 'off',
     'no-unreachable': ((env.NODE_ENV === 'production') ? 'error' : 'warn'),
     'no-use-before-define': ['error', { functions: false }],

--- a/app/javascript/check_in_ratings/app.vue
+++ b/app/javascript/check_in_ratings/app.vue
@@ -19,7 +19,7 @@ div(v-else) {{bootstrap.partner_ratings_hidden_reason}}
 </template>
 
 <script>
-import { cloneDeep } from 'lodash';
+import { cloneDeep } from 'lodash-es';
 import Ratings from './components/ratings.vue';
 
 export default {

--- a/app/javascript/check_in_ratings/components/ratings.vue
+++ b/app/javascript/check_in_ratings/components/ratings.vue
@@ -26,7 +26,7 @@ button.mt1.h3(v-if='editable' @click='updateCheckIn') Update Check-in
 </template>
 
 <script>
-import { range } from 'lodash';
+import { range } from 'lodash-es';
 import EmojiButton from './emoji_button.vue';
 
 export default {

--- a/bin/test/tasks/run_file_size_checks.rb
+++ b/bin/test/tasks/run_file_size_checks.rb
@@ -9,7 +9,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
   # file size constraints in kilobytes
   CONSTRAINTS = {
     'charts*.js' => (340..350),
-    'check_in_ratings*.js' => (255..265),
+    'check_in_ratings*.js' => (195..205),
     'check_in_ratings*.css' => (10..15),
     'groceries*.js' => (425..435),
     'groceries*.css' => (105..115),


### PR DESCRIPTION
This should decrease the bundle size.

Enable eslint `no-restricted-imports` rule to ensure that we always use `lodash-es` in the future.