### PR TITLE
Improve branch coverage for MailgunViaHttp

### DIFF
--- a/lib/email/mailgun_via_http.rb
+++ b/lib/email/mailgun_via_http.rb
@@ -61,7 +61,7 @@ module Email
         subject: mail['Subject'].to_s,
         from: mail['From'].to_s,
         'h:Reply-To' => mail['Reply-To'].to_s,
-        html: mail.body.to_s.presence || mail.html_part&.body.presence || '<div></div>',
+        html: mail.body.to_s.presence || '<div></div>',
       }
 
       if mail.has_attachments?

--- a/spec/lib/email/mailgun_via_http_spec.rb
+++ b/spec/lib/email/mailgun_via_http_spec.rb
@@ -58,4 +58,21 @@ RSpec.describe Email::MailgunViaHttp do
       end
     end
   end
+
+  describe '#post_body' do
+    subject(:post_body) { mailgun_via_http.send(:post_body, mail) }
+
+    context 'when the mail body is empty' do
+      before do
+        expect(mail).to receive(:body).and_return(instance_double(Mail::Body, to_s: ''))
+        expect(mail).to receive(:has_attachments?).and_return(false)
+      end
+
+      let(:mail) { mail_from_raw_email_fixture('empty_body') }
+
+      it 'returns a hash with default empty HTML tags for the :html key' do
+        expect(post_body[:html]).to eq('<div></div>')
+      end
+    end
+  end
 end


### PR DESCRIPTION
Also, remove a branch that I don't think we'll ever enter (which I believe because, when adding a test for it, the test suggested that there's a bug in the code that I've never seen surface, namely that `mail.html_part&.body.presence` should be `mail.html_part&.body.to_s.presence` because `body` is always a present `Mail::Body` maybe)?