### PR TITLE
Allow enforcing uniqueness of Sidekiq jobs/arguments while executing

### DIFF
--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -1,23 +1,75 @@
 # frozen_string_literal: true
 
+require 'digest/sha1'
+
 module ApplicationWorker
+  extend Memoist
   include Sidekiq::Worker # rubocop:disable CustomCops/DontIncludeSidekiqWorker
+
+  MAX_RETRY_WAIT_TIME = 30 # seconds
 
   # borrowed from https://github.com/mperham/sidekiq/blob/v6.1.0/lib/sidekiq/worker.rb#L137-L142
   def self.prepended(base)
     base.include(Sidekiq::Worker::Options)
     base.extend(Sidekiq::Worker::ClassMethods)
+
+    class << base
+      attr_accessor :unique_while_executing
+    end
   end
 
-  def perform(...)
-    disable_flag_name = "disable_#{self.class.name.underscore}_worker".to_sym
-    if Flipper.enabled?(disable_flag_name)
-      logger.info(<<~LOG.squish)
-        Skipping #{self.class.name} job because the `#{disable_flag_name}` flag is enabled.
-      LOG
-      return
-    end
+  def perform(*args)
+    with_lock_or_reschedule(args) do
+      disable_flag_name = "disable_#{self.class.name.underscore}_worker".to_sym
+      if Flipper.enabled?(disable_flag_name)
+        logger.info(<<~LOG.squish)
+          Skipping #{self.class.name} job because the `#{disable_flag_name}` flag is enabled.
+        LOG
+        return
+      end
 
-    super
+      super
+    end
+  end
+
+  private
+
+  def with_lock_or_reschedule(args)
+    if !self.class.unique_while_executing || lock_obtained?(args)
+      begin
+        yield
+      ensure
+        remove_lock(args) if self.class.unique_while_executing
+      end
+    else
+      reschedule(args)
+    end
+  end
+
+  def lock_obtained?(args)
+    Sidekiq.redis do |conn|
+      conn.call('set', lock_key(args), 'locked', nx: true, ex: MAX_RETRY_WAIT_TIME)
+    end
+  end
+
+  def reschedule(args)
+    reschedule_wait = rand((1..MAX_RETRY_WAIT_TIME))
+    Rails.logger.info(<<~LOG.squish)
+      Rescheduling #{self.class.name} worker with args #{args}
+      in #{reschedule_wait} seconds because uniqueness lock
+      could not be obtained.
+    LOG
+    self.class.perform_in(reschedule_wait, *args)
+  end
+
+  def remove_lock(args)
+    Sidekiq.redis do |conn|
+      conn.call('del', lock_key(args))
+    end
+  end
+
+  memoize \
+  def lock_key(args)
+    "sidekiq-unique:#{self.class.name}:#{Digest::SHA1.hexdigest(JSON.dump(args))}"
   end
 end

--- a/app/workers/create_ip_block.rb
+++ b/app/workers/create_ip_block.rb
@@ -3,6 +3,8 @@
 class CreateIpBlock
   prepend ApplicationWorker
 
+  self.unique_while_executing = true
+
   def perform(ip, reason = nil)
     ip_block = IpBlock.find_or_initialize_by(ip:)
     if ip_block.new_record?
@@ -16,11 +18,7 @@ class CreateIpBlock
           end.
           join("\n")
 
-      begin
-        ip_block.update!(reason: block_reason)
-      rescue ActiveRecord::RecordNotUnique => error # can happen due to race condition
-        Rollbar.warn(error)
-      end
+      ip_block.update!(reason: block_reason)
     end
   end
 end

--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -6,6 +6,8 @@ class SaveRequest
   extend Memoist
   prepend ApplicationWorker
 
+  self.unique_while_executing = true
+
   delegate(
     :delete_request_data,
     :initial_stashed_json,
@@ -17,6 +19,8 @@ class SaveRequest
   def perform(request_id)
     @request_id = request_id
     @stashed_data_manager = SaveRequest::StashedDataManager.new(@request_id)
+
+    return if Request.exists?(request_id: @request_id)
 
     if can_save_request?
       if ban_reasons.present?
@@ -72,7 +76,6 @@ class SaveRequest
     [
       ('Initial stashed JSON for request logging was blank' if initial_stashed_json.blank?),
       ('Final stashed JSON for request logging was blank' if final_stashed_json.blank?),
-      ('Request was already saved' if Request.exists?(request_id: @request_id)),
     ].compact
   end
 

--- a/app/workers/send_log_reminder_emails.rb
+++ b/app/workers/send_log_reminder_emails.rb
@@ -3,6 +3,8 @@
 class SendLogReminderEmails
   prepend ApplicationWorker
 
+  self.unique_while_executing = true
+
   def perform
     Log.needing_reminder.find_each do |log|
       log.update!(reminder_last_sent_at: Time.current)

--- a/config/initializers/std_lib.rb
+++ b/config/initializers/std_lib.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 require 'csv' # for Logs::UploadsController
+require 'digest/sha1' # for ApplicationWorker uniqueness enforcement
 require 'fileutils' # assets:precompile

--- a/spec/workers/create_ip_block_spec.rb
+++ b/spec/workers/create_ip_block_spec.rb
@@ -9,27 +9,10 @@ RSpec.describe CreateIpBlock do
     let(:ip) { Faker::Internet.public_ip_v4_address }
 
     context 'when there is already an IpBlock with the specified IP' do
-      let!(:ip_block) { create(:ip_block, ip:) }
+      before { create(:ip_block, ip:) }
 
       it 'does not create a new IpBlock or raise an error' do
         expect { perform }.not_to change { IpBlock.count }
-      end
-
-      # this can happen in a multithreading environment race condition; simulate w/ stubbing here
-      context 'when new_record? returns false' do
-        before do
-          expect(IpBlock).to receive(:find_or_initialize_by).with(ip:).and_return(ip_block)
-          expect(ip_block).to receive(:new_record?).at_least(:once).and_return(true) # really false
-        end
-
-        it 'does not raise an error' do
-          expect { perform }.not_to raise_error
-        end
-
-        it 'sends a warning to Rollbar' do
-          expect(Rollbar).to receive(:warn).with(ActiveRecord::RecordNotUnique).and_call_original
-          expect { perform }.not_to raise_error
-        end
       end
     end
 


### PR DESCRIPTION
When the `unique_while_executing` option is set for a worker class, then no other instances of that job should execute concurrently with a given set of arguments while one instance of that worker is executing with those arguments. If an attempt is made to execute such a job concurrently, then it will be rescheduled to retry after a random interval (currently between 1 and 30 seconds later).

This simplifies the `CreateIpBlock` worker (making it no longer necessary to guard against a certain race condition therein) and hopefully will also avoid certain errors in the `SaveRequest` worker.