### PR TITLE
Don't log Rack::Attack `request_id`

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -81,13 +81,12 @@ end
 
 # https://github.com/rack/rack-attack#logging--instrumentation
 ActiveSupport::Notifications.
-  subscribe(/rack_attack/) do |name, _start, _finish, request_id, payload|
+  subscribe(/rack_attack/) do |name, _start, _finish, _request_id, payload|
     next if payload.keys == [:discriminator] # from InstrumentFail2BanEventMonkeypatch
 
     request = payload[:request]
     Rails.logger.info(<<~LOG.squish)
       [rack-attack]
-      [#{request_id}]
       event=#{name}
       ip=#{request.ip}
       fullpath=#{request.fullpath}


### PR DESCRIPTION
This is not the "request ID" added early on in our web stack and used to track requests; it's an ID that seems to be particular to Rack::Attack.