### PR TITLE
Move from hotwire-livereload to vite-plugin-full-reload

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,7 +76,6 @@ end
 group :development do
   gem 'better_errors'
   gem 'binding_of_caller'
-  gem 'hotwire-livereload'
   gem 'http_logger'
   gem 'letter_opener'
   gem 'listen'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,10 +268,6 @@ GEM
       hashids (~> 1.0)
     hashids (1.0.6)
     hashie (5.0.0)
-    hotwire-livereload (1.3.1)
-      actioncable (>= 6.0.0)
-      listen (>= 3.0.0)
-      railties (>= 6.0.0)
     http_logger (0.7.0)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
@@ -714,7 +710,6 @@ DEPENDENCIES
   haml
   haml-rails
   hashid-rails
-  hotwire-livereload
   http_logger
   immigrant
   isolator

--- a/app/views/layouts/application.haml
+++ b/app/views/layouts/application.haml
@@ -38,7 +38,6 @@
 
     - if Rails.env.development? && !ENV['PRODUCTION_ASSET_CONFIG'].present?
       = vite_client_tag
-      = hotwire_livereload_tags
     = ts_tag('styles')
     = content_for(:extra_css)
     = content_for(:page_assets)

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -86,14 +86,6 @@ Rails.application.configure do
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
 
-  config.hotwire_livereload.disable_default_listeners = true
-  config.hotwire_livereload.listen_paths = %w[
-    app/views
-    app/helpers
-    app/assets/stylesheets
-  ].map { Rails.root.join(_1) }
-  config.hotwire_livereload.force_reload_paths = config.hotwire_livereload.listen_paths
-
   # Email
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "stylelint-scss": "^5.3.2",
     "typescript": "^5.4.3",
     "vite": "^5.2.2",
+    "vite-plugin-full-reload": "^1.1.0",
     "vite-plugin-ruby": "^5.0.0",
     "vue-tsc": "^2.0.7"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ devDependencies:
   vite:
     specifier: ^5.2.2
     version: 5.2.2(sass@1.72.0)
+  vite-plugin-full-reload:
+    specifier: ^1.1.0
+    version: 1.1.0
   vite-plugin-ruby:
     specifier: ^5.0.0
     version: 5.0.0(vite@5.2.2)
@@ -4144,6 +4147,13 @@ packages:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+    dev: true
+
+  /vite-plugin-full-reload@1.1.0:
+    resolution: {integrity: sha512-3cObNDzX6DdfhD9E7kf6w2mNunFpD7drxyNgHLw+XwIYAgb+Xt16SEXo0Up4VH+TMf3n+DSVJZtW2POBGcBYAA==}
+    dependencies:
+      picocolors: 1.0.0
+      picomatch: 2.3.1
     dev: true
 
   /vite-plugin-ruby@5.0.0(vite@5.2.2):

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,11 +1,19 @@
-import { defineConfig } from 'vite'
-import RubyPlugin from 'vite-plugin-ruby'
-import ElementPlus from 'unplugin-element-plus/vite'
-import vue from '@vitejs/plugin-vue'
-import path from 'path'
+/* eslint-env node */
+
+import { defineConfig } from 'vite';
+import RubyPlugin from 'vite-plugin-ruby';
+import ElementPlus from 'unplugin-element-plus/vite';
+import vue from '@vitejs/plugin-vue';
+import path from 'path';
+import FullReload from 'vite-plugin-full-reload';
 
 export default defineConfig({
   plugins: [
+    FullReload([
+      'app/views/**/*',
+      'app/helpers/**/*',
+      'app/assets/stylesheets/**/*',
+    ]),
     RubyPlugin(),
     ElementPlus(),
     vue(),
@@ -13,8 +21,8 @@ export default defineConfig({
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './app/javascript'),
-      'img': path.resolve(__dirname, './app/assets/images'),
-      'css': path.resolve(__dirname, './app/assets/stylesheets'),
+      img: path.resolve(__dirname, './app/assets/images'),
+      css: path.resolve(__dirname, './app/assets/stylesheets'),
     },
   },
-})
+});


### PR DESCRIPTION
I appreciate what `hotwire-livereload` provided, but I think I might remove some hotwire gems and/or JS packages, and, in general, I think it makes more sense to lean on Vite here. For example, Vite doesn't require an authenticated connection, whereas `hotwire-livereload` does (at least, as I have it currently configured on master, by connecting through ApplicationCable::Connection).