### PR TITLE
Bump codecov/codecov-action from v3 to v4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -86,7 +86,7 @@ jobs:
         path: spec/fixtures/
         retention-days: 5
     - name: Upload Code Coverage
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         directory: tmp/simple_cov
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -88,7 +88,7 @@ jobs:
     - name: Upload Code Coverage
       uses: codecov/codecov-action@v4
       with:
-        directory: tmp/simple_cov
+        token: ${{ secrets.CODECOV_TOKEN }}
 
   deploy-and-prerender:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}


### PR DESCRIPTION
v3 is generating a warning in GitHub about node 16 deprecation.