### PR TITLE
[database.yml] Don't specify username in dev, use ENV['USER'] in test

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -31,7 +31,7 @@ development:
   # To create additional roles in postgres see `$ createuser --help`.
   # When left blank, postgres will use the default role. This is
   # the same name as the operating system user that initialized the database.
-  username: david_runger
+  # username: david_runger
 
   # The password associated with the postgres role (username).
   #password:
@@ -61,7 +61,7 @@ test:
   <<: *default
   database: david_runger_test<%= ENV['DB_SUFFIX'] %>
   host: <%= ENV.fetch('POSTGRES_HOST', 'localhost') %>
-  username: <%= ENV.key?('CI') ? ENV['POSTGRES_USER'] : 'david_runger' %>
+  username: <%= ENV.key?('CI') ? ENV['POSTGRES_USER'] : ENV['USER'] %>
   password: <%= ENV['PGPASSWORD'] || '' %>
 
 # As with config/secrets.yml, you never want to store sensitive information,


### PR DESCRIPTION
This makes it easier to initialize a database locally, when a `david_runger` Postgres role doesn't exist (and we don't want to create one).