### PR TITLE
Quiet Vite logs only in CI

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -8,7 +8,7 @@ import FullReload from 'vite-plugin-full-reload';
 import RubyPlugin from 'vite-plugin-ruby';
 
 export default defineConfig({
-  logLevel: 'warn',
+  logLevel: process.env.CI ? 'warn' : undefined,
   plugins: [
     FullReload([
       'app/assets/stylesheets/**/*',


### PR DESCRIPTION
When the Vite log level is 'warn', we don't get any feedback about the status locally when running Vite.