### PR TITLE
Add net-protocol as a dependency of net-pop in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -343,6 +343,7 @@ GEM
       date
       net-protocol
     net-pop (0.1.2)
+      net-protocol
     net-protocol (0.2.2)
       timeout
     net-smtp (0.5.0)


### PR DESCRIPTION
```
gem uninstall net-pop
gem install net-pop
bundle update net-pop
```

Many thanks to https://stackoverflow.com/a/78620570/4009384 for the solution!

Bug: https://github.com/ruby/net-pop/issues/ 26

Fix: https://github.com/ruby/ruby/pull/ 11006

I have not yet seen concrete problems caused by this issue for this repo, but I did see a problem for other repos, [here](https://github.com/davidrunger/runger_actions/actions/runs/9672980386/job/26686187510?pr=570) and [here](https://github.com/davidrunger/runger_config/actions/runs/9672982937/job/26686194697?pr=20).

```
Downloading net-pop-0.1.2 revealed dependencies not in the API or the lockfile
(net-protocol (>= 0)).
Running `bundle update net-pop` should fix the problem.
Error: The process '/opt/hostedtoolcache/Ruby/3.3.3/x64/bin/bundle' failed with exit code 34
```