### PR TITLE
[nginx] Don't try to load mime types

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -26,7 +26,7 @@ http {
     client_max_body_size   16M;
 
     # MIME
-    include                mime.types;
+    # include                mime.types;
     default_type           application/octet-stream;
 
     # Logging


### PR DESCRIPTION
It seems that they aren't available on our image:

> nginx: [emerg] open() "/etc/nginx/mime.types" failed (2: No such file > or directory) in /etc/nginx/nginx.conf:29