### PR TITLE
Change development S3 bucket name to david-runger-uploads-development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,4 @@
 RAILS_ENV=development
-S3_BUCKET=david-runger-development-uploads
 WEB_CONCURRENCY=0 # run web server without concurrency for more clearly structured log output
 RAILS_MAX_THREADS=1 # run web server without concurrency for more clearly structured log output
 VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true # this is set on Dokku, so set it here, too

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -7,5 +7,5 @@ amazon:
   namespace: active_storage_uploads
   access_key_id: <%= Rails.application.credentials.aws&.dig(:access_key_id) || ENV['AWS_ACCESS_KEY_ID'] %>
   secret_access_key: <%= Rails.application.credentials.aws&.dig(:secret_access_key) || ENV['AWS_SECRET_ACCESS_KEY'] %>
-  bucket: <%= ENV.fetch('S3_BUCKET', 'david-runger-uploads') %>
+  bucket: david-runger-uploads<%= Rails.env.local? ? "-#{Rails.env}" : '' %>
   region: us-east-1


### PR DESCRIPTION
I picked this from #4569 . This is the Rails recommended way of doing it. I have already created a new bucket in S3 matching this new name and deleted the previous one. This leaves the production bucket name unchanged, so no change is needed there.