### PR TITLE
Remove `PORT=3000` env var from `.env.development`

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,4 +3,3 @@ S3_BUCKET=david-runger-development-uploads
 WEB_CONCURRENCY=0 # run web server without concurrency for more clearly structured log output
 RAILS_MAX_THREADS=1 # run web server without concurrency for more clearly structured log output
 VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true # this is set on Dokku, so set it here, too
-PORT=3000 # specify port because otherwise foreman uses 5000


### PR DESCRIPTION
Foreman doesn't respect this, anyway, when it's in `.env.development` rather than `.env` (which foreman does check by default), so just remove it.