### PR TITLE
[admin] Stop showing filters for associations on users index page

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -2,6 +2,8 @@
 
 ActiveAdmin.register(User) do
   permit_params :email
+  filter :email
+  filter :created_at
 
   controller do
     def find_resource


### PR DESCRIPTION
Instead, just show filters for email and created_at. The association filters were generating slow queries and also probably using a large amount of memory.