### PR TITLE
Only run system clear command in test runner if TERM is present

### DIFF
--- a/bin/test/runner.rb
+++ b/bin/test/runner.rb
@@ -32,7 +32,7 @@ class Test::Runner < Pallets::Workflow
       if Test::RequirementsResolver.verify?
         confirm_config
       else
-        system('clear')
+        system('clear') if ENV['TERM']
         register_tasks_and_run
       end
     end
@@ -43,7 +43,7 @@ class Test::Runner < Pallets::Workflow
     end
 
     def print_config
-      system('clear')
+      system('clear') if ENV['TERM']
 
       ap('Running these tasks:')
       ap(required_tasks.map(&:name).map { _1.gsub('Test::Tasks::', '') }.sort)


### PR DESCRIPTION
https://stackoverflow.com/a/33679937/4009384

This will hopefully eliminate warnings like this: https://github.com/davidrunger/david_runger/actions/runs/7968121124/job/21751883893#step:9:23

```
TERM environment variable not set.
```