### PR TITLE
[docker-compose/x-rails-config] Add back production env_file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ x-rails-config: &default-rails-config
       condition: service_healthy
     redis:
       condition: service_healthy
+  # NOTE: We need this to have DATABASE_URL in bin/docker-entrypoint.
   env_file:
     - .env.production.local
   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ x-rails-config: &default-rails-config
       condition: service_healthy
     redis:
       condition: service_healthy
+  env_file:
+    - .env.production.local
   environment:
     MEMCACHED_PASSWORD: ''
     MEMCACHED_URL: memcached://memcached:11211


### PR DESCRIPTION
I had thought maybe we don't need this because dotenv will load the `.env.production.local` environment variables into the Rails environment, rather than needing these environment variables available at the broader system level. However, we are getting an error when e.g. trying to boot the `clock` service:

> clock-1 | /app/bin/docker-entrypoint: line 5: DATABASE_URL: unbound > variable

This makes sense, because `docker-entrypoint` is just a bash script, and so the Rails context (including dotenv loading the `.env.production.local` file) is not initialized.

In this change, we fix this by adding back the `env_file` for `x-rails-config` to make those env vars available at the image level.