### PR TITLE
Remove dependent: :destroy for correct_answer_selections association

### DIFF
--- a/app/admin/quizzes.rb
+++ b/app/admin/quizzes.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register(Quiz) do
       if params[:action] == 'destroy'
         collection =
           collection.includes(
-            participations: %i[correct_answer_selections quiz_question_answer_selections],
+            participations: :quiz_question_answer_selections,
             questions: { answers: :selections },
           )
       end

--- a/app/models/quiz_participation.rb
+++ b/app/models/quiz_participation.rb
@@ -27,6 +27,8 @@ class QuizParticipation < ApplicationRecord
     foreign_key: :participation_id,
     inverse_of: :participation,
   )
+  # rubocop:disable Rails/HasManyOrHasOneDependent
+  # We don't need `:dependent` option because this is a subset of `quiz_question_answer_selections`
   has_many(
     :correct_answer_selections,
     -> {
@@ -34,11 +36,11 @@ class QuizParticipation < ApplicationRecord
         merge(QuizQuestion.closed).
         where(quiz_question_answers: { is_correct: true })
     },
-    dependent: :destroy,
     class_name: 'QuizQuestionAnswerSelection',
     foreign_key: :participation_id,
     inverse_of: :participation,
   )
+  # rubocop:enable Rails/HasManyOrHasOneDependent
 
   validates :display_name, presence: true, uniqueness: { scope: :quiz_id }
   validates :participant_id, uniqueness: { scope: :quiz_id }


### PR DESCRIPTION
We don't need `:dependent` option because this is a subset of `quiz_question_answer_selections`, which are specified with `dependent: :destroy`. Also, a foreign key guarantees that no `correct_answer_selections` will be left dangling.