### PR TITLE
Bump bundler from 2.4.13 to 2.4.19

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -711,4 +711,4 @@ RUBY VERSION
    ruby 3.2.2p53
 
 BUNDLED WITH
-   2.4.13
+   2.4.19


### PR DESCRIPTION
When the Gemfile.lock mentions an older version than what I have on my machine, then `bundle install` generates a warning message and switches to the older version. Let's avoid that.