### PR TITLE
Include acting_browser_uuid automatically in cable messages [DEV-53]

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -14,7 +14,6 @@ class Api::ItemsController < ApplicationController
 
   def update
     authorize(@item)
-    @item.acting_browser_uuid = cookies[:browser_uuid]
     if @item.update(item_params)
       render json: @item
     else

--- a/app/controllers/api/log_entries_controller.rb
+++ b/app/controllers/api/log_entries_controller.rb
@@ -3,7 +3,6 @@ class Api::LogEntriesController < ApplicationController
     authorize(LogEntry)
     log = (current_user || auth_token_user).logs.find(params.dig(:log_entry, :log_id))
     @log_entry = log.log_entries.build(log_entry_params)
-    @log_entry.acting_browser_uuid = cookies[:browser_uuid]
 
     if @log_entry.valid?
       LogEntries::Save.run!(log_entry: @log_entry)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -64,6 +64,7 @@ class ApplicationController < ActionController::Base
   def set_browser_uuid
     # NOTE: This cookie cannot be HTTP-only because we read it in JavaScript code.
     cookies[:browser_uuid] ||= SecureRandom.uuid
+    Current.browser_uuid = cookies[:browser_uuid]
   end
 
   def _render_with_renderer_json(resource, options)

--- a/app/models/concerns/json_broadcastable.rb
+++ b/app/models/concerns/json_broadcastable.rb
@@ -1,10 +1,6 @@
 module JsonBroadcastable
   extend ActiveSupport::Concern
 
-  included do
-    attr_accessor :acting_browser_uuid
-  end
-
   module ClassMethods
     def broadcasts_json_to(channel, channel_target_proc)
       after_create_commit(
@@ -30,7 +26,7 @@ module JsonBroadcastable
     channel.broadcast_to(
       channel_target,
       action:,
-      acting_browser_uuid:,
+      acting_browser_uuid: Current.browser_uuid,
       model: as_json,
     )
   end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,3 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :browser_uuid
+end


### PR DESCRIPTION
... that are sent via JsonBroadcastable. This is accomplished using the ActiveSupport::CurrentAttributes class, which I generally don't love the concept of, but I think that this is a pretty good use case.