### PR TITLE
Reduce email incineration time from 1 week to 2 days

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -72,7 +72,7 @@ class DavidRunger::Application < Rails::Application
   ENV['FIXTURES_PATH'] ||= 'spec/fixtures' if ENV.fetch('RAILS_ENV', nil) == 'test'
 
   # Time until incoming mail incineration. Default is 30 days, but we don't need that long.
-  config.action_mailbox.incinerate_after = 1.week
+  config.action_mailbox.incinerate_after = 2.days
 
   # https://github.com/hotwired/turbo-rails/blob/9d53529/README.md#compatibility-with-rails-ujs
   config.action_view.form_with_generates_remote_forms = false


### PR DESCRIPTION
These clutter up AWS while they exist. We don't need them to exist long.