### PR TITLE
Run RuboCop if the diff mentions runger_style

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -194,7 +194,10 @@ class Test::RequirementsResolver
         !diff_mentions?('prettier')
     },
     Test::Tasks::RunRubocop => proc {
-      !ruby_files_changed? && !rubocop_files_changed? && !diff_mentions?('rubocop')
+      !ruby_files_changed? &&
+        !rubocop_files_changed? &&
+        !diff_mentions?('rubocop') &&
+        !diff_mentions?('runger_style')
     },
     Test::Tasks::RunStylelint => proc { !files_with_css_changed? && !diff_mentions?('stylelint') },
     Test::Tasks::SetupDb => proc { running_locally? },


### PR DESCRIPTION
Motivation: in this build https://github.com/davidrunger/david_runger/actions/runs/9812265651/job/27095984960?pr=4559 for this PR https://github.com/davidrunger/david_runger/pull/4559 we did not run rubocop, even though that PR likely includes a breaking RuboCop configuration change.