### PR TITLE
Cd into the application directory at beginning of back-up-db-to-s3.sh

### DIFF
--- a/bin/server/back-up-db-to-s3.sh
+++ b/bin/server/back-up-db-to-s3.sh
@@ -2,6 +2,9 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
+# Move to the application directory
+cd /root/david_runger
+
 # Clean up from previous runs
 rm -rf tmp/backup
 

--- a/config/server/crontab.txt
+++ b/config/server/crontab.txt
@@ -11,5 +11,5 @@
 # trim docker images (daily at 07:42 UTC, 1:42am or 2:42am CT)
 42 7 * * *  docker system prune --all --force
 
-# back up database (daily at 06:10 UTC, 12:10am or 1:10am CT)
-10 6 * * *  /root/david_runger/bin/server/back-up-db-to-s3.sh
+# back up database (daily at 07:32 UTC, 1:32am or 2:32am CT)
+32 7 * * *  /root/david_runger/bin/server/back-up-db-to-s3.sh


### PR DESCRIPTION
This is necessary when this job is executed via crontab, in which case the script will be executed from an initial directory of `/root`.

Also, change the schedule, so that I can try to see today whether this works.