### PR TITLE
Specify a flexible range (>=20.8.0 <22) for node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "david_runger",
   "private": true,
   "engines": {
-    "node": "20.8.0",
+    "node": ">=20.8.0 <22",
     "pnpm": ">=9.4.0 <10"
   },
   "browserslist": [


### PR DESCRIPTION
I think that the specific node version might be [causing problems](https://github.com/davidrunger/david_runger/network/updates/845119565) for Dependabot?, and I don't think non-major Node changes are likely to negatively impact this project, so I think that the looser range is fine.

Note that we still have a specific Node version (20.8.0) specified in `.nvmrc`; this looser range is just checked e.g. when running `pnpm install`.