### PR TITLE
Mention the quick-selector keyboard shortcut [LOG-7]

### DIFF
--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -3,8 +3,9 @@ div
   header.flex.justify-between.p-2
     div {{currentUser.email}}
   .text-center
-    LogSelector
+    LogSelectorModal
     router-view(:key='$route.fullPath').m-8
+    footer.mb-4 Tip: Super+k will open the log selector.
 </template>
 
 <script setup lang="ts">
@@ -16,7 +17,7 @@ import { useBootstrap } from '@/lib/composables/useBootstrap';
 import { useLogsStore } from '@/logs/store';
 import { useModalStore } from '@/shared/modal/store';
 
-import LogSelector from './components/LogSelector.vue';
+import LogSelectorModal from './components/LogSelectorModal.vue';
 import type { Bootstrap, CurrentUser } from './types';
 
 const logsStore = useLogsStore();

--- a/app/javascript/logs/components/LogSelectorModal.vue
+++ b/app/javascript/logs/components/LogSelectorModal.vue
@@ -54,11 +54,11 @@ function resetQuickSelector() {
 
 useSubscription('logs:route-changed', resetQuickSelector);
 
-const showingLogSelector = computed(() => {
+const showingLogSelectorModal = computed(() => {
   return modalStore.showingModal({ modalName: 'log-selector' });
 });
 
-watch(showingLogSelector, () => {
+watch(showingLogSelectorModal, () => {
   // Wait a tick for input to render, then focus it. Autofocus only works once, so we need this.
   setTimeout(() => {
     if (logSearchInput.value) {


### PR DESCRIPTION
Also, rename LogSelector to LogSelectorModal because I think that the latter makes it more clear that this element will not be rendered by default (and I was touching template code where that fact is relevant).