### PR TITLE
Don't set NGINX headers that duplicate/override headers set by Rails

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -74,6 +74,21 @@ http {
         default "$proxy_forwarded_elem";
     }
 
+    map $upstream_http_x_xss_protection $x_xss_protection {
+        default $upstream_http_x_xss_protection;
+        "" "1; mode=block";
+    }
+
+    map $upstream_http_x_content_type_options $x_content_type_options {
+        default $upstream_http_x_content_type_options;
+        "" "nosniff";
+    }
+
+    map $upstream_http_referrer_policy $referrer_policy {
+        default $upstream_http_referrer_policy;
+        "" "no-referrer";
+    }
+
     # Load configs
     include /etc/nginx/conf.d/*.conf;
     include /etc/nginx/sites-enabled/*;

--- a/config/nginx/nginxconfig.io/security.conf
+++ b/config/nginx/nginxconfig.io/security.conf
@@ -1,7 +1,13 @@
 # security headers
-add_header X-XSS-Protection          "1; mode=block" always;
-add_header X-Content-Type-Options    "nosniff" always;
-add_header Referrer-Policy           "same-origin" always;
+proxy_hide_header X-XSS-Protection;
+add_header X-XSS-Protection $x_xss_protection always;
+
+proxy_hide_header X-Content-Type-Options;
+add_header X-Content-Type-Options $x_content_type_options always;
+
+proxy_hide_header Referrer-Policy;
+add_header Referrer-Policy $referrer_policy always;
+
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
 
 # . files


### PR DESCRIPTION
When looking at our response headers via `curl`, I noticed that the following headers were duplicated:

```
referrer-policy: strict-origin-when-cross-origin
referrer-policy: same-origin

x-content-type-options: nosniff
x-content-type-options: nosniff

x-xss-protection: 0
x-xss-protection: 1; mode=block
```

I think that the top header in each pairing comes from Rails and that the second header in each pairing comes from NGINX.

In this commit, we stop setting these headers in NGINX in a way that duplicates/conflicts with the headers set by Rails. If Rails (the "upstream") has set these headers, we'll use those. Otherwise, NGINX will set these headers with default values.

Big shoutout to this StackOverflow answer for having this solution: https://stackoverflow.com/a/44761645/4009384 .