### PR TITLE
Run autocorrecting linters in series [DEV-34]

### DIFF
--- a/bin/githooks/pre-push
+++ b/bin/githooks/pre-push
@@ -4,8 +4,5 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 bin/lint/gitleaks
 
-background-and-notify bin/lint/eslint
-background-and-notify bin/lint/prettier
-background-and-notify bin/lint/rubocop
-background-and-notify bin/lint/stylelint
+background-and-notify bin/lint/autocorrecting-linters
 background-and-notify bin/lint/typescript

--- a/bin/githooks/pre-push
+++ b/bin/githooks/pre-push
@@ -4,5 +4,5 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 bin/lint/gitleaks
 
-background-and-notify bin/lint/autocorrecting-linters
+background-and-silence bin/lint/autocorrecting-linters
 background-and-notify bin/lint/typescript

--- a/bin/lint/autocorrecting-linters
+++ b/bin/lint/autocorrecting-linters
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Executes linters that might make autocorrections.
+#
+# NOTE: These need to be run in sequence in order to avoid possible concurrency
+# bugs re: reporting whether files were changed or not.
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+bin/lint/eslint
+bin/lint/prettier
+bin/lint/rubocop
+bin/lint/stylelint

--- a/bin/lint/autocorrecting-linters
+++ b/bin/lint/autocorrecting-linters
@@ -7,7 +7,7 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-bin/lint/eslint
-bin/lint/prettier
-bin/lint/rubocop
-bin/lint/stylelint
+perform-background-step bin/lint/eslint
+perform-background-step bin/lint/prettier
+perform-background-step bin/lint/rubocop
+perform-background-step bin/lint/stylelint


### PR DESCRIPTION
This avoids a bug that can occur where linters might falsely report that changes were made, due to running at the same time as another linter that does make file changes via autocorrection.