### PR TITLE
Remove prism from Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,8 +61,6 @@ group :development, :test do
   gem 'dotenv'
   gem 'immigrant'
   gem 'isolator'
-  # Source prism from GitHub for unreleased fixes, e.g. https://github.com/ruby/prism/pull/ 2563 .
-  gem 'prism', github: 'ruby/prism', require: false
   gem 'pry-byebug', require: false
   gem 'rubocop', require: false
   gem 'rubocop-performance', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,12 +6,6 @@ GIT
       msgpack
       redis (~> 5.0)
 
-GIT
-  remote: https://github.com/ruby/prism.git
-  revision: 6a15e475c9512fdcbffacdf2cc9867ce7e3811c5
-  specs:
-    prism (0.24.0)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -392,6 +386,7 @@ GEM
     percy-capybara (5.0.0)
       capybara (>= 3)
     pg (1.5.6)
+    prism (0.25.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -706,7 +701,6 @@ DEPENDENCIES
   paper_trail
   percy-capybara
   pg
-  prism!
   pry-byebug
   puma
   pundit


### PR DESCRIPTION
It is still indirectly pulled in via runger_style. We shouldn't need to pull it from GitHub anymore because the fix we were depending on should be included in the latest release.