### PR TITLE
Install pnpm via npm (no longer GitHub Action)

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,13 +44,12 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         bundler-cache: true
-    - uses: pnpm/action-setup@v2
-      with:
-        version: 8
     - uses: actions/setup-node@v4
       with:
         node-version-file: .nvmrc
         cache: pnpm
+    - name: Install pnpm
+      run: npm install -g pnpm@8
     - name: Run tests & linters
       run: bin/pallets --verbose -r ./bin/run-tests.rb
       env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -49,6 +49,14 @@ jobs:
         node-version-file: .nvmrc
     - name: Install pnpm
       run: npm install -g pnpm@8
+    - name: Set pnpm store directory
+      run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+    - uses: actions/cache@v4
+      name: Set up pnpm cache
+      with:
+        path: ${{ env.PNPM_STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: ${{ runner.os }}-pnpm-store-
     - name: Run tests & linters
       run: bin/pallets --verbose -r ./bin/run-tests.rb
       env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -47,7 +47,6 @@ jobs:
     - uses: actions/setup-node@v4
       with:
         node-version-file: .nvmrc
-        cache: pnpm
     - name: Install pnpm
       run: npm install -g pnpm@8
     - name: Run tests & linters


### PR DESCRIPTION
The GitHub Action is not producing a deprecation warning: https://github.com/pnpm/action-setup/issues/ 99 . They're working on fixing it, but I am not sure waiting is worthwhile.