### PR TITLE
Don't save `Request`s for UptimeRobot pings

### DIFF
--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -23,7 +23,9 @@ class SaveRequest
     return if Request.exists?(request_id: @request_id)
 
     if can_save_request?
-      if ban_reasons.present?
+      if uptime_robot_ping?
+        delete_request_data
+      elsif ban_reasons.present?
         ban_requesting_ip
         delete_request_data
       else
@@ -38,6 +40,11 @@ class SaveRequest
   private
 
   memoize \
+  def uptime_robot_ping?
+    params['uptime_robot'].present?
+  end
+
+  memoize \
   def ban_reasons
     ban_reasons = []
 
@@ -50,8 +57,12 @@ class SaveRequest
 
   memoize \
   def params_keys_and_values
-    params = stashed_data['params']
     params.keys + params.values
+  end
+
+  memoize \
+  def params
+    stashed_data['params']
   end
 
   def ban_requesting_ip

--- a/spec/workers/save_request_spec.rb
+++ b/spec/workers/save_request_spec.rb
@@ -88,6 +88,19 @@ RSpec.describe SaveRequest do
           end
         end
 
+        context 'when the request was an UptimeRobot ping' do
+          let(:stubbed_additional_data) { super().merge('params' => { 'uptime_robot' => '1' }) }
+
+          it 'does not create a request' do
+            expect { perform }.not_to change { Request.count }
+          end
+
+          it 'deletes the stashed data' do
+            perform
+            expect(stubbed_data_manager).to have_received(:delete_request_data)
+          end
+        end
+
         context 'when there is an auth_token_id in the initial stashed JSON' do
           let(:stubbed_initial_stashed_json) { super().merge('auth_token_id' => auth_token.id) }
           let(:auth_token) { AuthToken.first! }


### PR DESCRIPTION
Creating these requests makes it much more difficult to see within ActiveAdmin all of the requests that I'm actually interested in.