### PR TITLE
Relax pnpm constraint and don't check version in tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -45,6 +45,8 @@ jobs:
       with:
         bundler-cache: true
     - uses: pnpm/action-setup@v2
+      with:
+        version: 8
     - uses: actions/setup-node@v3
       with:
         node-version-file: .nvmrc

--- a/bin/test/tasks/check_versions.rb
+++ b/bin/test/tasks/check_versions.rb
@@ -14,9 +14,11 @@ class Test::Tasks::CheckVersions < Pallets::Task
       node --version && [ "$(node --version)" = '#{node_version}' ]
     COMMAND
 
-    pnpm_version = JSON.parse(File.read('package.json'))['packageManager'].delete_prefix('pnpm@')
+    pnpm_version_specification = JSON.parse(File.read('package.json')).dig('engines', 'pnpm')
+    puts("Specified pnpm version/range: #{pnpm_version_specification}")
+    # Log only; don't check that it is within the range (since that would be a bit complex).
     execute_system_command(<<~COMMAND)
-      pnpm --version && [ "$(pnpm --version)" = '#{pnpm_version}' ]
+      pnpm --version
     COMMAND
   end
 end

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "david_runger",
   "private": true,
   "engines": {
-    "node": "18.16.0"
+    "node": "18.16.0",
+    "pnpm": ">=8.8.0 <9"
   },
-  "packageManager": "pnpm@8.7.4",
   "browserslist": [
     ">10%"
   ],


### PR DESCRIPTION
I am relaxing the constraint because `pnpm` bugs me to keep it up to date on my local machine, and I don't want to have to submit a PR every time that I do so.