### PR TITLE
[specs] Address Selenium deprecation warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,12 +59,11 @@ WebMock.disable_net_connect!(
 OmniAuth.config.test_mode = true
 
 Capybara.register_driver(:chrome_headless) do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [options])
+  options = Selenium::WebDriver::Chrome::Options.new(args: %w[headless])
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options:)
 end
 Capybara.register_driver(:chrome_headful) do |app|
-  options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox disable-gpu])
-  Capybara::Selenium::Driver.new(app, browser: :chrome, capabilities: [options])
+  Capybara::Selenium::Driver.new(app, browser: :chrome)
 end
 unless use_headful_chrome
   Capybara::Screenshot.register_driver(:chrome_headless) do |driver, path|


### PR DESCRIPTION
This error was being logged in specs:

```
WARN Selenium [DEPRECATION] [:capabilities] The :capabilities parameter
for Selenium::WebDriver::Chrome::Driver is deprecated. Use :options
argument with an instance of Selenium::WebDriver::Chrome::Driver
instead.
```

The solution given by that error message seems unclear/misleading/wrong, but, anyway, this change addresses those deprecations.

While here, I removed the `no-sandbox` and `disable-gpu` options, which no longer seem to be needed/helpful (if, indeed, either or both ever were).