### PR TITLE
Add freezolite commit to .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -4,3 +4,6 @@ cb2e57260b704c6230d173cb9e901b75531694f0
 
 # Apply Prettier formatting (#4464)
 34eaefc553c57f31247f27aac7abce36df1b034d
+
+# Use freezolite (no more frozen_string_literal comments) [DEV-2] (#4679)
+1bde9063bbb1f097efd4674009d744bb22de6d5c


### PR DESCRIPTION
This commit touched almost every Ruby file in the whole project. It doesn't really matter too much, as far as `git blame` goes, since most of the changes were just deleting frozen string literal comments. However, I have some tools (e.g. `ghist`) that respect `.git-blame-ignore-revs` in other contexts, too, and I mostly want to add this commit for the sake of those tools, where it will matter.