### PR TITLE
Force reloading of RedisOptions when checking test coverage

### DIFF
--- a/spec/lib/redis_options_spec.rb
+++ b/spec/lib/redis_options_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+load Rails.root.join('lib/redis_options.rb') if $checking_test_coverage
+
 RSpec.describe RedisOptions do
   context 'when not providing a database number' do
     subject(:redis_options) { RedisOptions.new }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,7 @@ elsif (
   (executed_spec_files = ARGV.grep(%r{\Aspec/.+_spec\.rb}).presence) &&
     executed_spec_files&.size == 1
 )
+  $checking_test_coverage = true
   require_relative '../tools/simplecov/formatter/terminal.rb'
   SimpleCov::Formatter::Terminal.executed_spec_files = executed_spec_files
   SimpleCov.formatter = SimpleCov::Formatter::Terminal


### PR DESCRIPTION
This is an issue with `spring`.