### PR TITLE
[logs/text] Only animate the first log entry [LOG-13]

### DIFF
--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -4,10 +4,11 @@
     table.text-log-table
       TransitionGroup(name='appear-vertically-list')
         EditableTextLogRow(
-          v-for='logEntry in sortedLogEntries'
+          v-for='(logEntry, index) in sortedLogEntries'
           :key='logEntry.id'
           :log='log'
           :logEntry='logEntry'
+          :class="{ '!transition-none': index !== 0 }"
         )
     el-button(v-if='!showAllEntries' @click='showAllEntries = true').
       Show all entries


### PR DESCRIPTION
Otherwise, all newly revealed log entries animate after clicking "Show all entries", which we don't want (distracting / CPU usage).