### PR TITLE
Read Node version from `.nvmrc` file rather than hardcoding

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -46,7 +46,7 @@ jobs:
         bundler-cache: true
     - uses: actions/setup-node@v3
       with:
-        node-version: 18.12.1
+        node-version-file: .nvmrc
     - name: Cache node_modules
       uses: actions/cache@v3
       with:

--- a/bin/test/tasks/check_versions.rb
+++ b/bin/test/tasks/check_versions.rb
@@ -9,8 +9,9 @@ class Test::Tasks::CheckVersions < Pallets::Task
       ruby --version && [ "$(ruby --version | cut -c1-11)" = 'ruby #{ruby_version} ' ]
     COMMAND
 
+    node_version = File.read('.nvmrc').rstrip
     execute_system_command(<<~COMMAND)
-      node --version && [ "$(node --version)" = 'v18.12.1' ]
+      node --version && [ "$(node --version)" = '#{node_version}' ]
     COMMAND
 
     execute_system_command(<<~COMMAND)


### PR DESCRIPTION
Now, to update the Node version we just need to update: - `.nvmrc` - `engines.node` field in `package.json`