### PR TITLE
Make <a href=...> CSS color override selector less specific

### DIFF
--- a/app/assets/stylesheets/tailwind_overrides.scss
+++ b/app/assets/stylesheets/tailwind_overrides.scss
@@ -2,6 +2,11 @@ html {
   line-height: 1.15;
 }
 
+// NOTE: We want this selector to be as unspecific as possible, to make it easier to override.
+[href] {
+  @apply text-blue-600 visited:text-purple-600
+}
+
 // NOTE: We nest the selectors within `body` to give them additional specificity.
 body {
   h2 {
@@ -11,10 +16,6 @@ body {
   img,
   svg {
     display:inline;
-  }
-
-  a[href] {
-    @apply text-blue-600 visited:text-purple-600
   }
 
   p {


### PR DESCRIPTION
This means that the resume link (which looks like a button) on the homepage will be white (as we want), rather than purple, after visiting it.