### PR TITLE
Update CSP to work with Safari & local iPhone development

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -9,19 +9,28 @@
 Rails.application.configure do
   config.content_security_policy do |policy|
     extra_sources = []
+    extra_connect_sources = []
+    # :nocov:
     if Rails.env.development?
-      # :nocov:
       extra_sources << 'https://davidrunger.com' # allow assets from production for local prerenders
       if !ENV.key?('PRODUCTION_ASSET_CONFIG')
         extra_sources << 'ws://localhost:3036' # vite live reloading websockets server
         extra_sources << 'http://localhost:3036' # vite asset server
+
+        local_hostname = ENV.fetch('LOCAL_HOSTNAME', nil)
+        if local_hostname && !local_hostname.empty? # rubocop:disable Rails/Present
+          extra_sources << "ws://#{local_hostname}:3036"
+          extra_sources << "http://#{local_hostname}:3036"
+        end
       end
-      # :nocov:
+    elsif Rails.env.production?
+      extra_connect_sources << 'wss://davidrunger.com'
     end
+    # :nocov:
 
     policy.default_src(:none)
     policy.base_uri(:self)
-    policy.connect_src(:self, *extra_sources)
+    policy.connect_src(:self, *extra_sources, *extra_connect_sources)
     policy.manifest_src(:self, *extra_sources)
     policy.form_action(:self, 'https://accounts.google.com')
     policy.font_src(:self, :https, :data, *extra_sources)


### PR DESCRIPTION
fixes rb#530 https://rollbar.com/davidjrunger/davidrunger/items/530/

Safari seems to enforce the `connect-src` policy more strictly/accurately than Firefox does? It was noting the absence of `wss://davidrunger.com` in our whitelisted sources, but Firefox wasn't.