### PR TITLE
Have spring ignore `spec/fixtures/` directory

### DIFF
--- a/config/spring.rb
+++ b/config/spring.rb
@@ -14,6 +14,7 @@ module SpringWatcherListenIgnorer
       log/|
       node_modules/|
       personal/|
+      spec/fixtures/|
       tmp/
       )
     }x)


### PR DESCRIPTION
We don't need Spring to worry about reloading the app because fixtures have changed.