### PR TITLE
[groceries] Respond from a before_action if no items to update

### DIFF
--- a/app/controllers/api/items/bulk_updates_controller.rb
+++ b/app/controllers/api/items/bulk_updates_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Api::Items::BulkUpdatesController < ApplicationController
+  before_action :ensure_items_present, only: %i[create]
+
   def create
     items.includes(:store).find_each { |item| authorize(item, :update?) }
     Items::BulkUpdate::Create.run!(items: items.to_a, attributes_change: attributes_change.to_h)
@@ -8,6 +10,10 @@ class Api::Items::BulkUpdatesController < ApplicationController
   end
 
   private
+
+  def ensure_items_present
+    head(:no_content) if items.empty?
+  end
 
   def bulk_update_params
     params.require(:bulk_update).permit(item_ids: [], attributes_change: {})

--- a/spec/controllers/api/items/bulk_updates_controller_spec.rb
+++ b/spec/controllers/api/items/bulk_updates_controller_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe Api::Items::BulkUpdatesController do
         expect(store.items.needed.size).to be >= 2
       end
 
-      context 'when the needed item ids are posted as `item_ids`' do
-        let(:item_ids) { store.items.needed.ids }
+      context 'when the `attributes_change` is `{ needed: 0 }`' do
+        let(:attributes_change) { { needed: 0 } }
 
-        context 'when the `attributes_change` is `{ needed: 0 }`' do
-          let(:attributes_change) { { needed: 0 } }
+        context 'when the needed item ids are posted as `item_ids`' do
+          let(:item_ids) { store.items.needed.ids }
 
           it 'changes `needed` for each needed item to zero' do
             expect {
@@ -34,6 +34,16 @@ RSpec.describe Api::Items::BulkUpdatesController do
             }.to change {
               store.items.needed.size
             }.to(0)
+          end
+        end
+
+        context 'when item_ids is an empty array' do
+          let(:item_ids) { [] }
+
+          it 'responds with no content' do
+            post_create
+
+            expect(response).to have_http_status(204)
           end
         end
       end


### PR DESCRIPTION
fixes rb#556 https://rollbar.com/davidjrunger/davidrunger/items/556/

A `Pundit::AuthorizationNotPerformedError` was being raised when there were no items to update. We avoid the requirement that authorization be performed by returning early from a `before_action`.