### PR TITLE
Compare gitleaks to origin/master rather than to master

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,7 @@
 pre-push:
   commands:
     gitleaks:
-      run: gitleaks detect --log-opts="master...HEAD" --verbose &> /dev/null
+      run: gitleaks detect --log-opts="origin/master...HEAD" --verbose &> /dev/null
 
 skip_output:
   - meta


### PR DESCRIPTION
fix rb#502

(^ It doesn't actually; I'm testing something.)

It ideally shouldn't ever make a difference whether we compare to master vs origin/master, but origin/master is probably the right one to go with, if master and origin/master diverge.