### PR TITLE
Improve store validation failure UX [GROC-18]

### DIFF
--- a/app/controllers/api/stores_controller.rb
+++ b/app/controllers/api/stores_controller.rb
@@ -30,7 +30,7 @@ class Api::StoresController < ApplicationController
     if @store.save
       render json: @store, status: :created
     else
-      render json: { errors: @store.errors.to_hash }, status: :unprocessable_entity
+      render json: { errors: @store.errors.full_messages }, status: :unprocessable_entity
     end
   end
 

--- a/app/javascript/groceries/components/Sidebar.vue
+++ b/app/javascript/groceries/components/Sidebar.vue
@@ -80,8 +80,9 @@ const { postingStore } = storeToRefs(groceriesStore);
 const expanded = computed(() => !collapsed.value);
 
 async function handleNewStoreSubmission() {
-  await groceriesStore.createStore(formData.newStoreName);
-  formData.newStoreName = '';
+  if (await groceriesStore.createStore(formData.newStoreName)) {
+    formData.newStoreName = '';
+  }
 }
 </script>
 

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -4,9 +4,9 @@ import { defineStore } from 'pinia';
 import { Bootstrap, CheckInStatus, Item, Store } from '@/groceries/types';
 import { emit } from '@/lib/event_bus';
 import * as RoutesType from '@/rails_assets/routes';
+import { http } from '@/shared/http';
 import { kyApi } from '@/shared/ky';
 import { getById, safeGetById } from '@/shared/store_helpers';
-import { http } from '@/shared/http';
 
 declare const Routes: typeof RoutesType;
 

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -88,7 +88,7 @@ export const useGroceriesStore = defineStore('groceries', {
         },
       };
 
