### PR TITLE
Tell Prettier not to warn on files it doesn't know how to parse

### DIFF
--- a/bin/lint/prettier
+++ b/bin/lint/prettier
@@ -17,7 +17,7 @@ set -x # print executed commands
 
 if [[ $files_for_prettier != "" ]]; then
   # shellcheck disable=SC2086
-  if ! prettier --check $files_for_prettier ; then
+  if ! prettier --check --ignore-unknown $files_for_prettier ; then
     set +e
     files_to_autocorrect=$(prettier --list-different $files_for_prettier)
     set -e


### PR DESCRIPTION
For example, I just pushed a change with a `.nvmrc` file, which (via our pre-push git hook) generated this warning: "[error] No parser could be inferred for file "/home/david/code/david_runger/.nvmrc"."

To avoid such warnings when pushing to GitHub, we'll suppress them with the `--ignore-unknown` Prettier CLI flag.