### PR TITLE
[specs][groceries][items factory] Make range of needed items smaller

### DIFF
--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -22,7 +22,7 @@ FactoryBot.define do
     needed { rand(2) }
 
     trait :needed do
-      needed { rand(1..8) }
+      needed { rand(1..2) }
     end
 
     trait :unneeded do


### PR DESCRIPTION
I think that this change makes us more likely to catch edge cases that might happen around needed=1 (since, for example, in that case there will be no count displayed for that item in the check-in modal).