### PR TITLE
Move workout lists from within `NewWorkoutForm` to `Workout`

### DIFF
--- a/app/javascript/workouts/new_workout_form.vue
+++ b/app/javascript/workouts/new_workout_form.vue
@@ -1,79 +1,62 @@
 <template lang='pug'>
-div.m2
-  form.mt3
-    h2.h2 New Workout
-    .my1
+form
+  h2.h2 New Workout
+  .my1
+    label
+      | Minutes
+      el-input(
+        v-model.number='workoutsStore.workout.minutes'
+        name='minutes'
+        type='number'
+        step='0.1'
+      )
+  .my1
+    label
+      | Sets
+      el-input(
+        v-model.number='workoutsStore.workout.numberOfSets'
+        name='numberOfSets'
+        type='number'
+      )
+  .my1.clearfix.flex(v-for='(exercise, index) in workout.exercises')
+    .col.col-6
       label
-        | Minutes
+        | Exercise
         el-input(
-          v-model.number='workoutsStore.workout.minutes'
-          name='minutes'
-          type='number'
-          step='0.1'
+          v-model='exercise.name'
+          :name='`exercise-${index}-name`'
+          type='text'
         )
-    .my1
+    .col.col-5
       label
-        | Sets
+        | Reps per set
         el-input(
-          v-model.number='workoutsStore.workout.numberOfSets'
-          name='numberOfSets'
+          v-model.number='exercise.reps'
+          :name='`exercise-${index}-reps`'
           type='number'
         )
-    .my1.clearfix.flex(v-for='(exercise, index) in workout.exercises')
-      .col.col-6
-        label
-          | Exercise
-          el-input(
-            v-model='exercise.name'
-            :name='`exercise-${index}-name`'
-            type='text'
-          )
-      .col.col-5
-        label
-          | Reps per set
-          el-input(
-            v-model.number='exercise.reps'
-            :name='`exercise-${index}-reps`'
-            type='number'
-          )
-      .col.col-1.flex.flex-column.items-center.justify-center
-        button(type='button' @click='removeExercise(index)') X
-    .my1.center
-      el-button(
-        @click='workout.exercises.push({})'
-      ) Add exercise
-    .mt3.center
-      el-button(
-        type='primary'
-        @click='this.workoutsStore.initializeWorkout()'
-      ) Initialize Workout!
-  div.my2
-    h2.h2 Previous workouts
-    WorkoutsTable(
-      :isOwnWorkouts='true'
-      :workouts='workouts'
-    )
-  div.my2
-    h2.h2 Others' workouts
-    WorkoutsTable(:workouts='others_workouts')
+    .col.col-1.flex.flex-column.items-center.justify-center
+      button(type='button' @click='removeExercise(index)') X
+  .my1.center
+    el-button(
+      @click='workout.exercises.push({})'
+    ) Add exercise
+  .mt2.center
+    el-button(
+      type='primary'
+      @click='this.workoutsStore.initializeWorkout()'
+    ) Initialize Workout!
 </template>
 
 <script>
 import { mapState } from 'pinia';
 
 import { useWorkoutsStore } from '@/workouts/store';
-import WorkoutsTable from './workouts_table.vue';
 
 export default {
-  components: {
-    WorkoutsTable,
-  },
-
   computed: {
     ...mapState(useWorkoutsStore, [
-      'others_workouts',
       'workout',
-      'workouts',
     ]),
   },
 

--- a/app/javascript/workouts/workout.vue
+++ b/app/javascript/workouts/workout.vue
@@ -1,7 +1,17 @@
 <template lang='pug'>
 div(v-if='workoutIsInProgress')
   WorkoutPlan(v-bind='workout')
-NewWorkoutForm(v-else)
+.px3.py1(v-else)
+  NewWorkoutForm
+  div.my2
+    h2.h2 Previous workouts
+    WorkoutsTable(
+      :isOwnWorkouts='true'
+      :workouts='workouts'
+    )
+  div.my2
+    h2.h2 Others' workouts
+    WorkoutsTable(:workouts='others_workouts')
 </template>
 
 <script>
@@ -9,16 +19,20 @@ import { mapState } from 'pinia';
 import { useWorkoutsStore } from '@/workouts/store';
 import NewWorkoutForm from './new_workout_form.vue';
 import WorkoutPlan from './workout_plan.vue';
+import WorkoutsTable from './workouts_table.vue';
 
 export default {
   components: {
     NewWorkoutForm,
     WorkoutPlan,
+    WorkoutsTable,
   },
 
   computed: mapState(useWorkoutsStore, [
+    'others_workouts',
     'workout',
     'workoutIsInProgress',
+    'workouts',
   ]),
 };
 </script>


### PR DESCRIPTION
It just doesn't make logical/naming sense for these lists to be within the `NewWorkoutForm` component.

Link ignoring whitespace-only diffs: https://github.com/davidrunger/david_runger/pull/2021/files?w=1 .