### PR TITLE
Add 'Content-Disposition: inline' header for routes responses

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -106,7 +106,7 @@ Rails.application.routes.draw do
   end
 
   def plain_text_response(text)
-    [200, { 'Content-Type' => 'text/plain' }, [text]]
+    [200, { 'Content-Disposition' => 'inline', 'Content-Type' => 'text/plain' }, [text]]
   end
 
   # Google periodically re-verifies this route, so we need to leave it here indefinitely


### PR DESCRIPTION
Relevant prior work: #4784

After that PR, `/sha` now displays for me in-browser, but `/google83c07e1014ea4a70` still does not. Rather, it downloads as a file. Hopefully this change will cause both to display in the browser.