### PR TITLE
Remove node buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,1 @@
-https://github.com/heroku/heroku-buildpack-nodejs.git
 https://github.com/heroku/heroku-buildpack-ruby.git


### PR DESCRIPTION
We don't need this anymore now that we are using assets compiled during tests in production. 🎉