### PR TITLE
Remove packageManager from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
     "node": ">=20.15.0 <22",
     "pnpm": ">=9.4.0 <10"
   },
-  "packageManager": "pnpm@9.4.0",
   "browserslist": [
     ">10%"
   ],


### PR DESCRIPTION
This was added in 4312f1f / #4427 . deivid-rodriguez says that the problem which motivated that addition should be fixed ( https://github.com/dependabot/dependabot-core/issues/ 9684#issuecomment-2194264170 ), so let's try removing it.