### PR TITLE
Remove base NODE_ENV=test env var from CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -55,7 +55,6 @@ jobs:
         CI: true
         AWS_EC2_METADATA_DISABLED: true
         RAILS_ENV: test
-        NODE_ENV: test
         DISABLE_SPRING: 1
         PERCY_SKIP_UPDATE_CHECK: 1
         VITE_RUBY_AUTO_BUILD: false


### PR DESCRIPTION
This causes warnings to be printed that otherwise aren't printed, and I'm not sure that we get any benefit from it.