### PR TITLE
[groceries] Remove "Notes" heading from grocery store

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -28,7 +28,6 @@
     span(v-if='wasCopiedRecently') Copied!
 
   div.mb1
-    h3.h3 Notes
     el-input(
       v-if='editingNotes'
       type='textarea'


### PR DESCRIPTION
This saves valuable screen real estate (especially on mobile).

I thought about removing the feature altogether, since none of the current 30 stores in the database have any notes, but I have found it pretty useful in the past, so I'll leave it, for now, without the heading.