### PR TITLE
[groceries] Only modify item after network requests have cleared

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -16,6 +16,7 @@ class Api::ItemsController < ApplicationController
 
   def update
     authorize(@item)
+    @item.acting_browser_uuid = cookies[:browser_uuid]
     if @item.update(item_params)
       render json: @item
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
 
   before_action :authenticate_user!
   before_action :set_paper_trail_whodunnit
+  before_action :set_browser_uuid
 
   after_action :verify_authorized, unless: :skip_authorization?
 
@@ -42,6 +43,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def set_browser_uuid
+    cookies[:browser_uuid] ||= SecureRandom.uuid
+  end
 
   def _render_with_renderer_json(resource, options)
     if resource.is_a?(ApplicationRecord)

--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -12,6 +12,7 @@
 <script>
 import { mapState } from 'pinia';
 import { get } from 'lodash-es';
+import Cookies from 'js-cookie';
 import actionCableConsumer from '@/channels/consumer';
 import { useGroceriesStore } from '@/groceries/store';
 import Sidebar from './components/sidebar.vue';
@@ -61,7 +62,10 @@ export default {
               this.groceriesStore.addItem({ itemData: data.model });
             } else if (data.action === 'destroyed') {
               this.groceriesStore.deleteItem({ item: data.model });
-            } else if (data.action === 'updated') {
+            } else if (
+              data.action === 'updated' &&
+                Cookies.get('browser_uuid') !== data.acting_browser_uuid
+            ) {
               this.groceriesStore.modifyItem({ attributes: data.model });
             }
           },

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -161,8 +161,11 @@ const actions = {
         { json: { item: attributes } },
       ).json();
 
-    this.modifyItem({ item, attributes: updatedItemData });
     this.decrementPendingRequests();
+
+    if (!this.debouncingOrWaitingOnNetwork) {
+      this.modifyItem({ item, attributes: updatedItemData });
+    }
   },
 
   async updateStore({ store, attributes }) {

--- a/app/models/concerns/json_broadcastable.rb
+++ b/app/models/concerns/json_broadcastable.rb
@@ -3,6 +3,10 @@
 module JsonBroadcastable
   extend ActiveSupport::Concern
 
+  included do
+    attr_accessor :acting_browser_uuid
+  end
+
   module ClassMethods
     def broadcasts_json_to(channel, channel_target_proc)
       after_create_commit(
@@ -28,6 +32,7 @@ module JsonBroadcastable
     channel.broadcast_to(
       channel_target,
       action:,
+      acting_browser_uuid:,
       model: as_json,
     )
   end

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-vue": "^9.8.0",
     "fuzzyset.js": "^1.0.7",
+    "js-cookie": "^3.0.1",
     "keycode": "^2.2.1",
     "ky": "^0.33.1",
     "lodash-es": "^4.17.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1803,7 +1803,6 @@ chartjs-adapter-luxon@1.3.0:
 
 "chartkick@https://github.com/ankane/chartkick.js":
   version "4.2.0"
-  uid "496528f68e7cc297d54b66e3383bd42ea98a8f95"
   resolved "https://github.com/ankane/chartkick.js#496528f68e7cc297d54b66e3383bd42ea98a8f95"
   optionalDependencies:
     chart.js ">=3.0.2"
@@ -3047,6 +3046,11 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+js-cookie@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"
+  integrity sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==
 
 js-sdsl@^4.1.4:
   version "4.2.0"


### PR DESCRIPTION
And don't modify item based on websocket update triggered from own browser.

This fixes a bug wherein, while updating an item in quick succession, sometimes the needed item count would skip back to a previous value, as it received an intermediate update confirmation and applied it.