### PR TITLE
Send CSP violations to Rollbar it info level

### DIFF
--- a/app/controllers/api/csp_reports_controller.rb
+++ b/app/controllers/api/csp_reports_controller.rb
@@ -15,7 +15,7 @@ class Api::CspReportsController < ApplicationController
     skip_authorization
 
     if send_csp_violation_to_rollbar?
-      Rollbar.error(Error.new(CspViolation), csp_report_params:)
+      Rollbar.info(Error.new(CspViolation), csp_report_params:)
     end
 
     csp_report =

--- a/spec/controllers/api/csp_reports_controller_spec.rb
+++ b/spec/controllers/api/csp_reports_controller_spec.rb
@@ -54,8 +54,8 @@ RSpec.describe Api::CspReportsController do
         'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:105.0) Gecko/20100101 Firefox/105.0'
       end
 
-      it 'sends an error to Rollbar' do
-        expect(Rollbar).to receive(:error).with(CspViolation, hash_including(:csp_report_params))
+      it 'sends an exception to Rollbar at info level' do
+        expect(Rollbar).to receive(:info).with(CspViolation, hash_including(:csp_report_params))
 
         post_create
       end


### PR DESCRIPTION
Having these at `error` level was more useful when our CSP was new and we were getting legit violations. Now, it's pretty much just noise from crawlers and whatnot trying to inject scripts into the page.