### PR TITLE
Exclude gitignored files and schema.rb from RuboCop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,3 +9,10 @@ inherit_gem:
 
 require:
   - ./tools/custom_cops/dont_include_sidekiq_worker.rb
+
+AllCops:
+  Exclude:
+  <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
+    - <%= path.sub(/^!! /, '').sub(/\/$/, '/**/*').rstrip %>
+  <% end %>
+    - db/schema.rb


### PR DESCRIPTION
This overrides the `runger_style` Excludes list. The benefit of this is that we can simply run `bin/rubocop` and it will lint only the files in the repo that we want to be linted (e.g. not Ruby files in `personal/`).

I started to explore this because I think that running RuboCop against the whole repo, rather than a list of specific spec files, can be a lot faster.

![image](https://github.com/davidrunger/david_runger/assets/8197963/ef425c62-0104-40e6-8954-00f1dd6f9eb7)

This cannot be done in the `runger_style` config, because then the working directory for the `git status --ignored --porcelain` command is `runger_style` rather than the project repo.