### PR TITLE
[dev] Set config.hotwire_livereload.disable_default_listeners = true

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,6 +86,7 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
+  config.hotwire_livereload.disable_default_listeners = true
   config.hotwire_livereload.listen_paths = %w[
     app/views
     app/helpers


### PR DESCRIPTION
Without this, the page was reloading when modifying JavaScript files, which isn't why I added this gem. I added it just to live reload HAML views. Vue/Vite manage JavaScript reloading for our JavaScript apps.