### PR TITLE
Implement http library with ky (not xior)

### DIFF
--- a/app/javascript/shared/http.ts
+++ b/app/javascript/shared/http.ts
@@ -12,7 +12,7 @@ const hooks: Hooks = {
           toast(error, { type: 'error' });
         }
 
-        return new Response(undefined, {status: response.status});
+        return new Response(undefined, { status: response.status });
       }
     },
   ],

--- a/app/javascript/shared/http.ts
+++ b/app/javascript/shared/http.ts
@@ -1,39 +1,41 @@
-import xior from 'xior';
+import ky, { type Hooks } from 'ky';
 
 import { toast } from '@/lib/toast';
+
+const hooks: Hooks = {
+  afterResponse: [
+    async (_request, _options, response) => {
+      if (response.status === 422) {
+        const { errors } = await response.json();
+
+        for (const error of errors) {
+          toast(error, { type: 'error' });
+        }
+
+        return new Response(undefined, {status: response.status});
+      }
+    },
+  ],
+};
 
 const csrfMetaTag = document.querySelector('meta[name="csrf-token"]');
 const csrfToken = csrfMetaTag?.getAttribute('content');
 
-const headers =
-  csrfToken ?
-    {
-      'X-CSRF-Token': csrfToken,
-    }
-  : {};
+if (csrfToken) {
+  hooks['beforeRequest'] = [
+    (request) => {
+      request.headers.set('X-CSRF-Token', csrfToken);
+    },
+  ];
+}
 
-const xiorInstance = xior.create({
-  headers,
+const kyApi = ky.extend({
+  hooks,
+  throwHttpErrors: false,
 });
-
-xiorInstance.interceptors.response.use(
-  (successfulResponse) => successfulResponse,
-  (error) => {
-    if (error?.response?.status === 422) {
-      const { errors } = error.response.data;
-
-      for (const error of errors) {
-        toast(error, { type: 'error' });
-      }
-    }
-
-    return false;
-  },
-);
 
 export const http = {
   async post<T>(url: string, data: object) {
-    const response = await xiorInstance.post<T>(url, data);
-    return response.data;
+    return (await kyApi.post(url, { json: data }).json()) as T;
   },
 };

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -13,7 +13,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'copy_to_clipboard*.js' => (2..12),
     'emoji_picker*.js' => (235..245),
     'groceries*.css' => (100..110),
-    'groceries*.js' => (410..420),
+    'groceries*.js' => (403..413),
     'home*.css' => (0..10),
     'home*.js' => (136..146),
     'logs*.css' => (95..105),

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
     "vue-chartjs": "^5.3.1",
     "vue-router": "^4.4.0",
     "vue-tabler-icons": "^2.21.0",
-    "when-dom-ready": "^1.2.12",
-    "xior": "^0.5.5"
+    "when-dom-ready": "^1.2.12"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,9 +113,6 @@ importers:
       when-dom-ready:
         specifier: ^1.2.12
         version: 1.2.12
-      xior:
-        specifier: ^0.5.5
-        version: 0.5.5
     devDependencies:
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.3.1
@@ -2809,10 +2806,6 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
-  tiny-lru@11.2.11:
-    resolution: {integrity: sha512-27BIW0dIWTYYoWNnqSmoNMKe5WIbkXsc0xaCQHd3/3xT2XMuMJrzHdrO9QBFR14emBz1Bu0dOAs2sCBBrvgPQA==}
-    engines: {node: '>=12'}
-
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
     engines: {node: '>=4'}
@@ -2846,10 +2839,6 @@ packages:
     engines: {node: '>=16'}
     peerDependencies:
       typescript: '>=4.2.0'
-
-  ts-deepmerge@7.0.1:
-    resolution: {integrity: sha512-JBFCmNenZdUCc+TRNCtXVM6N8y/nDQHAcpj5BlwXG/gnogjam1NunulB9ia68mnqYI446giMfpqeBFFkOleh+g==}
-    engines: {node: '>=14.13.1'}
 
   ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
@@ -3132,9 +3121,6 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-
-  xior@0.5.5:
-    resolution: {integrity: sha512-tMJUiuFgfww5SHi8IhiEFoYVNA3scUqZAPUuc2dJB0yYorDM+PYR7Bqcoz07g8pa55xPuJwIDPLX0SDRhZscmg==}
 
   xml-name-validator@4.0.0:
     resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
@@ -6087,8 +6073,6 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
-  tiny-lru@11.2.11: {}
-
   to-fast-properties@2.0.0: {}
 
   to-regex-range@5.0.1:
@@ -6110,8 +6094,6 @@ snapshots:
   ts-api-utils@1.3.0(typescript@5.5.4):
     dependencies:
       typescript: 5.5.4
-
-  ts-deepmerge@7.0.1: {}
 
   ts-interface-checker@0.1.13: {}
 
@@ -6402,11 +6384,6 @@ snapshots:
       signal-exit: 4.1.0
 
   ws@8.17.1: {}
-
-  xior@0.5.5:
-    dependencies:
-      tiny-lru: 11.2.11
-      ts-deepmerge: 7.0.1
 
   xml-name-validator@4.0.0: {}
 


### PR DESCRIPTION
I like the xior API better, but Ky is much more popular that xior, and part of the point of wrapping the 3rd party library is so that I can provide myself with whichever API I want, and we only need to use the 3rd party library within the http.ts file, so Ky's relatively slight inferiority isn't a huge problem.