### PR TITLE
Change default Puma WEB_CONCURRENCY from 2 to 0

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,7 +23,7 @@ environment(ENV.fetch('RAILS_ENV', 'development'))
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-workers(ENV.fetch('WEB_CONCURRENCY', 2))
+workers(ENV.fetch('WEB_CONCURRENCY', 0))
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
Lately, we've been having errors when running Vite during deploys. I suspect that this might be due to inadequate memory availability. Let's make more memory available by using single-process Puma.