### PR TITLE
[BannedPathFragment] Allow `%` in value

### DIFF
--- a/app/models/banned_path_fragment.rb
+++ b/app/models/banned_path_fragment.rb
@@ -17,7 +17,7 @@ class BannedPathFragment < ApplicationRecord
   validates(
     :value,
     presence: true,
-    format: { with: /\A[a-z0-9]+\z/ },
+    format: { with: /\A[a-z0-9%]+\z/ },
     uniqueness: true,
   )
 end

--- a/spec/models/banned_path_fragment_spec.rb
+++ b/spec/models/banned_path_fragment_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe BannedPathFragment do
 
   it { is_expected.to validate_presence_of(:value) }
   it { is_expected.to allow_value('phpmyadmin').for(:value) }
+  it { is_expected.to allow_value('%25alevins%25').for(:value) }
   it { is_expected.not_to allow_value('/phpmyadmin').for(:value) }
   it { is_expected.not_to allow_value('old-wp').for(:value) }
 end


### PR DESCRIPTION
This allows banning URL-encoded fragments.