### PR TITLE
[home links checker] Log error to Rollbar at info level (not warn)

### DIFF
--- a/app/workers/check_home_links/checker.rb
+++ b/app/workers/check_home_links/checker.rb
@@ -54,7 +54,7 @@ class CheckHomeLinks::Checker
       request.options.timeout = 5
     end
   rescue => error
-    Rollbar.warn(error, url:)
+    Rollbar.info(error, url:)
     nil
   end
 end

--- a/spec/workers/check_home_links/checker_spec.rb
+++ b/spec/workers/check_home_links/checker_spec.rb
@@ -44,6 +44,15 @@ RSpec.describe CheckHomeLinks::Checker do
           # rubocop:enable RSpec/AnyInstance
         end
 
+        it 'sends the error to Rollbar it info level' do
+          expect(Rollbar).
+            to receive(:info).
+            with(Faraday::ConnectionFailed, url:).
+            and_call_original
+
+          perform
+        end
+
         it 'sends an AdminMailer#bad_home_link email', queue_adapter: :test do
           expect { perform }.
             to enqueue_mail(AdminMailer, :bad_home_link).


### PR DESCRIPTION
This is basically just because I want all of the unresolved errors in Rollbar to be at info level (or lower).