### PR TITLE
Remove rspec-retry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,6 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec-instafail', require: false
   gem 'rspec-rails'
-  gem 'rspec-retry'
   gem 'rspec-wait'
   gem 'selenium-devtools'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -475,8 +475,6 @@ GEM
       rspec-expectations (~> 3.11)
       rspec-mocks (~> 3.11)
       rspec-support (~> 3.11)
-    rspec-retry (0.6.2)
-      rspec-core (> 3.3)
     rspec-support (3.12.0)
     rspec-wait (0.0.9)
       rspec (>= 3, < 4)
@@ -666,7 +664,6 @@ DEPENDENCIES
   rollbar
   rspec-instafail
   rspec-rails
-  rspec-retry
   rspec-wait
   rubocop
   rubocop-performance

--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe 'Quizzes app' do
 
       # a participant joins
       Capybara.using_session('Quiz participant session') do
-        wait_for do
+        wait(20.seconds).for do
           sign_in(participant)
           visit(quiz_path)
           page.has_css?('input#display_name')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,7 +43,6 @@ require 'sidekiq/testing'
 require 'mail'
 require 'percy/capybara'
 require 'super_diff/rspec-rails'
-require 'rspec/retry'
 
 # w/o this, Sidekiq's `logger` prints to STDOUT (bad); with this, it prints to `log/test.log` (good)
 sidekiq_logger = Sidekiq::Logger.new(Rails.root.join('log/test.log').to_s)
@@ -152,20 +151,6 @@ RSpec.configure do |config|
   config.include(ActionMailbox::TestHelper, type: :mailer)
   config.include(MailSpecHelpers, type: :mailbox)
   config.include(MailSpecHelpers, type: :mailer)
-
-  # rspec-retry options
-  config.verbose_retry = true
-  config.display_try_failure_messages = true
-  config.around(:each, type: :feature) do |example|
-    example.run_with_retry(retry: 2) # this actually means 'try: 2', i.e. retry just once
-  end
-  config.retry_callback =
-    proc do |ex|
-      if ex.metadata[:type] == :feature
-        Capybara.reset!
-        page.driver.reset!
-      end
-    end
 
   config.before(:suite) do
     # Reset FactoryBot sequences to an arbitrarily high number to avoid collisions with


### PR DESCRIPTION
I might add it back at some point, but for now I am removing it because I want to see if there are some flaky specs that can be un-flaked.

Appropriately enough, the first build of this failed in CI, so I tried to make some changes to maybe make `spec/features/quizzes_spec.rb` more reliable.