### PR TITLE
Use long Capybara wait timeout around the whole quizzes feature test

### DIFF
--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe 'Quizzes app' do
   context 'when user is signed in' do
     before { sign_in(quiz_owner) }
 
-    it 'allows creating a new quiz, joining the quiz, answering questions, etc' do
+    it 'allows creating a new quiz, joining the quiz, answering questions, etc', wait_time: 10 do
       # visit new quiz page
       visit(new_quiz_path)
 
@@ -81,9 +81,7 @@ RSpec.describe 'Quizzes app' do
 
       # participant chooses an incorrect answer
       Capybara.using_session('Quiz participant session') do
-        Capybara.using_wait_time(10) do
-          choose(second_question.answers.first!.content)
-        end
+        choose(second_question.answers.first!.content)
         click_button('Submit')
       end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -218,6 +218,12 @@ RSpec.configure do |config|
       )
   end
 
+  config.around(:each, :wait_time) do |example|
+    Capybara.using_wait_time(example.metadata[:wait_time]) do
+      example.run
+    end
+  end
+
   config.before(:each, type: :controller) do
     # When executed, a Rails middleware will ensure that a `request_id` is set for each request.
     # However, middleware does not run for controller tests.


### PR DESCRIPTION
I have seen some flaking in this test locally and maybe also in GitHub actions. Hopefully this will reduce that flaking.