### PR TITLE
[rack-attack] Add more logged info (REMOTE_ADDR and ip)

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -82,7 +82,6 @@ Rack::Attack.blocklist('fail2ban pentesters') do |request|
         request.get_header('action_dispatch.request_id'),
         request.get_header('REMOTE_ADDR'),
         request.ip,
-        request.remote_ip,
         request.fullpath,
         request.each_header.select do |key, _v|
           key.start_with?('HTTP_')

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -80,6 +80,9 @@ Rack::Attack.blocklist('fail2ban pentesters') do |request|
       Rails.logger.info([
         'rack-attack-blocked-request-info',
         request.get_header('action_dispatch.request_id'),
+        request.get_header('REMOTE_ADDR'),
+        request.ip,
+        request.remote_ip,
         request.fullpath,
         request.each_header.select do |key, _v|
           key.start_with?('HTTP_')


### PR DESCRIPTION
I'm still trying to figure out why the IP isn't the end-user's originating IP when we create an IpBlock.