### PR TITLE
Switch from flat sitemap to sitemap index (w/ link to blog sitemap)

### DIFF
--- a/public/root-sitemap.xml
+++ b/public/root-sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  <url>
+    <loc>https://davidrunger.com/</loc>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://davidrunger.com/David-Runger-Resume.pdf</loc>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://davidrunger.com/login/</loc>
+    <priority>0.5</priority>
+  </url>
+</urlset>

--- a/public/sitemap.txt
+++ b/public/sitemap.txt
@@ -1,4 +1,0 @@
-https://davidrunger.com/
-https://davidrunger.com/David-Runger-Resume.pdf
-https://davidrunger.com/blog/
-https://davidrunger.com/login/

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,19 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  <url>
-    <loc>https://davidrunger.com/</loc>
-    <priority>1.0</priority>
-  </url>
-  <url>
-    <loc>https://davidrunger.com/David-Runger-Resume.pdf</loc>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://davidrunger.com/blog/</loc>
-    <priority>0.8</priority>
-  </url>
-  <url>
-    <loc>https://davidrunger.com/login/</loc>
-    <priority>0.5</priority>
-  </url>
-</urlset>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap>
+    <loc>https://davidrunger.com/root-sitemap.xml</loc>
+  </sitemap>
+  <sitemap>
+    <loc>https://davidrunger.com/blog/sitemap.xml</loc>
+  </sitemap>
+</sitemapindex>


### PR DESCRIPTION
Also, delete `sitemap.txt`, because I wasn't able in my brief search attempt to find an established way to link from a text sitemap to other sitemaps.

Also, remove https://davidrunger.com/blog/ from the (now so called) `root-sitemap.xml`, because it's included in the blog's sitemap.