### PR TITLE
[docker-compose/postgres] Remove user from pg_isready healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       - ./ssl-data/certbot/www:/var/www/_letsencrypt
   postgres:
     healthcheck:
-      test: ['CMD', 'pg_isready', '-U', 'postgres']
+      test: ['CMD', 'pg_isready']
       interval: 2s
       timeout: 1s
       retries: 10


### PR DESCRIPTION
Even if the specified user doesn't exist (which, in our database, a `postgres` user indeed does not exist) the command still exits with 0 (making the user part not really meaningful/useful), and yet the nonexistence of the user does cause a log line to be written in the postgres server logs, which is not great, because I guess that these healthchecks are performed continuously at pretty frequent intervals, so this was generating a lot of log lines about a postgres user not existing.