### PR TITLE
[tests] Make `CheckTypescript` wait for client-side route helpers

### DIFF
--- a/bin/test/requirements_resolver.rb
+++ b/bin/test/requirements_resolver.rb
@@ -16,8 +16,9 @@ class Test::RequirementsResolver
 
         # Installation / Setup
         Test::Tasks::YarnInstall => nil,
-        Test::Tasks::CompileJavaScript => Test::Tasks::YarnInstall,
-        Test::Tasks::CheckTypescript => Test::Tasks::YarnInstall,
+        Test::Tasks::BuildRouteHelpers => Test::Tasks::YarnInstall,
+        Test::Tasks::CheckTypescript => Test::Tasks::BuildRouteHelpers,
+        Test::Tasks::CompileJavaScript => Test::Tasks::BuildRouteHelpers,
         Test::Tasks::SetupDb => nil,
         Test::Tasks::BuildFixtures => Test::Tasks::SetupDb,
         Test::Tasks::CreateDbCopies => Test::Tasks::BuildFixtures,

--- a/bin/test/tasks/build_route_helpers.rb
+++ b/bin/test/tasks/build_route_helpers.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class Test::Tasks::BuildRouteHelpers < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    execute_rake_task('build_js_routes')
+  end
+end

--- a/bin/test/tasks/compile_java_script.rb
+++ b/bin/test/tasks/compile_java_script.rb
@@ -5,7 +5,6 @@ class Test::Tasks::CompileJavaScript < Pallets::Task
 
   def run
     execute_system_command('rm -rf public/vite/ public/vite-admin/')
-    execute_rake_task('build_js_routes')
     execute_system_command(
       'bin/vite build --force',
       {


### PR DESCRIPTION
Now that we are type-checking our client-side route helpers (since #2428), we need the routes and their type definitions to be compiled before running the TypeScript check.