### PR TITLE
Switch from hamlit to haml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'faraday-multipart'
 gem 'flipper'
 gem 'flipper-redis'
 gem 'flipper-ui'
-gem 'hamlit'
+gem 'haml'
 gem 'hashid-rails'
 gem 'js-routes', '2.2.4', require: false
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,7 +250,7 @@ GEM
     formtastic_i18n (0.7.0)
     globalid (1.0.1)
       activesupport (>= 5.0)
-    hamlit (3.0.3)
+    haml (6.1.1)
       temple (>= 0.8.2)
       thor
       tilt
@@ -570,7 +570,7 @@ GEM
       attr_extras (>= 6.2.4)
       diff-lcs
       patience_diff
-    temple (0.9.1)
+    temple (0.10.0)
     thor (1.2.1)
     tilt (2.0.11)
     timeout (0.3.1)
@@ -641,7 +641,7 @@ DEPENDENCIES
   flipper
   flipper-redis
   flipper-ui
-  hamlit
+  haml
   hashid-rails
   hotwire-livereload
   http_logger


### PR DESCRIPTION
From the [hamlit README][1]:

> Hamlit's implementation was copied to Haml 6. From Haml 6, you don't > need to switch to Hamlit.

> Both Haml 6 and Hamlit are still maintained by @k0kubun. While you > don't need to immediately deprecate Hamlit, Haml 6 has more > maintainers and you'd better start a new project with Haml rather than > Hamlit, given no performance difference between them.

[1]: https://github.com/k0kubun/hamlit