### PR TITLE
[davidrunger.com.conf] Use variable to set rails container proxy_pass

### DIFF
--- a/config/nginx/sites-enabled/davidrunger.com.conf
+++ b/config/nginx/sites-enabled/davidrunger.com.conf
@@ -18,7 +18,8 @@ server {
 
     # reverse proxy
     location / {
-        proxy_pass            http://127.0.0.1:3000;
+        set $rails_container  "rails:3000";
+        proxy_pass            http://$rails_container;
         proxy_set_header Host $host;
         include               nginxconfig.io/proxy.conf;
     }


### PR DESCRIPTION
It doesn't seem to work when this is inlined (`proxy_pass http://rails:3000;`), but using a variable like this does seem to work.