### PR TITLE
Check `request.fullpath` (not just `path`) for banned fragments

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -29,10 +29,11 @@ class Rack::Attack
     end
 
     def blocked_path?(request)
-      return true if request.fullpath.include?("\u0000")
-      return false if WHITELISTED_PATH_PREFIXES.any? { request.fullpath.start_with?(_1) }
+      fullpath = request.fullpath
+      return true if fullpath.include?("\u0000")
+      return false if WHITELISTED_PATH_PREFIXES.any? { fullpath.start_with?(_1) }
 
-      fragments = request.path.split(PATH_FRAGMENT_SEPARATOR_REGEX)
+      fragments = fullpath.split(PATH_FRAGMENT_SEPARATOR_REGEX)
       fragments.map!(&:presence)
       fragments.compact!
       fragments.any? do |fragment|


### PR DESCRIPTION
This will include any query strings in the check.

fixes rb#545 https://rollbar.com/davidjrunger/davidrunger/items/545/