### PR TITLE
Copy deploy script to server for execution

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -126,8 +126,10 @@ jobs:
       - name: Set GIT_REV environment variable
         uses: ./.github/actions/git_rev
 
-      - name: Run deploy script on server
-        run: ssh "${{secrets.SERVER_USER_AND_IP}}" "GIT_REV='$GIT_REV' bash -s" < bin/server/deploy.sh
+      - name: Copy deploy script to server and execute it
+        run: |
+          scp bin/server/deploy.sh "${{secrets.SERVER_USER_AND_IP}}:/tmp/"
+          ssh "${{secrets.SERVER_USER_AND_IP}}" "bash /tmp/deploy.sh && rm /tmp/deploy.sh"
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
There seems to be an issue with our current approach where `docker compose exec` swallows all the rest of the script. Hopefully this will avoid that.