### PR TITLE
[groceries] Animate new items using Vue TransitionGroup [GROC-11]

### DIFF
--- a/app/assets/stylesheets/animations/appear_vertically.scss
+++ b/app/assets/stylesheets/animations/appear_vertically.scss
@@ -1,34 +1,31 @@
+.appear-and-disappear-vertically-list-enter-active,
+.appear-and-disappear-vertically-list-leave-active,
+.appear-and-disappear-vertically-list-move {
+  transition: all 0.4s ease-out;
+}
+
 .appear-vertically-list-enter-active {
-  transition: all 0.8s ease;
+  transition: all 0.7s ease-out;
 }
 
-.appear-vertically-list-enter-from {
+.appear-and-disappear-vertically-list-leave-active {
+  position: absolute;
+}
+
+.appear-vertically-list-enter-from,
+.appear-and-disappear-vertically-list-enter-from,
+.appear-and-disappear-vertically-list-leave-to {
   opacity: 0;
-  transform: scale(1, 0);
+  transform: scaleY(0.01);
 }
 
-.appear-vertically-list-enter-to {
+.appear-vertically-list-enter-to,
+.appear-and-disappear-vertically-list-enter-to,
+.appear-and-disappear-vertically-list-leave-from {
   opacity: 1;
-  transform: scale(1, 1);
+  transform: scaleY(1);
 }
 
 .appear-vertically-list-leave-active {
   display: none;
-}
-
-@keyframes appear-vertically {
-  from {
-    opacity: 0;
-    transform: scale(1, 0);
-  }
-
-  to {
-    opacity: 1;
-    transform: scale(1, 1);
-  }
-}
-
-.appear-vertically {
-  animation-name: appear-vertically;
-  animation-duration: 0.8s;
 }

--- a/app/javascript/groceries/components/Item.vue
+++ b/app/javascript/groceries/components/Item.vue
@@ -1,6 +1,6 @@
 <template lang="pug">
-.grocery-item.flex.items-center(
-  :class='{unneeded: item.needed <= 0, "appear-vertically": item.newlyAdded}'
+.grocery-item.flex.items-center.w-full(
+  :class='{ unneeded: item.needed <= 0 }'
 )
   .left.whitespace-nowrap
     button.increment.text-2xl.js-link.text-green-600.leading-unset(

--- a/app/javascript/groceries/components/Store.vue
+++ b/app/javascript/groceries/components/Store.vue
@@ -51,7 +51,11 @@
         :disabled='v$.$invalid'
       ) Add
 
-  .items-list.mt-0.mb-0
+  TransitionGroup(
+    name='appear-and-disappear-vertically-list'
+    tag='div'
+    class='items-list relative mt-0 mb-0'
+  )
     Item(
       v-for='item in sortedItems'
       :item="item"

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -57,11 +57,7 @@ export const useGroceriesStore = defineStore('groceries', {
       // don't add item to store if it's already there
       if (safeGetById(store.items, itemData.id)) return;
 
-      itemData.newlyAdded = true;
-      store.items.unshift(itemData);
-      setTimeout(() => {
-        itemData.newlyAdded = false;
-      }, 1000);
+      store.items.push(itemData);
     },
 
     async createItem({

--- a/app/javascript/groceries/types.ts
+++ b/app/javascript/groceries/types.ts
@@ -5,7 +5,6 @@ export interface Item {
   in_cart?: boolean;
   name: string;
   needed: number;
-  newlyAdded: boolean;
   skipped?: boolean;
   store_id: number;
 }


### PR DESCRIPTION
One advantage of this is that we no longer need to manually manage a `newlyAdded` property on the grocery items (which always felt a little hacky). Another advantage is that this actually smoothly animates the other items up and down, I think, whereas previously the other items would jerk up and down.