### PR TITLE
Remove base element styles from text_log.vue component

### DIFF
--- a/app/assets/stylesheets/tailwind_overrides.scss
+++ b/app/assets/stylesheets/tailwind_overrides.scss
@@ -25,6 +25,18 @@ body {
     @apply my-2 text-xl font-bold;
   }
 
+  h4 {
+    @apply my-1 text-lg font-bold;
+  }
+
+  h5 {
+    @apply my-1 text-base font-bold;
+  }
+
+  h6 {
+    @apply my-1 text-sm font-bold;
+  }
+
   img,
   svg {
     display:inline;

--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -59,17 +59,7 @@ export default {
 };
 </script>
 
-<style lang='scss'>
-// (re-)set some default styles for markdown formatting
-em { font-style: italic; }
-strong { font-weight: bold; }
-h1 { font-size: 2em; }
-h2 { font-size: 1.5em; }
-h3 { font-size: 1.17em; }
-h4 { font-size: 1em; }
-h5 { font-size: 0.83em; }
-h6 { font-size: 0.75em; }
-
+<style lang="scss">
 ol {
   counter-reset: item;
 


### PR DESCRIPTION
Move the heading styles that are not already in tailwind_overrides.scss there.

The `strong` and `em` tags seem to already be styled as desired by browsers and/or the Tailwind reset.

Motivations: Simplify the code. Reduce wasted CSS page weight. These styles would be formatted by Prettier in a way that is unacceptable to stylelint (no newlines between the rules).