### PR TITLE
[groceries] Increase specificity of `.copy-to-clipboard` selector

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -321,7 +321,8 @@ button.choose-stores {
   margin-top: calc(-1 * var(--space-1));
 }
 
-.copy-to-clipboard {
+// repeat class to increase specificity to override element plus default margin-left
+.copy-to-clipboard.copy-to-clipboard {
   margin-left: 0;
 }
 


### PR DESCRIPTION
This is so that the `margin-left` rule will be respected (which it's currently not being respected, in the production build).