### PR TITLE
Remove debug require statement from prerender script

### DIFF
--- a/bin/prerender
+++ b/bin/prerender
@@ -10,7 +10,6 @@ require 'aws-sdk-s3'
 require 'dotenv/load' if ENV.fetch('CI', nil) != 'true'
 require 'ferrum'
 require 'nokogiri'
-require 'debug' if ENV.fetch('CI', nil) != 'true'
 
 class Prerenderer
   def initialize


### PR DESCRIPTION
We don't have `debug` in the Gemfile anymore.