### PR TITLE
Validate uniqueness of store name (per user) [GROC-17]

### DIFF
--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  index_stores_on_user_id  (user_id)
+#  index_stores_on_user_id_and_name  (user_id,name) UNIQUE
 #
 
 class Store < ApplicationRecord

--- a/app/models/store.rb
+++ b/app/models/store.rb
@@ -20,6 +20,7 @@ class Store < ApplicationRecord
   belongs_to :user
   has_many :items, dependent: :destroy
   validates :name, presence: true
+  validates :name, uniqueness: { scope: :user_id }
   validates :viewed_at, presence: true
 
   has_paper_trail

--- a/app/serializers/store_serializer.rb
+++ b/app/serializers/store_serializer.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  index_stores_on_user_id  (user_id)
+#  index_stores_on_user_id_and_name  (user_id,name) UNIQUE
 #
 
 class StoreSerializer < ApplicationSerializer

--- a/db/migrate/20240724072532_add_unique_user_id_name_index_for_stores.rb
+++ b/db/migrate/20240724072532_add_unique_user_id_name_index_for_stores.rb
@@ -1,0 +1,6 @@
+class AddUniqueUserIdNameIndexForStores < ActiveRecord::Migration[7.1]
+  def change
+    remove_index :stores, :user_id
+    add_index :stores, %i[user_id name], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2022_12_05_173107) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_24_072532) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -289,7 +289,7 @@ ActiveRecord::Schema[7.1].define(version: 2022_12_05_173107) do
     t.datetime "viewed_at", precision: nil, null: false
     t.text "notes"
     t.boolean "private", default: false, null: false
-    t.index ["user_id"], name: "index_stores_on_user_id"
+    t.index ["user_id", "name"], name: "index_stores_on_user_id_and_name", unique: true
   end
 
   create_table "text_log_entries", force: :cascade do |t|

--- a/spec/factories/stores.rb
+++ b/spec/factories/stores.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  index_stores_on_user_id  (user_id)
+#  index_stores_on_user_id_and_name  (user_id,name) UNIQUE
 #
 
 FactoryBot.define do

--- a/spec/models/store_spec.rb
+++ b/spec/models/store_spec.rb
@@ -1,0 +1,3 @@
+RSpec.describe Store do
+  it { is_expected.to validate_uniqueness_of(:name).scoped_to(:user_id) }
+end

--- a/spec/serializers/store_serializer_spec.rb
+++ b/spec/serializers/store_serializer_spec.rb
@@ -13,7 +13,7 @@
 #
 # Indexes
 #
-#  index_stores_on_user_id  (user_id)
+#  index_stores_on_user_id_and_name  (user_id,name) UNIQUE
 #
 
 RSpec.describe(StoreSerializer) do


### PR DESCRIPTION
Currently, an attempted violation of this uniqueness validation is not handled elegantly in the UX. When a user attempts to submit a duplicate store, the add-new-store button gets disabled and doesn't get re-enabled, and we give no feedback to the user about why a new store is not created. I created GROC~18 to improve the UX.