### PR TITLE
Sleep a half second after devicon font loads for Percy snapshot

### DIFF
--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -14,6 +14,8 @@ RSpec.describe 'Home page', :prerendering_disabled do
       wait_for do
         page.evaluate_script('document.fonts.check("65px devicon")')
       end.to eq(true)
+
+      sleep(0.5)
     end
 
     page.percy_snapshot('Homepage')


### PR DESCRIPTION
A [Percy build][1] flaked recently (maybe somehow due to the switch to Tailwind? the timing seems very suspicious) so I am going to add this extra half second sleep to try to allow enough time for fonts/CSS to be parsed etc for a stable Percy snapshot of the homepage.

[1]: https://percy.io/David-Runger/david_runger/builds/34790045/changed/1902141723