### PR TITLE
Add padding at the bottom of the workout page

### DIFF
--- a/app/javascript/workout/workout_plan.vue
+++ b/app/javascript/workout/workout_plan.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-div
+.pb4
   .my2
     .h1(v-if='timer') Time Elapsed: {{secondsAsTime(secondsElapsed)}}
     div(v-else)


### PR DESCRIPTION
This will make it easier to scroll down and click the end-workout button (rather than having it squeezed up against the bottom of the page).