### PR TITLE
Comment out the `rails_credentials` diff driver in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-config/credentials/*.yml.enc diff=rails_credentials
-config/credentials.yml.enc diff=rails_credentials
+# Uncomment the below lines to view decrypted credentials in git diffs.
+# config/credentials/*.yml.enc diff=rails_credentials
+# config/credentials.yml.enc diff=rails_credentials


### PR DESCRIPTION
Uncomment these to see decrypted credentials in diffs. However, I want to comment this out by default so that git diffs are shown more quicky and don't depend on Rails (such as gems being installed, etc.).