### PR TITLE
[docker-compose] Put all rails services on the external network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,9 @@ x-rails-config: &default-rails-config
     MEMCACHED_URL: memcached://memcached:11211
     RAILS_ENV: production
     REDIS_URL: redis://redis:6379
+  networks:
+    - external
+    - internal
 
 services:
   certbot:
@@ -34,12 +37,8 @@ services:
         condition: service_completed_successfully
       worker:
         condition: service_started
-    networks:
-      - internal
   initialize_database:
     <<: *default-rails-config
-    networks:
-      - internal
   memcached:
     healthcheck:
       # https://github.com/docker-library/memcached/issues/ 91#issuecomment-1733748674
@@ -102,18 +101,12 @@ services:
         condition: service_completed_successfully
     expose:
       - '3000'
-    networks:
-      - external
-      - internal
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']
     depends_on:
       initialize_database:
         condition: service_completed_successfully
-    networks:
-      - external
-      - internal
 
 networks:
   external:


### PR DESCRIPTION
Although they don't all need to be on the external network during their operation, they do all need to be on the external network during their builds, to download our compiled assets from S3 and to download skedjewel.