### PR TITLE
[docker-compose] Add most Rails services to the external network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,13 +16,13 @@ x-rails-config: &default-rails-config
     MEMCACHED_URL: memcached://memcached:11211
     RAILS_ENV: production
     REDIS_URL: redis://redis:6379
-  networks:
-    - internal
 
 services:
   certbot:
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
     image: certbot/certbot
+    networks:
+      - external
     volumes:
       - ./ssl-data/certbot/conf:/etc/letsencrypt
       - ./ssl-data/certbot/www:/var/www/_letsencrypt
@@ -34,8 +34,12 @@ services:
         condition: service_completed_successfully
       worker:
         condition: service_started
+    networks:
+    - internal
   initialize_database:
     <<: *default-rails-config
+    networks:
+    - internal
   memcached:
     healthcheck:
       # https://github.com/docker-library/memcached/issues/ 91#issuecomment-1733748674
@@ -98,12 +102,18 @@ services:
         condition: service_completed_successfully
     expose:
       - '3000'
+    networks:
+    - external
+    - internal
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']
     depends_on:
       initialize_database:
         condition: service_completed_successfully
+    networks:
+    - external
+    - internal
 
 networks:
   external:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,11 +35,11 @@ services:
       worker:
         condition: service_started
     networks:
-    - internal
+      - internal
   initialize_database:
     <<: *default-rails-config
     networks:
-    - internal
+      - internal
   memcached:
     healthcheck:
       # https://github.com/docker-library/memcached/issues/ 91#issuecomment-1733748674
@@ -103,8 +103,8 @@ services:
     expose:
       - '3000'
     networks:
-    - external
-    - internal
+      - external
+      - internal
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']
@@ -112,8 +112,8 @@ services:
       initialize_database:
         condition: service_completed_successfully
     networks:
-    - external
-    - internal
+      - external
+      - internal
 
 networks:
   external:


### PR DESCRIPTION
When a service is only part of the internal network, I think that it cannot even access the outside Internet. We do want that behavior for some services (i.e. our databases, which have no need to communicate with the Internet), but most of our Rails services need to be able to communicate out (e.g. to download assets from S3 or to send errors to Rollbar). I think that `clock` does not need access to the external Internet, though, so I'm just putting that Rails service on the `internal` network only.

The services that we are adding in this change to the `external` network still should not have their ports exposed to the external internet, since we aren't using a `--ports` CLI flag or a `ports` option in `docker-compose.yml` (except for `nginx`, which we do want/need to expose to the external Internet).