### PR TITLE
Show time to next round as "0:00" if workout is just one set

### DIFF
--- a/app/javascript/workouts/workout_plan.vue
+++ b/app/javascript/workouts/workout_plan.vue
@@ -86,6 +86,8 @@ export default {
     },
 
     intervalInMinutes() {
+      if (this.numberOfSets === 1) return 0;
+
       return this.minutes / (this.numberOfSets - 1);
     },
 
@@ -210,6 +212,8 @@ export default {
     },
 
     secondsAsTime(seconds) {
+      if (seconds <= 0) return '0:00';
+
       const minutesAsDecimal = seconds / 60;
       const wholeMinutes = Math.floor(minutesAsDecimal);
       const secondsRemainder = Math.floor(seconds - (60 * wholeMinutes));


### PR DESCRIPTION
Previously, it showed as "NaN:NaN" or something like that (because of a divide-by-zero error, I think).