### PR TITLE
Increase deployment timeout from 10 to 15 minutes

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -99,7 +99,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: test
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Clone repo
         uses: actions/checkout@v4


### PR DESCRIPTION
Today, a [deployment][1] took 8m 54s, which is a bit too close to 10 minutes for my comfort.

We [recently][2] switched to deploying using a Dockerfile. I think that this will result in builds that are often faster. However, I think that the first build of each day (after the scheduled nightly Docker image pruning has been done) will be relatively slow, because none of the steps will be cached.

[1]: https://github.com/davidrunger/david_runger/actions/runs/10164795333/job/28111231088 [2]: https://github.com/davidrunger/david_runger/pull/4741