### PR TITLE
Use standalone `workoutIsInProgress` attribute (not `workout.active`)

### DIFF
--- a/app/javascript/workouts/store.js
+++ b/app/javascript/workouts/store.js
@@ -2,26 +2,30 @@ import { defineStore } from 'pinia';
 import { kyApi } from '@/shared/ky';
 import { get } from 'lodash-es';
 
-const state = () => ({
-  ...window.davidrunger.bootstrap,
-  workout:
+const state = () => {
+  const workout =
     get(window, 'davidrunger.bootstrap.current_user.preferences.default_workout') ||
       {
         minutes: null,
         numberOfSets: null,
         exercises: [{}],
-        active: false,
-      },
-});
+      };
+
+  return {
+    ...window.davidrunger.bootstrap,
+    workout,
+    workoutIsInProgress: false,
+  };
+};
 
 const actions = {
   completeWorkout({ completedWorkout }) {
     this.workouts = this.workouts.concat(completedWorkout);
-    this.workout.active = false;
+    this.workoutIsInProgress = false;
   },
 
   initializeWorkout() {
-    this.workout.active = true;
+    this.workoutIsInProgress = true;
     kyApi.
       patch(
         Routes.api_user_path({ id: this.current_user.id }),

--- a/app/javascript/workouts/workout.vue
+++ b/app/javascript/workouts/workout.vue
@@ -1,5 +1,5 @@
 <template lang='pug'>
-div(v-if='workout.active')
+div(v-if='workoutIsInProgress')
   WorkoutPlan(v-bind='workout')
 NewWorkoutForm(v-else)
 </template>
@@ -18,6 +18,7 @@ export default {
 
   computed: mapState(useWorkoutsStore, [
     'workout',
+    'workoutIsInProgress',
   ]),
 };
 </script>

--- a/spec/features/workout_spec.rb
+++ b/spec/features/workout_spec.rb
@@ -27,5 +27,45 @@ RSpec.describe 'Workout app' do
       expect(page).to have_text("Others' workouts\nNone", normalize_ws: false)
       expect(page).not_to have_text('Loading')
     end
+
+    context 'when the user has a default workout saved in their preferences' do
+      before do
+        user.update(
+          preferences: {
+            'default_workout' => {
+              'minutes' => minutes,
+              'exercises' => [
+                { 'name' => exercise_1_name, 'reps' => exercise_1_reps },
+                { 'name' => exercise_2_name, 'reps' => exercise_2_reps },
+              ],
+              'numberOfSets' => sets,
+            },
+          },
+        )
+      end
+
+      let(:minutes) { 20 }
+      let(:sets) { 10 }
+      let(:exercise_1_name) { 'pushups' }
+      let(:exercise_1_reps) { 15 }
+      let(:exercise_2_name) { 'chinups' }
+      let(:exercise_2_reps) { 5 }
+
+      it 'renders the new-workout form preloaded with their default workout' do
+        visit workout_path
+
+        expect(page).to have_text('New Workout')
+        expect(page).to have_css('form')
+
+        expect(page).to have_field('minutes', with: minutes)
+        expect(page).to have_field('numberOfSets', with: sets)
+        expect(page).to have_field('exercise-0-name', with: exercise_1_name)
+        expect(page).to have_field('exercise-0-reps', with: exercise_1_reps)
+        expect(page).to have_field('exercise-1-name', with: exercise_2_name)
+        expect(page).to have_field('exercise-1-reps', with: exercise_2_reps)
+
+        expect(page).to have_button('Initialize Workout!')
+      end
+    end
   end
 end


### PR DESCRIPTION
This fixes a bug wherein the user was not shown the new-workout-form upon visiting `/workout` if they had previously completed a workout. By storing `active` as a property of `workout`, we were posting that to the server and saving it in the user's preferences upon workout completion, which isn't what we want.