### PR TITLE
Set config.action_dispatch.show_exceptions to :none/:all

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -35,7 +35,7 @@ Rails.application.configure do
   config.cache_store = :null_store
 
   # Raise exceptions instead of rendering exception templates.
-  config.action_dispatch.show_exceptions = false
+  config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -287,7 +287,7 @@ RSpec.configure do |config|
     env_config = Rails.application.env_config
     original_show_exceptions = env_config['action_dispatch.show_exceptions']
     original_show_detailed_exceptions = env_config['action_dispatch.show_detailed_exceptions']
-    env_config['action_dispatch.show_exceptions'] = true
+    env_config['action_dispatch.show_exceptions'] = :all
     env_config['action_dispatch.show_detailed_exceptions'] = false
 
     spec.run


### PR DESCRIPTION
This change should fix deprecation warnings like the following.

https://github.com/davidrunger/david_runger/actions/runs/7968478855/job/21752819972#step:9:131

> DEPRECATION WARNING: Setting action_dispatch.show_exceptions to false is deprecated. Set to :none instead. (called from block (5 levels) in <top (required)> at /home/runner/work/david_runger/david_runger/spec/requests/users/omniauth_callbacks_controller_spec.rb:10)

https://github.com/davidrunger/david_runger/actions/runs/7968478855/job/21752819972#step:9:304

> DEPRECATION WARNING: Setting action_dispatch.show_exceptions to true is deprecated. Set to :all instead. (called from block (4 levels) in <top (required)> at /home/runner/work/david_runger/david_runger/spec/features/error_handling_spec.rb:9)