### PR TITLE
[logs] Increase contrast of input text in reminder settings [LOG-16]

### DIFF
--- a/app/javascript/logs/components/EditLogRemindersModal.vue
+++ b/app/javascript/logs/components/EditLogRemindersModal.vue
@@ -118,4 +118,9 @@ async function updateLog() {
 input {
   width: 30px;
 }
+
+input,
+select {
+  background: inherit;
+}
 </style>


### PR DESCRIPTION
This change makes it so that the input and select will have whiteish text on a black background (as opposed to whiteish text on a whiteish background, as before).