### PR TITLE
[groceries] Show numberOfItemsGotten/numberOfItemsNeeded

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -74,7 +74,7 @@
           @click='manageCheckInStores'
         ) Choose stores
       h3.bold.mb2.
-        What did you get?
+        What did you get? ({{itemsToZero.length}}/{{neededCheckInItems.length}})
       ul.check-in-items-list
         li.flex.items-center.mb1(
           v-for='(item, index) in neededCheckInItems'


### PR DESCRIPTION
On mobile Safari, which seemingly refuses to show scrollbars unless the user is scrolling, this should reduce the chance that a user will not realize that there are some items hidden out of view.