### PR TITLE
Don't set NODE_ENV to production when pnpm installing locally

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -32,7 +32,7 @@ namespace :assets do
     run_logged_system_command('rm -rf public/assets/ public/vite/ public/vite-admin/')
     run_logged_system_command('rm -f app/javascript/rails_assets/routes.js')
     run_logged_system_command('bin/rails build_js_routes', { 'DISABLE_SPRING' => '1' })
-    run_logged_system_command('pnpm install', { 'NODE_ENV' => 'production' })
+    run_logged_system_command('pnpm install')
     run_logged_system_command(
       'bin/vite build --force',
       {


### PR DESCRIPTION
I don't think it's set (at least not to production) when we build assets in CI, so we shouldn't set it to production locally.