### PR TITLE
[docker-compose] Rework depends_on listings for Rails services

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -24,8 +24,8 @@ bin/server/install.sh
 # Rebuild the app.
 bin/build-docker production
 
-# Launch new Rails services.
-docker compose up --detach clock nginx web worker
+# Launch fresh services.
+docker compose up --detach
 
 # Run release tasks.
 docker compose exec web bin/server/release-tasks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,8 @@ x-rails-config: &default-rails-config
   build:
     context: .
   depends_on:
-    memcached:
-      condition: service_healthy
-    postgres:
-      condition: service_healthy
-    redis:
-      condition: service_healthy
+    initialize_database:
+      condition: service_completed_successfully
   # NOTE: We need this to have DATABASE_URL in bin/docker-entrypoint.
   env_file:
     - .env.production.local
@@ -31,13 +27,15 @@ services:
   clock:
     <<: *default-rails-config
     command: ['bin/skedjewel']
-    depends_on:
-      initialize_database:
-        condition: service_completed_successfully
-      worker:
-        condition: service_started
   initialize_database:
     <<: *default-rails-config
+    depends_on:
+      memcached:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
   memcached:
     healthcheck:
       # https://github.com/docker-library/memcached/issues/ 91#issuecomment-1733748674
@@ -113,17 +111,11 @@ services:
   web:
     <<: *default-rails-config
     command: ['bin/rails', 'server']
-    depends_on:
-      initialize_database:
-        condition: service_completed_successfully
     expose:
       - '3000'
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']
-    depends_on:
-      initialize_database:
-        condition: service_completed_successfully
 
 networks:
   external:


### PR DESCRIPTION
The problem with what we were doing before is that we had some service-specific `depends_on` declarations that were overriding (as opposed to adding to) the default `depends_on` declaration for `x-rails-config`. For example, `clock` was not depending on `redis`, which it should do.

I think that this might be the cause of errors like this when trying to boot `clock`:

> clock-1 | Skedjewel 0.0.13 is running with PID 1. > clock-1 | Unhandled exception: Socket::ConnectError: Error connecting to 'localhost:6379': Connection refused (Redis::CannotConnectError)

This new configuration has most Rails services `depends_on` initialize_database. The exception is initialize_database itself, which depends on memcached, postgres, and redis. Hopefully this setup will ensure a reliable bootup chain.