### PR TITLE
[groceries] Reload all store data when resuming from sleep

### DIFF
--- a/app/controllers/api/stores_controller.rb
+++ b/app/controllers/api/stores_controller.rb
@@ -5,6 +5,29 @@ class Api::StoresController < ApplicationController
 
   before_action :set_store, only: %i[destroy update]
 
+  def index
+    authorize(Store)
+
+    spouse = current_user.spouse
+
+    render json: {
+      own_stores:
+        StoreSerializer.new(
+          current_user.stores.includes(:items),
+          params: { current_user: },
+        ).as_json,
+      spouse_stores:
+        if spouse
+          StoreSerializer.new(
+            spouse.stores.where.not(private: true).includes(:items),
+            params: { current_user: },
+          ).as_json
+        else
+          []
+        end,
+    }
+  end
+
   def create
     authorize(Store)
     @store = current_user.stores.build(store_params.merge(viewed_at: Time.current))

--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -39,6 +39,18 @@ export default {
 
     const spouseId = get(window, 'davidrunger.bootstrap.spouse.id');
     if (spouseId) {
+      // HACK: add on to the installEventHandlers method because it's called when the ActionCable
+      // connection is re-established after having been broken (though it's also called when
+      // first loading the page, which we don't need, so ignore that one)
+      const originalInstallEventHandlers =
+        actionCableConsumer.connection.installEventHandlers.bind(actionCableConsumer.connection);
+      let isFirstInstall = true;
+      actionCableConsumer.connection.installEventHandlers = () => {
+        if (!isFirstInstall) this.groceriesStore.pullStoreData();
+        isFirstInstall = false;
+        originalInstallEventHandlers();
+      };
+
       actionCableConsumer.subscriptions.create(
         {
           channel: 'GroceriesChannel',

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { filter, last, pick, sortBy } from 'lodash-es';
+import { filter, get, last, pick, sortBy } from 'lodash-es';
 import { kyApi } from '@/shared/ky';
 import { emit } from '@/lib/event_bus';
 
@@ -93,6 +93,22 @@ const actions = {
   deleteStore({ store: deletedStore }) {
     this.own_stores = this.own_stores.filter(store => store !== deletedStore);
     kyApi.delete(Routes.api_store_path(deletedStore.id));
+  },
+
+  pullStoreData() {
+    kyApi.get(Routes.api_stores_path()).json().
+      then(data => {
+        this.own_stores = data.own_stores.map(store => {
+          const preexistingStore = helpers.getById(this.own_stores, store.id);
+          store.viewed_at = get(preexistingStore, 'viewed_at');
+          return store;
+        });
+        this.spouse_stores = data.spouse_stores.map(store => {
+          const preexistingStore = helpers.getById(this.spouse_stores, store.id);
+          store.viewed_at = get(preexistingStore, 'viewed_at');
+          return store;
+        });
+      });
   },
 
   incrementPendingRequests() {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,7 +74,7 @@ Rails.application.routes.draw do
     resources :log_entries, only: %i[create destroy index update]
     resources :log_shares, only: %i[create destroy]
     resources :logs, only: %i[create destroy update]
-    resources :stores, only: %i[create update destroy] do
+    resources :stores, only: %i[index create update destroy] do
       resources :items, only: %i[create]
     end
     resources :users, only: %i[update]

--- a/spec/controllers/api/stores_controller_spec.rb
+++ b/spec/controllers/api/stores_controller_spec.rb
@@ -5,6 +5,25 @@ RSpec.describe Api::StoresController do
 
   let(:user) { users(:user) }
 
+  describe '#index' do
+    subject(:get_index) { get(:index) }
+
+    it "returns the user's own_stores and spouse_stores" do
+      get_index
+      expect(json_response.keys).to match_array(%w[own_stores spouse_stores])
+    end
+
+    context 'when the user does not have a spouse' do
+      before { user.marriage&.destroy! }
+
+      it "returns the user's own_stores and spouse_stores" do
+        get_index
+        expect(json_response.keys).to match_array(%w[own_stores spouse_stores])
+        expect(json_response['spouse_stores']).to eq([])
+      end
+    end
+  end
+
   describe '#create' do
     subject(:post_create) { post(:create, params:) }
 


### PR DESCRIPTION
This is so that any updates that the spouse has made in the meantime (since the phone was locked, etc) will be pulled in.