### PR TITLE
Remove @formkit/auto-animate [LOG-1]

### DIFF
--- a/app/javascript/logs/components/data_renderers/text_log.vue
+++ b/app/javascript/logs/components/data_renderers/text_log.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .flex.justify-center
   .container
-    table.text-log-table(v-auto-animate)
+    table.text-log-table
       EditableTextLogRow(
         v-for='logEntry in sortedLogEntries'
         :key='logEntry.id'

--- a/app/javascript/packs/logs_app.ts
+++ b/app/javascript/packs/logs_app.ts
@@ -1,4 +1,3 @@
-import { autoAnimatePlugin } from '@formkit/auto-animate/vue';
 import { createPinia } from 'pinia';
 import { markRaw } from 'vue';
 
@@ -17,4 +16,3 @@ app.use(pinia);
 app.component('Modal', Modal);
 useElementPlus(app);
 app.use(router);
-app.use(autoAnimatePlugin);

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     ">10%"
   ],
   "dependencies": {
-    "@formkit/auto-animate": "1.0.0-beta.6",
     "@hotwired/turbo": "^8.0.4",
     "@hotwired/turbo-rails": "^8.0.4",
     "@rails/actioncable": "^7.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@formkit/auto-animate':
-        specifier: 1.0.0-beta.6
-        version: 1.0.0-beta.6
       '@hotwired/turbo':
         specifier: ^8.0.4
         version: 8.0.4
@@ -518,9 +515,6 @@ packages:
 
   '@floating-ui/utils@0.1.1':
     resolution: {integrity: sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==}
-
-  '@formkit/auto-animate@1.0.0-beta.6':
-    resolution: {integrity: sha512-PVDhLAlr+B4Xb7e+1wozBUWmXa6BFU8xUPR/W/E+TsQhPS1qkAdAsJ25keEnFrcePSnXHrOsh3tiFbEToOzV9w==}
 
   '@hotwired/turbo-rails@8.0.4':
     resolution: {integrity: sha512-GHCv5+B2VzYZZvMFpg/g9JLx/8pl/8chcubSB7T+Xn1zYOMqAKB6cT80vvWUzxdwfm/2KfaRysfDz+BmvtjFaw==}
@@ -3461,8 +3455,6 @@ snapshots:
       '@floating-ui/utils': 0.1.1
 
   '@floating-ui/utils@0.1.1': {}
-
-  '@formkit/auto-animate@1.0.0-beta.6': {}
 
   '@hotwired/turbo-rails@8.0.4':
     dependencies:


### PR DESCRIPTION
The library did what it promised, but I think it really hurts performance on a text log page with a lot of entries, so I am going to remove it.

It might be nice, in the future, to manually animate the appearance of a new text log entry into the list. I've created an issue for that: https://davidrunger.atlassian.net/browse/LOG-9 .