### PR TITLE
Update plugin name in tsconfig to @vue/language-plugin-pug [DEV-8]

### DIFF
--- a/app/javascript/home/components/projects.vue
+++ b/app/javascript/home/components/projects.vue
@@ -17,23 +17,23 @@ HomeSection(section='projects' title='Projects')
       ul
 
         li.
-          #[a(:href='this.$routes.groceries_path()') Groceries]* -
+          #[a(:href='$routes.groceries_path()') Groceries]* -
           the collaborative family grocery list, built to be mobile-friendly for use on-the-go
 
         li.
-          #[a(:href='this.$routes.workout_path()') Workout]* -
+          #[a(:href='$routes.workout_path()') Workout]* -
           an app for tracking workouts over time, and to stay on-pace within a workout
 
         li.
-          #[a(:href='this.$routes.logs_path()') Logs]* -
+          #[a(:href='$routes.logs_path()') Logs]* -
           track whatever you want with various log types (text, number, duration, and/or counter)
 
         li.
-          #[a(:href='this.$routes.quizzes_path()') Quizzes]* -
+          #[a(:href='$routes.quizzes_path()') Quizzes]* -
           a multi-person quiz app that uses ActionCable websockets for real-time interactivity
 
         li.
-          #[a(:href='this.$routes.check_ins_path()') Check-ins]* -
+          #[a(:href='$routes.check_ins_path()') Check-ins]* -
           track how well your emotional needs are being met in your marriage/relationship
 
       p #[i *Google login required]

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -178,7 +178,8 @@ class Test::RequirementsResolver
       !files_with_js_changed? &&
         !diff_mentions?('tsc|typescript') &&
         !file_changed?('package.json') &&
-        !file_changed?('pnpm-lock.yaml')
+        !file_changed?('pnpm-lock.yaml') &&
+        !file_changed?('tsconfig.json')
     },
     Test::Tasks::RunEslint => proc {
       !files_with_js_changed? &&

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,7 @@
     }
   },
   "vueCompilerOptions": {
-    "plugins": ["@volar/vue-language-plugin-pug"]
+    "plugins": ["@vue/language-plugin-pug"]
   },
   "include": [
     "app/javascript/**/*.ts",


### PR DESCRIPTION
This should have been done as part of #3173 / 72f9d693 , which replaced `@volar/vue-language-plugin-pug` with `@vue/language-plugin-pug`.