### PR TITLE
[groceries] Allow touchmove event when scale is 1

### DIFF
--- a/app/javascript/groceries/groceries.vue
+++ b/app/javascript/groceries/groceries.vue
@@ -17,6 +17,7 @@ import Cookies from 'js-cookie';
 import actionCableConsumer from '@/channels/consumer';
 import { useGroceriesStore } from '@/groceries/store';
 import { ItemBroadcast } from '@/groceries/types';
+import { IphoneTouchEvent } from '@/shared/types';
 import Sidebar from './components/sidebar.vue';
 import Store from './components/store.vue';
 
@@ -39,7 +40,11 @@ export default defineComponent({
     // https://stackoverflow.com/a/59492869/4009384
     document.addEventListener(
       'touchmove',
-      (event) => { event.preventDefault(); },
+      (event) => {
+        if ((event as IphoneTouchEvent).scale !== 1) {
+          event.preventDefault();
+        }
+      },
       { passive: false },
     );
 

--- a/app/javascript/shared/types.ts
+++ b/app/javascript/shared/types.ts
@@ -3,3 +3,7 @@ export interface JsonBroadcast {
   action: string
   model: object
 }
+
+export interface IphoneTouchEvent extends TouchEvent {
+  scale: number
+}


### PR DESCRIPTION
This fixes a bug wherein users cannot scroll when using an iPhone.