### PR TITLE
[logs] Drop 'clipboard' dependency [LOG-11]

### DIFF
--- a/app/javascript/logs/components/log.vue
+++ b/app/javascript/logs/components/log.vue
@@ -68,7 +68,7 @@ div
         el-button(v-else class='button-new-tag' size='small' @click='showInput') + Share with email
       div.mt-2 Shareable link: {{shareableUrl}}
       div
-        el-button.copy-to-clipboard(size='small')
+        el-button(size='small' @click='copyShareableUrlToClipboard')
           span(v-if='wasCopiedRecently') Copied!
           span(v-else) Copy to clipboard
       div.mt-2
@@ -83,7 +83,6 @@ div
 
 <script lang="ts">
 import { useTitle } from '@vueuse/core';
-import ClipboardJS from 'clipboard';
 import { ElInput } from 'element-plus';
 import { mapState } from 'pinia';
 import { h } from 'vue';
@@ -177,6 +176,16 @@ export default {
   },
 
   methods: {
+    copyShareableUrlToClipboard() {
+      navigator.clipboard.writeText(this.shareableUrl);
+
+      this.wasCopiedRecently = true;
+
+      setTimeout(() => {
+        this.wasCopiedRecently = false;
+      }, 1800);
+    },
+
     destroyLastEntry() {
       const confirmation = window.confirm(
         `Are you sure that you want to delete the last entry from the ${this.log.name} log?`,
@@ -253,18 +262,6 @@ ${this.log.name}`);
         },
       );
     },
-  },
-
-  mounted() {
-    const clipboard = new ClipboardJS('.copy-to-clipboard', {
-      text: () => this.shareableUrl,
-    });
-    clipboard.on('success', () => {
-      this.wasCopiedRecently = true;
-      setTimeout(() => {
-        this.wasCopiedRecently = false;
-      }, 1800);
-    });
   },
 
   setup() {

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -18,7 +18,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'home*.css' => (0..10),
     'home*.js' => (136..146),
     'logs*.css' => (95..105),
-    'logs*.js' => (800..810),
+    'logs*.js' => (790..800),
     'marriage*.js' => (10..20),
     'quizzes*.js' => (123..133),
     'styles*.css' => (9..19),

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "chart.js": "^4.4.3",
     "chartjs-adapter-luxon": "^1.3.1",
     "chartkick": "^5.0.1",
-    "clipboard": "^2.0.11",
     "dompurify": "^3.1.6",
     "easytimer.js": "^4.6.0",
     "element-plus": "^2.7.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,9 +44,6 @@ importers:
       chartkick:
         specifier: ^5.0.1
         version: 5.0.1
-      clipboard:
-        specifier: ^2.0.11
-        version: 2.0.11
       dompurify:
         specifier: ^3.1.6
         version: 3.1.6
@@ -1207,9 +1204,6 @@ packages:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
 
-  clipboard@2.0.11:
-    resolution: {integrity: sha512-C+0bbOqkezLIsmWSvlsXS0Q0bmkugu7jcfMIACB+RDEntIzQIkdr148we28AfSloQLRdZlYL/QYyrq05j/3Faw==}
-
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -1343,9 +1337,6 @@ packages:
   define-properties@1.2.0:
     resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
     engines: {node: '>= 0.4'}
-
-  delegate@3.2.0:
-    resolution: {integrity: sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==}
 
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
@@ -1736,9 +1727,6 @@ packages:
 
   globjoin@0.1.4:
     resolution: {integrity: sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==}
-
-  good-listener@1.2.2:
-    resolution: {integrity: sha512-goW1b+d9q/HIwbVYZzZ6SsTr4IgE+WA44A0GmPIQstuOrgsFcT7VEJ48nmr9GaRtNu0XTKacFLGnBPAM6Afouw==}
 
   gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -2618,9 +2606,6 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  select@1.1.2:
-    resolution: {integrity: sha512-OwpTSOfy6xSs1+pwcNrv0RBMOzI39Lp3qQKUTPVVPRjCdNa5JH/oPRiqsesIskK8TVgmRiHwO4KXlV2Li9dANA==}
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2821,9 +2806,6 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
-
-  tiny-emitter@2.1.0:
-    resolution: {integrity: sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -4291,12 +4273,6 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  clipboard@2.0.11:
-    dependencies:
-      good-listener: 1.2.2
-      select: 1.1.2
-      tiny-emitter: 2.1.0
-
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -4405,8 +4381,6 @@ snapshots:
     dependencies:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
-
-  delegate@3.2.0: {}
 
   delegates@1.0.0: {}
 
@@ -4943,10 +4917,6 @@ snapshots:
       slash: 3.0.0
 
   globjoin@0.1.4: {}
-
-  good-listener@1.2.2:
-    dependencies:
-      delegate: 3.2.0
 
   gopd@1.0.1:
     dependencies:
@@ -5831,8 +5801,6 @@ snapshots:
       immutable: 4.3.4
       source-map-js: 1.2.0
 
-  select@1.1.2: {}
-
   semver@6.3.1: {}
 
   semver@7.6.0:
@@ -6103,8 +6071,6 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
-
-  tiny-emitter@2.1.0: {}
 
   to-fast-properties@2.0.0: {}
 


### PR DESCRIPTION
The 'clipboard' dependency seems to be mostly about setting up DOM elements to copy to clipboard, but we don't really need that, since we are using Vue to define DOM behavior. The actual copying is easy to do via `navigator.clipboard.writeText(textToCopy)`.