### PR TITLE
Change references to "master" branch to "main"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,7 +6,7 @@ on:
       - '*'
   push:
     branches:
-      - master
+      - main
 
 jobs:
   test:
@@ -91,7 +91,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   deploy-and-prerender:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: test
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![codecov](https://codecov.io/gh/davidrunger/david_runger/branch/master/graph/badge.svg)](https://codecov.io/gh/davidrunger/david_runger)
+[![codecov](https://codecov.io/gh/davidrunger/david_runger/branch/main/graph/badge.svg)](https://codecov.io/gh/davidrunger/david_runger)
 [![This project is using Percy.io for visual regression testing.](https://percy.io/static/images/percy-badge.svg)](https://percy.io/David-Runger/david_runger)
 
 # [davidrunger.com](https://www.davidrunger.com/)

--- a/app/javascript/home/components/projects.vue
+++ b/app/javascript/home/components/projects.vue
@@ -53,7 +53,7 @@ HomeSection(section='projects' title='Projects')
         li.
 
           The app's 2,500+ lines of Ruby code are
-          #[a(href='https://app.codecov.io/gh/davidrunger/david_runger/tree/master') #[span.bold 100%] covered by tests]
+          #[a(href='https://app.codecov.io/gh/davidrunger/david_runger/tree/main') #[span.bold 100%] covered by tests]
           written with #[a(href='https://rspec.info/') RSpec].
 
         li.

--- a/bin/test/diff_helpers.rb
+++ b/bin/test/diff_helpers.rb
@@ -23,7 +23,7 @@ module DiffHelpers
   memo_wise \
   def diff
     ensure_master_is_present
-    `git log master..HEAD --full-diff --source --format="" --unified=0 -p . \
+    `git log main..HEAD --full-diff --source --format="" --unified=0 -p . \
       | grep -Ev "^(diff |index |--- a/|\\+\\+\\+ b/|@@ )"`
   end
 
@@ -33,23 +33,23 @@ module DiffHelpers
   end
 
   def ensure_master_is_present
-    if !system('git log -1 --pretty="%H" master > /dev/null 2>&1')
-      puts('`master` branch is not present; fetching it now...')
-      system('git fetch origin master:master --depth=1', exception: true)
-      puts('Done fetching origin master branch.')
+    if !system('git log -1 --pretty="%H" main > /dev/null 2>&1')
+      puts('`main` branch is not present; fetching it now...')
+      system('git fetch origin main:main --depth=1', exception: true)
+      puts('Done fetching origin main branch.')
     end
   end
 
   memo_wise \
   def files_added_in?(directory)
     ensure_master_is_present
-    `git diff --name-only --diff-filter=A master HEAD #{directory}`.rstrip.split("\n").any?
+    `git diff --name-only --diff-filter=A main HEAD #{directory}`.rstrip.split("\n").any?
   end
 
   memo_wise \
   def files_changed
     ensure_master_is_present
-    `git diff --name-only $(git merge-base HEAD master)`.rstrip.split("\n")
+    `git diff --name-only $(git merge-base HEAD main)`.rstrip.split("\n")
   end
 
   memo_wise \

--- a/bin/test/tasks/compile_java_script.rb
+++ b/bin/test/tasks/compile_java_script.rb
@@ -19,7 +19,7 @@ class Test::Tasks::CompileJavaScript < Pallets::Task
         'VITE_RUBY_PUBLIC_OUTPUT_DIR' => 'vite-admin',
       },
     )
-    if ENV.fetch('CI', nil) == 'true' && ENV.fetch('GITHUB_REF_NAME') == 'master'
+    if ENV.fetch('CI', nil) == 'true' && ENV.fetch('GITHUB_REF_NAME') == 'main'
       execute_rake_task('assets:upload_vite_assets')
     end
   end

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,7 +1,7 @@
 pre-push:
   commands:
     gitleaks:
-      run: gitleaks detect --log-opts="origin/master...HEAD" --verbose &> /dev/null
+      run: gitleaks detect --log-opts="origin/main...HEAD" --verbose &> /dev/null
 
 skip_output:
   - meta


### PR DESCRIPTION
I have renamed the "master" branch in GitHub to "main", so we need to update these references to reflect that change.