### PR TITLE
Cancel in-progress tests already running on branch if new tests start

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   test:
+    concurrency:
+      cancel-in-progress: true
+      group: test-${{ github.ref_name }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     services:


### PR DESCRIPTION
I usually do this manually on `main`, anyway, after merging a bunch of PRs in a short period of time, and I also try to do this on a branch after I push up a new change while tests are running. This will now do it automatically for me! :)