### PR TITLE
[specs/feature] Fail if any JS errors occur (and log trace) [DEV-23]

### DIFF
--- a/app/javascript/admin_packs/charts.ts
+++ b/app/javascript/admin_packs/charts.ts
@@ -3,4 +3,8 @@ import Chartkick from 'chartkick';
 
 import 'chartjs-adapter-luxon';
 
+// @ts-expect-error NOTE: Importing Chartkick seems to overwrite `window.$` with
+// Chartkick's `Chart` object, which is minified as `$`? Undo this.
+window.$ = window.jQuery;
+
 Chartkick.use(Chart);

--- a/app/javascript/home/components/HomeHero.vue
+++ b/app/javascript/home/components/HomeHero.vue
@@ -25,6 +25,8 @@ import { useHomeStore } from '@/home/store';
 
 import HomeHeader from './HomeHeader.vue';
 
+const something = window.notThere.someProperty;
+
 const homeRef = ref(null);
 const homeStore = useHomeStore();
 

--- a/app/javascript/home/components/HomeHero.vue
+++ b/app/javascript/home/components/HomeHero.vue
@@ -25,8 +25,6 @@ import { useHomeStore } from '@/home/store';
 
 import HomeHeader from './HomeHeader.vue';
 
-const something = window.notThere.someProperty;
-
 const homeRef = ref(null);
 const homeStore = useHomeStore();
 

