### PR TITLE
Add `haml-rails` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'flipper'
 gem 'flipper-redis'
 gem 'flipper-ui'
 gem 'haml'
+gem 'haml-rails'
 gem 'hashid-rails'
 gem 'js-routes', '2.2.4', require: false
 gem 'jwt'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -254,6 +254,11 @@ GEM
       temple (>= 0.8.2)
       thor
       tilt
+    haml-rails (2.1.0)
+      actionpack (>= 5.1)
+      activesupport (>= 5.1)
+      haml (>= 4.0.6)
+      railties (>= 5.1)
     has_scope (0.8.0)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -642,6 +647,7 @@ DEPENDENCIES
   flipper-redis
   flipper-ui
   haml
+  haml-rails
   hashid-rails
   hotwire-livereload
   http_logger


### PR DESCRIPTION
Among other features, this automatically causes rails generators to create haml (rather than erb) files.