### PR TITLE
Always render at least a nonce in the bootstrap data

### DIFF
--- a/app/controllers/concerns/bootstrappable.rb
+++ b/app/controllers/concerns/bootstrappable.rb
@@ -3,12 +3,17 @@
 module Bootstrappable
   extend ActiveSupport::Concern
 
+  included do
+    helper_method :bootstrap
+  end
+
   private
 
-  def bootstrap(data)
+  def bootstrap(data = {})
     # Adding a `nonce` ensures that the bootstrap data is always unique, which is useful because
     # that ensures that turbo will always evaluate the `<script>` tag(s) within which it's wrapped.
     @bootstrap_data ||= { nonce: SecureRandom.uuid }
     @bootstrap_data.merge!(data)
+    @bootstrap_data
   end
 end

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -33,8 +33,7 @@
     = csrf_meta_tags
     = javascript_tag(nonce: true) do
       window.davidrunger = {env: '#{Rails.env}'};
-      window.davidrunger.bootstrap = JSON.parse(
-      "#{raw(escape_javascript((@bootstrap_data || {}).to_json))}");
+      window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript((bootstrap).to_json))}");
 
     - if Rails.env.development? && !ENV['PRODUCTION_ASSET_CONFIG'].present?
       = vite_client_tag


### PR DESCRIPTION
This isn't solving any definite problem for me, but it has bothered me before that sometimes the bootstrap data is completely empty, and it feels like a good thing to do.