### PR TITLE
Include `--frozen-lockfile` option for CI pnpm install command

### DIFF
--- a/bin/test/tasks/pnpm_install.rb
+++ b/bin/test/tasks/pnpm_install.rb
@@ -4,6 +4,6 @@ class Test::Tasks::PnpmInstall < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    execute_system_command('pnpm install --silent')
+    execute_system_command('pnpm install --frozen-lockfile --silent')
   end
 end


### PR DESCRIPTION
This is recommended by these docs: https://github.com/actions/setup-node/blob/869f4dd0c7f320ae834c2724d92a364de3893c24/docs/advanced-usage.md

> Ensure that `pnpm-lock.yaml` is always committed, when on CI pass `--frozen-lockfile` to `pnpm install` when installing packages.