### PR TITLE
Add route to display currently deployed Git SHA [DEV-11]

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -111,6 +111,8 @@ Rails.application.routes.draw do
     to: ->(_env) { [200, {}, ['google-site-verification: google83c07e1014ea4a70.html']] },
   )
 
+  get('sha', to: ->(_env) { [200, {}, [ENV.fetch('GIT_REV').first(8)]] })
+
   get '/404', to: 'errors#not_found', via: :all
   get '/422', to: 'errors#unacceptable', via: :all
   get '/500', to: 'errors#internal_error', via: :all

--- a/spec/features/git_sha_spec.rb
+++ b/spec/features/git_sha_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe 'Git SHA endpoint', :rack_test_driver do
+  subject(:visit_git_sha_path) { visit('/sha') }
+
+  context 'when a GIT_REV env var is present' do
+    around do |spec|
+      ClimateControl.modify(GIT_REV: git_sha) do
+        spec.run
+      end
+    end
+
+    let(:git_sha) { 'b18d253eab03e0eb8d7f7dc995ececd326ad9fd5' }
+
+    it 'renders the first 8 characters of the Git SHA' do
+      visit_git_sha_path
+
+      expect(page.text).to eq(git_sha.first(8))
+    end
+  end
+end


### PR DESCRIPTION
The endpoint is `/sha`.

This might be useful in debugging situations or when deploying in order to definitively check what code is currently deployed.

For the sake of security paranoia, we'll display only the first 8 characters of the Git SHA (not all 40).