### PR TITLE
[check-ins] Import types specifically as types

### DIFF
--- a/app/javascript/check_ins/App.vue
+++ b/app/javascript/check_ins/App.vue
@@ -21,7 +21,7 @@ div(v-else) {{checkInsStore.partner_ratings_hidden_reason}}
 <script setup lang="ts">
 import actionCableConsumer from '@/channels/consumer';
 import { useCheckInsStore } from '@/check_ins/store';
-import { Bootstrap, NeedSatisfactionRating } from '@/check_ins/types';
+import type { Bootstrap, NeedSatisfactionRating } from '@/check_ins/types';
 import { useBootstrap } from '@/lib/composables/useBootstrap';
 
 import Ratings from './components/Ratings.vue';

--- a/app/javascript/check_ins/components/Ratings.vue
+++ b/app/javascript/check_ins/components/Ratings.vue
@@ -26,10 +26,10 @@ button.btn-primary.mt-2.h3(v-if='editable && !submitted' @click='submitCheckIn')
 <script setup lang="ts">
 import { range } from 'lodash-es';
 import { storeToRefs } from 'pinia';
-import { PropType } from 'vue';
+import type { PropType } from 'vue';
 
 import { useCheckInsStore } from '@/check_ins/store';
-import { NeedSatisfactionRating, Rating } from '@/check_ins/types';
+import type { NeedSatisfactionRating, Rating } from '@/check_ins/types';
 
 import EmojiButton from './EmojiButton.vue';
 


### PR DESCRIPTION
This seems to be required with `script setup`, for whatever reason (although tests passed without this change, so maybe it only impacts the development environment?).