### PR TITLE
Always bold the next-round countdown timer

### DIFF
--- a/app/javascript/workouts/workout_plan.vue
+++ b/app/javascript/workouts/workout_plan.vue
@@ -36,7 +36,9 @@
               v-model.number='setsArray[index].timeAdjustment'
               :disabled='index <= currentRoundIndex'
             )
-          td(:class='nextRoundCountdownClass(index)') {{timeColumnValue(index)}}
+          td(
+            :class='nextRoundCountdownClasses(index)'
+          ) {{timeColumnValue(index)}}
           td(
             v-for='exercise in setsArray[index].exercises'
           )
@@ -186,16 +188,17 @@ export default {
       }));
     },
 
-    nextRoundCountdownClass(index) {
+    nextRoundCountdownClasses(index) {
       if (index !== this.currentRoundIndex + 1) return '';
 
+      const classes = ['bold'];
       if (this.secondsUntilNextRound <= 10) {
-        return ['red', 'bold'];
+        classes.push('red');
       } else if (this.secondsUntilNextRound <= 30) {
-        return 'orange';
-      } else {
-        return '';
+        classes.push('orange');
       }
+
+      return classes;
     },
 
     saveWorkout() {


### PR DESCRIPTION
Now that it has been moved into the table (rather than on the right side, as it was before), it's a bit hard to pick out. The bolding should help with that.