### PR TITLE
Only configure `Isolator` in development and test

### DIFF
--- a/config/initializers/isolator.rb
+++ b/config/initializers/isolator.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
-Isolator.configure do |config|
-  config.raise_exceptions = true
+# `Isolator` is not available in production (per the Gemfile)
+if Rails.env.in?(%w[development test])
+  Isolator.configure do |config|
+    config.raise_exceptions = true
+  end
 end


### PR DESCRIPTION
It's not available in production (since it's in the development/test Gemfile group).