### PR TITLE
Add frontend assets directories to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,9 @@ docs
 log
 node_modules
 personal
+public/assets
+public/vite
+public/vite-admin
 spec
 tmp
 !tmp/cache/bootsnap


### PR DESCRIPTION
Previously, I would execute `rm -rf ...` on my host machine to ensure that these assets weren't being copied from my host machine to the image being built. Instead, let's guarantee that these assets are not copied (and simplify the build command/process) by adding them to the `.dockerignore`.