### PR TITLE
[githooks_check] Run only in development and test

### DIFF
--- a/config/initializers/0g_githooks_check.rb
+++ b/config/initializers/0g_githooks_check.rb
@@ -6,7 +6,8 @@
 
 # :nocov:
 if (
-  ENV['SKIP_GITHOOKS_CHECK'].blank? &&
+  Rails.env.local? &&
+    ENV['SKIP_GITHOOKS_CHECK'].blank? &&
     ENV['CI'].blank? &&
     `git config core.hooksPath`.strip != 'tools/githooks'
 )


### PR DESCRIPTION
We [failed][1] trying to deploy the previous version to production (which is expected; I had intended to add the Rails environment check before, but I forgot to do so).

[1]: https://github.com/davidrunger/david_runger/actions/runs/9669803160/job/26677217927