### PR TITLE
Get git SHA from ENV when deploying

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -64,7 +64,7 @@ Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
       get(response_target: "tmp/#{directory_name}.zip")
   end
 
-  git_sha = `git rev-parse HEAD`.strip
+  git_sha = ENV.fetch('GIT_REV')
   raise('Could not determine git SHA!') if git_sha.empty?
 
   download_s3_zip(git_sha, 'vite')


### PR DESCRIPTION
Within the Dokku container, we don't actually have `git` (I guess).