### PR TITLE
Remove `app/controllers/lib/` from autoload paths

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -72,7 +72,6 @@ class DavidRunger::Application < Rails::Application
   extra_load_paths = [
     Rails.root.join('lib'),
     Rails.root.join(*%w[lib refinements]),
-    Rails.root.join(*%w[app controllers lib]),
   ].map(&:to_s).map(&:freeze)
   config.eager_load_paths.concat(extra_load_paths)
   config.add_autoload_paths_to_load_path = false


### PR DESCRIPTION
We no longer have such a directory.