### PR TITLE
Import chartjs-adapter-luxon after all other imports

### DIFF
--- a/app/javascript/components/charts/line_chart.vue
+++ b/app/javascript/components/charts/line_chart.vue
@@ -18,8 +18,8 @@ import {
   Tooltip, LineElement, LinearScale, PointElement, TimeScale, ChartData, Point, TooltipItem,
   ChartOptions,
 } from 'chart.js';
-import 'chartjs-adapter-luxon';
 import { merge } from 'lodash-es';
+import 'chartjs-adapter-luxon';
 
 ChartJS.register(
   Tooltip, LineElement, LinearScale, PointElement, TimeScale,


### PR DESCRIPTION
Because `chartjs-adapter-luxon` is an import used for its "side effects", `@ianvs/prettier-plugin-sort-imports` cannot be confident in moving it farther up. Therefore, in preparation for our upcoming mega Prettier formatting PR, we'll instead move it all the way to the bottom, where it will be left by `@ianvs/prettier-plugin-sort-imports`, as opposed to being left randomly in the middle of the import list.