### PR TITLE
Add a longer (10s) Capybara wait time for part of flaky quizzes spec

### DIFF
--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -81,7 +81,9 @@ RSpec.describe 'Quizzes app' do
 
       # participant chooses an incorrect answer
       Capybara.using_session('Quiz participant session') do
-        choose(second_question.answers.first!.content)
+        Capybara.using_wait_time(10) do
+          choose(second_question.answers.first!.content)
+        end
         click_button('Submit')
       end
 


### PR DESCRIPTION
The default wait time is 2 seconds, so this increases it to 5x that.