### PR TITLE
[deploy] Run the server install script as part of each deploy

### DIFF
--- a/bin/server/boot-services.sh
+++ b/bin/server/boot-services.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Boot the services that we want/need booted in order to run the web app.
+
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
+# NOTE: These aren't the only services that need to be booted, but, via
+# `depends_on` declarations, these services will also cause all other necessary
+# services to be booted.
 docker compose up --detach clock nginx

--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -13,6 +13,9 @@ if [ "$current_commit" != "$GIT_REV" ] ; then
   exit 1
 fi
 
+# Run the install script.
+bin/server/install.sh
+
 # Rebuild the app.
 docker compose build \
   --build-arg "GIT_REV=$GIT_REV" \


### PR DESCRIPTION
Usually, this will have no effect (since the install script will usually have already been executed, and since it should be idempotent), but running the install script each time that we deploy makes it easy to ensure that the latest version is always "installed". Since the install script should be fast and idempotent, there shouldn't really be much downside to doing this.