### PR TITLE
[groceries] Update existing item objects after reconnecting

### DIFF
--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -101,6 +101,17 @@ const actions = {
         const existingStore = helpers.getById(existingStores, storeDatum.id);
         storeDatum.viewed_at = get(existingStore, 'viewed_at') ?? storeDatum.viewed_at;
         if (existingStore) {
+          const items = [];
+          for (const itemDatum of storeDatum.items) {
+            const existingItem = helpers.getById(existingStore.items, itemDatum.id);
+            if (existingItem) {
+              Object.assign(existingItem, itemDatum);
+              items.push(existingItem);
+            } else {
+              items.push(itemDatum);
+            }
+          }
+          storeDatum.items = items;
           Object.assign(existingStore, storeDatum);
         } else {
           existingStores.push(storeDatum);


### PR DESCRIPTION
This fixes at least one bug: skipped items becoming unskipped after reconnecting to the Internet, because the list of skipped items had a reference to the old item object(s), but the stores were (prior to this PR) being updated with new item objects.

Unfortunately, it's hard to write a feature test for this, because I haven't figured out how to disconnect from the Internet (affecting a WebSocket connection) and reconnect with capybara. JavaScript unit tests might answer, but that'd probably be a pretty annoying test to write, and we don't have a JavaScript unit test harness set up right now.