### PR TITLE
[cron] Only prune docker system weekly on Saturday (not daily)

### DIFF
--- a/config/server/crontab.txt
+++ b/config/server/crontab.txt
@@ -1,15 +1,15 @@
-# reboot server (saturday at 08:56 UTC, 2:56am or 3:56am CT)
-56 8 * * 6  reboot
-
-# restart dokku app (daily at 08:32 UTC, 2:32am or 3:32am CT)
-32 8 * * *  docker compose restart
-
 # renice puma and nginx to have maximum CPU priority (each every other minute)
 */2 * * * *  ps aux | grep [p]uma | awk {'print $2'} | xargs renice -n -20 -p
 1-59/2 * * * *  ps aux | grep -E '[n]ginx.*process' | awk {'print $2'} | xargs renice -n -20 -p
 
-# trim docker images (daily at 07:42 UTC, 1:42am or 2:42am CT)
-42 7 * * *  docker system prune --all --force
-
 # back up database (daily at 07:32 UTC, 1:32am or 2:32am CT)
 32 7 * * *  /root/david_runger/bin/server/back-up-db-to-s3.sh
+
+# restart dokku app (daily at 08:26 UTC, 2:26am or 3:26am CT)
+26 8 * * *  docker compose restart
+
+# trim docker images (Saturday at 08:55 UTC, 2:55am or 3:55am CT)
+55 8 * * 6  docker system prune --all --force
+
+# reboot server (Saturday at 09:22 UTC, 3:22am or 4:22am CT)
+22 9 * * 6  reboot


### PR DESCRIPTION
**Motivation:** When we run `docker system prune --all --force`, we clear the build cache, which makes the next build much slower than it otherwise would be. Rather than having one build per day be slowed in this way, let's have just one build per week slowed in this way.

Also, tweak the times and ordering of the other cron jobs.