### PR TITLE
Rework docker secrets management to use .env.production.local

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .env*
+!.env.production.local
 .git
 .github
 .ruby-lsp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # ENV secrets
-.env.development.local
+.env.*.local
 
 # Gems
 /.bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,14 +55,11 @@ RUN bundle exec bootsnap precompile --gemfile
 COPY . .
 
 ARG GIT_REV
-ARG RAILS_MASTER_KEY
-
-ENV GIT_REV=${GIT_REV} \
-  RAILS_MASTER_KEY=${RAILS_MASTER_KEY} \
-  DOCKER_BUILD="true"
 
 # Build public/assets/, download public/vite/ and public/vite-admin/, and download skedjewel.
-RUN VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true \
+RUN DOCKER_BUILD=true \
+  GIT_REV=${GIT_REV} \
+  VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true \
   bundle exec rails assets:precompile
 
 # Precompile bootsnap code for faster boot times

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'connection_pool'
 gem 'csv'
 gem 'dalli'
 gem 'devise'
+gem 'dotenv'
 gem 'draper'
 gem 'faraday'
 gem 'faraday-multipart'
@@ -58,7 +59,6 @@ group :development, :test do
   gem 'amazing_print'
   gem 'annotate', require: false
   gem 'bullet'
-  gem 'dotenv'
   gem 'immigrant'
   gem 'isolator'
   gem 'pry-byebug', require: false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       redis:
         condition: service_healthy
     env_file:
-      - .env.development.local
+      - .env.production.local
     environment:
       DATABASE_URL: postgres://david_runger:@postgres:5432/david_runger_production
       MEMCACHED_PASSWORD: ''


### PR DESCRIPTION
This simplifies the build process. I think that simply managing secrets in a `.env.production.local` file on my production server will be a pretty easy way to manage production secrets.