### PR TITLE
Remove grocery item from the UI only after it's deleted on server

### DIFF
--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -67,8 +67,13 @@ const actions = {
 
   deleteItem({ item }) {
     const store = this.currentStore;
-    store.items = store.items.filter(storeItem => storeItem !== item);
-    kyApi.delete(Routes.api_item_path(item.id));
+
+    this.incrementPendingRequests();
+    kyApi.delete(Routes.api_item_path(item.id)).
+      then(() => {
+        this.decrementPendingRequests();
+        store.items = store.items.filter(storeItem => storeItem !== item);
+      });
   },
 
   deleteStore({ store: deletedStore }) {


### PR DESCRIPTION
Although a bit slower, I think that this UX makes more sense to the user (who maybe expects a certain amount of HTTP wait time) and makes the user more confident that the item has been deleted on the server.