### PR TITLE
[specs] Add `ensure` blocks to `around` blocks

### DIFF
--- a/spec/features/rack_attack_spec.rb
+++ b/spec/features/rack_attack_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'Rack::Attack', :rack_test_driver do
 
       spec.run
 
+    ensure
       Rack::Attack.cache.store = original_rack_attack_store
       Rails.cache.clear
     end

--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
 
       spec.run
 
+    ensure
       OmniAuth.config.test_mode = original_omni_auth_test_mode
     end
 
@@ -65,6 +66,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
 
         spec.run
 
+      ensure
         page.driver.browser.devtools.callbacks.clear # might avoid slowing down subsequent requests?
         page.driver.browser.devtools.fetch.disable
       end

--- a/spec/requests/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe Users::OmniauthCallbacksController do
 
         spec.run
 
+      ensure
         ActionController::Base.allow_forgery_protection = original_allow_forgery_protection
       end
 


### PR DESCRIPTION
It has come to my attention (1) that, although RSpec will catch exceptions raised within _examples_ while nested within an `around` block, RSpec apparently does _not_ catch exceptions raised within nested `around` blocks (and maybe likewise for `before` blocks). As a result, cleanup steps in the `around` block that we expect to run after `spec.run` might not run if an error is raised within a nested `around` block. By adding an `ensure`, we ensure that these cleanup commands will be executed.

1: The output from [this test run][1] shows failures for `expect(OmniAuth.config.test_mode).to eq(true)` because in another spec we weren't reaching `OmniAuth.config.test_mode = original_omni_auth_test_mode` because an error (`cannot load such file selenium/devtools/v110`) was occurring within a nested `around` block.

[1]: https://github.com/davidrunger/david_runger/actions/runs/4222155236/jobs/7330315636