### PR TITLE
Move UsersController to MyAccountController and stop taking id param

### DIFF
--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -4,20 +4,20 @@ class AuthTokensController < ApplicationController
   def create
     authorize(AuthToken)
     AuthTokens::Create.run!(user: current_user)
-    redirect_to(edit_user_path(current_user))
+    redirect_to(edit_my_account_path)
   end
 
   def destroy
     authorize(@auth_token)
     @auth_token.destroy!
-    redirect_to(edit_user_path(current_user))
+    redirect_to(edit_my_account_path)
   end
 
   def update
     authorize(@auth_token)
     @auth_token.update!(auth_token_params)
     flash[:notice] = 'Updated auth token successfully!'
-    redirect_to(edit_user_path(current_user))
+    redirect_to(edit_my_account_path)
   end
 
   private

--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -1,11 +1,11 @@
-class UsersController < ApplicationController
+class MyAccountController < ApplicationController
   self.container_classes = %w[p-8]
 
   def destroy
     @user =
       User.includes(
         logs: %i[log_shares number_log_entries text_log_entries],
-      ).find(params[:id])
+      ).find(current_user.id)
     authorize(@user)
 
     @user.destroy!
@@ -15,8 +15,14 @@ class UsersController < ApplicationController
   end
 
   def edit
-    @user = User.find(params[:id])
+    @user = current_user
     authorize(@user)
     render :edit
+  end
+
+  def show
+    @user = current_user
+    authorize(@user)
+    render :show
   end
 end

--- a/app/javascript/groceries/components/LoggedInHeader.vue
+++ b/app/javascript/groceries/components/LoggedInHeader.vue
@@ -6,7 +6,7 @@ el-menu
       index='1-1'
       :disabled='true'
     ) {{currentUser.email}}
-    a(:href="routes.edit_user_path(currentUser)")
+    a(:href="routes.my_account_path()")
       el-menu-item(index='1-2') My Account
     a.js-link(@click='signOut')
       el-menu-item(index='1-3') Sign Out

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,8 @@
 class UserPolicy < ApplicationPolicy
+  def show?
+    own_record?
+  end
+
   private
 
   def own_record?

--- a/app/views/my_account/edit.html.haml
+++ b/app/views/my_account/edit.html.haml
@@ -1,6 +1,3 @@
-- content_for(:page_assets) do
-  = ts_tag('ujs')
-
 %div.my-8
   %h2.h3 Auth tokens (advanced feature; safe to ignore)
   - current_user.auth_tokens.each do |auth_token|
@@ -22,10 +19,3 @@
 
   %div.mt-4
     = button_to('Create New Auth Token', auth_tokens_path(method: :post), class: 'btn-primary')
-
-%div.my-8
-  %h2.h3 My Account
-  %div
-    = button_to('Delete Account', user_path(current_user),
-      method: :delete, class: 'btn-danger',
-      data: { confirm: "Are you sure that you want to completely and permanently delete your account (#{current_user.email})?" })

--- a/app/views/my_account/show.html.haml
+++ b/app/views/my_account/show.html.haml
@@ -1,0 +1,16 @@
+- content_for(:page_assets) do
+  = ts_tag('ujs')
+
+%h1 My Account
+
+%div.mt-4
+  %b Email:
+  = @user.email
+
+%div.mt-4
+  = link_to('Manage Auth Tokens', edit_my_account_path)
+
+%div.mt-4
+  = button_to('Delete Account', my_account_path,
+    method: :delete, class: 'btn-danger',
+    data: { confirm: "Are you sure that you want to completely and permanently delete your account (#{current_user.email})?" })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
     named_routes['new_session'] = named_routes['login']
     named_routes['new_user_session'] = named_routes['login']
   end
+  resource :my_account, controller: :my_account, only: %i[destroy edit show]
 
   get 'blog', to: 'blog#index'
   get 'blog/:slug', to: 'blog#show'
@@ -31,7 +32,7 @@ Rails.application.routes.draw do
   end
   get 'logs/:slug', to: 'logs#index', as: :log # routing to specific log will be done by Vue Router
 
-  resources :users, only: %i[destroy edit] do
+  resources :users, only: [] do
     get 'logs/:slug', to: 'logs#index', as: :shared_log
   end
 

--- a/spec/controllers/my_account_controller_spec.rb
+++ b/spec/controllers/my_account_controller_spec.rb
@@ -1,8 +1,8 @@
-RSpec.describe UsersController do
+RSpec.describe MyAccountController do
   let(:user) { users(:user) }
 
   describe '#destroy' do
-    subject(:delete_destroy) { delete(:destroy, params: { id: user_to_destroy.id }) }
+    subject(:delete_destroy) { delete(:destroy) }
 
     let(:user_to_destroy) { users(:user) }
 
@@ -44,7 +44,7 @@ RSpec.describe UsersController do
   end
 
   describe '#edit' do
-    subject(:get_edit) { get(:edit, params: { id: user.id }) }
+    subject(:get_edit) { get(:edit) }
 
     context 'when signed in' do
       before { sign_in(user) }

--- a/spec/features/account_deletion_spec.rb
+++ b/spec/features/account_deletion_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Account deletion' do
     let(:user) { users(:user) }
 
     it 'allows the user to delete their account and redirects to the homepage with a flash message', :prerendering_disabled do
-      visit edit_user_path(user)
+      visit edit_my_account_path
 
       accept_confirm { click_on('Delete Account') }
 

--- a/spec/features/account_deletion_spec.rb
+++ b/spec/features/account_deletion_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'Account deletion' do
     let(:user) { users(:user) }
 
     it 'allows the user to delete their account and redirects to the homepage with a flash message', :prerendering_disabled do
-      visit edit_my_account_path
+      visit my_account_path
 
       accept_confirm { click_on('Delete Account') }
 


### PR DESCRIPTION
Motivations:
1. Make the controller more secure by eliminating the possibility of IDOR by now simply referencing `current_user` rather than a User by id.
2. Allow providing a universal path (`/my_account`) for account management, rather than each user having a different path for account management. This is useful, for example, to put in a privacy policy.

Also, add a MyAccountController#show action (which takes some of the view code that was previously in #edit). Motivation: this makes the URL cleaner (just `/my_account`, rather than `/my_account/edit`), and also I think it just makes sense to have a #show page where the user can see their own account info and on which we can place the button to destroy the user's account.