### PR TITLE
[routes] Specify Content-Type text/plain for routes responses

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -108,10 +108,25 @@ Rails.application.routes.draw do
   # Google periodically re-verifies this route, so we need to leave it here indefinitely
   get(
     'google83c07e1014ea4a70',
-    to: ->(_env) { [200, {}, ['google-site-verification: google83c07e1014ea4a70.html']] },
+    to: ->(_env) do
+      [
+        200,
+        { 'Content-Type' => 'text/plain' },
+        ['google-site-verification: google83c07e1014ea4a70.html'],
+      ]
+    end,
   )
 
-  get('sha', to: ->(_env) { [200, {}, [ENV.fetch('GIT_REV').first(8)]] })
+  get(
+    'sha',
+    to: ->(_env) do
+      [
+        200,
+        { 'Content-Type' => 'text/plain' },
+        [ENV.fetch('GIT_REV')],
+      ]
+    end,
+  )
 
   get '/404', to: 'errors#not_found', via: :all
   get '/422', to: 'errors#unacceptable', via: :all

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -105,28 +105,17 @@ Rails.application.routes.draw do
     mount Flipper::UI.app(Flipper) => '/flipper'
   end
 
+  def plain_text_response(text)
+    [200, { 'Content-Type' => 'text/plain' }, [text]]
+  end
+
   # Google periodically re-verifies this route, so we need to leave it here indefinitely
   get(
     'google83c07e1014ea4a70',
-    to: ->(_env) do
-      [
-        200,
-        { 'Content-Type' => 'text/plain' },
-        ['google-site-verification: google83c07e1014ea4a70.html'],
-      ]
-    end,
+    to: ->(_env) { plain_text_response('google-site-verification: google83c07e1014ea4a70.html') },
   )
 
-  get(
-    'sha',
-    to: ->(_env) do
-      [
-        200,
-        { 'Content-Type' => 'text/plain' },
-        [ENV.fetch('GIT_REV')],
-      ]
-    end,
-  )
+  get('sha', to: ->(_env) { plain_text_response(ENV.fetch('GIT_REV')) })
 
   get '/404', to: 'errors#not_found', via: :all
   get '/422', to: 'errors#unacceptable', via: :all

--- a/spec/features/git_sha_spec.rb
+++ b/spec/features/git_sha_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe 'Git SHA endpoint', :rack_test_driver do
 
     let(:git_sha) { 'b18d253eab03e0eb8d7f7dc995ececd326ad9fd5' }
 
-    it 'renders the first 8 characters of the Git SHA' do
+    it 'renders the full Git SHA' do
       visit_git_sha_path
 
-      expect(page.text).to eq(git_sha.first(8))
+      expect(page.text).to eq(git_sha)
     end
   end
 end


### PR DESCRIPTION
Currently, when going to `/google83c07e1014ea4a70` or `/sha`, my browser downloads the content. I think that this is because of the `add_header X-Content-Type-Options "nosniff" always;` option in our NGINX config. I think that adding this Content-Type header will allow the browser to display the content directly in the browser, as it would do before, and as we want.

Also, show the whole git SHA, rather than just the first 8 characters. The git SHAs are all available on the public GitHub, anyway, and I think being able to see the full SHA is nice.