### PR TITLE
[vite.config.mjs] Add "logLevel: 'warn'" for cleaner CI output

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -8,6 +8,7 @@ import FullReload from 'vite-plugin-full-reload';
 import RubyPlugin from 'vite-plugin-ruby';
 
 export default defineConfig({
+  logLevel: 'warn',
   plugins: [
     FullReload([
       'app/assets/stylesheets/**/*',


### PR DESCRIPTION
This will also change the log level when running vite locally, which is maybe slightly less than ideal, but I think that it's an overall win, because the vite output in CI is decently verbose (some dozens of lines).