### PR TITLE
Remove auto-animate from groceries store list

### DIFF
--- a/app/assets/stylesheets/animations/appear_vertically.scss
+++ b/app/assets/stylesheets/animations/appear_vertically.scss
@@ -1,0 +1,16 @@
+@keyframes appear-vertically {
+  from {
+    opacity: 0;
+    transform: scale(1, 0);
+  }
+
+  to {
+    opacity: 1;
+    transform: scale(1, 1);
+  }
+}
+
+.appear-vertically {
+  animation-name: appear-vertically;
+  animation-duration: 0.7s;
+}

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1,4 +1,5 @@
 @import "variables";
+@import "animations/appear_vertically";
 @import "components/spinner";
 @import "components/parallax";
 @import "elements/input";

--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -1,6 +1,6 @@
 <template lang='pug'>
 .grocery-item.flex.items-center(
-  :class='{unneeded: item.needed <= 0}'
+  :class='{unneeded: item.needed <= 0, "appear-vertically": item.newlyAdded}'
 )
   .left.nowrap
     button.increment.h2.js-link.olive(@click='setNeeded(item, item.needed + 1)' title='Increment')
@@ -62,10 +62,6 @@ export default {
       this.editingName = true;
       // wait a tick for input to render, then focus it
       setTimeout(() => { this.$refs['item-name-input'].focus(); });
-    },
-
-    isJustAdded(item) {
-      return !!item.createdAt && item.createdAt > ((new Date()).valueOf() - 1000);
     },
 
     setNeeded(item, needed) {

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -57,7 +57,7 @@ div.mt1.mb2.ml3.mr2
           :disabled='v$.$invalid'
         ) Add
 
-    .items-list.mt0.mb0(v-auto-animate)
+    .items-list.mt0.mb0
       Item(
         v-for='item in sortedItems'
         :item="item"

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -14,8 +14,11 @@ const actions = {
       post(Routes.api_store_items_path(store.id), { json: { item: itemAttributes } }).
       json().
       then(itemData => {
+        itemData.newlyAdded = true;
         this.decrementPendingRequests();
         this.addItem({ store, itemData });
+
+        setTimeout(() => { itemData.newlyAdded = false; }, 1000);
       });
   },
 

--- a/app/javascript/packs/groceries_app.js
+++ b/app/javascript/packs/groceries_app.js
@@ -1,4 +1,3 @@
-import { autoAnimatePlugin } from '@formkit/auto-animate/vue';
 import { createPinia } from 'pinia';
 
 import { renderApp } from '@/shared/customized_vue';
@@ -13,4 +12,3 @@ app.use(pinia);
 app.component('Modal', Modal);
 useKy(app);
 useElementPlus(app);
-app.use(autoAnimatePlugin);

--- a/bin/test/tasks/run_file_size_checks.rb
+++ b/bin/test/tasks/run_file_size_checks.rb
@@ -11,7 +11,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'charts*.js' => (340..350),
     'check_in_ratings*.js' => (165..175),
     'check_in_ratings*.css' => (10..15),
-    'groceries*.js' => (385..395),
+    'groceries*.js' => (380..390),
     'groceries*.css' => (100..110),
     'home*.js' => (120..130),
     'home*.css' => (1..4),


### PR DESCRIPTION
And add back the `appear-vertically` animation in a way that works. (Previously, the `createdAt` timestamp that was being checked to determine whether to apply that class was always blank.)