### PR TITLE
[checkins] Await API response in submitCheckIn

### DIFF
--- a/app/javascript/check_ins/store.ts
+++ b/app/javascript/check_ins/store.ts
@@ -34,7 +34,7 @@ export const useCheckInsStore = defineStore('check-ins', {
     },
 
     async submitCheckIn() {
-      kyApi.
+      await kyApi.
         post(
           Routes.api_check_in_check_in_submissions_path(
             this.check_in.id,


### PR DESCRIPTION
Without this, the request could be cancelled by subsequent code that navigates to a new page.

I think that a currently flaky test already essentially tries to test this; hopefully this change will make that spec not flaky.