### PR TITLE
Drop dotenv-rails; use only dotenv and remove custom require

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -58,7 +58,7 @@ group :development, :test do
   gem 'amazing_print'
   gem 'annotate', require: false
   gem 'bullet'
-  gem 'dotenv-rails', require: 'dotenv/rails-now'
+  gem 'dotenv'
   gem 'immigrant'
   gem 'isolator'
   gem 'pry-byebug', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,9 +194,6 @@ GEM
     diff-lcs (1.5.1)
     docile (1.4.0)
     dotenv (3.0.2)
-    dotenv-rails (3.0.2)
-      dotenv (= 3.0.2)
-      railties (>= 6.1)
     draper (4.0.2)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -698,7 +695,7 @@ DEPENDENCIES
   dalli
   database_consistency
   devise
-  dotenv-rails
+  dotenv
   draper
   factory_bot_rails
   faker


### PR DESCRIPTION
`dotenv-rails` is no longer needed as of dotenv 3.0.0 and is soft-deprecated (https://github.com/bkeepers/dotenv/blob/main/Changelog.md#300).

I don't think that the require statement seems to be needed (any longer?), either, when using Rails.