### PR TITLE
[groceries] Extract a CheckInItem component [GROC-14]

### DIFF
--- a/app/javascript/groceries/components/CheckInItem.vue
+++ b/app/javascript/groceries/components/CheckInItem.vue
@@ -1,0 +1,134 @@
+<template lang="pug">
+li.flex.items-center.break-word.mb-2(
+  :class='aboutToMoveToClass()'
+)
+  input(
+    type='checkbox'
+    :checked='item.in_cart'
+    @change='toggleItemInCart'
+    :disabled='item.skipped'
+    :id='`trip-checkin-item-${item.id}`'
+  )
+  label.ml-2(:for='`trip-checkin-item-${item.id}`')
+    span(:class='{ "text-gray-500": item.skipped }')
+      span {{item.name}}
+      span(v-if='item.needed > 1') {{' '}} ({{item.needed}})
+    span {{ ' ' }}
+    el-button(
+      v-if="item.skipped"
+      link
+      type='primary'
+      @click='unskip'
+    ) Unskip
+    el-button(
+      v-else
+      link
+      type='primary'
+      @click='skip'
+    ) Skip
+</template>
+
+<script setup lang="ts">
+import type { PropType } from 'vue';
+
+import { useGroceriesStore } from '@/groceries/store';
+import type { Item } from '@/groceries/types';
+
+const props = defineProps({
+  item: {
+    type: Object as PropType<Item>,
+    required: true,
+  },
+});
+
+const MOVE_TIMEOUT = 500;
+const MOVING_TO_STATUS_TO_CLASS_MAP = {
+  'in-cart': 'bg-green-200',
+  needed: 'bg-orange-200',
+  skipped: 'bg-red-200',
+};
+const CLEAR_BACKGROUND_COLOR_TIMEOUT = 1200;
+
+const groceriesStore = useGroceriesStore();
+
+function aboutToMoveToClass() {
+  if (props.item.aboutToMoveTo) {
+    return MOVING_TO_STATUS_TO_CLASS_MAP[props.item.aboutToMoveTo];
+  }
+}
+
+function skip() {
+  if (props.item.aboutToMoveTo) return;
+
+  groceriesStore.setItemAboutToMoveTo({
+    item: props.item,
+    aboutToMoveTo: 'skipped',
+  });
+
+  setTimeout(() => {
+    groceriesStore.skipItem({ item: props.item });
+  }, MOVE_TIMEOUT);
+
+  setTimeout(() => {
+    groceriesStore.setItemAboutToMoveTo({
+      item: props.item,
+      aboutToMoveTo: null,
+    });
+  }, CLEAR_BACKGROUND_COLOR_TIMEOUT);
+}
+
+function toggleItemInCart() {
+  if (props.item.aboutToMoveTo) return;
+
+  groceriesStore.setItemAboutToMoveTo({
+    item: props.item,
+    aboutToMoveTo: props.item.in_cart ? 'needed' : 'in-cart',
+  });
+
+  setTimeout(() => {
+    groceriesStore.setItemInCart({
+      item: props.item,
+      inCart: !props.item.in_cart,
+    });
+  }, MOVE_TIMEOUT);
+
+  setTimeout(() => {
+    groceriesStore.setItemAboutToMoveTo({
+      item: props.item,
+      aboutToMoveTo: null,
+    });
+  }, CLEAR_BACKGROUND_COLOR_TIMEOUT);
+}
+
+function unskip() {
+  if (props.item.aboutToMoveTo) return;
+
+  groceriesStore.setItemAboutToMoveTo({
+    item: props.item,
+    aboutToMoveTo: 'needed',
+  });
+
+  setTimeout(() => {
+    groceriesStore.unskipItem({ item: props.item });
+  }, MOVE_TIMEOUT);
+
+  setTimeout(() => {
+    groceriesStore.setItemAboutToMoveTo({
+      item: props.item,
+      aboutToMoveTo: null,
+    });
+  }, CLEAR_BACKGROUND_COLOR_TIMEOUT);
+}
+</script>
+
+<style scoped lang="scss">
+li {
+  transition: all 0.15s ease-out;
+}
+
+// double class in selector to increase specificity of this override
+.el-button.el-button.is-link {
+  padding: 0;
+  vertical-align: unset;
+}
+</style>

--- a/app/javascript/groceries/components/CheckInItemsList.vue
+++ b/app/javascript/groceries/components/CheckInItemsList.vue
@@ -3,50 +3,19 @@ section(v-if="items.length > 0")
   h3.font-bold.mb-2 {{ title }} ({{ items.length }})
 
   ul.check-in-items-list.text-base.mb-2
