### PR TITLE
[specs] Use new have_flash_message matcher in more places [DEV-49]

### DIFF
--- a/spec/controllers/question_uploads_controller_spec.rb
+++ b/spec/controllers/question_uploads_controller_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe QuestionUploadsController do
       it 'renders the new form with an error message' do
         post_create
         expect(response.body).to have_css('form textarea[name="questions"]')
-        expect(response.body).to have_text(<<~TEXT.squish)
+        expect(response.body).to have_flash_message(<<~TEXT.squish, type: :alert)
           Wrong number of correct answers for question 'Do you think that smarter people are usually
           capable of deeper love?'!
         TEXT

--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -30,7 +30,10 @@ RSpec.describe 'Logging in as an AdminUser via Google auth' do
       expect { click_on(class: 'google-login') }.not_to change { AdminUser.count }
       expect(AdminUser.find_by(email: stubbed_admin_user_email)).to eq(nil)
 
-      expect(page).to have_text("#{stubbed_admin_user_email} is not authorized to access admin")
+      expect(page).to have_flash_message(
+        "#{stubbed_admin_user_email} is not authorized to access admin",
+        type: :alert,
+      )
       expect(page).to have_current_path('/admin/login')
     end
   end

--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Check-Ins app' do
             wait_for { ActionMailer::Base.deliveries.size }.to eq(num_emails_before + 1)
           end
 
-          expect(page).to have_text('Invitation sent.')
+          expect(page).to have_flash_message('Invitation sent.', type: :notice)
 
           # add an emotional need
           click_on('Click here')

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'proposing marriage to another user' do
             wait_for { ActionMailer::Base.deliveries.size }.to eq(num_emails_before + 1)
           end
 
-          expect(page).to have_text('Invitation sent.')
+          expect(page).to have_flash_message('Invitation sent.', type: :notice)
 
           # log in proposee and accept the proposal
           Capybara.using_session('proposee') do

--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -104,7 +104,7 @@ RSpec.describe 'Quizzes app' do
 
       accept_confirm { click_on('Delete') }
 
-      expect(page).to have_text("Destroyed quiz '#{quiz_to_destroy.name}'.")
+      expect(page).to have_flash_message("Destroyed quiz '#{quiz_to_destroy.name}'.", type: :notice)
       expect(Quiz.find_by(id: quiz_to_destroy.id)).to eq(nil)
     end
   end


### PR DESCRIPTION
These are all of the places where we can use this new matcher that I saw at first glance when searching for `have_text`. I certainly might have missed some, but that's fine, if so.