### PR TITLE
[puma] Add set_remote_address(header: 'X-Forwarded-For')

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,6 +23,10 @@ environment(ENV.fetch('RAILS_ENV', 'development'))
 #
 workers(ENV.fetch('WEB_CONCURRENCY', 0))
 
+# Set `env['REMOTE_ADDR']` (which will be used to determine `request.ip`) to the
+# `X-Forwarded-For` header value.
+set_remote_address(header: 'X-Forwarded-For')
+
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write


### PR DESCRIPTION
I think that this _might_ make `request.ip` resolve to the originating user's IP address, rather than the Cloudflare address, as is currently happening. Let's try it and see.