### PR TITLE
Replace "\r\r\n" with "\r\n" when parsing incoming emails [LOG-2]

### DIFF
--- a/lib/refinements/parsed_mail_body.rb
+++ b/lib/refinements/parsed_mail_body.rb
@@ -15,16 +15,17 @@ module Refinements::ParsedMailBody
 
       trimmed_body.rstrip.
         # remove newlines that were added just to break up long lines
-        gsub(/\S+\n\S+/) do |match|
-          word_before_newline = match.split("\n").first
+        gsub(/\S+\r?\n\S+/) do |match|
+          word_before_newline = match.split(/\r?\n/).first
           if word_before_newline.in?(words_truly_before_newlines)
             # leave the newline in if the user intends for the word to be followed by a newline
             match
           else
             # otherwise, change the newline to a space (i.e. recombine the wrapped lines)
-            match.tr("\n", ' ')
+            match.gsub(/\r?\n/, ' ')
           end
-        end
+        end.
+        gsub("\r\n", "\n")
     end
 
     private

--- a/lib/refinements/parsed_mail_body.rb
+++ b/lib/refinements/parsed_mail_body.rb
@@ -7,6 +7,8 @@ module Refinements::ParsedMailBody
       unparsed_body.sub!(/\A[\s\S]*^Content-Transfer-Encoding:.+\n+/, '')
       # decode quoted-printable encoding
       unparsed_body = unparsed_body.unpack1('M').force_encoding('utf-8')
+      # Clean up "\r\r\n" sequences to "\r\n".
+      unparsed_body.gsub!("\r\r\n", "\r\n")
       # trim content from the end of the body ("On [date/time] [person/email] wrote:[...]")
       trimmed_body = RungerEmailReplyTrimmer.trim(unparsed_body)
       return nil if trimmed_body.nil?

--- a/spec/fixtures/raw_emails/multiline.eml
+++ b/spec/fixtures/raw_emails/multiline.eml
@@ -1,0 +1,61 @@
+MIME-Version: 1.0
+From: David Runger <davidjrunger@gmail.com>
+Date: Mon, 22 Jul 2024 11:19:04 -0500
+Subject: Re: Submit a log entry for your "Gratitude Journal" log
+To: Gratitude Journal Log Entries <log-entries|log/21@mg.davidrunger.com>
+Content-Type: multipart/alternative; boundary="0000000000000e7b94061dd86882"
+
+--0000000000000e7b94061dd86882
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+1. my work monitor is working pretty well
+2. we haven't had any major maintenance issues with the house we're renting
+3. Mom and Dad came to visit and were very generous with their time and
+decently generous with their money
+
+On Mon, Jul 22, 2024 at 11:04=E2=80=AFAM DavidRunger.com <
+log-reminders@davidrunger.com> wrote:
+
+> Submit a new log entry here:
+>
+> https://davidrunger.com/logs/gratitude-journal
+>
+> *Tip:* To create a log entry, you can simply reply to this email with the
+> desired log entry content.
+>
+
+--0000000000000e7b94061dd86882
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+<div dir=3D"ltr"><div>1. my work monitor is working pretty well</div><div>2=
+. we haven&#39;t had any major maintenance issues with the house we&#39;re =
+renting<br></div><div>3. Mom and Dad came to visit and were very generous w=
+ith their time and decently generous with their money</div></div><br><div c=
+lass=3D"gmail_quote"><div dir=3D"ltr" class=3D"gmail_attr">On Mon, Jul 22, =
+2024 at 11:04=E2=80=AFAM DavidRunger.com &lt;<a href=3D"mailto:log-reminder=
+s@davidrunger.com">log-reminders@davidrunger.com</a>&gt; wrote:<br></div><b=
+lockquote class=3D"gmail_quote" style=3D"margin:0px 0px 0px 0.8ex;border-le=
+ft:1px solid rgb(204,204,204);padding-left:1ex"><u></u>
+
+ =20
+   =20
+   =20
+ =20
+
+  <div>
+    <p>Submit a new log entry here:</p>
+<p><a href=3D"https://davidrunger.com/logs/gratitude-journal" target=3D"_bl=
+ank">https://davidrunger.com/logs/gratitude-journal</a></p>
+<p>
+<b>Tip:</b>
+To create a log entry, you can simply reply to this email with the desired =
+log entry content.
+</p>
+
+  </div>
+
+</blockquote></div>
+
+--0000000000000e7b94061dd86882--

--- a/spec/lib/refinements/parsed_mail_body_spec.rb
+++ b/spec/lib/refinements/parsed_mail_body_spec.rb
@@ -188,5 +188,32 @@ RSpec.describe Refinements::ParsedMailBody do
         expect(parsed_body).to eq(nil)
       end
     end
+
+    context 'when the email body has lines that get split up' do
+      before { RSpec::Mocks.space.proxy_for(mail).reset }
+
+      let(:mail) { mail_from_raw_email_fixture('multiline') }
+
+      it 'parses the email into the correct lines' do
+        parsed_lines = parsed_body.split("\n")
+
+        expect(parsed_lines.size).to eq(3)
+
+        expect(parsed_lines[0]).to eq(<<~LINE.squish)
+          1. my work monitor is working pretty well
+        LINE
+        expect(parsed_lines[1]).to eq(<<~LINE.squish)
+          2. we haven't had any major maintenance issues with the house we're renting
+        LINE
+        expect(parsed_lines[2]).to eq(<<~LINE.squish)
+          3. Mom and Dad came to visit and were very generous with their time and decently generous
+          with their money
+        LINE
+      end
+
+      it 'does not include info about the original email' do
+        expect(parsed_body).not_to include('wrote:')
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm not totally sure if these character sequences occur in production, but they were occurring in my development testing, and I do think that they probably occur in production, too.

Prior to this change, I was able to reproduce the bug. With this change, the bug no longer occurs. So, I think this has a decent chance of fixing the bug in production, too.