### PR TITLE
Unflake groceries feature spec by using cable channel_prefix [GROC-2]

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -8,7 +8,7 @@ development:
 
 test:
   <<: *default
-  channel_prefix: david_runger_test
+  channel_prefix: david_runger_test<%= ENV['DB_SUFFIX'] %>
   url: redis://localhost:6379
 
 production:


### PR DESCRIPTION
Concurrently executing specs (e.g. a spec in the feature specs and an API controller specs) could interfere with each other because, previously, there shared the same ActionCable channels.

Trying to use separate Redis database numbers to solve this problem doesn't seem to work, because it seems that Redis publish events are global across all database numbers of an instance.

Instead, the endorsed/official approach to keep things separated in the world of ActionCable via the Redis adapter is to use the `channel_prefix` option to provide a namespace, which this change does by leveraging the `DB_SUFFIX` environment variable that is set during tests for our different test suites.

I'm pretty sure that this will indeed fix the flakiness, as I was able to figure out reliable reproduction steps, and this change did fix that case of flakiness.

https://guides.rubyonrails.org/action_cable_overview.html#redis-adapter