### PR TITLE
Delete unneeded/redundant flex-0 and flex-1 CSS classes

### DIFF
--- a/app/assets/stylesheets/utils/flex.scss
+++ b/app/assets/stylesheets/utils/flex.scss
@@ -1,11 +1,3 @@
-.flex-0 {
-  flex: 0;
-}
-
-.flex-1 {
-  flex: 1;
-}
-
 .flex-2 {
   flex: 2;
 }

--- a/app/javascript/groceries/components/sidebar.vue
+++ b/app/javascript/groceries/components/sidebar.vue
@@ -20,7 +20,7 @@ aside.border-r.border-neutral-400(
               name='newStoreName'
               placeholder='Add a store'
             )
-          el-button.flex-0(
+          el-button(
             native-type='submit'
             :disabled='postingStore || v$.$invalid'
           ) Add

--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -46,7 +46,7 @@
         name='newItemName'
       )
     .ml-2
-      el-button.flex-0.button.button-outline(
+      el-button.button.button-outline(
         native-type='submit'
         :disabled='v$.$invalid'
       ) Add


### PR DESCRIPTION
In the `flex-0` case, it didn't seem to be having any effect.

In the `flex-1` case, Tailwind provides a class of the same name, so while we continue to need it in the markup, we don't need it in our own stylesheet.