### PR TITLE
Bump sidekiq from 7.0.6 to 7.0.8

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,7 @@ gem 'request_store'
 gem 'request_store-sidekiq'
 gem 'rollbar'
 gem 'sassc' # used by ActiveAdmin asset pipeline
-gem 'sidekiq', '7.0.6' # pinned to 7.0.6 to see if that fixes rb#562
+gem 'sidekiq'
 gem 'sprockets-rails'
 gem 'strip_attributes'
 gem 'vite_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -535,7 +535,7 @@ GEM
       activesupport (>= 6, < 8)
     shoulda-matchers (5.3.0)
       activesupport (>= 5.2.0)
-    sidekiq (7.0.6)
+    sidekiq (7.0.8)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
       rack (>= 2.2.4)
@@ -698,7 +698,7 @@ DEPENDENCIES
   selenium-devtools
   selenium-webdriver
   shoulda-matchers
-  sidekiq (= 7.0.6)
+  sidekiq
   simple_cov-formatter-terminal
   simplecov
   simplecov-cobertura


### PR DESCRIPTION
This should reintroduce Redis timeout exceptions (which started affecting us in Sidekiq 7.0.7). I'm going to then take a look at the Redis slowlog and see if it sheds any light on why these timeouts are happening.