### PR TITLE
Downgrade tailwindcss from 3.4.6 to 3.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "stylelint-config-standard-scss": "^11.1.0",
     "stylelint-scss": "^5.3.2",
     "tailwind-config-viewer": "^2.0.4",
-    "tailwindcss": "^3.4.6",
+    "tailwindcss": "^3.4.4",
     "typescript": "^5.5.3",
     "vite": "^5.3.4",
     "vite-plugin-full-reload": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,10 +191,10 @@ importers:
         version: 5.3.2(stylelint@15.11.0(typescript@5.5.3))
       tailwind-config-viewer:
         specifier: ^2.0.4
-        version: 2.0.4(tailwindcss@3.4.6)
+        version: 2.0.4(tailwindcss@3.4.4)
       tailwindcss:
-        specifier: ^3.4.6
-        version: 3.4.6
+        specifier: ^3.4.4
+        version: 3.4.4
       typescript:
         specifier: ^5.5.3
         version: 5.5.3
@@ -2788,8 +2788,8 @@ packages:
     peerDependencies:
       tailwindcss: 1 || 2 || 2.0.1-compat || 3
 
-  tailwindcss@3.4.6:
-    resolution: {integrity: sha512-1uRHzPB+Vzu57ocybfZ4jh5Q3SdlH7XW23J5sQoM9LhE9eIOlzxer/3XPSsycvih3rboRsvt0QCmzSrqyOYUIA==}
+  tailwindcss@3.4.4:
+    resolution: {integrity: sha512-ZoyXOdJjISB7/BcLTR6SEsLgKtDStYyYZVLsUtWChO4Ps20CBad7lfJKVDiejocV4ME1hLmyY0WJE3hSDcmQ2A==}
     engines: {node: '>=14.0.0'}
     hasBin: true
 
@@ -6019,7 +6019,7 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
 
-  tailwind-config-viewer@2.0.4(tailwindcss@3.4.6):
+  tailwind-config-viewer@2.0.4(tailwindcss@3.4.4):
     dependencies:
       '@koa/router': 12.0.1
       commander: 6.2.1
@@ -6029,11 +6029,11 @@ snapshots:
       open: 7.4.2
       portfinder: 1.0.32
       replace-in-file: 6.3.5
-      tailwindcss: 3.4.6
+      tailwindcss: 3.4.4
     transitivePeerDependencies:
       - supports-color
 
-  tailwindcss@3.4.6:
+  tailwindcss@3.4.4:
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2


### PR DESCRIPTION
A bug seems to have been introduced, I think in 3.4.5, which is currently causing some visual regressions in production. The problem seems to be that, in some cases, when using pug templates, the last listed class does not get picked up (for example, a `z-10` class in Modal.vue and `leading-unset` in Item.vue).

Possibly relevant issues:

https://github.com/tailwindlabs/tailwindcss/issues/ 14005

https://github.com/tailwindlabs/tailwindcss/issues/ 14013