### PR TITLE
Change worker unique while executing setting from accessor to command

### DIFF
--- a/app/workers/create_ip_block.rb
+++ b/app/workers/create_ip_block.rb
@@ -3,7 +3,7 @@
 class CreateIpBlock
   prepend ApplicationWorker
 
-  self.unique_while_executing = true
+  unique_while_executing!
 
   def perform(ip, reason = nil)
     ip_block = IpBlock.find_or_initialize_by(ip:)

--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -6,7 +6,7 @@ class SaveRequest
   extend Memoist
   prepend ApplicationWorker
 
-  self.unique_while_executing = true
+  unique_while_executing!
 
   delegate(
     :delete_request_data,

--- a/app/workers/send_log_reminder_emails.rb
+++ b/app/workers/send_log_reminder_emails.rb
@@ -3,7 +3,7 @@
 class SendLogReminderEmails
   prepend ApplicationWorker
 
-  self.unique_while_executing = true
+  unique_while_executing!
 
   def perform
     Log.needing_reminder.find_each do |log|

--- a/spec/workers/application_worker_spec.rb
+++ b/spec/workers/application_worker_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe ApplicationWorker do
     context 'when the worker sets unique_while_executing to true' do
       before do
         StubbedTestJob.class_eval do
-          self.unique_while_executing = true
+          unique_while_executing!
         end
       end
 


### PR DESCRIPTION
This was flagged by reek, and I agree that it's better this way.