### PR TITLE
Fail build immediately if building vite assets fails

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -35,13 +35,14 @@ namespace :assets do
 end
 
 Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
-  system('bin/vite build --force')
+  system('bin/vite build --force', exception: true)
   system(
     {
       'VITE_RUBY_ENTRYPOINTS_DIR' => 'admin_packs',
       'VITE_RUBY_PUBLIC_OUTPUT_DIR' => 'vite-admin',
     },
     'bin/vite build --force',
+    exception: true,
   )
 end
 


### PR DESCRIPTION
I don't know if this will exactly work in our production deploy pipeline. We'll test it there.