### PR TITLE
Create alphanumeric random values for AuthTokens (not UUIDs)

### DIFF
--- a/app/actions/auth_tokens/create.rb
+++ b/app/actions/auth_tokens/create.rb
@@ -4,6 +4,6 @@ class AuthTokens::Create < ApplicationAction
   requires :user, User
 
   def execute
-    user.auth_tokens.create!(secret: SecureRandom.uuid)
+    user.auth_tokens.create!(secret: SecureRandom.alphanumeric(22))
   end
 end


### PR DESCRIPTION
We get greater entropy in fewer characters and without the wasted space of dashes.