### PR TITLE
Stop nesting "Users" within redundant "Users" menu in admin

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 ActiveAdmin.register(User) do
-  menu parent: 'Users'
   permit_params :email
 
   controller do


### PR DESCRIPTION
Previously, "Admin Users" were also in this menu, but they were removed in 1bd2f80 / #1916 .