### PR TITLE
Escape newline with backslash in multiline backticks shell string

### DIFF
--- a/bin/test/diff_helpers.rb
+++ b/bin/test/diff_helpers.rb
@@ -23,7 +23,7 @@ module DiffHelpers
   memo_wise \
   def diff
     ensure_master_is_present
-    `git log master..HEAD --full-diff --source --format="" --unified=0 -p .
+    `git log master..HEAD --full-diff --source --format="" --unified=0 -p . \
       | grep -Ev "^(diff |index |--- a/|\\+\\+\\+ b/|@@ )"`
   end
 


### PR DESCRIPTION
https://stackoverflow.com/a/9998837/4009384

I'm hoping this will fix the following error: https://github.com/davidrunger/david_runger/actions/runs/7968004293/job/21751592340#step:9:26

```
sh: 2: Syntax error: "|" unexpected
```