### PR TITLE
[docker-compose] Add 'POSTGRES_INITDB_ARGS: --auth=scram-sha-256'

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,6 +68,8 @@ services:
       - ./ssl-data/certbot/conf:/etc/letsencrypt
       - ./ssl-data/certbot/www:/var/www/_letsencrypt
   postgres:
+    env_file:
+      - .env.postgres.local
     healthcheck:
       test: ['CMD', 'pg_isready', '-U', 'david_runger']
       interval: 2s
@@ -79,6 +81,7 @@ services:
     volumes:
       - postgresql:/var/lib/postgresql/data
     environment:
+      POSTGRES_INITDB_ARGS: --auth=scram-sha-256
       POSTGRES_USER: david_runger
   redis:
     command: redis-server


### PR DESCRIPTION
This should initialize the database in such a way as to require a password to connect to the database (even from the same machine).

Also, use a `.env.postgres.local` file to store the Postgres password.