### PR TITLE
[RunBrakeman] Use 'log_stdout_only_on_failure: true' option

### DIFF
--- a/lib/test/tasks/run_brakeman.rb
+++ b/lib/test/tasks/run_brakeman.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunBrakeman < Pallets::Task
 
   def run
     # skip `application_worker.rb` because it has `...`, which the brakeman parser cannot understand
-    execute_system_command(<<~COMMAND.squish)
+    execute_system_command(<<~COMMAND.squish, log_stdout_only_on_failure: true)
       bin/brakeman
         --quiet
         --no-pager


### PR DESCRIPTION
Even with the `--quiet` flag, the brakeman output is one of our most verbose (i.e. cluttering) steps in CI, which I don't think is worth it because the output usually has almost no value and the check rarely fails. Let's print the output only on failure.