### PR TITLE
Don't show note input for counter logs

### DIFF
--- a/app/javascript/logs/components/new_log_entry_form.vue
+++ b/app/javascript/logs/components/new_log_entry_form.vue
@@ -28,7 +28,7 @@ div
       )
       el-input.new-log-input(
         :class='{mb1: isNumeric}'
-        v-if='isNumeric'
+        v-if='isDuration || isNumber'
         placeholder='Note (optional)'
         v-model='newLogEntryNote'
         type='text'


### PR DESCRIPTION
The notes don't get displayed in the UI (bar graphs), so it's just confusing / unhelpful to show an input for a note.