### PR TITLE
Uniq the URLs in CheckHomeLinks::Launcher

### DIFF
--- a/app/workers/check_home_links/launcher.rb
+++ b/app/workers/check_home_links/launcher.rb
@@ -19,7 +19,7 @@ class CheckHomeLinks::Launcher
     links.filter_map do |link|
       href = link.attr('href')
       href if href.match?(%r{\A(https?:)?//})
-    end
+    end.uniq
   end
 
   memoize \


### PR DESCRIPTION
If a URL is present 2+ times in the home page, still only check it once.