### PR TITLE
Don't assume that template refs exist

### DIFF
--- a/app/javascript/groceries/components/Item.vue
+++ b/app/javascript/groceries/components/Item.vue
@@ -73,7 +73,9 @@ function editItemName() {
   editingName.value = true;
   // wait a tick for input to render, then focus it
   setTimeout(() => {
-    (itemNameInput.value as unknown as HTMLInputElement).focus();
+    if (itemNameInput.value) {
+      (itemNameInput.value as HTMLInputElement).focus();
+    }
   });
 }
 

--- a/app/javascript/home/components/HomeHeader.vue
+++ b/app/javascript/home/components/HomeHeader.vue
@@ -52,7 +52,10 @@ const { homeIsVisible } = storeToRefs(homeStore);
 
 function collapseMobileMenu() {
   homeStore.menuOpen = false;
-  (menuToggleCheckbox.value as unknown as HTMLInputElement).checked = false;
+
+  if (menuToggleCheckbox.value) {
+    (menuToggleCheckbox.value as HTMLInputElement).checked = false;
+  }
 }
 </script>
 

--- a/app/javascript/logs/components/EditLogSharingSettingsModal.vue
+++ b/app/javascript/logs/components/EditLogSharingSettingsModal.vue
@@ -112,7 +112,9 @@ function savePubliclyViewableChange(newPubliclyViewableState: boolean) {
 function showInput() {
   inputVisible.value = true;
   nextTick(() => {
-    (saveTagInput.value as unknown as typeof ElInput).$refs.input.focus();
+    if (saveTagInput.value) {
+      (saveTagInput.value as typeof ElInput).$refs.input.focus();
+    }
   });
 }
 </script>

--- a/app/javascript/logs/components/NewLogEntryForm.vue
+++ b/app/javascript/logs/components/NewLogEntryForm.vue
@@ -127,7 +127,9 @@ onMounted(() => {
 
 function focusLogEntryInput() {
   setTimeout(() => {
-    (logInput.value as unknown as typeof ElInput).focus();
+    if (logInput.value) {
+      (logInput.value as typeof ElInput).focus();
+    }
   });
 }
 


### PR DESCRIPTION
I saw an error in my JS console (while working on LOG~5) about "cannot focus undefined" or whatnot. I think TypeScript was trying to warn me about this, too; this change lets us remove `as unknown`.

I think that this might reflect a race condition?, where if we try to focus the logInput, but it doesn't yet exist and only later gets rendered, then the logInput will never be automatically focused? If so, then that's not ideal, but I guess it's no worse than the current situation, where the same thing will happen, and also a JavaScript exception will be thrown. So, this is probably at least an improvement. This conditional also, I think, more explicitly suggests that potential issue, which is also probably a good thing. Maybe we'll fix it, in the future (if, indeed, it's a real risk).