### PR TITLE
Don't generate helper modules

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,8 +53,8 @@ class DavidRunger::Application < Rails::Application
   # These settings can be overridden in specific environments using the files
   # in config/environments, which are processed later.
 
-  # Don't generate system test files.
-  config.generators.system_tests = nil
+  config.generators.helper = false
+  config.generators.system_tests = false
   config.generators do |g|
     g.factory_bot(dir: 'spec/factories')
   end


### PR DESCRIPTION
I think that helpers (which are all global throughout controllers and views) are generally not a great part of Rails, and I rarely use them, so let's not generate them when running e.g. 'bin/rails g controller [...]'.