### PR TITLE
Close modal when (re)selecting current log [LOG-20]

### DIFF
--- a/app/javascript/logs/components/LogSelectorModal.vue
+++ b/app/javascript/logs/components/LogSelectorModal.vue
@@ -73,6 +73,7 @@ function selectHighlightedLog() {
 
 function selectLog(log: Log) {
   router.push({ name: 'log', params: { slug: log.slug } });
+  resetQuickSelector();
 }
 </script>
 


### PR DESCRIPTION
We had been relying upon `useSubscription('logs:route-changed', resetQuickSelector)` (which is elsewhere in this file), but that doesn't do anything when selecting the current log, since the route doesn't change. By putting `resetQuickSelector()` in `selectLog`, we'll avoid that issue, i.e. we'll close and reset the quick selector even when the user reselects the current log. We might now be double resetting the quick selector sometimes, but I think that's fine. I do think we want to keep the `useSubscription('logs:route-changed', resetQuickSelector)` listener, because only that listener will be triggered if the user clicks a log with their mouse (vs this `selectLog` function, which is triggered by hitting the Enter key on the keyboard).