### PR TITLE
[groceries] Remove copy-to-clipboard functionality

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -22,10 +22,6 @@
       @click='initializeTripCheckIn'
       :size='$is_mobile_device ? "small" : null'
     ) Check in items
-    el-button.copy-to-clipboard.mt1(
-      :size='$is_mobile_device ? "small" : null'
-    ) Copy to clipboard
-    span(v-if='wasCopiedRecently') Copied!
 
   div.mb1
     el-input(
@@ -127,7 +123,6 @@
 <script lang='ts'>
 import { defineComponent } from 'vue';
 import { mapState, StoreDefinition } from 'pinia';
-import ClipboardJS from 'clipboard';
 import { EditIcon } from 'vue-tabler-icons';
 import { required } from '@vuelidate/validators';
 import { useVuelidate } from '@vuelidate/core';
@@ -169,25 +164,7 @@ export default defineComponent({
       itemsToZero: [],
       modalStore: useModalStore(),
       newItemName: '',
-      wasCopiedRecently: false,
     };
-  },
-
-  mounted() {
-    const clipboard = new ClipboardJS('.copy-to-clipboard', {
-      text: () => {
-        // ensure that the current store is in the checkInStores
-        this.groceriesStore.addCheckInStore({ store: this.store });
-
-        return this.neededCheckInItems.
-          map((item: ItemType) => `${item.name} (${item.needed})`).
-          join('\n');
-      },
-    });
-    clipboard.on('success', () => {
-      this.wasCopiedRecently = true;
-      setTimeout(() => { this.wasCopiedRecently = false; }, 3000);
-    });
   },
 
   methods: {
@@ -329,11 +306,6 @@ button.choose-stores {
 // https://stackoverflow.com/a/30891910/4009384
 .buttons-container {
   margin-top: calc(-1 * var(--space-1));
-}
-
-// repeat class to increase specificity to override element plus default margin-left
-.copy-to-clipboard.copy-to-clipboard {
-  margin-left: 0;
 }
 
 .store-container {

--- a/bin/test/tasks/run_file_size_checks.rb
+++ b/bin/test/tasks/run_file_size_checks.rb
@@ -13,7 +13,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'check_ins*.js' => (170..180),
     'check_ins_index*.js' => (5..15),
     'groceries*.css' => (100..110),
-    'groceries*.js' => (400..410),
+    'groceries*.js' => (391..401),
     'home*.css' => (0..10),
     'home*.js' => (130..140),
     'logs*.css' => (100..110),

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe 'Groceries app' do
         store = user.stores.reorder(viewed_at: :desc).first!
         expect(page).to have_text(store.name)
         expect(page).to have_button('Check in items')
-        expect(page).to have_button('Copy to clipboard')
 
         item = store.items.first!
         expect(page).to have_text(/#{item.name} +\(#{item.needed}\)/)


### PR DESCRIPTION
I never use this feature anymore, and I don't think any other users do, so I think it's just not worth its maintenance and pageweight cost.