### PR TITLE
Simplify guard condition for IP address in FetchIpInfoForRequest

### DIFF
--- a/app/workers/fetch_ip_info_for_request.rb
+++ b/app/workers/fetch_ip_info_for_request.rb
@@ -15,7 +15,7 @@ class FetchIpInfoForRequest
 
   def write_location_info(request)
     ip = request.ip
-    return if ip.blank? || (Rails.env.development? && ip.in?(LOCAL_IPS))
+    return if ip.in?(LOCAL_IPS)
 
     ip_info = Rails.cache.fetch(cache_key(ip), expires_in: 4.weeks) { ip_info_from_api(ip) }
     request.update!(ip_info)

--- a/spec/workers/fetch_ip_info_for_request_spec.rb
+++ b/spec/workers/fetch_ip_info_for_request_spec.rb
@@ -27,5 +27,14 @@ RSpec.describe FetchIpInfoForRequest do
           to([location, isp])
       end
     end
+
+    context 'when the request IP is a localhost IP' do
+      before { request.update!(ip: '127.0.0.1') } # rubocop:disable Style/IpAddresses
+
+      it 'does not make a request to Rails.cache' do
+        expect(Rails.cache).not_to receive(:fetch)
+        perform
+      end
+    end
   end
 end


### PR DESCRIPTION
The IP cannot be blank because model and database validations require it to be present. There's no need to fetch info for a localhost IP in any environment.