### PR TITLE
[proposal mailer] Repeat subject explanation in email body

### DIFF
--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -2,11 +2,11 @@
 
 class ProposalMailer < ApplicationMailer
   def proposal_created(proposer_id, proposee_email)
-    proposer = User.find(proposer_id)
+    @proposer = User.find(proposer_id)
     @token = JWT.encode({ proposer_id: }, Rails.application.credentials.jwt_secret!, 'HS512')
     mail(
       to: proposee_email,
-      subject: %(#{proposer.email} wants you to join their marriage on DavidRunger.com),
+      subject: %(#{@proposer.email} wants you to join their marriage on davidrunger.com),
     )
   end
 end

--- a/app/views/mailers/proposal_mailer/proposal_created.haml
+++ b/app/views/mailers/proposal_mailer/proposal_created.haml
@@ -1,3 +1,7 @@
 %p
-  Accept the invitation by clicking this link:
-  #{link_to('accept', accept_proposals_url(token: @token))}.
+  #{@proposer.email} wants you to join their marriage on davidrunger.com.
+
+%p
+  %b= link_to('Click here', accept_proposals_url(token: @token))
+
+  to accept the invitation.

--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -58,7 +58,9 @@ RSpec.describe 'Check-Ins app' do
             end.to eq(true)
 
             open_email(proposee.email)
-            current_email.click_on('accept')
+            # rubocop:disable Capybara/ClickLinkOrButtonStyle
+            current_email.click_link('Click here', href: %r{/proposals/accept\?token=.+})
+            # rubocop:enable Capybara/ClickLinkOrButtonStyle
             expect(page).to have_content('Marriage created.')
           end
         end


### PR DESCRIPTION
I tested this flow recently and found it a bit confusing that the body didn't have the context that we previously assumed would be read (and remembered) in the subject line.