### PR TITLE
Lazy-load offscreen images [HOME-3]

### DIFF
--- a/app/javascript/home/components/About.vue
+++ b/app/javascript/home/components/About.vue
@@ -5,6 +5,7 @@ HomeSection(section='about', title='About me', :renderHeadingManually='true')
       .flex-2.mt-4
         .text-center.mt-4.mb-8
           img.about-image.box-shadow(
+            loading='lazy'
             src='~img/david.webp'
             alt='A picture of me'
           )

--- a/app/javascript/home/components/Projects.vue
+++ b/app/javascript/home/components/Projects.vue
@@ -175,6 +175,7 @@ HomeSection(section='projects' title='Projects')
         a(href='https://github.com/davidrunger/serpent') GitHub
     template(v-slot:image)
       img.box-shadow(
+        loading='lazy'
         src='~img/serpent.webp'
         alt='Serpent Game'
       )
@@ -208,6 +209,7 @@ HomeSection(section='projects' title='Projects')
         a(href='https://github.com/davidrunger/simple_cov-formatter-terminal') GitHub
     template(v-slot:image)
       img(
+        loading='lazy'
         src='~img/simplecov-terminal.webp'
         alt='SimpleCov::Formatter::Terminal'
       )
@@ -243,6 +245,7 @@ HomeSection(section='projects' title='Projects')
         a(href='https://github.com/davidrunger/skedjewel') GitHub
     template(v-slot:image)
       img.box-shadow(
+        loading='lazy'
         src='~img/skedjewel.webp'
         alt='skedjewel.yml'
       )


### PR DESCRIPTION
This is easy to do by simply using browsers' native `loading='lazy'` attribute for the `img`s.

I this change, we're adding this attribute to four images. Chrome suggested three of them, but I also decided to add it to `david.jpg`, as well, even though Chrome did not suggest that (I'm guessing because Chrome is not going to lazy-load it, anyway, since it's near enough to the top of the page).

NOTE: Due to a Firefox bug, the `loading` attribute must come _before_ the `src` attribute. https://stackoverflow.com/a/76252772/4009384 / https://bugzilla.mozilla.org/show_bug.cgi?id=1647077 .