### PR TITLE
Install capybara from GitHub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ end
 group :test do
   gem 'addressable'
   gem 'brakeman', require: false
-  gem 'capybara'
+  gem 'capybara', github: 'teamcapybara/capybara'
   gem 'capybara-email'
   gem 'capybara-screenshot'
   gem 'climate_control'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,20 @@ GIT
       msgpack
       redis (~> 5.0)
 
+GIT
+  remote: https://github.com/teamcapybara/capybara.git
+  revision: 43e32a84954817caeba2313db7a7599417893f9f
+  specs:
+    capybara (3.39.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -150,15 +164,6 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
-    capybara (3.39.0)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.8)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
     capybara-email (3.0.2)
       capybara (>= 2.4, < 4.0)
       mail
@@ -627,7 +632,7 @@ DEPENDENCIES
   brakeman
   browser
   bullet
-  capybara
+  capybara!
   capybara-email
   capybara-screenshot
   chartkick


### PR DESCRIPTION
This is because there is [a fix][1] that has been merged into capybara's main branch but not yet released via RubyGems. We can go back to RubyGems once capybara has a new release with that fix.

[1]: https://github.com/teamcapybara/capybara/pull/ 2667