### PR TITLE
Broadcast LogEntry creation (etc) via JsonBroadcastable (not manual)

### DIFF
--- a/app/actions/log_entries/save.rb
+++ b/app/actions/log_entries/save.rb
@@ -3,6 +3,5 @@ class LogEntries::Save < ApplicationAction
 
   def execute
     log_entry.save!
-    LogEntriesChannel.broadcast_to(log_entry.log, LogEntrySerializer.new(log_entry).as_json)
   end
 end

--- a/app/controllers/api/log_entries_controller.rb
+++ b/app/controllers/api/log_entries_controller.rb
@@ -3,6 +3,8 @@ class Api::LogEntriesController < ApplicationController
     authorize(LogEntry)
     log = (current_user || auth_token_user).logs.find(params.dig(:log_entry, :log_id))
     @log_entry = log.log_entries.build(log_entry_params)
+    @log_entry.acting_browser_uuid = cookies[:browser_uuid]
+
     if @log_entry.valid?
       LogEntries::Save.run!(log_entry: @log_entry)
       render json: @log_entry, status: :created

--- a/app/javascript/logs/types.ts
+++ b/app/javascript/logs/types.ts
@@ -1,3 +1,5 @@
+import { JsonBroadcast } from '@/shared/types';
+
 export type LogEntryDataValue = string | number;
 export type LogDataType = 'counter' | 'duration' | 'number' | 'text';
 
@@ -51,3 +53,7 @@ export type Bootstrap = {
   log_input_types: Array<LogInputType>;
   toast_messages: Array<string>;
 };
+
+export interface LogEntryBroadcast extends JsonBroadcast {
+  model: LogEntry;
+}

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -14,10 +14,14 @@
 #
 
 class LogEntry < ApplicationRecord
+  include JsonBroadcastable
+
   belongs_to :log
   has_one :user, through: :log
 
   validates :data, presence: true
+
+  broadcasts_json_to(LogEntriesChannel, ->(log_entry) { log_entry.log })
 
   def self.policy_class
     LogEntryPolicy

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -137,7 +137,9 @@ RSpec.describe 'Logs app' do
           and_return(Time.current)
         LogEntriesChannel.broadcast_to(
           log_entry.log,
-          LogEntrySerializer.new(log_entry).as_json.merge(
+          acting_browser_uuid: SecureRandom.uuid,
+          action: 'created',
+          model: LogEntrySerializer.new(log_entry).as_json.merge(
             id: LogEntries::TextLogEntry.maximum(:id) + 1,
           ),
         )

--- a/spec/mailboxes/log_entries_mailbox_spec.rb
+++ b/spec/mailboxes/log_entries_mailbox_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe LogEntriesMailbox do
     it 'broadcasts the creation of the new log entry', :action_cable_test_adapter do
       expect { processed_mail }.
         to broadcast_to(LogEntriesChannel.broadcasting_for(log)).
-        with(hash_including(data: Float(body)))
+        with(hash_including(model: hash_including(data: Float(body))))
     end
   end
 end


### PR DESCRIPTION
Motivation: This better standardizes and also automates the process of broadcasting log entry related events, which should make LOG~5 easier.