### PR TITLE
[pre-push] Remove TypeScript check

### DIFF
--- a/bin/githooks/pre-push
+++ b/bin/githooks/pre-push
@@ -6,4 +6,3 @@ lint gitleaks
 
 background-and-silence bin/lint/autocorrecting-linters
 background-and-notify lint shellcheck
-background-and-notify lint typescript


### PR DESCRIPTION
Motivation: The TypeScript check seems to use up a pretty nontrivial amount of the not overly abundant resources on my little computer. And I think it's relatively rare that I push a PR that has TypeScript violations. So I'm not sure it's worth the cost (somewhat overwhelming my computer) to run the TypeScript checks locally. We will still check types in CI.