### PR TITLE
Log commands starting later in the Prettier script

### DIFF
--- a/bin/lint/prettier
+++ b/bin/lint/prettier
@@ -13,9 +13,10 @@ files_for_prettier=$(
 )
 
 set -e # exit on any error
-set -x # print executed commands
 
 if [[ $files_for_prettier != "" ]]; then
+  set -x # print executed commands
+
   # shellcheck disable=SC2086
   if ! prettier --check --ignore-unknown $files_for_prettier ; then
     set +e


### PR DESCRIPTION
I don't think we need to see the `[[ $files_for_prettier != "" ]]` check logged.