### PR TITLE
[bin/server] Rename script from startup.sh to system-startup.sh

### DIFF
--- a/bin/server/install.sh
+++ b/bin/server/install.sh
@@ -4,4 +4,4 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-ln -sf "$HOME/david_runger/bin/server/startup.sh" /etc/rc.local
+ln -sf "$HOME/david_runger/bin/server/system-startup.sh" /etc/rc.local

--- a/bin/server/system-startup.sh
+++ b/bin/server/system-startup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-# This script (startup.sh in the david_runger repo) is not intended to be
+# This script (system-startup.sh in the david_runger repo) is not intended to be
 # executed directly, but rather to be symlinked to `/etc/rc.local`, so that it's
 # contents will be executed at system startup.
 


### PR DESCRIPTION
When I was looking through these script names, I couldn't remember right away what `startup.sh` does, largely because I was thinking it might refer to the startup of the application. Actually, it refers to startup of the system. Let's name it to reflect that.