### PR TITLE
[rack-attack] Store 'fullpath' (not just 'path') in Redis on block

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -87,7 +87,7 @@ Rack::Attack.blocklist('fail2ban pentesters') do |request|
           key.start_with?('HTTP_')
         end.sort.to_h,
       ])
-      IpBlocks::StoreRequestBlockInRedis.run!(ip: request.ip, path: request.path)
+      IpBlocks::StoreRequestBlockInRedis.run!(ip: request.ip, path: request.fullpath)
     end
 
     is_blocked_path


### PR DESCRIPTION
This way, if/when an `IpBlock` is created, it will also include any query params in the request, if present, which I think could be meaningful/informative.