### PR TITLE
Remove auto_strip_attributes gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ ruby File.read('.ruby-version').rstrip
 
 gem 'activeadmin'
 gem 'alba'
-gem 'auto_strip_attributes'
 gem 'aws-sdk-s3'
 gem 'bootsnap', require: false
 gem 'browser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -108,8 +108,6 @@ GEM
       ruby2_keywords (>= 0.0.2)
     ast (2.4.2)
     attr_extras (7.1.0)
-    auto_strip_attributes (2.6.0)
-      activerecord (>= 4.0)
     aws-eventstream (1.2.0)
     aws-partitions (1.834.0)
     aws-sdk-core (3.185.1)
@@ -646,7 +644,6 @@ DEPENDENCIES
   alba
   amazing_print
   annotate
-  auto_strip_attributes
   aws-sdk-s3
   better_errors
   binding_of_caller

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,6 +24,8 @@ class Item < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { scope: :store_id }
 
+  strip_attributes collapse_spaces: true
+
   has_paper_trail
 
   scope :needed, -> { where('items.needed > 0') }

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -24,8 +24,6 @@ class Item < ApplicationRecord
 
   validates :name, presence: true, uniqueness: { scope: :store_id }
 
-  auto_strip_attributes :name, squish: true
-
   has_paper_trail
 
   scope :needed, -> { where('items.needed > 0') }

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Api::ItemsController do
       end
 
       context 'when the item name contains leading or trailing whitespace' do
-        let(:params) { super().deep_merge(item: { name: ' cheese ' }) }
+        let(:params) { super().deep_merge(item: { name: " cheese \t puffs " }) }
 
         it 'strips the whitespace' do
           expect { post_create }.
             to change { store.reload.items.order(:created_at).last!.name }.
-            to('cheese')
+            to('cheese puffs')
         end
       end
     end


### PR DESCRIPTION
We also have the strip_attributes gem, which does the same thing (without needing to declare it manually).