### PR TITLE
Install runger_style from RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -66,7 +66,7 @@ group :development, :test do
   gem 'rubocop-performance', require: false
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
-  gem 'runger_style', github: 'davidrunger/runger_style', require: false
+  gem 'runger_style', require: false
   gem 'spring-commands-rspec'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,13 +21,6 @@ GIT
       msgpack
       redis (~> 5.0)
 
-GIT
-  remote: https://github.com/davidrunger/runger_style.git
-  revision: 61b0b4923c2e478d50f6d4a580a1c0842aa0d1c6
-  specs:
-    runger_style (0.2.23.alpha)
-      rubocop (>= 1.38.0, < 2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -522,6 +515,8 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    runger_style (0.2.22)
+      rubocop (>= 1.38.0, < 2)
     sanitize (6.0.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -696,7 +691,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec
-  runger_style!
+  runger_style
   sassc
   selenium-devtools
   selenium-webdriver


### PR DESCRIPTION
`runger_style` recently began to be released via RubyGems. This should make bundle installs a little faster.