### PR TITLE
Source pallets gem from GitHub fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -93,7 +93,7 @@ group :test do
   gem 'json-schema'
   gem 'launchy'
   gem 'nokogiri'
-  gem 'pallets'
+  gem 'pallets', github: 'davidrunger/pallets'
   gem 'percy-capybara'
   gem 'rails-controller-testing'
   gem 'rspec-instafail', require: false


### PR DESCRIPTION
This removes deprecation warnings that are printed when running tests. (See https://github.com/davidrunger/pallets/pull/1 .)

There is already a PR for this at the main pallets repo: https://github.com/linkyndy/pallets/pull/ 64

Unfortunately, I guess it looks like maybe `pallets` is no longer being maintained, though.