### PR TITLE
Whitelist Google OAuth path

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -4,7 +4,13 @@ class Rack::Attack
   PATH_FRAGMENT_SEPARATOR_REGEX = %r{/|\.|\?|-|_|=}
   PENTESTERS_PREFIX = 'pentesters-'
   PENTESTING_FINDTIME = 1.day.freeze
-  WHITELISTED_PATH_PREFIXES = %w[/flipper/ /sidekiq/ /vite/ /vite-admin/].freeze
+  WHITELISTED_PATH_PREFIXES = %w[
+    /auth/google_oauth2?
+    /flipper/
+    /sidekiq/
+    /vite-admin/
+    /vite/
+  ].freeze
 
   # Limit all IPs to 60 requests per clock minute
   # rubocop:disable Style/SymbolProc


### PR DESCRIPTION
We have an `auth` BannedPathFragment that otherwise triggers when authenticating. I'm really not sure why this is only coming up now? I guess something changed recently, but I can't figure out what that is.