### PR TITLE
Rescue ActiveRecord::RecordNotUnique errors in CreateIpBlock worker

### DIFF
--- a/app/workers/create_ip_block.rb
+++ b/app/workers/create_ip_block.rb
@@ -15,7 +15,12 @@ class CreateIpBlock
             "#{path} (at #{Time.zone.at(unix_time)})"
           end.
           join("\n")
-      ip_block.update!(reason: block_reason)
+
+      begin
+        ip_block.update!(reason: block_reason)
+      rescue ActiveRecord::RecordNotUnique => error # can happen due to race condition
+        Rollbar.warn(error)
+      end
     end
   end
 end

--- a/spec/workers/create_ip_block_spec.rb
+++ b/spec/workers/create_ip_block_spec.rb
@@ -9,10 +9,27 @@ RSpec.describe CreateIpBlock do
     let(:ip) { Faker::Internet.public_ip_v4_address }
 
     context 'when there is already an IpBlock with the specified IP' do
-      before { create(:ip_block, ip:) }
+      let!(:ip_block) { create(:ip_block, ip:) }
 
       it 'does not create a new IpBlock or raise an error' do
         expect { perform }.not_to change { IpBlock.count }
+      end
+
+      # this can happen in a multithreading environment race condition; simulate w/ stubbing here
+      context 'when new_record? returns false' do
+        before do
+          expect(IpBlock).to receive(:find_or_initialize_by).with(ip:).and_return(ip_block)
+          expect(ip_block).to receive(:new_record?).at_least(:once).and_return(true) # really false
+        end
+
+        it 'does not raise an error' do
+          expect { perform }.not_to raise_error
+        end
+
+        it 'sends a warning to Rollbar' do
+          expect(Rollbar).to receive(:warn).with(ActiveRecord::RecordNotUnique).and_call_original
+          expect { perform }.not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
fixes rb#502 https://rollbar.com/davidjrunger/davidrunger/items/502/

This can happen due to a race condition if there are multiple requests for banned endpoints in a short frame of time.