### PR TITLE
Don't specify Ruby version in GitHub Action workflow

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -40,10 +40,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 10 # this might cause issues if there are more than 10 commits in a PR (?)
-    - name: Set up Ruby 3.1.3
+    - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.1.3
         bundler-cache: true
     - uses: actions/setup-node@v3
       with:
@@ -102,10 +101,9 @@ jobs:
           git_remote_url: 'ssh://dokku@198.199.122.6:22/davidrunger'
           ssh_private_key: ${{secrets.SSH_PRIVATE_KEY}}
 
-      - name: Set up Ruby 3.1.3
+      - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.1.3
           bundler-cache: true
 
       - name: Prerender page(s) and upload them to S3


### PR DESCRIPTION
The `ruby/setup-ruby@v1` GitHub Action will automatically fall back to using the Ruby version specified in `.ruby-version`. So this'll be one less thing to update when bumping the Ruby version. :)