### PR TITLE
[docker-compose/postgres] Use david_runger user for healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       - ./ssl-data/certbot/www:/var/www/_letsencrypt
   postgres:
     healthcheck:
-      test: ['CMD', 'pg_isready']
+      test: ['CMD', 'pg_isready', '-U', 'david_runger']
       interval: 2s
       timeout: 1s
       retries: 10


### PR DESCRIPTION
Otherwise, I think we'll try to use a `root` user, which might not exist. But I think a `david_runger` user will hopefully exist, nice we have `POSTGRES_USER: david_runger` under `environment` for our `postgres` service.