### PR TITLE
Remove @types/marked

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/dompurify": "^3.0.5",
     "@types/js-cookie": "^3.0.6",
     "@types/lodash-es": "^4.17.12",
-    "@types/marked": "^6.0.0",
     "@types/rails__actioncable": "^6.1.11",
     "@types/rails__ujs": "^6.0.4",
     "@types/strftime": "^0.9.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,9 +129,6 @@ importers:
       '@types/lodash-es':
         specifier: ^4.17.12
         version: 4.17.12
-      '@types/marked':
-        specifier: ^6.0.0
-        version: 6.0.0
       '@types/rails__actioncable':
         specifier: ^6.1.11
         version: 6.1.11
@@ -755,10 +752,6 @@ packages:
 
   '@types/lodash@4.14.198':
     resolution: {integrity: sha512-trNJ/vtMZYMLhfN45uLq4ShQSw0/S7xCTLLVM+WM1rmFpba/VS42jVUgaO3w/NOLiWR/09lnYk0yMaA/atdIsg==}
-
-  '@types/marked@6.0.0':
-    resolution: {integrity: sha512-jmjpa4BwUsmhxcfsgUit/7A9KbrC48Q0q8KvnY107ogcjGgTFDlIL3RpihNpx2Mu1hM4mdFQjoVc4O6JoGKHsA==}
-    deprecated: This is a stub types definition. marked provides its own type definitions, so you do not need this installed.
 
   '@types/minimist@1.2.2':
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
@@ -3737,10 +3730,6 @@ snapshots:
       '@types/lodash': 4.14.198
 
   '@types/lodash@4.14.198': {}
-
-  '@types/marked@6.0.0':
-    dependencies:
-      marked: 13.0.2
 
   '@types/minimist@1.2.2': {}
 


### PR DESCRIPTION
From `pnpm add -D @percy/cli@latest`:

> WARN deprecated @types/marked@6.0.0: This is a stub types definition. > marked provides its own type definitions, so you do not need this > installed.