### PR TITLE
Compile test assets in production mode

### DIFF
--- a/bin/test/task_helpers.rb
+++ b/bin/test/task_helpers.rb
@@ -1,17 +1,23 @@
 # frozen_string_literal: true
 
 module Test::TaskHelpers
-  def execute_system_command(command)
+  def execute_system_command(command, env_vars = {})
     command = command.squish
-    puts("Running system command '#{command.yellow}' ...")
-    time = Benchmark.measure { system(command) }.real
+    puts("Running system command '#{command.yellow}' with ENV vars #{env_vars.to_s.yellow} ...")
+    time = Benchmark.measure { system(env_vars, command) }.real
     exit_code = $CHILD_STATUS.exitstatus
     update_job_result_exit_code(exit_code)
     if exit_code == 0
-      puts("'#{command}' succeeded (exited with #{exit_code}, took #{time.round(3)}).".green)
+      puts(<<~LOG.squish)
+        '#{command.green}' with ENV vars #{env_vars.to_s.green} succeeded
+        (exited with #{exit_code}, took #{time.round(3)}).
+      LOG
     else
       Test::Runner.exit_code = exit_code if Test::Runner.exit_code == 0
-      puts("'#{command}' failed (exited with #{exit_code}, took #{time.round(3)}).".red)
+      puts(<<~LOG.squish.red)
+        '#{command.red}' with ENV vars #{env_vars.to_s.red} failed
+        (exited with #{exit_code}, took #{time.round(3)}).
+      LOG
     end
   end
 

--- a/bin/test/tasks/compile_java_script.rb
+++ b/bin/test/tasks/compile_java_script.rb
@@ -6,10 +6,19 @@ class Test::Tasks::CompileJavaScript < Pallets::Task
   def run
     execute_system_command('rm -rf public/vite/')
     execute_rake_task('build_js_routes')
-    execute_system_command('bin/vite build --force')
     execute_system_command(
-      'VITE_RUBY_ENTRYPOINTS_DIR=admin_packs VITE_RUBY_PUBLIC_OUTPUT_DIR=vite-admin ' \
-      'bin/vite build --force',
+      'bin/vite build --force --debug',
+      {
+        'NODE_ENV' => 'production',
+      },
+    )
+    execute_system_command(
+      'bin/vite build --force --debug',
+      {
+        'NODE_ENV' => 'production',
+        'VITE_RUBY_ENTRYPOINTS_DIR' => 'admin_packs',
+        'VITE_RUBY_PUBLIC_OUTPUT_DIR' => 'vite-admin',
+      },
     )
   end
 end

--- a/bin/test/tasks/run_file_size_checks.rb
+++ b/bin/test/tasks/run_file_size_checks.rb
@@ -9,19 +9,19 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
   # file size constraints in kilobytes
   CONSTRAINTS = {
     'charts*.js' => (340..350),
-    'check_in_ratings*.js' => (195..205),
+    'check_in_ratings*.js' => (165..175),
     'check_in_ratings*.css' => (10..15),
-    'groceries*.js' => (425..435),
+    'groceries*.js' => (390..400),
     'groceries*.css' => (100..110),
-    'home*.js' => (150..160),
+    'home*.js' => (120..130),
     'home*.css' => (1..4),
-    'logs*.js' => (880..890),
+    'logs*.js' => (835..845),
     'logs*.css' => (100..110),
     'marriage*.js' => (10..20),
     'quizzes*.js' => (105..115),
     'styles*.css' => (15..25),
     'turbo*.js' => (70..80),
-    'workout*.js' => (425..440),
+    'workout*.js' => (395..405),
     'workout*.css' => (100..110),
   }.freeze
 


### PR DESCRIPTION
This is a step toward using assets compiled during test in production. It should also give us more accurate file sizes for the `RunFileSizeChecks` check.