### PR TITLE
[rack-attack] Remove request debugging logging

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -77,16 +77,6 @@ Rack::Attack.blocklist('fail2ban pentesters') do |request|
     is_blocked_path = Rack::Attack.blocked_path?(request)
 
     if is_blocked_path
-      Rails.logger.info([
-        'rack-attack-blocked-request-info',
-        request.get_header('action_dispatch.request_id'),
-        request.get_header('REMOTE_ADDR'),
-        request.ip,
-        request.fullpath,
-        request.each_header.select do |key, _v|
-          key.start_with?('HTTP_')
-        end.sort.to_h,
-      ])
       IpBlocks::StoreRequestBlockInRedis.run!(ip: request.ip, path: request.fullpath)
     end
 


### PR DESCRIPTION
In #4823, we fixed the issue that this logging aimed to help solve, so we don't really need this logging anymore.