### PR TITLE
Only attempt to load `~/.irbrc.rb` if it exists

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
-load '~/.irbrc.rb'
+home_irbrc_path = '~/.irbrc.rb'
+# this file is not expected to be there in production
+load(home_irbrc_path) if File.exist?(home_irbrc_path)
 
 IRB.conf[:USE_AUTOCOMPLETE] = false


### PR DESCRIPTION
Locally, I have such a file with my personalized configuration. In production, however, there is no such file. (As a result, this was silently erroring in production, causing `IRB.conf[:USE_AUTOCOMPLETE] = false` not to be executed.)