### PR TITLE
Unpin JavaScript dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.20.7",
     "@babel/plugin-syntax-dynamic-import": "^7.8.3",
     "@babel/preset-env": "^7.22.5",
-    "@formkit/auto-animate": "1.0.0-pre-alpha.3",
+    "@formkit/auto-animate": "1.0.0-beta.6",
     "@hotwired/turbo": "^7.3.0",
     "@hotwired/turbo-rails": "^7.3.0",
     "@rails/actioncable": "^7.0.5",
@@ -33,7 +33,7 @@
     "basscss-colors": "^2.2.0",
     "basscss-lighten": "^1.1.0",
     "chart.js": "^4.3.0",
-    "chartjs-adapter-luxon": "1.3.1",
+    "chartjs-adapter-luxon": "^1.3.1",
     "chartkick": "^5.0.1",
     "clipboard": "^2.0.11",
     "dompurify": "^3.0.3",
@@ -78,7 +78,7 @@
     "@volar/vue-language-plugin-pug": "^1.6.5",
     "@vue/eslint-config-typescript": "^11.0.3",
     "eslint-import-resolver-typescript": "^3.5.5",
-    "eslint-plugin-import": "2.27.5",
+    "eslint-plugin-import": "^2.27.5",
     "postcss": "^8.4.24",
     "postcss-html": "^1.5.0",
     "sass": "^1.63.5",
@@ -87,6 +87,6 @@
     "stylelint-config-standard-scss": "^9.0.0",
     "stylelint-scss": "^5.0.1",
     "typescript": "^5.1.3",
-    "vue-tsc": "1.8.1"
+    "vue-tsc": "^1.8.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -24,8 +24,8 @@ dependencies:
     specifier: ^7.22.5
     version: 7.22.5(@babel/core@7.22.5)
   '@formkit/auto-animate':
-    specifier: 1.0.0-pre-alpha.3
-    version: 1.0.0-pre-alpha.3(vue@3.3.4)
+    specifier: 1.0.0-beta.6
+    version: 1.0.0-beta.6
   '@hotwired/turbo':
     specifier: ^7.3.0
     version: 7.3.0
@@ -78,7 +78,7 @@ dependencies:
     specifier: ^4.3.0
     version: 4.3.0
   chartjs-adapter-luxon:
-    specifier: 1.3.1
+    specifier: ^1.3.1
     version: 1.3.1(chart.js@4.3.0)(luxon@3.3.0)
   chartkick:
     specifier: ^5.0.1
@@ -209,7 +209,7 @@ devDependencies:
     specifier: ^3.5.5
     version: 3.5.5(@typescript-eslint/parser@5.60.0)(eslint-plugin-import@2.27.5)(eslint@8.43.0)
   eslint-plugin-import:
-    specifier: 2.27.5
+    specifier: ^2.27.5
     version: 2.27.5(@typescript-eslint/parser@5.60.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.43.0)
   postcss:
     specifier: ^8.4.24
@@ -236,7 +236,7 @@ devDependencies:
     specifier: ^5.1.3
     version: 5.1.3
   vue-tsc:
-    specifier: 1.8.1
+    specifier: ^1.8.1
     version: 1.8.1(typescript@5.1.3)
 
 packages:
@@ -1784,18 +1784,8 @@ packages:
       '@floating-ui/core': 1.3.1
     dev: false
 
-  /@formkit/auto-animate@1.0.0-pre-alpha.3(vue@3.3.4):
-    resolution: {integrity: sha512-lMVZ3LFUIu0RIxCEwmV8nUUJQ46M2bv2NDU3hrhZivViuR1EheC8Mj5sx/ACqK5QLK8XB8z7GDIZBUGdU/9OZQ==}
-    peerDependencies:
-      react: ^16.8.0
-      vue: ^3.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      vue:
-        optional: true
-    dependencies:
-      vue: 3.3.4
+  /@formkit/auto-animate@1.0.0-beta.6:
+    resolution: {integrity: sha512-PVDhLAlr+B4Xb7e+1wozBUWmXa6BFU8xUPR/W/E+TsQhPS1qkAdAsJ25keEnFrcePSnXHrOsh3tiFbEToOzV9w==}
     dev: false
 
   /@hotwired/turbo-rails@7.3.0:


### PR DESCRIPTION
We cannot unpin @formkit/auto-animate, though, because it's in beta.