### PR TITLE
Include Toastify CSS styles in global styles.css stylesheet

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -124,7 +124,6 @@ import { EditIcon } from 'vue-tabler-icons';
 import { required } from '@vuelidate/validators';
 import { useVuelidate } from '@vuelidate/core';
 import Toastify from 'toastify-js';
-import 'toastify-js/src/toastify.css';
 import { useGroceriesStore, helpers } from '@/groceries/store';
 import { useModalStore } from '@/shared/modal/store';
 import { Item as ItemType, Store } from '@/groceries/types';

--- a/app/javascript/logs/components/log_reminder_schedule_form.vue
+++ b/app/javascript/logs/components/log_reminder_schedule_form.vue
@@ -40,7 +40,6 @@ import { PropType } from 'vue';
 import { useModalStore } from '@/shared/modal/store';
 import { useLogsStore } from '@/logs/store';
 import Toastify from 'toastify-js';
-import 'toastify-js/src/toastify.css';
 import { Log } from '@/logs/types';
 
 const TIME_UNIT_IN_SECONDS = {

--- a/app/javascript/logs/logs.vue
+++ b/app/javascript/logs/logs.vue
@@ -10,7 +10,6 @@ div
 <script lang='ts'>
 import { mapState } from 'pinia';
 import Toastify from 'toastify-js';
-import 'toastify-js/src/toastify.css';
 
 import { useLogsStore } from '@/logs/store';
 import { useModalStore } from '@/shared/modal/store';

--- a/app/javascript/packs/styles.ts
+++ b/app/javascript/packs/styles.ts
@@ -1,1 +1,2 @@
-import 'css/styles.scss';
+import 'css/styles.scss'
+import 'toastify-js/src/toastify.css';

--- a/app/javascript/workouts/confirm_workout_modal.vue
+++ b/app/javascript/workouts/confirm_workout_modal.vue
@@ -27,7 +27,6 @@ Modal(:name='modalName' width='85%', maxWidth='400px')
 
 <script lang='ts'>
 import Toastify from 'toastify-js';
-import 'toastify-js/src/toastify.css';
 import { useModalStore } from '@/shared/modal/store';
 import { useWorkoutsStore } from '@/workouts/store';
 import { Workout } from './types';

--- a/app/javascript/workouts/workouts_table.vue
+++ b/app/javascript/workouts/workouts_table.vue
@@ -26,7 +26,6 @@ import { useWorkoutsStore } from '@/workouts/store';
 import { sortBy } from 'lodash-es';
 import strftime from 'strftime';
 import Toastify from 'toastify-js';
-import 'toastify-js/src/toastify.css';
 import { PropType } from 'vue';
 import { Workout } from './types';
 

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -20,7 +20,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'logs*.js' => (790..800),
     'marriage*.js' => (10..20),
     'quizzes*.js' => (123..133),
-    'styles*.css' => (5..15),
+    'styles*.css' => (9..19),
     'turbo*.js' => (90..100),
     'workout*.css' => (93..103),
     'workout*.js' => (390..400),


### PR DESCRIPTION
**Downside:** This will somewhat increase the weight of our styles.css stylesheet and will load these styles on some pages that don't need them. I think that this adds about 4 KiB of CSS to the styles.css stylesheet.

**Upside:** These styles can now be reused across more apps (just loaded once), which should theoretically make overall CSS served be less for users who visit multiple Toastify-using apps, and also these CSS imports won't clutter up our JavaScript imports or need to be repeated so many times in our JavaScript code (and it will be easier to use more toasters elsewhere in the future).