### PR TITLE
Use $DATABASE_URL for psql command to check if DB already exists

### DIFF
--- a/bin/docker-entrypoint
+++ b/bin/docker-entrypoint
@@ -2,7 +2,7 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-if ! ( psql -U david_runger -h postgres -XtAc \
+if ! ( psql "$DATABASE_URL" -XtAc \
   "SELECT 1 FROM pg_database WHERE datname='david_runger_production'" | \
   grep -q 1
 ) ; then


### PR DESCRIPTION
We need this now that we have password authentication required on the database. The DATABASE_URL includes the password.