### PR TITLE
Remove `--debug` option from `bin/vite build` commands

### DIFF
--- a/bin/test/tasks/compile_java_script.rb
+++ b/bin/test/tasks/compile_java_script.rb
@@ -7,13 +7,13 @@ class Test::Tasks::CompileJavaScript < Pallets::Task
     execute_system_command('rm -rf public/vite/')
     execute_rake_task('build_js_routes')
     execute_system_command(
-      'bin/vite build --force --debug',
+      'bin/vite build --force',
       {
         'NODE_ENV' => 'production',
       },
     )
     execute_system_command(
-      'bin/vite build --force --debug',
+      'bin/vite build --force',
       {
         'NODE_ENV' => 'production',
         'VITE_RUBY_ENTRYPOINTS_DIR' => 'admin_packs',


### PR DESCRIPTION
We added this in 1e20729 in order to try to debug failing Dokku deploys. However, now that we aren't compiling JavaScript on Dokku anymore, this is no longer needed/useful.