### PR TITLE
Read Ruby version from `.ruby-version` file rather than hardcoding

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 source 'https://rubygems.org'
-ruby '3.2.2'
+ruby File.read('.ruby-version').rstrip
 
 gem 'activeadmin'
 gem 'alba'

--- a/bin/test/tasks/check_versions.rb
+++ b/bin/test/tasks/check_versions.rb
@@ -4,12 +4,15 @@ class Test::Tasks::CheckVersions < Pallets::Task
   include Test::TaskHelpers
 
   def run
+    ruby_version = File.read('.ruby-version').rstrip
     execute_system_command(<<~COMMAND)
-      ruby --version && [ "$(ruby --version | cut -c1-11)" = 'ruby 3.2.2 ' ]
+      ruby --version && [ "$(ruby --version | cut -c1-11)" = 'ruby #{ruby_version} ' ]
     COMMAND
+
     execute_system_command(<<~COMMAND)
       node --version && [ "$(node --version)" = 'v18.12.1' ]
     COMMAND
+
     execute_system_command(<<~COMMAND)
       yarn --version && [ "$(yarn --version)" = '1.22.19' ]
     COMMAND


### PR DESCRIPTION
Now to update the Ruby version we should just need to do two things: - update the Ruby version in the `.ruby-version` file - run `bundle update --ruby` to update the Gemfile.lock