### PR TITLE
Run non-Gitleaks pre-push checks in the background [DEV-27]

### DIFF
--- a/bin/githooks/pre-push
+++ b/bin/githooks/pre-push
@@ -2,9 +2,10 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-bin/lint/eslint
 bin/lint/gitleaks
-bin/lint/prettier
-bin/lint/rubocop
-bin/lint/stylelint
-bin/lint/typescript
+
+background-and-notify bin/lint/eslint
+background-and-notify bin/lint/prettier
+background-and-notify bin/lint/rubocop
+background-and-notify bin/lint/stylelint
+background-and-notify bin/lint/typescript

--- a/bin/lint/eslint
+++ b/bin/lint/eslint
@@ -25,15 +25,15 @@ if [[ $files_for_eslint != "" ]]; then
     git_diff_hash_after=$(git diff | sha1sum | choose 0)
 
     if [ "$git_diff_hash_before" == "$git_diff_hash_after" ] ; then
-      echo 'ESLint passed.'
+      write-background-notification 'Changed files satisfy ESLint.'
     else
-      blue 'There were ESLint violation(s). They were all autocorrected.'
+      write-background-notification 'There were ESLint violation(s). They were all autocorrected.'
       exit 1
     fi
   else
-    red 'There were ESLint error(s) that could not be autocorrected.'
+    write-background-notification 'There were ESLint violations(s) that could not be autocorrected.'
     exit 1
   fi
 else
-  echo 'No files need to be linted by ESLint.'
+  write-background-notification 'No files need to be linted by ESLint.'
 fi

--- a/bin/lint/prettier
+++ b/bin/lint/prettier
@@ -27,11 +27,11 @@ if [[ $files_for_prettier != "" ]]; then
   git_diff_hash_after=$(git diff | sha1sum | choose 0)
 
   if [ "$git_diff_hash_before" == "$git_diff_hash_after" ] ; then
-    echo 'All files are Prettier-compliant.'
+    write-background-notification 'Changed files satisfy Prettier.'
   else
-    blue 'There were Prettier violation(s). They were all corrected.'
+    write-background-notification 'There were Prettier violation(s). They were all corrected.'
     exit 1
   fi
 else
-  echo 'No files need to be linted by Prettier.'
+  write-background-notification 'No files need to be linted by Prettier.'
 fi

--- a/bin/lint/rubocop
+++ b/bin/lint/rubocop
@@ -31,15 +31,15 @@ if [[ $files_for_rubocop != "" ]]; then
     git_diff_hash_after=$(git diff | sha1sum | choose 0)
 
     if [ "$git_diff_hash_before" == "$git_diff_hash_after" ] ; then
-      : # (RuboCop printed a success message, so we don't need to do so here.)
+      write-background-notification 'Changed files satisfy RuboCop.'
     else
-      blue 'There were RuboCop violation(s). They were all autocorrected.'
+      write-background-notification 'There were RuboCop violation(s). They were all autocorrected.'
       exit 1
     fi
   else
-    red 'There were RuboCop error(s) that could not be autocorrected.'
+    write-background-notification 'There were RuboCop violation(s) that could not be autocorrected.'
     exit 1
   fi
 else
-  echo 'No files need to be linted by RuboCop.'
+  write-background-notification 'No files need to be linted by RuboCop.'
 fi

--- a/bin/lint/stylelint
+++ b/bin/lint/stylelint
@@ -25,15 +25,15 @@ if [[ $files_for_stylelint != "" ]]; then
     git_diff_hash_after=$(git diff | sha1sum | choose 0)
 
     if [ "$git_diff_hash_before" == "$git_diff_hash_after" ] ; then
-      echo 'Stylelint passed.'
+      write-background-notification 'Changed files satisfy Stylelint.'
     else
-      blue 'There were Stylelint violation(s). They were all autocorrected.'
+      write-background-notification 'There were Stylelint violation(s). They were all autocorrected.'
       exit 1
     fi
   else
-    red 'There were Stylelint error(s) that could not be autocorrected.'
+    write-background-notification 'There were Stylelint violation(s) that could not be autocorrected.'
     exit 1
   fi
 else
-  echo 'No files need to be linted by Stylelint.'
+  write-background-notification 'No files need to be linted by Stylelint.'
 fi

--- a/bin/lint/typescript
+++ b/bin/lint/typescript
@@ -12,7 +12,12 @@ files_for_typescript=$(
 
 if [[ $files_for_typescript != "" ]]; then
   set -x
-  ./node_modules/.bin/vue-tsc --noEmit
+  if ./node_modules/.bin/vue-tsc --noEmit ; then
+    write-background-notification 'Changed files satisfy TypeScript.'
+  else
+    write-background-notification 'There were TypeScript error(s).'
+    exit 1
+  fi
 else
-  echo 'No files need to be checked by TypeScript.'
+  write-background-notification 'No files need to be checked by TypeScript.'
 fi


### PR DESCRIPTION
This will get branches up to GitHub more quickly, and also _might_ be overall somewhat faster, since this will allow for some parallelization of the linting.

We're still going to run Gitleaks in a push-blocking serial fashion because we don't want it to be possible to push a secret to GitHub even for a moment.

See https://github.com/davidrunger/dotfiles/commit/71f7c24ccd97e3099ce6fedf05885c81d7d63e0a , which added to my dotfiles repo the necessary supporting scripts that are referenced herein (e.g. `background-and-notify` and `write-background-notification`).