### PR TITLE
[specs] Add section selector (and within block and expectation)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -748,4 +748,4 @@ RUBY VERSION
    ruby 3.3.3p89
 
 BUNDLED WITH
-   2.5.11
+   2.5.14

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -82,3 +82,4 @@ Rails.application.configure do
 end
 
 Rails.autoloaders.main.do_not_eager_load(Rails.root.join('spec/support/matchers/'))
+Rails.autoloaders.main.do_not_eager_load(Rails.root.join('spec/support/selectors/'))

--- a/spec/support/selectors/section.rb
+++ b/spec/support/selectors/section.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Borrowed from capybara_accessible_selectors:
+# https://github.com/citizensadvice/capybara_accessible_selectors/blob/v0.12.0/lib/capybara_accessible_selectors/selectors/section.rb
+
+Capybara.add_selector(:section) do
+  xpath do |locator, heading_level: (1..6), section_element: %i[
+    section
+    article
+    aside
+    form
+    main
+    header
+    footer
+  ], **|
+    heading = [
+      (XPath.attr(:role) == 'heading') &
+        Array(heading_level).map { XPath.attr(:'aria-level') == _1.to_s }.reduce(:|),
+      if Array(heading_level).include?(2)
+        (XPath.attr(:role) == 'heading') & !XPath.attr(:'aria-level')
+      end,
+      Array(heading_level).map { XPath.self(:"h#{_1}") & !XPath.attr(:'aria-level') }.reduce(:|),
+      Array(heading_level).map { XPath.attr(:'aria-level') == _1.to_s }.
+        reduce(:|) & %i[h1 h2 h3 h4 h5 h6].map { XPath.self(_1) }.reduce(:|),
+    ].compact.reduce(:|)
+
+    has_heading = XPath.function(
+      nil,
+      XPath.descendant[[
+        *[
+          :section,
+          :article,
+          :aside,
+          :form,
+          :main,
+          :header,
+          :footer,
+          *(1..6).map { :"h#{_1}" },
+        ].map { XPath.self(_1) },
+        XPath.attr(:role) == 'heading',
+      ].reduce(:|)],
+    )[1][heading]
+
+    if locator
+      has_heading = has_heading[XPath.string.n.is(locator.to_s)]
+    end
+
+    XPath.descendant(*Array(section_element).map(&:to_sym))[has_heading]
+  end
+end
+
+module ::Capybara::DSL
+  def within_section(...)
+    within(:section, ...)
+  end
+end
+
+module Capybara::RSpecMatchers
+  def have_section(locator = nil, **options, &optional_filter_block)
+    Matchers::HaveSelector.new(:section, locator, **options, &optional_filter_block)
+  end
+end


### PR DESCRIPTION
Borrowed from https://github.com/citizensadvice/capybara_accessible_selectors . I didn't want to install that whole gem because (1) it's not available via RubyGems (and I worry that there will be a performance impact during `bundle` operations from sourcing it via GitHub) and (2) it provides a lot more stuff than I probably would actually end up using, and I'd sort of rather keep things lean.