### PR TITLE
Delete display.scss util stylesheet

### DIFF
--- a/app/assets/stylesheets/utils/display.scss
+++ b/app/assets/stylesheets/utils/display.scss
@@ -1,3 +1,0 @@
-.inline {
-  display: inline;
-}


### PR DESCRIPTION
Tailwind will provide this same class (if needed), and we're not actually loading this stylesheet (anymore?), anyway.