### PR TITLE
[docker-entrypoint] Only prepare database if it doesn't already exist

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,6 +2,11 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-bin/rails db:prepare
+if ! ( psql -U david_runger -h postgres -XtAc \
+  "SELECT 1 FROM pg_database WHERE datname='david_runger_production'" | \
+  grep -q 1
+) ; then
+  bin/rails db:prepare
+fi
 
 exec "${@}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
         condition: service_started
   initialize_database:
     <<: *default-rails-config
-    command: ['bin/docker-entrypoint']
   memcached:
     healthcheck:
       # https://github.com/docker-library/memcached/issues/ 91#issuecomment-1733748674


### PR DESCRIPTION
This should save a significant amount of time when booting services that depend upon the initialize_database service.

Also, remove `command` option from `initialize_database` service, because this was causing `docker-entrypoint` to run twice (once because of that `command`, and once because it's the `ENTRYPOINT` in the Dockerfile`).