### PR TITLE
[CheckLinks::Checker] Add 429 as a possible expected LinkedIn status

### DIFF
--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -26,7 +26,7 @@ class CheckLinks::Checker
   # rubocop:disable Style/MutableConstant
   STATUS_EXPECTATIONS = {
     'https://www.commonlit.org/' => [200, 403],
-    'https://www.linkedin.com/in/davidrunger/' => [200, 999],
+    'https://www.linkedin.com/in/davidrunger/' => [200, 429, 999],
   }
   STATUS_EXPECTATIONS.default_proc =
     proc do |_hash, url|


### PR DESCRIPTION
I received an email this morning about having gotten a 429 from LinkedIn, which I am guessing might be part of a general blocking of DigitalOcean. Regardless, let's add that as a possible expected status.