### PR TITLE
Set 15 minute timeout limit for build (&deploy) GitHub Action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,6 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       # https://stackoverflow.com/q/57915791/4009384
       postgres:


### PR DESCRIPTION
We recently had a [build][1] run for 6 hours (which seems to be the default GitHub Actions timeout; "The job running on runner GitHub Actions 10 has exceeded the maximum execution time of 360 minutes."), whereas I don't think we expect the GitHub Action for this repo to ever take more than 15 minutes. Therefore, let's cap the execution time at 15 minutes, to save GitHub from wasting its machine time and so that we can get earlier feedback when a job is taking unexpectedly long.

[1]: https://github.com/davidrunger/david_runger/actions/runs/9629841305