### PR TITLE
Run eslint when package.json and/or yarn.lock have changed

### DIFF
--- a/bin/test/diff_helpers.rb
+++ b/bin/test/diff_helpers.rb
@@ -11,9 +11,13 @@ module DiffHelpers
 
   private
 
+  def file_changed?(filename)
+    files_changed.include?(filename)
+  end
+
   memoize \
   def db_schema_changed?
-    files_changed.include?('db/schema.rb')
+    file_changed?('db/schema.rb')
   end
 
   memoize \

--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -172,7 +172,12 @@ class Test::RequirementsResolver
     Test::Tasks::RunDatabaseConsistency => proc {
       !db_schema_changed? && !diff_mentions?('database_consistency')
     },
-    Test::Tasks::RunEslint => proc { !files_with_js_changed? && !diff_mentions?('eslint') },
+    Test::Tasks::RunEslint => proc {
+      !files_with_js_changed? &&
+        !diff_mentions?('eslint') &&
+        !file_changed?('package.json') &&
+        !file_changed?('yarn.lock')
+    },
     Test::Tasks::RunImmigrant => proc { !db_schema_changed? && !diff_mentions?('immigrant') },
     Test::Tasks::RunRubocop => proc {
       !ruby_files_changed? && !rubocop_files_changed? && !diff_mentions?('rubocop')


### PR DESCRIPTION
I noticed that #2327 makes eslint fail, but we weren't running eslint in CI.