### PR TITLE
[groceries] Show current count of items for each check-in section

### DIFF
--- a/app/javascript/groceries/components/check_in_items_list.vue
+++ b/app/javascript/groceries/components/check_in_items_list.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
 section(v-if="items.length > 0")
-  h3.font-bold.mb-2 {{ title }}
+  h3.font-bold.mb-2 {{ title }} ({{ items.length }})
 
   ul.check-in-items-list.mb-2
     li.flex.items-center.mb-2(


### PR DESCRIPTION
This is a small, but (IMO) a very nice UX addition. I think it will help to make sure that things aren't missed due to content being cut off the screen.