### PR TITLE
Use assets compiled during test in production

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -63,6 +63,7 @@ jobs:
         RAILS_ENV: test
         NODE_ENV: test
         DISABLE_SPRING: 1
+        VITE_RUBY_AUTO_BUILD: false
         SECRET_KEY_BASE: 0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b
         # The hostname used to communicate with the PostgreSQL service container
         POSTGRES_HOST: 127.0.0.1

--- a/bin/test/tasks/compile_java_script.rb
+++ b/bin/test/tasks/compile_java_script.rb
@@ -20,5 +20,6 @@ class Test::Tasks::CompileJavaScript < Pallets::Task
         'VITE_RUBY_PUBLIC_OUTPUT_DIR' => 'vite-admin',
       },
     )
+    execute_rake_task('assets:upload_vite_assets') if ENV.fetch('GITHUB_REF_NAME') == 'master'
   end
 end


### PR DESCRIPTION
This should reduce CPU and memory usage on our production server and also make our deploys more reliable (as they often fail with out of memory errors when building vite assets).