### PR TITLE
Set `PERCY_SKIP_UPDATE_CHECK=1` in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -63,6 +63,7 @@ jobs:
         RAILS_ENV: test
         NODE_ENV: test
         DISABLE_SPRING: 1
+        PERCY_SKIP_UPDATE_CHECK: 1
         VITE_RUBY_AUTO_BUILD: false
         SECRET_KEY_BASE: 0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b
         # The hostname used to communicate with the PostgreSQL service container


### PR DESCRIPTION
Maybe this will make CI a tiny bit faster.

Reference: https://github.com/percy/cli/pull/ 1127