### PR TITLE
[nginx/davidrunger] Refer to 'web' (not 'rails') and use Docker DNS

### DIFF
--- a/config/nginx/sites-enabled/davidrunger.com.conf
+++ b/config/nginx/sites-enabled/davidrunger.com.conf
@@ -18,8 +18,10 @@ server {
 
     # reverse proxy
     location / {
-        set $rails_container  "rails:3000";
-        proxy_pass            http://$rails_container;
+        # Use Docker's embedded DNS to resolve container names
+        resolver              127.0.0.11;
+        set $david_runger_web "web:3000";
+        proxy_pass            http://$david_runger_web;
         proxy_set_header Host $host;
         include               nginxconfig.io/proxy.conf;
     }


### PR DESCRIPTION
For one thing, we split `rails` into `web` and other services, so that needs to be updated. Also, use the Docker DNS resolver (`127.0.0.11`) to make this work and/or to lay the groundwork for zero downtime rolling deploys.