### PR TITLE
Change custom cop base class: RuboCop::Cop::{Cop => Base} [DEV-42]

### DIFF
--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -4,7 +4,7 @@
 # request lifecycle into `Request` records saved to the Postgres database.
 class SaveRequest
   prepend MemoWise
-  include Sidekiq::Worker
+  prepend ApplicationWorker
 
   unique_while_executing!
 

--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -4,7 +4,7 @@
 # request lifecycle into `Request` records saved to the Postgres database.
 class SaveRequest
   prepend MemoWise
-  prepend ApplicationWorker
+  include Sidekiq::Worker
 
   unique_while_executing!
 

--- a/lib/test/task_helpers.rb
+++ b/lib/test/task_helpers.rb
@@ -118,8 +118,8 @@ module Test::TaskHelpers
   def record_failed_tests(stdout)
     job_result_hash[:failed_commands] ||= []
     stdout.
-      match(%r{\nFailed examples:\n{1,2}(^\S+rspec \./[^\n]+$)+\n{1,2}}m).[](1).
-      split("\n").
+      match(%r{\nFailed examples:\n{1,2}(.*)\n{1,2}(Randomized|Coverage)}m).[](1).
+      scan(%r{^\S{0,10}rspec \./.+$}).
       each do |failed_test|
         job_result_hash[:failed_commands] << failed_test.sub(%r{\A\e\[31mrspec ./}, '')
       end

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -11,7 +11,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
       DB_SUFFIX=_unit
       bin/rspec
       $(ls -d spec/*/ |
-        grep --extended-regex -v 'spec/(controllers|features|helpers)/' |
+        grep --extended-regex -v 'spec/(controllers|features|helpers)(/|$)' |
         tr '\\n' ' ')
       --format RSpec::Instafail --format progress --force-color
     COMMAND

--- a/tools/custom_cops/dont_include_sidekiq_worker.rb
+++ b/tools/custom_cops/dont_include_sidekiq_worker.rb
@@ -3,6 +3,8 @@
 # rubocop:disable Style/ClassAndModuleChildren
 module CustomCops
   class DontIncludeSidekiqWorker < RuboCop::Cop::Base
+    extend RuboCop::Cop::AutoCorrector
+
     MSG =
       'Use `prepend ApplicationWorker` rather than `include Sidekiq::Worker` ' \
       'or `include Sidekiq::Job`'
@@ -14,11 +16,7 @@ module CustomCops
     def on_send(node)
       return unless including_sidekiq_worker?(node)
 
-      add_offense(node)
-    end
-
-    def autocorrect(node)
-      lambda do |corrector|
+      add_offense(node) do |corrector|
         corrector.replace(node, 'prepend ApplicationWorker')
       end
     end

--- a/tools/custom_cops/dont_include_sidekiq_worker.rb
+++ b/tools/custom_cops/dont_include_sidekiq_worker.rb
@@ -2,7 +2,7 @@
 
 # rubocop:disable Style/ClassAndModuleChildren
 module CustomCops
-  class DontIncludeSidekiqWorker < RuboCop::Cop::Cop
+  class DontIncludeSidekiqWorker < RuboCop::Cop::Base
     MSG =
       'Use `prepend ApplicationWorker` rather than `include Sidekiq::Worker` ' \
       'or `include Sidekiq::Job`'


### PR DESCRIPTION
I think that this should fix at least one RuboCop deprecation warning that I have seen in the logs.

Example: https://github.com/davidrunger/david_runger/actions/runs/9880688707/job/27289828109?pr=4583#step:10:206

> /home/runner/work/david_runger/david_runger/vendor/bundle/ruby/3.3.0/gems/rubocop-1.65.0/lib/rubocop/cop/cop.rb:73: > warning: `support_autocorrect?` is deprecated. Use > `cop.class.support_autocorrect?`.