### PR TITLE
[bootstrap-letsencrypt] Use '-r' option correctly in read command

### DIFF
--- a/bin/ssl/bootstrap-letsencrypt.sh
+++ b/bin/ssl/bootstrap-letsencrypt.sh
@@ -12,7 +12,7 @@ email="davidjrunger@gmail.com" # Adding a valid address is strongly recommended
 staging=1 # Set to 1 if you're testing your setup to avoid hitting request limits
 
 if [ -d "$data_path" ]; then
-  read -pr "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
+  read -r -p "Existing data found for $domains. Continue and replace existing certificate? (y/N) " decision
   if [ "$decision" != "Y" ] && [ "$decision" != "y" ]; then
     exit
   fi


### PR DESCRIPTION
The `-p` option is for "prompt" and needs to be followed by the prompt, so the `-p` and `-r` flags should not be combined, as I had been doing before.