### PR TITLE
[githooks_check] Remove outdated comment about file name ordering

### DIFF
--- a/config/initializers/githooks_check.rb
+++ b/config/initializers/githooks_check.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# The name of this file uses lexicographical ordering. See:
-# https://stackoverflow.com/a/38927158/4009384 . To determine a new filename for
-# insertion, see: https://runkit.com/davidrunger/667b2a5707d6c60008d1fe66 .
-
 # :nocov:
 if (
   Rails.env.local? &&


### PR DESCRIPTION
This comment is not relevant anymore since #4535 / 5c7c8931 .