### PR TITLE
[groceries][check-in modal] Swap order of check-in & cancel buttons

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -85,16 +85,18 @@
       )
 
       div.flex.justify-around.mt-4
-        el-button(
-          @click='handleTripCheckinModalSubmit'
-          type='primary'
-          plain
-        ) Check in items in cart
+
         el-button(
           @click="modalStore.hideModal({ modalName: 'check-in-shopping-trip' })"
           type='primary'
           link
         ) Cancel
+
+        el-button(
+          @click='handleTripCheckinModalSubmit'
+          type='primary'
+          plain
+        ) Check in items in cart
 
   Modal(name='manage-check-in-stores' width='80%' maxWidth='370px')
     slot


### PR DESCRIPTION
Especially in a mobile-first world, I think that it makes more sense for the primary action (checking in the shopping trip) to be on the right-hand side, where it is more easily accessible to the finger(s) of a person holding a mobile phone with their right hand.