### PR TITLE
Don't show blank option for type in admin setting form

### DIFF
--- a/app/views/admin/settings/form.html.haml
+++ b/app/views/admin/settings/form.html.haml
@@ -6,7 +6,8 @@
 = semantic_form_for(@setting, url: url, html: { method: http_verb }) do |f|
   = f.inputs do
     = f.input :name, label: 'Name'
-    = f.input :type, label: 'Type', as: :select, collection: RedisConfig::TYPES
+    = f.input(:type, label: 'Type', as: :select, collection: RedisConfig::TYPES,
+      selected: @setting.type, include_blank: false)
     = f.input :value, label: 'Value', required: false
   = f.actions do
     = f.action :submit, label: submit_label


### PR DESCRIPTION
Also, select by default the setting's type (when editing).