### PR TITLE
[actioncable] Log IP and user_id when disconnecting

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -5,6 +5,7 @@ class ApplicationCable::Connection < ActionCable::Connection::Base
 
   def connect
     self.current_user = find_verified_user
+    @ip = request.remote_ip
   end
 
   private

--- a/config/initializers/monkeypatches/action_cable_connection_base.rb
+++ b/config/initializers/monkeypatches/action_cable_connection_base.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'lograge'
+require 'lograge/rails_ext/action_cable/connection/base'
+
+module ConnectionInstrumentationMonkeypatch
+  def notification_payload(method_name)
+    # @ip and current_user are set in ApplicationCable::Connection#connect
+    super.merge(ip: @ip, user_id: current_user&.id)
+  end
+end
+
+ActiveSupport.on_load(:action_cable_connection) { prepend ConnectionInstrumentationMonkeypatch }


### PR DESCRIPTION
This might be somewhat helpful when debugging (dis)connection and reconnection issues with ActionCable.

This monkeypatch supplements lograge's own monkeypatch (in that gem's `lograge/rails_ext/action_cable/connection/base`).

Unfortunately, it doesn't seem equally easy to add this information to the log line for connecting, because the `notification_payload` is invoked just _before_ `ApplicationCable::Connection#connect` (which sets `@ip` and `current_user`) gets called.