### PR TITLE
Disable autocomplete in irb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /node_modules
 /yarn-error.log
 .byebug_history
+.irb_history
 .gemtags
 .tags
 .tags_sorted_by_file

--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,3 @@
+load '~/.irbrc.rb'
+
+IRB.conf[:USE_AUTOCOMPLETE] = false


### PR DESCRIPTION
The autocomplete is nice, but slows down the REPL and reductes interactivity way too much. A personalized IRB initialization setup can still be kept in one's home directory; it will be loaded by this new `.irbrc` file.