### PR TITLE
Update gitleaks repo link

### DIFF
--- a/app/javascript/home/components/projects.vue
+++ b/app/javascript/home/components/projects.vue
@@ -159,7 +159,7 @@ HomeSection(section='projects' title='Projects')
             #[a(href='https://github.com/rack/rack-attack') Rack::Attack] IP blocking and request throttling,
             #[a(href='https://github.com/flyerhzm/bullet') Bullet] eager-loading enforcement,
             #[a(href='https://github.com/evilmartians/lefthook') Lefthook] git hook management,
-            #[a(href='https://github.com/zricethezav/gitleaks') Gitleaks] secret protection,
+            #[a(href='https://github.com/gitleaks/gitleaks') Gitleaks] secret protection,
             #[a(href='https://aws.amazon.com/s3/') AWS S3] blob storage,
             #[a(href='https://rollbar.com/') Rollbar] error tracking,
             and #[a(href='https://percy.io/David-Runger/david_runger') Percy] visual diff monitoring!


### PR DESCRIPTION
Apparently (per the `AdminMailer.bad_home_link` email that I received), the repo has been moved.