### PR TITLE
[groceries] Increase check-in modal font size [GROC-8]

### DIFF
--- a/app/javascript/groceries/components/check_in_items_list.vue
+++ b/app/javascript/groceries/components/check_in_items_list.vue
@@ -2,7 +2,7 @@
 section(v-if="items.length > 0")
   h3.font-bold.mb-2 {{ title }} ({{ items.length }})
 
-  ul.check-in-items-list.mb-2
+  ul.check-in-items-list.text-base.mb-2
     li.flex.items-center.mb-2(
       v-for='item in items'
       :key='item.id'


### PR DESCRIPTION
This only increases the font size a relatively little bit, from [0.95rem](https://github.com/davidrunger/david_runger/blob/4f9fd0cb/app/javascript/groceries/groceries.vue#L122-L124) (15.2px) to 1rem (16px), but I think it's a significant improvement.