### PR TITLE
Remove `net_http_connect_on_start: true` WebMock setting

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -56,7 +56,6 @@ WebMock.enable!
 WebMock.disable_net_connect!(
   allow_localhost: true,
   allow: 'david-runger-test-uploads.s3.amazonaws.com', # upload feature test failure screenshots
-  net_http_connect_on_start: true,
 )
 
 OmniAuth.config.test_mode = true


### PR DESCRIPTION
I think that I originally added this because I was running into this:

> If WebMock is enabled, you may encounter a "Too many open files" > error. A simple `page.find` call may cause thousands of HTTP requests > until the timeout occurs. By default, WebMock will cause each of these > requests to spawn a new connection. To work around this problem, you > may need to enable WebMock's `net_http_connect_on_start: true` > parameter.

~ https://github.com/teamcapybara/capybara#gotchas

However, I don't think I realized that this means that our tests actually try to connect to the Internet, which I don't want. (I noticed because some MailgunViaHttp tests were intermittently failing with connection errors, and verified by running the test suite with my WiFi turned off.)

I'm going to try removing this and see if the "Too many open files" error occurs again (hoping that it won't).