### PR TITLE
Tweak groceries app HTML/CSS so check-in modal always shows in Safari

### DIFF
--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -38,3 +38,11 @@ textarea {
 a {
   text-decoration: none;
 }
+
+.hidden-scrollbars {
+  scrollbar-width: none;  /* Firefox https://stackoverflow.com/a/38994837/4009384 */
+}
+
+.hidden-scrollbars::-webkit-scrollbar {
+  display: none;  /* Safari and Chrome https://stackoverflow.com/a/38994837/4009384 */
+}

--- a/app/javascript/groceries/components/sidebar.vue
+++ b/app/javascript/groceries/components/sidebar.vue
@@ -1,39 +1,40 @@
 <template lang='pug'>
-aside.border-right.border-gray.overflow-auto(
+aside.border-right.border-gray(
   :class='{ collapsed: !visible }'
 )
-  .sidebar-toggle__container.border-bottom
-    button.sidebar-toggle(
-      @click='this.visible = !visible'
-      :class='{ "rotated-180": visible }'
-    )
-      arrow-bar-right-icon(size='29')
-  nav
-    .store-lists-container.pb2
-      form.add-store.flex(@submit.prevent='createStore')
-        .flex-1.mr1
-          el-input(
-            type='text'
-            v-model='newStoreName'
-            name='newStoreName'
-            placeholder='Add a store'
-          )
-        el-button.flex-0(
-          native-type='submit'
-          :disabled='postingStore || v$.$invalid'
-        ) Add
-      .stores-list
-        StoreListEntry(
-          v-for='store in sortedStores'
-          :store='store'
-        )
-      div(v-if='sortedSpouseStores.length > 0')
-        .spouse-stores-header.h2 Spouse's Stores
+  .overflow-auto.vh-100.hidden-scrollbars
+    .sidebar-toggle__container.border-bottom
+      button.sidebar-toggle(
+        @click='this.visible = !visible'
+        :class='{ "rotated-180": visible }'
+      )
+        arrow-bar-right-icon(size='29')
+    nav
+      .store-lists-container.pb2
+        form.add-store.flex(@submit.prevent='createStore')
+          .flex-1.mr1
+            el-input(
+              type='text'
+              v-model='newStoreName'
+              name='newStoreName'
+              placeholder='Add a store'
+            )
+          el-button.flex-0(
+            native-type='submit'
+            :disabled='postingStore || v$.$invalid'
+          ) Add
         .stores-list
           StoreListEntry(
-            v-for='store in sortedSpouseStores'
+            v-for='store in sortedStores'
             :store='store'
           )
+        div(v-if='sortedSpouseStores.length > 0')
+          .spouse-stores-header.h2 Spouse's Stores
+          .stores-list
+            StoreListEntry(
+              v-for='store in sortedSpouseStores'
+              :store='store'
+            )
 </template>
 
 <script>
@@ -114,7 +115,6 @@ export default {
 aside {
   background: linear-gradient(to bottom, #458fc0 0%, #a8b2ce 50%, #b6bcd5 100%);
   transition: min-width 0.7s, width 0.7s, max-width 0.7s;
-  scrollbar-width: none;  /* Firefox https://stackoverflow.com/a/38994837/4009384 */
 
   .spouse-stores-header,
   :deep(.stores-list__item) {
@@ -146,10 +146,6 @@ aside {
       max-width: 280px;
     }
   }
-}
-
-aside::-webkit-scrollbar {
-  display: none;  /* Safari and Chrome https://stackoverflow.com/a/38994837/4009384 */
 }
 
 nav {

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -1,93 +1,94 @@
 <template lang="pug">
 div.mt1.mb2.ml3.mr2
-  h2.h2.store-name.bold.my2
-    input(
-      v-if='editingName'
-      type='text'
-      v-model='store.name'
-      @blur='stopEditingAndUpdateStoreName()'
-      @keydown.enter='stopEditingAndUpdateStoreName()'
-      ref='store-name-input'
-    )
-    span(v-if='!editingName') {{ store.name }}
-    a.edit-store.js-link.gray.ml1(@click='editStoreName')
-      edit-icon(size='27')
-    span(v-if='store.own_store')
-      el-button.ml1(v-if='store.private' size='small' @click='togglePrivacy') Make public
-      el-button.ml1(v-else size='small' @click='togglePrivacy') Make private
-    span.spinner--circle.ml1(v-if='debouncingOrWaitingOnNetwork')
-  div.mb2
-    el-button(id="show-modal" @click='initializeTripCheckinModal()').
-      Check in shopping trip
-    el-button.copy-to-clipboard Copy to clipboard
-    span(v-if='wasCopiedRecently') Copied!
-
-  div.mb1
-    h3.h3 Notes
-    el-input(
-      v-if='editingNotes'
-      type='textarea'
-      placeholder='Member phone number: 619-867-5309'
-      v-model='store.notes'
-      @blur='stopEditingAndUpdateStoreNotes()'
-      ref='store-notes-input'
-    )
-    p.pre-wrap(v-else)
-      | {{store.notes || 'No notes yet'}}
-      a.edit-store.js-link.gray.ml1(v-if='store.own_store' @click='editStoreNotes')
-        edit-icon(size='18')
-
-  form.flex(v-if='store.own_store' @submit.prevent='postNewItem')
-    .float-left
-      el-input.item-name-input(
-        placeholder='Add an item'
+  .store-container.overflow-auto.hidden-scrollbars
+    h2.h2.store-name.bold.my2
+      input(
+        v-if='editingName'
         type='text'
-        v-model='newItemName'
-        name='newItemName'
+        v-model='store.name'
+        @blur='stopEditingAndUpdateStoreName()'
+        @keydown.enter='stopEditingAndUpdateStoreName()'
+        ref='store-name-input'
       )
-    .ml1
-      el-button.flex-0.button.button-outline(
-        native-type='submit'
-        :disabled='v$.$invalid'
-      ) Add
+      span(v-if='!editingName') {{ store.name }}
+      a.edit-store.js-link.gray.ml1(@click='editStoreName')
+        edit-icon(size='27')
+      span(v-if='store.own_store')
+        el-button.ml1(v-if='store.private' size='small' @click='togglePrivacy') Make public
+        el-button.ml1(v-else size='small' @click='togglePrivacy') Make private
+      span.spinner--circle.ml1(v-if='debouncingOrWaitingOnNetwork')
+    div.mb2
+      el-button(id="show-modal" @click='initializeTripCheckinModal()').
+        Check in shopping trip
+      el-button.copy-to-clipboard Copy to clipboard
+      span(v-if='wasCopiedRecently') Copied!
 
-  .items-list.mt0.mb0(v-auto-animate)
-    Item(
-      v-for='item in sortedItems'
-      :item="item"
-      :key="item.id"
-      :ownStore='store.own_store'
-    )
+    div.mb1
+      h3.h3 Notes
+      el-input(
+        v-if='editingNotes'
+        type='textarea'
+        placeholder='Member phone number: 619-867-5309'
+        v-model='store.notes'
+        @blur='stopEditingAndUpdateStoreNotes()'
+        ref='store-notes-input'
+      )
+      p.pre-wrap(v-else)
+        | {{store.notes || 'No notes yet'}}
+        a.edit-store.js-link.gray.ml1(v-if='store.own_store' @click='editStoreNotes')
+          edit-icon(size='18')
 
-  Modal(name='check-in-shopping-trip' width='85%' maxWidth='400px')
-    slot
-      h3.bold.mb2.
-        What did you get?
-      ul.check-in-items-list
-        li.flex.items-center.mb1(
-          v-for='(item, index) in neededItems'
-          :key='item.id'
+    form.flex(v-if='store.own_store' @submit.prevent='postNewItem')
+      .float-left
+        el-input.item-name-input(
+          placeholder='Add an item'
+          type='text'
+          v-model='newItemName'
+          name='newItemName'
         )
-          input(
-            type='checkbox'
-            v-model='itemsToZero'
-            :value='item'
-            :id='`trip-checkin-item-${item.id}`'
+      .ml1
+        el-button.flex-0.button.button-outline(
+          native-type='submit'
+          :disabled='v$.$invalid'
+        ) Add
+
+    .items-list.mt0.mb0(v-auto-animate)
+      Item(
+        v-for='item in sortedItems'
+        :item="item"
+        :key="item.id"
+        :ownStore='store.own_store'
+      )
+
+    Modal(name='check-in-shopping-trip' width='85%' maxWidth='400px')
+      slot
+        h3.bold.mb2.
+          What did you get?
+        ul.check-in-items-list
+          li.flex.items-center.mb1(
+            v-for='(item, index) in neededItems'
+            :key='item.id'
           )
-          label.ml1(:for='`trip-checkin-item-${item.id}`')
-            span {{item.name}}
-            span(v-if='item.needed > 1') {{' '}} ({{item.needed}})
-      div.flex.justify-around.mt2
-        el-button(
-          @click='handleTripCheckinModalSubmit'
-          type='primary'
-          plain
-        ) Set checked items to 0 needed
-        el-button(
-          @click="$store.commit('hideModal', { modalName: 'check-in-shopping-trip' })"
-          type='primary'
-          link
-        ) Cancel
+            input(
+              type='checkbox'
+              v-model='itemsToZero'
+              :value='item'
+              :id='`trip-checkin-item-${item.id}`'
+            )
+            label.ml1(:for='`trip-checkin-item-${item.id}`')
+              span {{item.name}}
+              span(v-if='item.needed > 1') {{' '}} ({{item.needed}})
+        div.flex.justify-around.mt2
+          el-button(
+            @click='handleTripCheckinModalSubmit'
+            type='primary'
+            plain
+          ) Set checked items to 0 needed
+          el-button(
+            @click="$store.commit('hideModal', { modalName: 'check-in-shopping-trip' })"
+            type='primary'
+            link
+          ) Cancel
 </template>
 
 <script>
@@ -254,6 +255,10 @@ export default {
 </script>
 
 <style lang='scss' scoped>
+.store-container {
+  max-height: 97vh;
+}
+
 .item-name-input {
   max-width: 230px;
 }

--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -2,7 +2,7 @@
 div#groceries-app
   div#page.flex.vh-100
     Sidebar
-    main.flex-1.bg-cover.overflow-auto
+    main.flex-1.bg-cover
       Store(v-if='currentStore' :store='currentStore')
 </template>
 


### PR DESCRIPTION
Prior to these tweaks, for a store that had enough items that the list of items was taller than the page (necessitating scrolling) the check-in modal would display "under" / covered by the stores sidebar list.

Here's the diff with whitespace changes ignored: https://github.com/davidrunger/david_runger/pull/1984/files?w=1 .