--- a/app/javascript/logs/components/EditableTextLogRow.vue
+++ b/app/javascript/logs/components/EditableTextLogRow.vue
@@ -69,10 +69,9 @@ const html = computed((): string => {
 
 watch(editing, () => {
   setTimeout(() => {
-    if (editing.value) {
+    if (editing.value && textInput.value) {
       (
-        (textInput as unknown as typeof ElInput).$el
-          .children[0] as HTMLInputElement
+        (textInput.value as typeof ElInput).$el.children[0] as HTMLInputElement
       ).focus();
     }
   }, 0);

--- a/app/javascript/packs/quizzes.ts
+++ b/app/javascript/packs/quizzes.ts
@@ -97,15 +97,17 @@ function refresh() {
 }
 
 function addNewAnswerer(newAnswererName: string) {
-  const el = getDangerouslyById('quiz_question_answer_selections');
+  const el = document.getElementById('quiz_question_answer_selections');
 
-  const matchedLi = assert(
-    Array.from(el.querySelectorAll('li')).find(
-      (li) => li.innerText === newAnswererName,
-    ),
-  );
+  if (el) {
+    const matchedLi = assert(
+      Array.from(el.querySelectorAll('li')).find(
+        (li) => li.innerText === newAnswererName,
+      ),
+    );
 
-  matchedLi.classList.add('font-bold');
+    matchedLi.classList.add('font-bold');
+  }
 }
 
 function addNewParticipant(newParticipantName: string) {

--- a/app/javascript/shared/helpers.ts
+++ b/app/javascript/shared/helpers.ts
@@ -1,10 +1,10 @@
 export function assert<T>(value: T | undefined | null): T {
   if (typeof value === 'undefined') {
-    throw new Error('Value was undefined!');
+    throw new Error('[assert] Value was undefined!');
   }
 
   if (value === null) {
-    throw new Error('Value was null!');
+    throw new Error('[assert] Value was null!');
   }
 
   return value;

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -213,6 +213,7 @@ RSpec.configure do |config|
     activate_feature!(:disable_prerendering)
   end
 
+  # NOTE: Using `CupriteLogger.javascript_errors` like this is not thread-safe.
   config.around(:each, type: :feature) do |example|
     CupriteLogger.javascript_errors.clear
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,7 @@ Capybara.register_driver(:cuprite) do |app|
     window_size: [1200, 800],
     headless: !use_headful_chrome,
     process_timeout: 20,
+    logger: CupriteLogger.new,
   )
 end
 if is_ci
@@ -210,6 +211,14 @@ RSpec.configure do |config|
 
   config.before(:each, :prerendering_disabled) do
     activate_feature!(:disable_prerendering)
+  end
+
+  config.around(:each, type: :feature) do |example|
+    CupriteLogger.javascript_errors.clear
+
+    example.run
+
+    expect(CupriteLogger.javascript_errors).to be_empty
   end
 
   config.before(:each, :rails_env) do |example|

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -1,0 +1,36 @@
+require 'rainbow/refinement'
+
+using Rainbow
+
+class CupriteLogger
+  JSON_EXTRACTION_REGEX = /\A\s*[▶◀]\s+\d+.\d+ ({.*})\n?\z/
+  RUNTIME_EXCEPTION_THROWN = '"Runtime.exceptionThrown"'.freeze
+
+  def self.javascript_errors
+    @javascript_errors ||= []
+  end
+
+  def puts(message)
+    if message.include?(RUNTIME_EXCEPTION_THROWN) && (match = message.match(JSON_EXTRACTION_REGEX))
+      parsed_json = JSON.parse(match[1])
+      exception_preview_properties = parsed_json.dig('params', 'exceptionDetails', 'exception', 'preview', 'properties')
+      exception_message_data = exception_preview_properties.detect { _1['name'] == 'message' }
+      exception_message = exception_message_data['value']
+
+      full_stack_trace = parsed_json.dig('params', 'exceptionDetails', 'stackTrace', 'callFrames').map { _1.values_at('functionName', 'url') }
+      own_stack_trace = full_stack_trace.filter { _1[1].exclude?('/vite/@fs/') }
+
+      stack_trace = own_stack_trace.presence || full_stack_trace
+
+      formatted_stack_trace =
+        stack_trace.map do |function, url|
+          path = url.match(%r{http://.*/vite/(.+)(\?t=\d{10,})?})&.[](1)
+          "    from #{function.presence || '[anonymous function]'} in #{path || url}"
+        end
+
+      self.class.javascript_errors << exception_message
+      $stdout.puts("  JavaScript error: #{exception_message}".red)
+      $stdout.puts(formatted_stack_trace)
+    end
+  end
+end

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -12,6 +12,7 @@ class CupriteLogger
 
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics/MethodLength
   def puts(message)
     if message&.include?(RUNTIME_EXCEPTION_THROWN) && (match = message.match(JSON_EXTRACTION_REGEX))
       parsed_json = JSON.parse(match[1])
@@ -52,6 +53,7 @@ class CupriteLogger
       self.class.javascript_errors << exception_message
     end
   end
+  # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -24,7 +24,7 @@ class CupriteLogger
       exception_message =
         exception_description.
           split("\n").
-          take_while { !_1.match?(%r{at .*localhost:\d+/vite/}) }.
+          take_while { !_1.match?(%r{at .*localhost:\d+/vite(-admin)?/}) }.
           join("\n")
 
       full_stack_trace = parsed_json.dig(

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -11,8 +11,9 @@ class CupriteLogger
   end
 
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def puts(message)
-    if message.include?(RUNTIME_EXCEPTION_THROWN) && (match = message.match(JSON_EXTRACTION_REGEX))
+    if message&.include?(RUNTIME_EXCEPTION_THROWN) && (match = message.match(JSON_EXTRACTION_REGEX))
       parsed_json = JSON.parse(match[1])
       exception_preview_properties = parsed_json.dig(
         'params',
@@ -48,5 +49,6 @@ class CupriteLogger
       self.class.javascript_errors << exception_message
     end
   end
+  # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -10,6 +10,7 @@ class CupriteLogger
     @javascript_errors ||= []
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
   def puts(message)
     if message.include?(RUNTIME_EXCEPTION_THROWN) && (match = message.match(JSON_EXTRACTION_REGEX))
       parsed_json = JSON.parse(match[1])
@@ -28,9 +29,8 @@ class CupriteLogger
         'exceptionDetails',
         'stackTrace',
         'callFrames',
-      ).map {
-        _1.values_at('functionName', 'url')
-      }
+      ).map { _1.values_at('functionName', 'url') }
+
       own_stack_trace = full_stack_trace.filter { _1[1].exclude?('/vite/@fs/') }
 
       stack_trace = own_stack_trace.presence || full_stack_trace
@@ -46,4 +46,5 @@ class CupriteLogger
       $stdout.puts(formatted_stack_trace)
     end
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -3,7 +3,7 @@ require 'rainbow/refinement'
 using Rainbow
 
 class CupriteLogger
-  JSON_EXTRACTION_REGEX = /\A\s*[▶◀]\s+\d+.\d+ ({.*})\n?\z/
+  JSON_EXTRACTION_REGEX = /\A\s*[▶◀]\s+\d+\.\d+ ({.*})\n?\z/
   RUNTIME_EXCEPTION_THROWN = '"Runtime.exceptionThrown"'.freeze
 
   def self.javascript_errors

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -13,11 +13,24 @@ class CupriteLogger
   def puts(message)
     if message.include?(RUNTIME_EXCEPTION_THROWN) && (match = message.match(JSON_EXTRACTION_REGEX))
       parsed_json = JSON.parse(match[1])
-      exception_preview_properties = parsed_json.dig('params', 'exceptionDetails', 'exception', 'preview', 'properties')
+      exception_preview_properties = parsed_json.dig(
+        'params',
+        'exceptionDetails',
+        'exception',
+        'preview',
+        'properties',
+      )
       exception_message_data = exception_preview_properties.detect { _1['name'] == 'message' }
       exception_message = exception_message_data['value']
 
-      full_stack_trace = parsed_json.dig('params', 'exceptionDetails', 'stackTrace', 'callFrames').map { _1.values_at('functionName', 'url') }
+      full_stack_trace = parsed_json.dig(
+        'params',
+        'exceptionDetails',
+        'stackTrace',
+        'callFrames',
+      ).map {
+        _1.values_at('functionName', 'url')
+      }
       own_stack_trace = full_stack_trace.filter { _1[1].exclude?('/vite/@fs/') }
 
       stack_trace = own_stack_trace.presence || full_stack_trace

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -42,7 +42,8 @@ class CupriteLogger
         stack_trace.map do |function, url|
           path = url.match(%r{http://.*/vite/(.+)(\?t=\d{10,})?})&.[](1)
 
-          "    from #{function.presence || '[anonymous function]'} in #{path || url}"
+          "    from #{function.presence || '[anonymous function]'} in " \
+            "#{path ? "app/javascript/#{path}" : url}"
         end
 
       $stdout.puts("  JavaScript error: #{exception_message}".red)

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -38,6 +38,7 @@ class CupriteLogger
       formatted_stack_trace =
         stack_trace.map do |function, url|
           path = url.match(%r{http://.*/vite/(.+)(\?t=\d{10,})?})&.[](1)
+
           "    from #{function.presence || '[anonymous function]'} in #{path || url}"
         end
 

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -43,6 +43,7 @@ class CupriteLogger
         end
 
       self.class.javascript_errors << exception_message
+
       $stdout.puts("  JavaScript error: #{exception_message}".red)
       $stdout.puts(formatted_stack_trace)
     end

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -15,15 +15,17 @@ class CupriteLogger
   def puts(message)
     if message&.include?(RUNTIME_EXCEPTION_THROWN) && (match = message.match(JSON_EXTRACTION_REGEX))
       parsed_json = JSON.parse(match[1])
-      exception_preview_properties = parsed_json.dig(
+      exception_description = parsed_json.dig(
         'params',
         'exceptionDetails',
         'exception',
-        'preview',
-        'properties',
+        'description',
       )
-      exception_message_data = exception_preview_properties.detect { _1['name'] == 'message' }
-      exception_message = exception_message_data['value']
+      exception_message =
+        exception_description.
+          split("\n").
+          take_while { !_1.match?(%r{at .*localhost:\d+/vite/}) }.
+          join("\n")
 
       full_stack_trace = parsed_json.dig(
         'params',

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -42,10 +42,10 @@ class CupriteLogger
           "    from #{function.presence || '[anonymous function]'} in #{path || url}"
         end
 
-      self.class.javascript_errors << exception_message
-
       $stdout.puts("  JavaScript error: #{exception_message}".red)
       $stdout.puts(formatted_stack_trace)
+
+      self.class.javascript_errors << exception_message
     end
   end
   # rubocop:enable Metrics/CyclomaticComplexity


### PR DESCRIPTION
This will be good in two ways:
1. easier debugging when a JavaScript exception is the cause of a bug that causes a test to fail (e.g. instead of just `expected to find "David Runger" in ""`, we'll see the exception that caused the page to be blank due to a render error or whatnot)
2. it will help to avoid JavaScript exceptions creeping into production that developers and/or users might see (which are cluttering and ugly)