### PR TITLE
Ban IPs making requests with \0000 rather than creating a Request

### DIFF
--- a/app/workers/create_ip_block.rb
+++ b/app/workers/create_ip_block.rb
@@ -3,10 +3,11 @@
 class CreateIpBlock
   prepend ApplicationWorker
 
-  def perform(ip)
+  def perform(ip, reason = nil)
     ip_block = IpBlock.find_or_initialize_by(ip:)
     if ip_block.new_record?
       block_reason =
+        reason ||
         $redis_pool.
           with { |conn| conn.call('hgetall', "blocked-requests:#{ip}") }.
           transform_values { Integer(_1) }.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -279,6 +279,10 @@ RSpec.configure do |config|
     Capybara.use_default_driver
   end
 
+  config.around(:each, :inline_sidekiq) do |spec|
+    Sidekiq::Testing.inline! { spec.run }
+  end
+
   config.around(:each, :fake_aws_credentials) do |spec|
     original_credentials = Aws.config[:credentials]
 


### PR DESCRIPTION
fixes https://rollbar.com/davidjrunger/davidrunger/items/519/

This handles requests that don't get blocked by the `Rack::Attack` middleware (e.g. because they don't make it there because they request something served by the `ActionDispatch::Static` middleware).