### PR TITLE
Rescue Ferrum::ProcessTimeoutError and retry in Prerenderer

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     services:
       # https://stackoverflow.com/q/57915791/4009384
       postgres:
@@ -99,6 +99,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: test
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Clone repo
         uses: actions/checkout@v4

--- a/bin/prerender
+++ b/bin/prerender
@@ -16,7 +16,7 @@ class Prerenderer
     @browser = Ferrum::Browser.new(process_timeout: 20, timeout: 60)
   rescue Ferrum::ProcessTimeoutError => error
     puts("Rescued error: #{error}.")
-    puts("Retrying...")
+    puts('Retrying...')
     retry
   end
 

--- a/bin/prerender
+++ b/bin/prerender
@@ -14,6 +14,10 @@ require 'nokogiri'
 class Prerenderer
   def initialize
     @browser = Ferrum::Browser.new(process_timeout: 20, timeout: 60)
+  rescue Ferrum::ProcessTimeoutError => error
+    puts("Rescued error: #{error}.")
+    puts("Retrying...")
+    retry
   end
 
   def prerender(url:, filename:, expected_text:)


### PR DESCRIPTION
Sometimes ([example](https://github.com/davidrunger/david_runger/actions/runs/9882739082/job/27296241834#step:6:9)) we get errors like this during the prerendering process during a deployment:

> Browser did not produce websocket url within 20 seconds, try to increase `:process_timeout`).

This error is sort of not great, because it causes Uptime Robot to consider the website to be down, since, if prerendering failed, the initially rendered page HTML does not include the keyword that Uptime Robot looks for.

Rather than increasing the process timeout, as suggested in that error message, I'm going to try retrying, which will effectively double the total amount of time we spend waiting, and I wonder if retrying might be more reliable than just waiting longer (in case maybe something went irrecoverably wrong with the first initialization attempt, but which might work if me make a new, separate attempt).

As part of this change, I'm also setting a timeout for the overall deploy-and-prerender GitHub action, in case this keeps retrying endlessly, which I think is at least a theoretical risk.

I'm also going to tighten up the timeout for the test GitHub Action, while I'm at it. We can increase that, in the future, if we start bumping up against it, but I don't think that we currently ever do.