### PR TITLE
Remove support for block arg in `Faraday.json_connection` monkeypatch

### DIFF
--- a/config/initializers/monkeypatches/faraday.rb
+++ b/config/initializers/monkeypatches/faraday.rb
@@ -2,12 +2,10 @@
 
 module Faraday
   class << self
-    def json_connection(timeout: 60, &blk)
+    def json_connection
       new do |conn|
-        conn.options.timeout = timeout
         conn.request(:json)
         conn.response(:json)
-        blk&.call(conn)
       end
     end
   end

--- a/spec/config/initializers/monkeypatches/faraday_spec.rb
+++ b/spec/config/initializers/monkeypatches/faraday_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe(Faraday) do
+  describe '::json_connection' do
+    subject(:json_connection) { Faraday.json_connection }
+
+    it 'returns an instance of Faraday::Connection configured for JSON requests and responses' do
+      expect(json_connection).to be_instance_of(Faraday::Connection)
+      expect(json_connection.builder.handlers.map(&:name)).
+        to match_array([
+          Faraday::Request::Json,
+          Faraday::Response::Json,
+        ].map(&:name))
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,11 @@ if is_ci
 elsif ARGV.grep(%r{\Aspec/.+_spec\.rb}).size == 1
   require 'simple_cov/formatter/terminal'
   SimpleCov.formatter = SimpleCov::Formatter::Terminal
+  # rubocop:disable Performance/RedundantMerge
+  SimpleCov::Formatter::Terminal.spec_file_to_application_file_map.merge!(
+    %r{\Aspec/config/initializers/monkeypatches/} => 'config/initializers/monkeypatches/',
+  )
+  # rubocop:enable Performance/RedundantMerge
 end
 SimpleCov.coverage_dir('tmp/simple_cov')
 SimpleCov.start do


### PR DESCRIPTION
Also, remove configurable timeout argument.

We aren't using the timeout or block argument anywhere, and usage of the block argument is not covered by tests anywhere, so let's just remove it for now.

Also, add unit test coverage.