### PR TITLE
Store item skipp as boolean on item object (not skippedItems array)

### DIFF
--- a/app/javascript/groceries/components/item.vue
+++ b/app/javascript/groceries/components/item.vue
@@ -34,7 +34,7 @@
       link
       type='primary'
       @click='unskip(item)'
-      v-if='groceriesStore.skippedItems.includes(item)'
+      v-if='item.skipped'
     ) Unskip
   .delete.text-2xl.px-2.js-link.right.text-red-600.leading-unset(
     v-if='ownStore'

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -15,7 +15,6 @@ interface State {
   pendingRequests: number
   postingStore: boolean
   checkInStores: Store[]
-  skippedItems: Item[]
 }
 
 interface Nameable {
@@ -42,7 +41,6 @@ export const useGroceriesStore = defineStore('groceries', {
     pendingRequests: 0,
     postingStore: false,
     checkInStores: [],
-    skippedItems: [],
   }),
 
   actions: {
@@ -191,13 +189,11 @@ export const useGroceriesStore = defineStore('groceries', {
     },
 
     skipItem({ item }: { item: Item }) {
-      if (this.skippedItems.includes(item)) return;
-
-      this.skippedItems = [...this.skippedItems, item];
+      item.skipped = true;
     },
 
-    unskipItem({ item: itemToUnskip }: { item: Item }) {
-      this.skippedItems = this.skippedItems.filter(item => item.id !== itemToUnskip.id);
+    unskipItem({ item }: { item: Item }) {
+      item.skipped = false;
     },
 
     async updateItem({ item, attributes }: { item: Item, attributes: { name: string } }) {
@@ -266,7 +262,7 @@ export const useGroceriesStore = defineStore('groceries', {
         this.checkInStores.
           map(store => (
             store.items.filter(item => (
-              item.needed > 0 && !this.skippedItems.includes(item)
+              item.needed > 0 && !item.skipped
             ))
           )).flat(),
       );

--- a/app/javascript/groceries/types.ts
+++ b/app/javascript/groceries/types.ts
@@ -5,6 +5,7 @@ export interface Item {
   name: string
   needed: number
   newlyAdded: boolean
+  skipped?: boolean
   store_id: number
 }
 


### PR DESCRIPTION
I think it's easier to think about this way, the code is simpler / more concise, and it should also be more performant. I'm not sure why I used a skippedItems array initially. I'm guessing because it seemed wrong to put "ephemeral"/"optional" state on the Item type (which, up until now, has contained only required properties and properties that come from the database), but I don't think that this is really a compelling reason.