### PR TITLE
Have Selenium devtools version fallback to previous version if needed

### DIFF
--- a/config/initializers/monkeypatches/selenium_webdriver_chromium_driver.rb
+++ b/config/initializers/monkeypatches/selenium_webdriver_chromium_driver.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+if Rails.env.test?
+  class Selenium::WebDriver::Chromium::Driver < Selenium::WebDriver::Driver
+    protected
+
+    def devtools_version
+      Rails.logger.info(<<~LOG.squish)
+        Using monkeypateched Selenium::WebDriver::Chromium::Driver#devtools_version.
+      LOG
+      version = Integer(capabilities.browser_version.split('.').first)
+      begin
+        require "selenium/devtools/v#{@version}"
+        # :nocov:
+      rescue LoadError
+        previous_version = version - 1
+        puts(<<~LOG.squish)
+          LoadError occurred trying to load selenium-devtools #{version}, falling back to
+          #{previous_version}.
+        LOG
+        previous_version
+      else
+        version
+        # :nocov:
+      end
+    end
+  end
+end


### PR DESCRIPTION
When a new version of Chrome is released, then specs fail with the error below until we can bump our `selenium-devtools` gem to match the newly released Chrome version, which is especially problematic because a new version of the gem is not always released by the time that the new Chrome version is released.

```
LoadError: cannot load such file -- selenium/devtools/v112
/Users/david/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/bootsnap-1.16.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:29:in `require'
/Users/david/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/zeitwerk-2.6.7/lib/zeitwerk/kernel.rb:38:in `require'
/Users/david/.rbenv/versions/3.2.1/lib/ruby/gems/3.2.0/gems/selenium-devtools-0.111.0/lib/selenium/devtools.rb:26:in `load_version'
```

With this change, instead of erroring, we will fallback to using the previous devtools version from the `selenium-devtools` gem, which should hopefully be available.