### PR TITLE
[groceries] Add current store to checkInStores when copying

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -176,11 +176,14 @@ export default defineComponent({
 
   mounted() {
     const clipboard = new ClipboardJS('.copy-to-clipboard', {
-      text: () => (
-        this.neededCheckInItems.
+      text: () => {
+        // ensure that the current store is in the checkInStores
+        this.groceriesStore.addCheckInStore({ store: this.store });
+
+        return this.neededCheckInItems.
           map((item: ItemType) => `${item.name} (${item.needed})`).
-          join('\n')
-      ),
+          join('\n');
+      },
     });
     clipboard.on('success', () => {
       this.wasCopiedRecently = true;

--- a/app/javascript/groceries/store.js
+++ b/app/javascript/groceries/store.js
@@ -247,23 +247,8 @@ const getters = {
   },
 };
 
-// This allows us to do some initialization work (adding current store to check-in stores).
-// https://github.com/vuejs/pinia/discussions/1176#discussioncomment-2551258
-let store;
-export const useGroceriesStore = () => {
-  if (!store) {
-    const innerStore = defineStore('groceries', {
-      state,
-      actions,
-      getters,
-    });
-
-    store = innerStore();
-  }
-
-  if (!store.checkInStores.length) {
-    store.addCheckInStore({ store: store.currentStore });
-  }
-
-  return store;
-};
+export const useGroceriesStore = defineStore('groceries', {
+  state,
+  actions,
+  getters,
+});


### PR DESCRIPTION
... rather than upon initialization of the store (which required a somewhat ugly/confusing hack).