### PR TITLE
Remove Dokku CHECKS file

### DIFF
--- a/CHECKS
+++ b/CHECKS
@@ -1,5 +1,0 @@
-WAIT=3
-TIMEOUT=60
-ATTEMPTS=20
-
-/ David Runger


### PR DESCRIPTION
This should cause Dokku to stop running checks, which unfortunately we need to do because checks aren't working because of some issue caused by temporarily and thoughtlessly enabling the dokku letsencrypt plugin (which is not good because we're using Cloudflare for our SSL cert).