### PR TITLE
Revert "Revert "Downgrade `sidekiq` from 7.0.7 to 7.0.6""

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'request_store'
 gem 'request_store-sidekiq'
 gem 'rollbar'
 gem 'sassc' # used by ActiveAdmin asset pipeline
-gem 'sidekiq'
+gem 'sidekiq', '7.0.6' # pinned to 7.0.6 to see if that fixes rb#562
 gem 'sprockets-rails'
 gem 'strip_attributes'
 gem 'vite_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -535,7 +535,7 @@ GEM
       activesupport (>= 6, < 8)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.0.7)
+    sidekiq (7.0.6)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
@@ -698,7 +698,7 @@ DEPENDENCIES
   selenium-devtools
   selenium-webdriver
   shoulda-matchers
-  sidekiq
+  sidekiq (= 7.0.6)
   simple_cov-formatter-terminal
   simplecov
   simplecov-cobertura


### PR DESCRIPTION
Reverts davidrunger/david_runger#2658

I thought that #2639 didn't fix the issue, because the Redis timeout did occur once after merging that. But it occurred only once in the days that it was deployed, which is a much lower (better) error rate than what we get when 7.0.7 is deployed.