### PR TITLE
Move gitleaks pre-push check into a dedicated script

### DIFF
--- a/bin/githooks/pre-push
+++ b/bin/githooks/pre-push
@@ -2,9 +2,5 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-# Use gitleaks to protect against committed secrets.
-if ! gitleaks detect --log-opts="origin/main..." &> /dev/null ; then
-  gitleaks detect --log-opts="origin/main..." --verbose
-fi
-
+bin/lint/gitleaks
 bin/lint/prettier

--- a/bin/lint/gitleaks
+++ b/bin/lint/gitleaks
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+# Run Gitleaks.
+
+set -uo pipefail # don't allow undefined variables, pipes don't swallow errors
+
+# Use gitleaks to protect against committed secrets.
+if ! gitleaks detect --log-opts="origin/main..." &> /dev/null ; then
+  gitleaks detect --log-opts="origin/main..." --verbose
+fi


### PR DESCRIPTION
This leaves the pre-push script a bit tidier, rather than having it become (over time) increasingly cluttered with the actual implementations of a bunch of random checks.