### PR TITLE
Add script to build Docker image for specified Rails env [DEV-70]

### DIFF
--- a/bin/build-docker
+++ b/bin/build-docker
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# This script builds a Docker image of our Rails app with the specified Rails env.
+#
+# Example: build for development
+#   bin/build-docker development
+#
+# Example: build for production
+#   bin/build-docker production
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+rails_env=$1
+
+docker compose build \
+  --build-arg GIT_REV="$(git rev-parse origin/main)" \
+  --build-arg RUBY_VERSION="$(cat .ruby-version)" \
+  --build-arg RAILS_ENV="$rails_env" \
+  --progress=plain

--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -22,11 +22,7 @@ fi
 bin/server/install.sh
 
 # Rebuild the app.
-docker compose build \
-  --build-arg "GIT_REV=$GIT_REV" \
-  --build-arg "RUBY_VERSION=$(cat .ruby-version)" \
-  --build-arg "RAILS_ENV=production" \
-  --progress=plain
+bin/build-docker production
 
 # Launch new Rails services.
 docker compose up --detach clock nginx web worker


### PR DESCRIPTION
This isn't the main thing to finish DEV-70 (that would be #4815), but it's related, so I'm tagging that Jira issue here, as well. This makes it easy to build a Docker image for development with `bin/build-docker development`.