### PR TITLE
Don't allow `Test::Tasks::Exit` to be a dependency of itself

### DIFF
--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -75,6 +75,8 @@ class Test::RequirementsResolver
         end
 
         forces.each do |force|
+          next if force == Test::Tasks::Exit # don't allow Exit to be a dependency of itself
+
           if !force.in?(base_dependency_map[Test::Tasks::Exit])
             base_dependency_map[Test::Tasks::Exit] << force
           end


### PR DESCRIPTION
Without this, when setting `Test::Tasks::Exit` to `force` in `bin/test/.tests.yml`, pallets would hang / throw a Redis timeout error after running the other tests.