### PR TITLE
[docker-compose] Split 'rails' service into 'web', 'worker', 'clock'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,14 @@ services:
   clock:
     <<: *default-rails-config
     command: ['bin/skedjewel']
+    depends_on:
+      initialize_database:
+        condition: service_completed_successfully
+      worker:
+        condition: service_started
+  initialize_database:
+    <<: *default-rails-config
+    command: ['bin/docker-entrypoint']
   memcached:
     healthcheck:
       # https://github.com/docker-library/memcached/issues/ 91#issuecomment-1733748674
@@ -41,6 +49,11 @@ services:
       - internal
   nginx:
     command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
+    depends_on:
+      certbot:
+        condition: service_started
+      web:
+        condition: service_started
     image: nginx:1.27.0-alpine
     networks:
       - external
@@ -81,11 +94,17 @@ services:
   web:
     <<: *default-rails-config
     command: ['bin/rails', 'server']
+    depends_on:
+      initialize_database:
+        condition: service_completed_successfully
     expose:
       - '3000'
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']
+    depends_on:
+      initialize_database:
+        condition: service_completed_successfully
 
 networks:
   external:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,24 @@
+x-rails-config: &default-rails-config
+  build:
+    context: .
+  depends_on:
+    memcached:
+      condition: service_healthy
+    postgres:
+      condition: service_healthy
+    redis:
+      condition: service_healthy
+  env_file:
+    - .env.production.local
+  environment:
+    DATABASE_URL: postgres://david_runger:@postgres:5432/david_runger_production
+    MEMCACHED_PASSWORD: ''
+    MEMCACHED_URL: memcached://memcached:11211
+    RAILS_ENV: production
+    REDIS_URL: redis://redis:6379
+  networks:
+    - internal
+
 services:
   certbot:
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
@@ -5,6 +26,9 @@ services:
     volumes:
       - ./ssl-data/certbot/conf:/etc/letsencrypt
       - ./ssl-data/certbot/www:/var/www/_letsencrypt
+  clock:
+    <<: *default-rails-config
+    command: ["bin/skedjewel"]
   memcached:
     healthcheck:
       # https://github.com/docker-library/memcached/issues/ 91#issuecomment-1733748674
@@ -42,27 +66,6 @@ services:
     environment:
       POSTGRES_USER: david_runger
       POSTGRES_HOST_AUTH_METHOD: trust
-  rails:
-    build:
-      context: .
-    depends_on:
-      memcached:
-        condition: service_healthy
-      postgres:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-    env_file:
-      - .env.production.local
-    environment:
-      DATABASE_URL: postgres://david_runger:@postgres:5432/david_runger_production
-      MEMCACHED_PASSWORD: ''
-      MEMCACHED_URL: memcached://memcached:11211
-      POSTGRES_HOST: postgres
-      RAILS_ENV: production
-      REDIS_URL: redis://redis:6379
-    networks:
-      - internal
   redis:
     command: redis-server
     healthcheck:
@@ -75,6 +78,14 @@ services:
       - internal
     volumes:
       - redis:/data
+  web:
+    <<: *default-rails-config
+    command: ["bin/rails", "server"]
+    expose:
+      - "3000"
+  worker:
+    <<: *default-rails-config
+    command: ["bin/sidekiq"]
 
 networks:
   external:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - ./ssl-data/certbot/www:/var/www/_letsencrypt
   clock:
     <<: *default-rails-config
-    command: ["bin/skedjewel"]
+    command: ['bin/skedjewel']
   memcached:
     healthcheck:
       # https://github.com/docker-library/memcached/issues/ 91#issuecomment-1733748674
@@ -80,12 +80,12 @@ services:
       - redis:/data
   web:
     <<: *default-rails-config
-    command: ["bin/rails", "server"]
+    command: ['bin/rails', 'server']
     expose:
-      - "3000"
+      - '3000'
   worker:
     <<: *default-rails-config
-    command: ["bin/sidekiq"]
+    command: ['bin/sidekiq']
 
 networks:
   external:


### PR DESCRIPTION
This should make it easier to boot all needed services/containers/processes by just doing `docker compose up
--detach`.