### PR TITLE
Remove deployment from GitHub Actions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -94,33 +94,3 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
-  deploy-and-prerender:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
-    needs: test
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Clone repo
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Deploy to Dokku
-        uses: dokku/github-action@master
-        with:
-          git_push_flags: --force -vvv
-          git_remote_url: 'ssh://dokku@198.199.122.6:22/davidrunger'
-          ssh_private_key: ${{secrets.SSH_PRIVATE_KEY}}
-
-      - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          bundler-cache: true
-
-      - name: Prerender page(s) and upload them to S3
-        run: bin/prerender
-        env:
-          CI: true
-          AWS_ACCESS_KEY_ID: '${{secrets.AWS_ACCESS_KEY_ID}}'
-          AWS_SECRET_ACCESS_KEY: '${{secrets.AWS_SECRET_ACCESS_KEY}}'


### PR DESCRIPTION
I think I am going to move to a new box for deployment, so let's stop deploying to the Dokku image for now.