### PR TITLE
[RunFileSizeChecks] Print file sizes on a single line

### DIFF
--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -35,8 +35,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
         check_for_mismatched_files
         check_for_file_size_violations
 
-        puts('Bundle sizes (in kilobytes):')
-        pp(assets_and_size_in_kb)
+        puts("Bundle sizes (in kilobytes): #{assets_and_size_in_kb.inspect}")
       end.real
 
     if unspecified_files.none? && nonexistent_files.none? && file_size_violations.none?


### PR DESCRIPTION
This output is sort of verbose when each file takes up its own line. I think that printing everything on a single line is a better value, in terms of the cost of clutter in log output.