### PR TITLE
Unpin `js-routes` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,7 @@ gem 'flipper-ui'
 gem 'haml'
 gem 'haml-rails'
 gem 'hashid-rails'
-gem 'js-routes', '2.2.5', require: false
+gem 'js-routes', require: false
 gem 'jwt'
 gem 'lograge'
 gem 'memoist'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -658,7 +658,7 @@ DEPENDENCIES
   http_logger
   immigrant
   isolator
-  js-routes (= 2.2.5)
+  js-routes
   json-schema
   jwt
   launchy


### PR DESCRIPTION
We pinned the version in e68e384 / #844 with this message:

> js-routes 2.1.0 is causing deploy issues; I'm going to revert and then look into fixing that.

Dependabot has since been updating the gem, and apparently it doesn't cause deploy issues anymore (maybe since we don't even build JS assets when deploying anymore).