### PR TITLE
Downgrade `sidekiq` from 7.0.7 to 7.0.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'request_store'
 gem 'request_store-sidekiq'
 gem 'rollbar'
 gem 'sassc' # used by ActiveAdmin asset pipeline
-gem 'sidekiq'
+gem 'sidekiq', '7.0.6' # pinned to 7.0.6 to see if that fixes rb#562
 gem 'sprockets-rails'
 gem 'strip_attributes'
 gem 'vite_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -535,7 +535,7 @@ GEM
       activesupport (>= 6, < 8)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.0.7)
+    sidekiq (7.0.6)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
@@ -698,7 +698,7 @@ DEPENDENCIES
   selenium-devtools
   selenium-webdriver
   shoulda-matchers
-  sidekiq
+  sidekiq (= 7.0.6)
   simple_cov-formatter-terminal
   simplecov
   simplecov-cobertura


### PR DESCRIPTION
fixes rb#562

https://rollbar.com/davidjrunger/davidrunger/items/562/

I'm not sure if this will actually fix the above exception from occurring, but I think it's worth a shot. I think that the exception in question appeared within a day after deploying a change that bumped Sidekiq from 7.0.6 to 7.0.7, and that exception is occurring with a Sidekiq-only (plus redis dependencies) stack trace, and also the Sidekiq changelog for 7.0.7 includes "Fix redis-client API usage which could result in stuck Redis connections" which sounds potentially related, so let's see whether this downgrade will fix the issue.