-      const { data: newStoreData } = await http.post<Store>(
+      const newStoreData = await http.post<Store>(
         Routes.api_stores_path(),
         payload,
       );

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -6,6 +6,7 @@ import { emit } from '@/lib/event_bus';
 import * as RoutesType from '@/rails_assets/routes';
 import { kyApi } from '@/shared/ky';
 import { getById, safeGetById } from '@/shared/store_helpers';
+import { http } from '@/shared/http';
 
 declare const Routes: typeof RoutesType;
 
@@ -87,12 +88,17 @@ export const useGroceriesStore = defineStore('groceries', {
         },
       };
 
-      const newStoreData: Store = await kyApi
-        .post(Routes.api_stores_path(), { json: payload })
-        .json();
+      const { data: newStoreData } = await http.post<Store>(
+        Routes.api_stores_path(),
+        payload,
+      );
 
       this.postingStore = false;
-      this.own_stores.unshift(newStoreData);
+
+      if (newStoreData) {
+        this.own_stores.unshift(newStoreData);
+        return true;
+      }
     },
 
     decrementPendingRequests() {

--- a/app/javascript/shared/http.ts
+++ b/app/javascript/shared/http.ts
@@ -1,0 +1,28 @@
+import xior from 'xior';
+
+import { toast } from '@/lib/toast';
+import { assert } from '@/shared/helpers';
+
+const csrfMetaTag = document.querySelector('meta[name="csrf-token"]');
+const csrfToken = assert(csrfMetaTag?.getAttribute('content'));
+
+export const http = xior.create({
+  headers: {
+    'X-CSRF-Token': csrfToken,
+  },
+});
+
+http.interceptors.response.use(
+  (successfulResponse) => successfulResponse,
+  (error) => {
+    if (error?.response?.status === 422) {
+      const { errors } = error.response.data;
+
+      for (const error of errors) {
+        toast(error, { type: 'error' });
+      }
+    }
+
+    return false;
+  },
+);

--- a/app/javascript/shared/http.ts
+++ b/app/javascript/shared/http.ts
@@ -4,12 +4,17 @@ import { toast } from '@/lib/toast';
 import { assert } from '@/shared/helpers';
 
 const csrfMetaTag = document.querySelector('meta[name="csrf-token"]');
-const csrfToken = assert(csrfMetaTag?.getAttribute('content'));
+const csrfToken = csrfMetaTag?.getAttribute('content');
+
+const headers =
+  csrfToken ?
+    {
+      'X-CSRF-Token': csrfToken,
+    }
+  : {};
 
 export const http = xior.create({
-  headers: {
-    'X-CSRF-Token': csrfToken,
-  },
+  headers,
 });
 
 http.interceptors.response.use(

--- a/app/javascript/shared/http.ts
+++ b/app/javascript/shared/http.ts
@@ -12,11 +12,11 @@ const headers =
     }
   : {};
 
-export const http = xior.create({
+const xiorInstance = xior.create({
   headers,
 });
 
-http.interceptors.response.use(
+xiorInstance.interceptors.response.use(
   (successfulResponse) => successfulResponse,
   (error) => {
     if (error?.response?.status === 422) {
@@ -30,3 +30,10 @@ http.interceptors.response.use(
     return false;
   },
 );
+
+export const http = {
+  async post<T>(url: string, data: object) {
+    const response = await xiorInstance.post<T>(url, data);
+    return response.data;
+  },
+}

--- a/app/javascript/shared/http.ts
+++ b/app/javascript/shared/http.ts
@@ -36,4 +36,4 @@ export const http = {
     const response = await xiorInstance.post<T>(url, data);
     return response.data;
   },
-}
+};

--- a/app/javascript/shared/http.ts
+++ b/app/javascript/shared/http.ts
@@ -1,7 +1,6 @@
 import xior from 'xior';
 
 import { toast } from '@/lib/toast';
-import { assert } from '@/shared/helpers';
 
 const csrfMetaTag = document.querySelector('meta[name="csrf-token"]');
 const csrfToken = csrfMetaTag?.getAttribute('content');

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -13,7 +13,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'copy_to_clipboard*.js' => (2..12),
     'emoji_picker*.js' => (235..245),
     'groceries*.css' => (100..110),
-    'groceries*.js' => (405..415),
+    'groceries*.js' => (410..420),
     'home*.css' => (0..10),
     'home*.js' => (136..146),
     'logs*.css' => (95..105),

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "vue-chartjs": "^5.3.1",
     "vue-router": "^4.4.0",
     "vue-tabler-icons": "^2.21.0",
-    "when-dom-ready": "^1.2.12"
+    "when-dom-ready": "^1.2.12",
+    "xior": "^0.5.5"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       when-dom-ready:
         specifier: ^1.2.12
         version: 1.2.12
+      xior:
+        specifier: ^0.5.5
+        version: 0.5.5
     devDependencies:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.3.1
@@ -2806,6 +2809,10 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tiny-lru@11.2.11:
+    resolution: {integrity: sha512-27BIW0dIWTYYoWNnqSmoNMKe5WIbkXsc0xaCQHd3/3xT2XMuMJrzHdrO9QBFR14emBz1Bu0dOAs2sCBBrvgPQA==}
+    engines: {node: '>=12'}
+
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -2839,6 +2846,10 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
+
+  ts-deepmerge@7.0.1:
+    resolution: {integrity: sha512-JBFCmNenZdUCc+TRNCtXVM6N8y/nDQHAcpj5BlwXG/gnogjam1NunulB9ia68mnqYI446giMfpqeBFFkOleh+g==}
+    engines: {node: '>=14.13.1'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -3121,6 +3132,9 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
+
+  xior@0.5.5:
+    resolution: {integrity: sha512-tMJUiuFgfww5SHi8IhiEFoYVNA3scUqZAPUuc2dJB0yYorDM+PYR7Bqcoz07g8pa55xPuJwIDPLX0SDRhZscmg==}
 
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -6073,6 +6087,8 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tiny-lru@11.2.11: {}
+
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
@@ -6094,6 +6110,8 @@ snapshots:
   ts-api-utils@1.3.0(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
+
+  ts-deepmerge@7.0.1: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -6384,6 +6402,11 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@8.17.1: {}
+
+  xior@0.5.5:
+    dependencies:
+      tiny-lru: 11.2.11
+      ts-deepmerge: 7.0.1
 
   xml-name-validator@4.0.0: {}
 


### PR DESCRIPTION
I ended up adding a new HTTP library -- [xior](https://github.com/suhaotian/xior) -- because I think its API works out relatively well and it's relatively lightweight. I'm naming it as a generic `http` with the idea that maybe I will migrate more/all functionality to this xior implementation. Going forward, I want my current HTTP library to just be called `http`, and we can swap the implementation without needing to change any calling code.