### PR TITLE
[bin/run-test-step] Manually load relevant .env files

### DIFF
--- a/bin/run-test-step
+++ b/bin/run-test-step
@@ -11,6 +11,8 @@ if !defined?(Rails)
   exec('bin/rails', 'runner', __FILE__, *ARGV)
 end
 
+require 'dotenv'
+Dotenv.load('.env', '.env.test', '.env.test.local')
 require 'pallets'
 require './lib/test/runner.rb'
 "Test::Tasks::#{ARGV[0]}".safe_constantize.new.run


### PR DESCRIPTION
This way, for example, I can set a `PERCY_TOKEN` in `.env.test.local`, and it will be respected.