### PR TITLE
Fix pnpm-lock.yaml

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install pnpm
         run: npm install -g pnpm@9
       - name: Set pnpm store directory
-        run: echo "PNPM_STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+        run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_ENV
       - uses: actions/cache@v4
         name: Set up pnpm cache
         with:

--- a/lib/test/tasks/pnpm_install.rb
+++ b/lib/test/tasks/pnpm_install.rb
@@ -4,6 +4,6 @@ class Test::Tasks::PnpmInstall < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    execute_system_command('pnpm install --frozen-lockfile --silent')
+    execute_system_command('pnpm install --frozen-lockfile')
   end
 end

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,20 +897,11 @@ packages:
   '@volar/language-core@2.4.0-alpha.15':
     resolution: {integrity: sha512-mt8z4Fm2WxfQYoQHPcKVjLQV6PgPqyKLbkCVY2cr5RSaamqCHjhKEpsFX66aL4D/7oYguuaUw9Bx03Vt0TpIIA==}
 
-  '@volar/language-core@2.4.0-alpha.5':
-    resolution: {integrity: sha512-CX+0vrNoCcO3tGZYIn7kNHug/u6+EImfbZe0tI6x/lCZc0MBJ7t9f6AKJT+mHJZ3ePhva6NVNv8mY1tNEURd5A==}
-
   '@volar/language-service@2.4.0-alpha.15':
     resolution: {integrity: sha512-H5T5JvvqvWhG0PvvKPTM0nczTbTKQ+U87a8r0eahlH/ySi2HvIHO/7PiNKLxKqLNsiT8SX4U3QcGC8ZaNcC07g==}
 
   '@volar/source-map@2.4.0-alpha.15':
     resolution: {integrity: sha512-8Htngw5TmBY4L3ClDqBGyfLhsB8EmoEXUH1xydyEtEoK0O6NX5ur4Jw8jgvscTlwzizyl/wsN1vn0cQXVbbXYg==}
-
-  '@volar/source-map@2.4.0-alpha.15':
-    resolution: {integrity: sha512-8Htngw5TmBY4L3ClDqBGyfLhsB8EmoEXUH1xydyEtEoK0O6NX5ur4Jw8jgvscTlwzizyl/wsN1vn0cQXVbbXYg==}
-
-  '@volar/source-map@2.4.0-alpha.5':
-    resolution: {integrity: sha512-5OxMPGqbxaMuFXfj10k3xWwmJ2nb0b20kNaONAKxwUQxGY6nh6skX5AAFhIAbC8woplsVJpR0tAhgQR4S96VYQ==}
 
   '@volar/typescript@2.4.0-alpha.15':
     resolution: {integrity: sha512-U3StRBbDuxV6Woa4hvGS4kz3XcOzrWUKgFdEFN+ba1x3eaYg7+ytau8ul05xgA+UNGLXXsKur7fTUhDFyISk0w==}
@@ -3925,10 +3916,6 @@ snapshots:
     dependencies:
       '@volar/source-map': 2.4.0-alpha.15
 
-  '@volar/language-core@2.4.0-alpha.5':
-    dependencies:
-      '@volar/source-map': 2.4.0-alpha.5
-
   '@volar/language-service@2.4.0-alpha.15':
     dependencies:
       '@volar/language-core': 2.4.0-alpha.15
@@ -3937,8 +3924,6 @@ snapshots:
       vscode-uri: 3.0.8
 
   '@volar/source-map@2.4.0-alpha.15': {}
-
-  '@volar/source-map@2.4.0-alpha.5': {}
 
   '@volar/typescript@2.4.0-alpha.15':
     dependencies:


### PR DESCRIPTION
When running `pnpm install --frozen-lockfile`, I was getting this error:

```
ERR_PNPM_BROKEN_LOCKFILE The lockfile at
"/home/david/code/david_runger/pnpm-lock.yaml"
is broken: duplicated mapping key (909:3)

906 |   '@volar/source-map@2.4.0-alpha.15':
907 |     resolution: {integrity: sha51 ...
908 |
909 |   '@volar/source-map@2.4.0-alpha.15':
---------^
910 |     resolution: {integrity: sha51 ...
911 |
```

This seems to have been caused by a bad git resolution of PR #4555 and PR #4556 .

Fix:

```
rm pnpm-lock.yaml
pnpm install
```

Also, remove `--silent` flag from pnpm commands. Motivation: it wasn't clear what the problem was from looking at the build logs ( example: https://github.com/davidrunger/david_runger/actions/runs/9809328382/job/27087113972 ), because the error output was being silenced.