### PR TITLE
Add `max-height` and `overflow` rules for groceries check-in list

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -63,7 +63,7 @@ div.mt1.mb2.ml3.mr2
     slot
       h3.bold.mb2.
         What did you get?
-      ul
+      ul.check-in-items-list
         li.flex.items-center.mb1(
           v-for='(item, index) in neededItems'
           :key='item.id'
@@ -267,5 +267,10 @@ export default {
   &:hover {
     color: black;
   }
+}
+
+.check-in-items-list {
+  max-height: 60vw;
+  overflow: auto;
 }
 </style>

--- a/bin/test/tasks/run_file_size_checks.rb
+++ b/bin/test/tasks/run_file_size_checks.rb
@@ -11,7 +11,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'charts*.js' => (340..350),
     'check_in_ratings*.js' => (165..175),
     'check_in_ratings*.css' => (10..15),
-    'groceries*.js' => (390..400),
+    'groceries*.js' => (395..410),
     'groceries*.css' => (100..110),
     'home*.js' => (120..130),
     'home*.css' => (1..4),


### PR DESCRIPTION
Otherwise, on small devices, for stores with many needed items, the modal can grow taller than the page, making it impossible to access the "Cancel" button.