### PR TITLE
Don't use rails runner trick to execute release-tasks script

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -23,7 +23,7 @@ docker compose build \
 docker compose up --detach clock nginx web worker
 
 # Run release tasks.
-docker compose exec web bin/server/release-tasks
+docker compose exec web bin/rails runner bin/server/release-tasks.rb
 
 # Check out and update main branch.
 git checkout main

--- a/bin/server/release-tasks.rb
+++ b/bin/server/release-tasks.rb
@@ -1,10 +1,5 @@
 #!/usr/bin/env ruby
 
-# https://stackoverflow.com/a/77655338/4009384
-if !defined?(Rails)
-  exec('bin/rails', 'runner', __FILE__, *ARGV)
-end
-
 class Runner
   def run_task(task_description)
     print("#{task_description}... ")


### PR DESCRIPTION
I think that the `exec` in here might be causing the remaining bits of the `deploy.sh` script not to exit; I think that when `release-tasks` exits, the whole process exits. At least, that would explain what we're seeing in the logs: https://github.com/davidrunger/david_runger/actions/runs/10225938665/job/28295635507 and on the server where `main` is not getting checked out and updated at the end of the deployment process.