### PR TITLE
[cuprite] Increase `process_timeout` to 20 seconds

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,7 @@ Capybara.register_driver(:cuprite) do |app|
     app,
     window_size: [1200, 800],
     headless: !use_headful_chrome,
+    process_timeout: 20,
   )
 end
 if is_ci


### PR DESCRIPTION
This should lessen these errors:

```
Ferrum::ProcessTimeoutError:
Browser did not produce websocket url within 10 seconds,
try to increase `:process_timeout`.
See https://github.com/rubycdp/ferrum#customization
```