### PR TITLE
Add format.any blocks to ErrorsController to handle any request type

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -9,6 +9,7 @@ class ErrorsController < ApplicationController
     respond_to do |format|
       format.html { render file: 'public/404.html', status: :not_found, layout: false }
       format.json { render json: { error: 'Resource not found' }, status: :not_found }
+      format.any { render plain: 'Not found' }
     end
   end
 
@@ -16,6 +17,7 @@ class ErrorsController < ApplicationController
     respond_to do |format|
       format.html { render file: 'public/422.html', status: :unprocessable_entity, layout: false }
       format.json { render json: { error: 'Params unacceptable' }, status: :unprocessable_entity }
+      format.any { render plain: 'Params unacceptable' }
     end
   end
 
@@ -25,6 +27,7 @@ class ErrorsController < ApplicationController
       format.json do
         render json: { error: 'Internal server error' }, status: :internal_server_error
       end
+      format.any { render plain: 'Internal server error' }
     end
   end
 end


### PR DESCRIPTION
Otherwise, 404 requests with e.g. a `.js` extension produce a 500 error, I think.