### PR TITLE
Add config/storage.yml to prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
-pnpm-lock.yaml
-/app/javascript/rails_assets
 /.rubocop.yml
+/app/javascript/rails_assets
 /config/database.yml
+/config/storage.yml
 /vendor/bundle/
+/pnpm-lock.yaml


### PR DESCRIPTION
Picked from #4569 . Prettier doesn't know how to handle the ERB.