### PR TITLE
Allow for dashes in script tag asset fingerprint

### DIFF
--- a/spec/helpers/assets_helper_spec.rb
+++ b/spec/helpers/assets_helper_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AssetsHelper do
         %r{
           <
             script\s
-            src="/vite/assets/home_app-\w{8}\.js"\s
+            src="/vite/assets/home_app-[\w-]{8}\.js"\s
             type="module"\s
             defer="defer"
           ></script>


### PR DESCRIPTION
Apparently, sometimes vite includes dashes in the fingerprint.