### PR TITLE
[groceries] Lighten background colors when moving items

### DIFF
--- a/app/javascript/groceries/components/CheckInItemsList.vue
+++ b/app/javascript/groceries/components/CheckInItemsList.vue
@@ -42,9 +42,9 @@ import { Item } from '@/groceries/types';
 
 const MOVE_TIMEOUT = 500;
 const MOVING_TO_STATUS_TO_CLASS_MAP = {
-  'in-cart': 'bg-green-300',
+  'in-cart': 'bg-green-200',
   needed: 'bg-orange-200',
-  skipped: 'bg-red-400',
+  skipped: 'bg-red-200',
 };
 const CLEAR_BACKGROUND_COLOR_TIMEOUT = 1200;
 


### PR DESCRIPTION
Before, the colors were dark enough that it made it a bit difficult to read the item text.