### PR TITLE
Bump actions/upload-artifact from v3 to v4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -79,7 +79,7 @@ jobs:
         CODECOV_TOKEN: "${{secrets.CODECOV_TOKEN}}"
         RAILS_MASTER_KEY: "${{secrets.RAILS_MASTER_KEY}}"
     - name: Save fixtures artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: failure()
       with:
         name: fixtures


### PR DESCRIPTION
This addresses a node 16 deprecation warning.