### PR TITLE
[checkins] Don't serialize and subscribe with marriage id

### DIFF
--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -10,7 +10,6 @@ class CheckInsController < ApplicationController
     authorize(CheckIn)
     @title = 'Marriage check-ins'
     @marriage = current_user.marriage.decorate
-    bootstrap(marriage: MarriageSerializer.new(@marriage))
     render :index
   end
 
@@ -40,7 +39,6 @@ class CheckInsController < ApplicationController
     check_in_need_satisfaction_ratings = @check_in.need_satisfaction_ratings
 
     bootstrap_data = {
-      marriage: @check_in.marriage.serializer,
       check_in: @check_in.serializer,
       user_ratings_of_partner:
         NeedSatisfactionRatingSerializer.new(

--- a/app/javascript/check_ins/app.vue
+++ b/app/javascript/check_ins/app.vue
@@ -32,7 +32,6 @@ export default {
     actionCableConsumer.subscriptions.create(
       {
         channel: 'CheckInsChannel',
-        marriage_id: window.davidrunger.bootstrap.marriage.id,
       },
       {
         received: (data) => {

--- a/app/javascript/packs/check_ins_index.js
+++ b/app/javascript/packs/check_ins_index.js
@@ -3,7 +3,6 @@ import actionCableConsumer from '@/channels/consumer';
 actionCableConsumer.subscriptions.create(
   {
     channel: 'CheckInsChannel',
-    marriage_id: window.davidrunger.bootstrap.marriage.id,
   },
   {
     received(data) {

--- a/spec/controllers/check_ins_controller_spec.rb
+++ b/spec/controllers/check_ins_controller_spec.rb
@@ -42,7 +42,6 @@ RSpec.describe CheckInsController do
       end
 
       it 'sets the correct bootstrap data for the check-in' do
-        expect(bootstrap_data['marriage'].keys).to eq(%w[id])
         expect(bootstrap_data['check_in'].keys).to eq(%w[id])
       end
     end


### PR DESCRIPTION
It's not necessary, since each user only has one marriage and in the CheckInsChannel we just use `current_user.marriage.presence!`.