### PR TITLE
Add User#display_name method

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,4 +70,8 @@ class User < ApplicationRecord
     flush_cache # clear memoized methods
     super
   end
+
+  def display_name
+    email.split('@').first
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -77,4 +77,16 @@ RSpec.describe User do
       end
     end
   end
+
+  describe '#display_name' do
+    subject(:display_name) { user.display_name }
+
+    before { user.update!(email: "#{email_prefix}@gmail.com") }
+
+    let(:email_prefix) { 'tom.talbot' }
+
+    it 'returns the part of the email before "@"' do
+      expect(display_name).to eq(email_prefix)
+    end
+  end
 end


### PR DESCRIPTION
This will be used by ActiveAdmin to display users in a better way than e.g. `#<User:0x00007f2eb0fa9a70>`.