### PR TITLE
Serialize Store#viewed_at in some format that is generated in JS

### DIFF
--- a/app/serializers/store_serializer.rb
+++ b/app/serializers/store_serializer.rb
@@ -27,7 +27,7 @@ class StoreSerializer < ActiveModel::Serializer
   end
 
   def viewed_at
-    own_store? ? store.viewed_at : nil
+    own_store? ? store.viewed_at.utc.iso8601(3) : nil # match time format to the JavaScript one
   end
 
   private


### PR DESCRIPTION
This ensures that comparing the `viewed_at` times will be consistent regardless of whether that timestamp is created/set by JavaScript code or this server serialization.