### PR TITLE
[docker-compose/rails] Delete DATABASE_URL env var

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ x-rails-config: &default-rails-config
   env_file:
     - .env.production.local
   environment:
-    DATABASE_URL: postgres://david_runger:@postgres:5432/david_runger_production
     MEMCACHED_PASSWORD: ''
     MEMCACHED_URL: memcached://memcached:11211
     RAILS_ENV: production


### PR DESCRIPTION
Instead, we now supply a DATABASE_URL that includes a password via `.env.production.local`. Having this `DATABASE_URL` in `environment` for the Rails config is problematic because it overrides the value from the `.env.production.local` file.