### PR TITLE
Remove solargraph

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,6 @@ group :development, :test do
   gem 'rubocop-rails', require: false
   gem 'rubocop-rspec', require: false
   gem 'runger_style', require: false
-  gem 'solargraph', require: false
   gem 'spring-commands-rspec'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,10 +132,8 @@ GEM
       aws-sigv4 (~> 1.8)
     aws-sigv4 (1.8.0)
       aws-eventstream (~> 1, >= 1.0.2)
-    backport (1.2.0)
     base64 (0.2.0)
     bcrypt (3.1.20)
-    benchmark (0.3.0)
     better_errors (2.10.1)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
@@ -209,7 +207,6 @@ GEM
     drb (2.2.1)
     dry-cli (1.0.0)
     dry-initializer (3.1.1)
-    e2mmap (0.1.0)
     erubi (1.12.0)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -284,7 +281,6 @@ GEM
       reline (>= 0.4.2)
     isolator (1.0.1)
       sniffer (>= 0.5.0)
-    jaro_winkler (1.5.6)
     jmespath (1.6.2)
     jquery-rails (4.6.0)
       rails-dom-testing (>= 1, < 3)
@@ -309,10 +305,6 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
-    kramdown (2.4.0)
-      rexml
-    kramdown-parser-gfm (1.1.0)
-      kramdown (~> 2.0)
     language_server-protocol (3.17.0.3)
     launchy (2.5.2)
       addressable (~> 2.8)
@@ -472,7 +464,6 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (2.8.4)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     redis (5.1.0)
@@ -492,8 +483,6 @@ GEM
     responders (3.1.1)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    reverse_markdown (2.1.1)
-      nokogiri
     rexml (3.2.6)
     rollbar (3.5.2)
     rouge (4.2.1)
@@ -601,22 +590,6 @@ GEM
     sniffer (0.5.0)
       anyway_config (>= 1.0)
       dry-initializer (~> 3)
-    solargraph (0.50.0)
-      backport (~> 1.2)
-      benchmark
-      bundler (~> 2.0)
-      diff-lcs (~> 1.4)
-      e2mmap
-      jaro_winkler (~> 1.5)
-      kramdown (~> 2.3)
-      kramdown-parser-gfm (~> 1.1)
-      parser (~> 3.0)
-      rbs (~> 2.0)
-      reverse_markdown (~> 2.0)
-      rubocop (~> 1.38)
-      thor (~> 1.0)
-      tilt (~> 2.0)
-      yard (~> 0.9, >= 0.9.24)
     spring (4.1.3)
     spring-commands-rspec (1.0.4)
       spring (>= 0.9.1)
@@ -666,7 +639,6 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yard (0.9.36)
     zeitwerk (2.6.13)
 
 PLATFORMS
@@ -758,7 +730,6 @@ DEPENDENCIES
   simple_cov-formatter-terminal
   simplecov
   simplecov-cobertura
-  solargraph
   spring
   spring-commands-rspec
   spring-watcher-listen


### PR DESCRIPTION
I am going to use pheen/fuzzy_ruby_server instead (and, actually, I have been using it for a little while now; I'm surprised that I haven't removed solargraph before).