### PR TITLE
Bump ActiveRecord::Schema from 7.0 to 7.1

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_05_173107) do
+ActiveRecord::Schema[7.1].define(version: 2022_12_05_173107) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 


### PR DESCRIPTION
I guess that this is the result of running `db:migrate` after having moved to `config.load_defaults(7.1)`.