### PR TITLE
Revert "Bump runger_style from `5c64e17` to `70a51d9`"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,7 +23,7 @@ GIT
 
 GIT
   remote: https://github.com/davidrunger/runger_style.git
-  revision: 70a51d91a324c23a0dcd206f2d4ef6008b66beca
+  revision: 5c64e1787d8815c4b294382164c0d9b794d05768
   specs:
     runger_style (0.2.22.alpha)
       rubocop (>= 1.38.0, < 2)


### PR DESCRIPTION
Reverts davidrunger/david_runger#2348

The PR being reverted here introduced an error:

```
Error: unrecognized cop or department Style/RequireOrder found in /Users/david/.rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/bundler/gems/runger_style-70a51d91a324/rulesets/default.yml
```

It wasn't caught before because we didn't run rubocop on that PR.