### PR TITLE
Don't check time of path request when adding IpBlock reason

### DIFF
--- a/app/workers/create_ip_block.rb
+++ b/app/workers/create_ip_block.rb
@@ -11,9 +11,7 @@ class CreateIpBlock
           with { |conn| conn.call('hgetall', "blocked-requests:#{ip}") }.
           transform_values { Integer(_1) }.
           filter_map do |path, unix_time|
-            if unix_time >= Integer(Rack::Attack::PENTESTING_FINDTIME.ago)
-              "#{path} (at #{Time.zone.at(unix_time)})"
-            end
+            "#{path} (at #{Time.zone.at(unix_time)})"
           end.
           join("\n")
       ip_block.update!(reason: block_reason)


### PR DESCRIPTION
We expire this value in Redis after `Rack::Attack::PENTESTING_FINDTIME`, so it should always be the case, anyway, that the time of the path request, if it's still in Redis, is within the `Rack::Attack::PENTESTING_FINDTIME` limit.