### PR TITLE
Hardcode URL pattern for median_response_time_in_past_day monitor

### DIFF
--- a/app/workers/data_monitors/home_index_requests.rb
+++ b/app/workers/data_monitors/home_index_requests.rb
@@ -30,7 +30,7 @@ class DataMonitors::HomeIndexRequests < DataMonitors::Base
   def median_response_time_in_past_day
     home_requests_in_past_day.
       where.not(total: nil).
-      where('url LIKE ?', "#{Rails.application.routes.url_helpers.root_url}%").
+      where('url LIKE ?', 'https://davidrunger.com/%').
       where.not('url LIKE ?', '%/?prerender=true').
       select('PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY "total") AS "percentile"').
       to_a.first.percentile&.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -2,8 +2,6 @@
 
 require 'active_support/core_ext/integer/time'
 
-Rails.application.routes.default_url_options[:host] = 'davidrunger.com'
-
 Rails.application.configure do
   # Prepare the ingress controller used to receive mail
   config.action_mailbox.ingress = :mailgun

--- a/spec/workers/data_monitors/home_index_requests_spec.rb
+++ b/spec/workers/data_monitors/home_index_requests_spec.rb
@@ -6,42 +6,29 @@ RSpec.describe DataMonitors::HomeIndexRequests do
   describe '#perform' do
     subject(:perform) { worker.perform }
 
-    context 'when the Rails route helpers return a root_url' do
-      before do
-        expect(Rails.application.routes.url_helpers).
-          to receive(:root_url).
-          and_return('https://davidrunger.com/')
-      end
+    it 'verifies some data expectations' do
+      expect(worker).to receive(:verify_data_expectation).at_least(:twice).and_call_original
+      perform
+    end
 
-      it 'verifies some data expectations' do
-        expect(worker).to receive(:verify_data_expectation).at_least(:twice).and_call_original
-        perform
-      end
+    context 'when the `number_of_requests_in_past_day` expectation fails' do
+      before { Request.find_each(&:destroy) }
 
-      context 'when the `number_of_requests_in_past_day` expectation fails' do
-        before { Request.find_each(&:destroy) }
+      let(:full_check_name) { 'DataMonitors::HomeIndexRequests#number_of_requests_in_past_day' }
 
-        let(:full_check_name) { 'DataMonitors::HomeIndexRequests#number_of_requests_in_past_day' }
-
-        context 'when no email has been sent within the past 24 hours' do
-          it 'enqueues an email', :frozen_time, queue_adapter: :test do
-            expect { perform }.
-              to enqueue_mail(DataMonitorMailer, :expectation_not_met).
-              with(full_check_name, 0, String, Time.current.to_s)
-          end
+      context 'when no email has been sent within the past 24 hours' do
+        it 'enqueues an email', :frozen_time, queue_adapter: :test do
+          expect { perform }.
+            to enqueue_mail(DataMonitorMailer, :expectation_not_met).
+            with(full_check_name, 0, String, Time.current.to_s)
         end
+      end
 
-        context 'when an email has been sent within the past 24 hours' do
-          before do
-            expect(Rails.application.routes.url_helpers).
-              to receive(:root_url).
-              and_return('https://davidrunger.com/')
-            DataMonitors::HomeIndexRequests.new.perform
-          end
+      context 'when an email has been sent within the past 24 hours' do
+        before { DataMonitors::HomeIndexRequests.new.perform }
 
-          it 'does not enqueue an email', :frozen_time, queue_adapter: :test do
-            expect { perform }.not_to enqueue_mail(DataMonitorMailer, :expectation_not_met)
-          end
+        it 'does not enqueue an email', :frozen_time, queue_adapter: :test do
+          expect { perform }.not_to enqueue_mail(DataMonitorMailer, :expectation_not_met)
         end
       end
     end


### PR DESCRIPTION
This doesn't work locally, since we don't set `Rails.application.routes.default_url_options[:host]` there. We could set it locally, but that doesn't seem right. Let's just hardcode it.