### PR TITLE
Don't lint .lock or .haml files with Prettier

### DIFF
--- a/bin/lint/prettier
+++ b/bin/lint/prettier
@@ -9,7 +9,7 @@ set -uo pipefail # don't allow undefined variables, pipes don't swallow errors
 files_for_prettier=$(
   changed-not-deleted-files | \
     rg '\.' | \
-    rg -v '\.rb$'
+    rg -v '\.(haml|lock|rb)$'
 )
 
 set -e # exit on any error

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -188,7 +188,7 @@ class Test::RequirementsResolver
     },
     Test::Tasks::RunImmigrant => proc { !db_schema_changed? && !diff_mentions?('immigrant') },
     Test::Tasks::RunPrettier => proc {
-      all_changed_file_extensions_are_among?(%w[lock rb]) &&
+      all_changed_file_extensions_are_among?(%w[haml lock rb]) &&
         !dotfile_changed? &&
         !diff_mentions?('prettier')
     },


### PR DESCRIPTION
I was not able to surface an actively maintained HAML plugin for Prettier.