### PR TITLE
[docker] Make RAILS_ENV a build arg [DEV-70]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .env*
+!.env.development.local
 !.env.production.local
 .git
 .github

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,9 @@ RUN --mount=type=cache,sharing=private,target=/var/lib/apt/lists \
   apt-get install --no-install-recommends -y \
   libjemalloc2 postgresql-client
 
-ENV RAILS_ENV="production"
+ARG RAILS_ENV
+RUN test -n "$RAILS_ENV"
+ENV RAILS_ENV=${RAILS_ENV}
 
 # Use jemalloc for memory savings.
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
@@ -77,5 +79,8 @@ COPY --from=build /app /app
 # Add GIT_REV env var permanently to the image
 ARG GIT_REV
 ENV GIT_REV=${GIT_REV}
+
+# Add ENV var to indicate that this is a Docker-built image.
+ENV DOCKER_BUILT=true
 
 ENTRYPOINT ["/app/bin/docker-entrypoint"]

--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -25,6 +25,7 @@ bin/server/install.sh
 docker compose build \
   --build-arg "GIT_REV=$GIT_REV" \
   --build-arg "RUBY_VERSION=$(cat .ruby-version)" \
+  --build-arg "RAILS_ENV=production" \
   --progress=plain
 
 # Launch new Rails services.

--- a/bin/spring
+++ b/bin/spring
@@ -2,7 +2,11 @@
 # This file loads Spring without using loading other gems in the Gemfile, in order to be fast.
 # It gets overwritten when you run the `spring binstub` command.
 
-if !defined?(Spring) && [nil, 'development', 'test'].include?(ENV.fetch('RAILS_ENV', nil))
+if (
+  !defined?(Spring) &&
+    [nil, 'development', 'test'].include?(ENV.fetch('RAILS_ENV', nil)) &&
+    %w[DOCKER_BUILD DOCKER_BUILT].none? { ENV.key?(_1) }
+)
   require 'bundler'
 
   Bundler.locked_gems.specs.find { |spec| spec.name == 'spring' }&.tap do |spring|

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,8 @@ Bundler.require(*Rails.groups)
 
 require 'freezolite/auto'
 
+IS_DOCKER = %w[DOCKER_BUILD DOCKER_BUILT].any? { ENV.key?(_1) }
+
 module DavidRunger
   CANONICAL_DOMAIN = 'davidrunger.com'.freeze
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,11 +1,13 @@
 require 'active_support/core_ext/integer/time'
 
 Rails.application.configure do
-  config.after_initialize do
-    Bullet.enable = true
-    Bullet.rails_logger = true
-    Bullet.raise = true
-    Bullet.counter_cache_enable = false
+  if !IS_DOCKER
+    config.after_initialize do
+      Bullet.enable = true
+      Bullet.rails_logger = true
+      Bullet.raise = true
+      Bullet.counter_cache_enable = false
+    end
   end
 
   # Settings specified here will take precedence over those in config/application.rb.
@@ -83,7 +85,9 @@ Rails.application.configure do
 
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
-  config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  if !IS_DOCKER
+    config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  end
 
   # Email
   config.action_mailer.perform_deliveries = true

--- a/config/initializers/githooks_check.rb
+++ b/config/initializers/githooks_check.rb
@@ -3,6 +3,7 @@ if (
   Rails.env.local? &&
     ENV['SKIP_GITHOOKS_CHECK'].blank? &&
     ENV['CI'].blank? &&
+    !IS_DOCKER &&
     `git config core.hooksPath`.strip != 'bin/githooks'
 )
   $stderr.puts(<<~ERROR)

--- a/config/initializers/http_logger.rb
+++ b/config/initializers/http_logger.rb
@@ -1,4 +1,4 @@
-if Rails.env.development?
+if Rails.env.development? && !IS_DOCKER
   # :nocov:
   HttpLogger.log_headers = true
   # :nocov:

--- a/config/initializers/isolator.rb
+++ b/config/initializers/isolator.rb
@@ -1,5 +1,5 @@
 # `Isolator` is not available in production (per the Gemfile)
-if Rails.env.in?(%w[development test])
+if Rails.env.local? && !IS_DOCKER
   Isolator.configure do |config|
     config.raise_exceptions = true
   end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,6 @@ x-rails-config: &default-rails-config
       condition: service_healthy
     redis:
       condition: service_healthy
-  env_file:
-    - .env.production.local
   environment:
     MEMCACHED_PASSWORD: ''
     MEMCACHED_URL: memcached://memcached:11211


### PR DESCRIPTION
This way, we can build with `RAILS_ENV=production` for production and `RAILS_ENV=development` when running locally.

However, even when we boot the app locally with `RAILS_ENV=development`, we still don't install gems from the `development` or `test` bundler groups. So, this PR adds a number of additional checks against a new `IS_DOCKER` constant, so that we don't try to use development-/test- only gems when running the app locally via Docker (with `RAILS_ENV=development`).