### PR TITLE
Remove debug gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,7 +56,6 @@ group :development, :test do
   gem 'amazing_print'
   gem 'annotate', require: false
   gem 'bullet'
-  gem 'debug', require: false
   gem 'dotenv-rails', require: 'dotenv/rails-now'
   gem 'immigrant'
   gem 'pry-byebug', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,9 +218,6 @@ GEM
     dalli (3.2.2)
     database_consistency (1.2.2)
       activerecord (>= 3.2)
-    debug (1.6.2)
-      irb (>= 1.3.6)
-      reline (>= 0.3.1)
     debug_inspector (1.1.0)
     devise (4.8.1)
       bcrypt (~> 3.0)
@@ -300,9 +297,6 @@ GEM
       has_scope (~> 0.6)
       railties (>= 5.2, < 7.1)
       responders (>= 2, < 4)
-    io-console (0.5.11)
-    irb (1.4.1)
-      reline (>= 0.3.0)
     jmespath (1.6.1)
     jquery-rails (4.5.0)
       rails-dom-testing (>= 1, < 3)
@@ -469,8 +463,6 @@ GEM
     redlock (1.3.1)
       redis (>= 3.0.0, < 6.0)
     regexp_parser (2.5.0)
-    reline (0.3.1)
-      io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)
     request_store-sidekiq (0.1.0)
@@ -640,7 +632,6 @@ DEPENDENCIES
   connection_pool
   dalli
   database_consistency
-  debug
   devise
   dotenv-rails
   draper


### PR DESCRIPTION
We switched back to `pry-byebug` in 3a7ce8e (see more details there). As a result, we aren't really using `debug` anymore. Much love to the gem, and I think it's great to have a debugging tool in Ruby core, and it works pretty well, but it's not for me right now.