### PR TITLE
Bump pnpm `lockfileVersion` and add `settings`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,8 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
 
 dependencies:
   '@babel/cli':


### PR DESCRIPTION
I think that this diff was generated by running `pnpm install`.