### PR TITLE
Enable YJIT via an initializer

### DIFF
--- a/config/initializers/enable_yjit.rb
+++ b/config/initializers/enable_yjit.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Automatically enable YJIT as of Ruby 3.3, as it brings very
+# sizeable performance improvements.
+
+# If you are deploying to a memory constrained environment
+# you may want to delete this file, but otherwise it's free
+# performance.
+if defined?(RubyVM::YJIT.enable)
+  Rails.application.config.after_initialize do
+    RubyVM::YJIT.enable
+  end
+end


### PR DESCRIPTION
This is better than doing it via an env var, because this way we don't JIT the boot time stuff, which apparently is a good thing. https://youtu.be/--0pXVadtII?si=BEC8-FnDyJw5nIED&t=748

Another thing I like about this change is that it puts the config in the codebase, rather than in an environment variable. I don't think that this setting is something that we will want to be changing/toggling on short notice (which would make an environment variable relatively compelling).

I have removed the `RUBY_YJIT_ENABLE=1` env var from the Dokku config.