### PR TITLE
[production.rb] Always force SSL and assume SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -56,10 +56,10 @@ Rails.application.configure do
 
   # Assume all access to the app is happening through a SSL-terminating reverse proxy.
   # Can be used together with config.force_ssl for Strict-Transport-Security and secure cookies.
-  config.assume_ssl = ENV.key?('DOKKU_PROXY_SSL_PORT')
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  config.force_ssl = ENV.key?('DOKKU_PROXY_SSL_PORT')
+  config.force_ssl = true
 
   # Log to STDOUT by default
   config.logger = ActiveSupport::Logger.new(STDOUT).


### PR DESCRIPTION
In #4741, we changed this to only force SSL and assume SSL if `DOKKU_PROXY_SSL_PORT` was present in the environment. This allowed testing the app via Docker locally without using HTTPS (by not setting `DOKKU_PROXY_SSL_PORT`).

However, currently, it's no longer possible to test the app locally with Docker, anyway, because our NGINX setup (which sits in front of the Rails server) forces SSL before the request even gets to Rails.

Maybe at some point in the future I'll figure out how to make the app runnable again via Docker locally, but, for now, let's just go back to hardcoding these values as true.