### PR TITLE
Bump skedjewel from 0.0.1.alpha-4 to 0.0.1.alpha5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,4 @@ export
 /config/credentials/development.key
 /config/credentials/test.key
 /config/credentials/production.key
-bin/skedjewel
+/bin/skedjewel

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -77,7 +77,7 @@ Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
   bin_path = Rails.root.join('bin')
   skedjewel_url =
     'https://github.com/davidrunger/skedjewel/releases/download/' \
-    'v0.0.1.alpha-4/skedjewel-v0.0.1.alpha-4-linux'
+    'v0.0.1.alpha5/skedjewel-v0.0.1.alpha5-linux'
   system(<<~SH.squish, exception: true)
     curl -L #{skedjewel_url} > skedjewel &&
       mv skedjewel #{bin_path}/ &&


### PR DESCRIPTION
This release is compiled with `--static`, which seems to be necessary.