### PR TITLE
Add back isolator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :development, :test do
   gem 'bullet'
   gem 'dotenv-rails', require: 'dotenv/rails-now'
   gem 'immigrant'
+  gem 'isolator'
   gem 'pry-byebug', require: false
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
     annotate (3.2.0)
       activerecord (>= 3.2, < 8.0)
       rake (>= 10.4, < 14.0)
+    anyway_config (2.6.2)
+      ruby-next-core (~> 1.0)
     arbre (1.7.0)
       activesupport (>= 3.0.0)
       ruby2_keywords (>= 0.0.2)
@@ -210,6 +212,7 @@ GEM
     drb (2.2.0)
       ruby2_keywords
     dry-cli (1.0.0)
+    dry-initializer (3.1.1)
     e2mmap (0.1.0)
     erubi (1.12.0)
     factory_bot (6.4.5)
@@ -287,6 +290,8 @@ GEM
     irb (1.11.1)
       rdoc
       reline (>= 0.4.2)
+    isolator (1.0.1)
+      sniffer (>= 0.5.0)
     jaro_winkler (1.5.6)
     jmespath (1.6.2)
     jquery-rails (4.6.0)
@@ -550,6 +555,7 @@ GEM
       rubocop (~> 1.40)
       rubocop-capybara (~> 2.17)
       rubocop-factory_bot (~> 2.22)
+    ruby-next-core (1.0.0)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     runger_actions (0.19.2)
@@ -595,6 +601,9 @@ GEM
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
+    sniffer (0.5.0)
+      anyway_config (>= 1.0)
+      dry-initializer (~> 3)
     solargraph (0.50.0)
       backport (~> 1.2)
       benchmark
@@ -707,6 +716,7 @@ DEPENDENCIES
   hotwire-livereload
   http_logger
   immigrant
+  isolator
   js-routes
   json-schema
   jwt

--- a/config/initializers/isolator.rb
+++ b/config/initializers/isolator.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# `Isolator` is not available in production (per the Gemfile)
+if Rails.env.in?(%w[development test])
+  Isolator.configure do |config|
+    config.raise_exceptions = true
+  end
+end


### PR DESCRIPTION
`isolator` was incompatible with Ruby 3.3.0 because of a bug in its dependency `anyway_config` ( https://github.com/palkan/anyway_config/issues/ 144 ), so we removed it in #3702/, but the bug in `anyway_config` has been fixed now.