### PR TITLE
Don't require prism

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,7 +62,7 @@ group :development, :test do
   gem 'immigrant'
   gem 'isolator'
   # Source prism from GitHub for unreleased fixes, e.g. https://github.com/ruby/prism/pull/ 2563 .
-  gem 'prism', github: 'ruby/prism'
+  gem 'prism', github: 'ruby/prism', require: false
   gem 'pry-byebug', require: false
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false


### PR DESCRIPTION
We don't need it required, so let's save a tiny bit of resources by not requiring it.