### PR TITLE
[log uploads] Specify action correctly via `:url` keyword

### DIFF
--- a/app/controllers/logs/uploads_controller.rb
+++ b/app/controllers/logs/uploads_controller.rb
@@ -21,7 +21,7 @@ class Logs::UploadsController < ApplicationController
 
     if log_entries.all?(&:valid?)
       log_entries.each do |log_entry|
-        CreateLogEntry.perform_async(log_entry.class.name, log_entry.attributes.as_json)
+        CreateLogEntry.perform_async(log_entry.class.name, log_entry.attributes.compact.to_json)
       end
       flash[:notice] = 'Data uploaded successfully! Give it a moment to enter the database.'
       redirect_to(log_path(slug: log.slug))

--- a/app/views/logs/uploads/new.haml
+++ b/app/views/logs/uploads/new.haml
@@ -10,7 +10,7 @@
       %code.monospace note
       (optional)
 
-= form_with(action: logs_uploads_path, method: :post, multipart: true) do
+= form_with(url: logs_uploads_path, method: :post, multipart: true) do
   = hidden_field_tag(:authenticity_token, form_authenticity_token)
   %div
     %label{for: 'log_id'} Log

--- a/app/workers/create_log_entry.rb
+++ b/app/workers/create_log_entry.rb
@@ -3,8 +3,8 @@
 class CreateLogEntry
   prepend ApplicationWorker
 
-  def perform(log_entry_klass, log_entry_attributes)
+  def perform(log_entry_klass, log_entry_attributes_json)
     klass = log_entry_klass.constantize
-    klass.create!(log_entry_attributes)
+    klass.create!(JSON(log_entry_attributes_json))
   end
 end

--- a/spec/controllers/logs/uploads_controller_spec.rb
+++ b/spec/controllers/logs/uploads_controller_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Logs::UploadsController do
     it 'renders a form to upload log entry data for a selected log and tips for usage' do
       get_new
 
+      expect(response.body).to have_css("form[action='#{logs_uploads_path}'][method='post']")
       expect(response.body).to have_css('form select[name=log_id]')
       expect(response.body).to have_css('form input[type=file]')
       expect(response.body).to have_text('Recommended CSV columns')


### PR DESCRIPTION
How did this ever work??? I'm so confused.

Also, obey for `CreateLogEntry` Sidekiq's new strict arguments requirement (JSON "native types" only, which I guess doesn't include hashes).