### PR TITLE
Install rails-reverse-proxy from RubyGems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,10 +36,7 @@ gem 'puma'
 gem 'pundit'
 gem 'rack-attack'
 gem 'rails'
-gem 'rails-reverse-proxy',
-  # https://github.com/axsuul/rails-reverse-proxy/pull/76
-  github: 'davidrunger/rails-reverse-proxy',
-  ref: 'f801620d2c7b94bc7fbecebe3cdbae46aa021656'
+gem 'rails-reverse-proxy'
 gem 'redis-client'
 gem 'redlock'
 gem 'request_store'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,15 +6,6 @@ GIT
       msgpack
       redis (~> 5.0)
 
-GIT
-  remote: https://github.com/davidrunger/rails-reverse-proxy.git
-  revision: f801620d2c7b94bc7fbecebe3cdbae46aa021656
-  ref: f801620d2c7b94bc7fbecebe3cdbae46aa021656
-  specs:
-    rails-reverse-proxy (0.12.0)
-      actionpack
-      addressable
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -461,6 +452,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-reverse-proxy (0.13.0)
+      actionpack
+      addressable
     railties (7.1.3)
       actionpack (= 7.1.3)
       activesupport (= 7.1.3)
@@ -741,7 +735,7 @@ DEPENDENCIES
   rack-attack
   rails
   rails-controller-testing
-  rails-reverse-proxy!
+  rails-reverse-proxy
   redis-client
   redlock
   request_store


### PR DESCRIPTION
My fix (https://github.com/axsuul/rails-reverse-proxy/pull/ 76) for the deprecation warning with Rack 3 was merged and released as rails-reverse-proxy 0.13.0!