### PR TITLE
[groceries/check-in] Keep bottom buttons always in view

### DIFF
--- a/app/javascript/groceries/components/store.vue
+++ b/app/javascript/groceries/components/store.vue
@@ -61,42 +61,42 @@
 
   Modal(name='check-in-shopping-trip' width='85%' maxWidth='400px')
     slot
-      .flex.items-center.mb-3
-        span Stores: {{checkInStoreNames}}
-        el-button.choose-stores.ml-2(
-          link
-          type='primary'
-          @click='manageCheckInStores'
-        ) Choose stores
+      .flex.flex-col.max-h-full
+        .shrink-0.flex.items-center.mb-3
+          span Stores: {{checkInStoreNames}}
+          el-button.choose-stores.ml-2(
+            link
+            type='primary'
+            @click='manageCheckInStores'
+          ) Choose stores
 
-      CheckInItemsList(
-        title="Needed"
-        :items="neededUnskippedCheckInItemsNotInCart"
-      )
+        .flex-1.overflow-y-auto
+          CheckInItemsList(
+            title="Needed"
+            :items="neededUnskippedCheckInItemsNotInCart"
+          )
 
-      CheckInItemsList(
-        title="In Cart"
-        :items="neededUnskippedCheckInItemsInCart"
-      )
+          CheckInItemsList(
+            title="In Cart"
+            :items="neededUnskippedCheckInItemsInCart"
+          )
 
-      CheckInItemsList(
-        title="Skipped"
-        :items="neededSkippedCheckInItems"
-      )
+          CheckInItemsList(
+            title="Skipped"
+            :items="neededSkippedCheckInItems"
+          )
 
-      div.flex.justify-around.mt-4
-
-        el-button(
-          @click="modalStore.hideModal({ modalName: 'check-in-shopping-trip' })"
-          type='primary'
-          link
-        ) Cancel
-
-        el-button(
-          @click='handleTripCheckinModalSubmit'
-          type='primary'
-          plain
-        ) Check in items in cart
+        .shrink-0.flex.justify-around.mt-4
+          el-button(
+            @click="modalStore.hideModal({ modalName: 'check-in-shopping-trip' })"
+            type='primary'
+            link
+          ) Cancel
+          el-button(
+            @click='handleTripCheckinModalSubmit'
+            type='primary'
+            plain
+          ) Check in items in cart
 
   Modal(name='manage-check-in-stores' width='80%' maxWidth='370px')
     slot


### PR DESCRIPTION
Prior to this change, if there were a lot of items to check in, then the "Cancel" and "Check in items in cart" buttons would be initially scrolled out of view and one would have to scroll down in order to interact with them. With this change, it's never necessary to scroll in order to interact with these buttons; they are kept always in view.