### PR TITLE
Source primary branch name dynamically for Gitleaks check

### DIFF
--- a/bin/lint/gitleaks
+++ b/bin/lint/gitleaks
@@ -5,8 +5,8 @@
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
 # Use gitleaks to protect against committed secrets.
-if ! gitleaks detect --log-opts="origin/main..." &> /dev/null ; then
-  gitleaks detect --log-opts="origin/main..." --verbose
+if ! gitleaks detect --log-opts="origin/$(main-branch)..." &> /dev/null ; then
+  gitleaks detect --log-opts="origin/$(main-branch)..." --verbose
 else
   echo 'Gitleaks did not detect any committed secrets.'
 fi


### PR DESCRIPTION
This is more DRY and means that future changes to the primary branch name won't require this script to be updated.