### PR TITLE
Support using Docker for Postgres database for local development

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -25,12 +25,13 @@ default: &default
 development:
   <<: *default
   database: david_runger_development
+  host: 127.0.0.1
 
   # The specified database role being used to connect to postgres.
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  #username: david_runger
+  username: david_runger
 
   # The password associated with the postgres role (username).
   #password:
@@ -60,7 +61,7 @@ test:
   <<: *default
   database: david_runger_test<%= ENV['DB_SUFFIX'] %>
   host: <%= ENV['POSTGRES_HOST'] || 'localhost' %>
-  username: <%= ENV['POSTGRES_USER'] %>
+  username: <%= ENV.key?('CI') ? ENV['POSTGRES_USER'] : 'david_runger' %>
   password: <%= ENV['PGPASSWORD'] || '' %>
 
 # As with config/secrets.yml, you never want to store sensitive information,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+---
+version: '3.8'
+
+services:
+  postgres:
+    image: postgres:15.1-alpine
+    volumes:
+      - postgresql:/var/lib/postgresql/data:delegated
+    ports:
+      - "127.0.0.1:5432:5432"
+    environment:
+      POSTGRES_USER: david_runger
+      POSTGRES_HOST_AUTH_METHOD: trust
+
+volumes:
+  postgresql:

--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,1 @@
+CREATE USER david_runger SUPERUSER;


### PR DESCRIPTION
It's also possible to continue using a "raw" Postgres database on the host machine (as long as that database has a Superuser named "david_runger", which can be created, if not already present).

Taken mostly from https://www.codewithjason.com/dockerize-rails-apps-database/.