### PR TITLE
[deploy] Run 'git reset --hard origin/main' after checking out main

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -27,5 +27,6 @@ docker compose down "${services_to_restart[@]}"
 # Launch new Rails services.
 docker compose up --detach "${services_to_restart[@]}"
 
-# Check out main branch.
+# Check out and update main branch.
 git checkout main
+git reset --hard origin/main


### PR DESCRIPTION
This will ensure that `main` is up to date on the server and will avoid annoying log messages about the main branch being behind origin/main.