### PR TITLE
Specify a canonical URL for all pages

### DIFF
--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -9,6 +9,7 @@
     %title= title
     %meta{name: 'title', content: title}
     %meta{property: 'og:title', content: title}
+    %link{rel: 'canonical', href: DavidRunger.canonical_url(request.path)}
 
     -# other metadata
     -# (note: the curly braces are necessary to avoid a warning about keyword params)
@@ -17,7 +18,6 @@
       %meta{property: 'og:type', content: 'website'}
       %meta{property: 'og:url', content: DavidRunger::CANONICAL_URL}
       %meta{property: 'og:image', content: image_url('david.jpg')}
-      %link{rel: 'canonical', href: DavidRunger::CANONICAL_URL}
     - if @description.present?
       %meta{name: 'description', content: @description}
       %meta{property: 'og:description', content: @description}

--- a/config/application.rb
+++ b/config/application.rb
@@ -19,6 +19,12 @@ Bundler.require(*Rails.groups)
 module DavidRunger
   CANONICAL_DOMAIN = 'davidrunger.com'
   CANONICAL_URL = "https://#{CANONICAL_DOMAIN}/".freeze
+
+  class << self
+    def canonical_url(path)
+      "https://#{CANONICAL_DOMAIN}#{path}"
+    end
+  end
 end
 
 class DavidRunger::Application < Rails::Application


### PR DESCRIPTION
Previously, we were only setting a canonical URL for the home page. Google Search was complaining about this w.r.t. e.g. the login page.