### PR TITLE
Break up .env file into .env.development and .env.development.local

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,5 @@
+RAILS_ENV=development
+WEB_CONCURRENCY=0 # run web server without concurrency for more clearly structured log output
+RAILS_MAX_THREADS=1 # run web server without concurrency for more clearly structured log output
+VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true # this is set on Dokku, so set it here, too
+PORT=3000 # specify port because otherwise foreman uses 5000

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile '~/.gitignore_global'
 
-.env
+.env.development.local
 /.bundle
 /log/*
 /tmp/*


### PR DESCRIPTION
We are committing the `.env.development` file (containing non-secret env vars) and not committing the `.env.development.local` one (containing secrets) per the advice at https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use.