### PR TITLE
Validate that BannedPathFragment has only lowercase letters, numbers

### DIFF
--- a/app/models/banned_path_fragment.rb
+++ b/app/models/banned_path_fragment.rb
@@ -18,7 +18,7 @@ class BannedPathFragment < ApplicationRecord
   validates(
     :value,
     presence: true,
-    format: { without: Rack::Attack::PATH_FRAGMENT_SEPARATOR_REGEX },
+    format: { with: /\A[a-z0-9]+\z/ },
     uniqueness: true,
   )
 end


### PR DESCRIPTION
This matters because we check `fragment.downcase` in `rack_attack.rb`, so we'll never get a match if the stored value has an uppercase letter.