### PR TITLE
[home] Use IntersectionObserver to ensure section is in view

### DIFF
--- a/app/javascript/home/scripts/position_listener.js
+++ b/app/javascript/home/scripts/position_listener.js
@@ -89,8 +89,19 @@ export function init() {
       enter(direction) {
         if (scrollHookHash === '#') return;
 
-        sectionsPartiallyInView.push(scrollHookHash);
-        updateHighlightedNavlink(direction);
+        function intersectionHandler(entries) {
+          entries.forEach(entry => {
+            if (entry.isIntersecting) {
+              if (!sectionsPartiallyInView.includes(scrollHookHash)) {
+                sectionsPartiallyInView.push(scrollHookHash);
+                updateHighlightedNavlink(direction);
+              }
+            }
+          });
+        }
+
+        const observer = new IntersectionObserver(intersectionHandler, { threshold: 1 });
+        observer.observe(scrollHook);
       },
       entered(direction) {
         if (scrollHookHash === '#') return;


### PR DESCRIPTION
This fixes a bug wherein upon going to http://localhost:3000/#contact and then scrolling up, sometimes the #about nav link would be highlighted, even when the about section wasn't in view.