### PR TITLE
[admin] Show only admin's email part before "@" as comment label

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -19,4 +19,8 @@ class AdminUser < ApplicationRecord
   devise
 
   has_paper_trail
+
+  def display_name
+    email.split('@').first
+  end
 end


### PR DESCRIPTION
It's too bad that we have to add this to the ActiveRecord model, i.e. that we can't use a decorator instead, but since the comment label is generated by ActiveAdmin, we don't have the ability to use a decorator for this case.

## Before

![image](https://user-images.githubusercontent.com/8197963/200899431-79aa5407-a55d-458e-9f1d-6ffdae1dcbc7.png)

## After

![image](https://user-images.githubusercontent.com/8197963/200899474-a2361ac8-2645-4828-841f-8692167f7c3a.png)
