### PR TITLE
Add /vite/ & /vite-admin/ to Rack::Attack WHITELISTED_PATH_PREFIXES

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -4,7 +4,7 @@ class Rack::Attack
   PATH_FRAGMENT_SEPARATOR_REGEX = %r{/|\.|\?|-|_}
   PENTESTERS_PREFIX = 'pentesters-'
   PENTESTING_FINDTIME = 1.day.freeze
-  WHITELISTED_PATH_PREFIXES = %w[/flipper/ /sidekiq/].freeze
+  WHITELISTED_PATH_PREFIXES = %w[/flipper/ /sidekiq/ /vite/ /vite-admin/].freeze
 
   # Limit all IPs to 60 requests per clock minute
   # rubocop:disable Style/SymbolProc


### PR DESCRIPTION
My own phone has been blocked for requesting an outdated Vite asset with a banned path fragment ("app" from "groceries_app"; I have since removed that banned path fragment).