### PR TITLE
Add `--debug` flag to Vite build commands

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -35,13 +35,13 @@ namespace :assets do
 end
 
 Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
-  system('bin/vite build --force', exception: true)
+  system('bin/vite build --force --debug', exception: true)
   system(
     {
       'VITE_RUBY_ENTRYPOINTS_DIR' => 'admin_packs',
       'VITE_RUBY_PUBLIC_OUTPUT_DIR' => 'vite-admin',
     },
-    'bin/vite build --force',
+    'bin/vite build --force --debug',
     exception: true,
   )
 end


### PR DESCRIPTION
Hopefully this will help us to figure out why our Vite builds are intermittently failing during deploys.