### PR TITLE
Only enable increment/decrement button hover effect if not on mobile

### DIFF
--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -143,8 +143,10 @@ button.increment {
     top: -1px;
   }
 
-  &:hover {
-    background: white;
+  @media (hover: hover) {
+    &:hover {
+      background: white;
+    }
   }
 }
 


### PR DESCRIPTION
Hover effects don't work well on mobile. In this case, clicking a grocery item increment or decrement button would enable the hover effect, which would remain active until clicking somewhere else.