### PR TITLE
Ignore Prettier formatting commit in git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,6 @@
 # (The following commit only touched one line and is basically just an example.)
 # Autocorrect rubocop Style/ParenthesesAroundCondition offenses
 cb2e57260b704c6230d173cb9e901b75531694f0
+
+# Apply Prettier formatting (#4464)
+34eaefc553c57f31247f27aac7abce36df1b034d


### PR DESCRIPTION
This PR is part of a planned four-part series:

1. [Set up Prettier](https://github.com/davidrunger/david_runger/pull/4460)
2. [Apply Prettier formatting](https://github.com/davidrunger/david_runger/pull/4464)
3. **[this PR]** [Ignore Prettier formatting commit in git blame](https://github.com/davidrunger/david_runger/pull/4473)
4. Add Prettier check to CI