-    li.flex.items-center.break-word.mb-2(
+    CheckInItem(
       v-for='item in items'
       :key='item.id'
-      :class='aboutToMoveToClass(item)'
+      :item='item'
     )
-      input(
-        type='checkbox'
-        :checked='item.in_cart'
-        @change='toggleItemInCart(item)'
-        :disabled='item.skipped'
-        :id='`trip-checkin-item-${item.id}`'
-      )
-      label.ml-2(:for='`trip-checkin-item-${item.id}`')
-        span(:class='{ "text-gray-500": item.skipped }')
-          span {{item.name}}
-          span(v-if='item.needed > 1') {{' '}} ({{item.needed}})
-        span {{ ' ' }}
-        el-button(
-          v-if="item.skipped"
-          link
-          type='primary'
-          @click='unskip(item)'
-        ) Unskip
-        el-button(
-          v-else
-          link
-          type='primary'
-          @click='skip(item)'
-        ) Skip
 </template>
 
 <script setup lang="ts">
 import type { PropType } from 'vue';
 
-import { useGroceriesStore } from '@/groceries/store';
 import type { Item } from '@/groceries/types';
 
-const MOVE_TIMEOUT = 500;
-const MOVING_TO_STATUS_TO_CLASS_MAP = {
-  'in-cart': 'bg-green-200',
-  needed: 'bg-orange-200',
-  skipped: 'bg-red-200',
-};
-const CLEAR_BACKGROUND_COLOR_TIMEOUT = 1200;
+import CheckInItem from './CheckInItem.vue';
 
 defineProps({
   items: {
@@ -58,66 +27,4 @@ defineProps({
     required: true,
   },
 });
-
-const groceriesStore = useGroceriesStore();
-
-function aboutToMoveToClass(item: Item) {
-  if (item.aboutToMoveTo) {
-    return MOVING_TO_STATUS_TO_CLASS_MAP[item.aboutToMoveTo];
-  }
-}
-
-function skip(item: Item) {
-  if (item.aboutToMoveTo) return;
-
-  item.aboutToMoveTo = 'skipped';
-
-  setTimeout(() => {
-    groceriesStore.skipItem({ item });
-  }, MOVE_TIMEOUT);
-
-  setTimeout(() => {
-    item.aboutToMoveTo = null;
-  }, CLEAR_BACKGROUND_COLOR_TIMEOUT);
-}
-
-function toggleItemInCart(item: Item) {
-  if (item.aboutToMoveTo) return;
-
-  item.aboutToMoveTo = item.in_cart ? 'needed' : 'in-cart';
-
-  setTimeout(() => {
-    item.in_cart = !item.in_cart;
-  }, MOVE_TIMEOUT);
-
-  setTimeout(() => {
-    item.aboutToMoveTo = null;
-  }, CLEAR_BACKGROUND_COLOR_TIMEOUT);
-}
-
-function unskip(item: Item) {
-  if (item.aboutToMoveTo) return;
-
-  item.aboutToMoveTo = 'needed';
-
-  setTimeout(() => {
-    groceriesStore.unskipItem({ item });
-  }, MOVE_TIMEOUT);
-
-  setTimeout(() => {
-    item.aboutToMoveTo = null;
-  }, CLEAR_BACKGROUND_COLOR_TIMEOUT);
-}
 </script>
-
-<style lang="scss">
-// double class in selector to increase specificity of this override
-.el-button.el-button.is-link {
-  padding: 0;
-  vertical-align: unset;
-}
-
-li {
-  transition: all 0.15s ease-out;
-}
-</style>

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -1,7 +1,7 @@
 import { filter, get, last, pick, sortBy } from 'lodash-es';
 import { defineStore } from 'pinia';
 
-import { Bootstrap, Item, Store } from '@/groceries/types';
+import { Bootstrap, CheckInStatus, Item, Store } from '@/groceries/types';
 import { emit } from '@/lib/event_bus';
 import * as RoutesType from '@/rails_assets/routes';
 import { kyApi } from '@/shared/ky';
@@ -189,6 +189,20 @@ export const useGroceriesStore = defineStore('groceries', {
 
     setCollectingDebounces({ value }: { value: boolean }) {
       this.collectingDebounces = value;
+    },
+
+    setItemAboutToMoveTo({
+      item,
+      aboutToMoveTo,
+    }: {
+      item: Item;
+      aboutToMoveTo: CheckInStatus | null;
+    }) {
+      item.aboutToMoveTo = aboutToMoveTo;
+    },
+
+    setItemInCart({ item, inCart }: { item: Item; inCart: boolean }) {
+      item.in_cart = inCart;
     },
 
     skipItem({ item }: { item: Item }) {

--- a/app/javascript/groceries/types.ts
+++ b/app/javascript/groceries/types.ts
@@ -1,7 +1,9 @@
 import { JsonBroadcast } from '@/shared/types';
 
+export type CheckInStatus = 'needed' | 'in-cart' | 'skipped';
+
 export interface Item {
-  aboutToMoveTo?: 'needed' | 'in-cart' | 'skipped' | null;
+  aboutToMoveTo?: CheckInStatus | null;
   id: number;
   in_cart?: boolean;
   name: string;


### PR DESCRIPTION
I ended up needing to move some of the functionality to the store because of a rule against mutating a prop. I guess that this is probably a good change. We were getting away with it before, I guess, because the prop was `items` (an array) and we were mutating its elements directly, which I guess wasn't detected as a violation.