### PR TITLE
[TruncateTables] Stop running `ANALYZE` before logging row counts

### DIFF
--- a/app/workers/truncate_tables.rb
+++ b/app/workers/truncate_tables.rb
@@ -14,7 +14,6 @@ class TruncateTables
   end
 
   def self.print_row_counts
-    ApplicationRecord.connection.execute('ANALYZE')
     ApplicationRecord.connection.execute(ROW_COUNT_SQL).to_a.each do |row|
       Rails.logger.info("#{row['n_live_tup']} rows - #{row['relname']}")
     end


### PR DESCRIPTION
`ANALYZE` is not exactly a fast command. I don't think it's worth invoking manually each time we run this worker.