### PR TITLE
Don't print redundant success messages in linters

### DIFF
--- a/bin/lint/prettier
+++ b/bin/lint/prettier
@@ -14,22 +14,27 @@ files_for_prettier=$(
 )
 
 if [[ $files_for_prettier != "" ]]; then
-  set -x # print executed commands
+  set +e
+  (
+    set -x
+    prettier --check --ignore-unknown $files_for_prettier
+  )
+  prettier_status=$?
+  set -e
 
-  # shellcheck disable=SC2086
-  if prettier --check --ignore-unknown $files_for_prettier ; then
-    echo 'Prettier linting passed.'
+  if [ $prettier_status -eq 0 ]; then
+    : # (Prettier printed a success message, so we don't need to do so here.)
   else
     set +e
     files_to_autocorrect=$(prettier --list-different $files_for_prettier)
     set -e
 
+    set -x
     prettier --write $files_to_autocorrect
+    { set +x; } 2>/dev/null
 
-    set +x
     blue "Autocorrected:"
     echo "$files_to_autocorrect" | tr ' ' '\n' | blue
-    set -x
 
     exit 1
   fi

--- a/bin/lint/rubocop
+++ b/bin/lint/rubocop
@@ -23,7 +23,7 @@ if [[ $files_for_rubocop != "" ]]; then
   set -e
 
   if [ $rubocop_status -eq 0 ]; then
-    : # (RuboCop will print a success message, so we don't need to do so here.)
+    : # (RuboCop printed a success message, so we don't need to do so here.)
   else
     red 'RuboCop failed. Retrying with autocorrect.'
     set +e

--- a/bin/lint/rubocop
+++ b/bin/lint/rubocop
@@ -23,7 +23,7 @@ if [[ $files_for_rubocop != "" ]]; then
   set -e
 
   if [ $rubocop_status -eq 0 ]; then
-    echo 'RuboCop linting passed.'
+    : # (RuboCop will print a success message, so we don't need to do so here.)
   else
     red 'RuboCop failed. Retrying with autocorrect.'
     set +e


### PR DESCRIPTION
Also, reduce debug logging of executed commands.