### PR TITLE
Source Capybara from RubyGems (no longer from GitHub)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,7 +84,7 @@ end
 group :test do
   gem 'addressable'
   gem 'brakeman', require: false
-  gem 'capybara', github: 'teamcapybara/capybara'
+  gem 'capybara'
   gem 'capybara-email'
   gem 'capybara-screenshot'
   gem 'climate_control'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,20 +21,6 @@ GIT
       msgpack
       redis (~> 5.0)
 
-GIT
-  remote: https://github.com/teamcapybara/capybara.git
-  revision: b211300c1656b7d1f7eb61e274609768a4c5779f
-  specs:
-    capybara (3.39.1)
-      addressable
-      matrix
-      mini_mime (>= 0.1.3)
-      nokogiri (~> 1.11)
-      rack (>= 1.6.0)
-      rack-test (>= 0.6.3)
-      regexp_parser (>= 1.5, < 3.0)
-      xpath (~> 3.2)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -164,6 +150,15 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (11.1.3)
+    capybara (3.39.1)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     capybara-email (3.0.2)
       capybara (>= 2.4, < 4.0)
       mail
@@ -344,7 +339,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
-    nokogiri (1.15.0)
+    nokogiri (1.15.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     oauth2 (2.0.9)
@@ -632,7 +627,7 @@ DEPENDENCIES
   brakeman
   browser
   bullet
-  capybara!
+  capybara
   capybara-email
   capybara-screenshot
   chartkick


### PR DESCRIPTION
The [fix that we needed][1] has now been released via RubyGems.

[1]: https://github.com/teamcapybara/capybara/pull/ 2667