### PR TITLE
[bootstrap-letsencrypt] Use --test-cert for staging (not --staging)

### DIFF
--- a/bin/ssl/bootstrap-letsencrypt.sh
+++ b/bin/ssl/bootstrap-letsencrypt.sh
@@ -64,7 +64,7 @@ case "$email" in
 esac
 
 # Enable staging mode if needed
-if [ $staging != "0" ]; then staging_arg="--staging"; fi
+if [ $staging != "0" ]; then staging_arg="--test-cert"; fi
 
 docker compose run --rm --entrypoint "\
   certbot certonly --webroot -w /var/www/_letsencrypt \


### PR DESCRIPTION
https://letsencrypt.org/docs/staging-environment/ :

> If you’re using Certbot, you can use our staging environment with the `--test-cert` or `--dry-run` flag.