### PR TITLE
[nginx] Remove 'Forwarded' header

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -53,27 +53,6 @@ http {
         ""      close;
     }
 
-    map $remote_addr $proxy_forwarded_elem {
-
-        # IPv4 addresses can be sent as-is
-        ~^[0-9.]+$        "for=$remote_addr";
-
-        # IPv6 addresses need to be bracketed and quoted
-        ~^[0-9A-Fa-f:.]+$ "for=\"[$remote_addr]\"";
-
-        # Unix domain socket names cannot be represented in RFC 7239 syntax
-        default           "for=unknown";
-    }
-
-    map $http_forwarded $proxy_add_forwarded {
-
-        # If the incoming Forwarded header is syntactically valid, append to it
-        "~^(,[ \\t]*)*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*([ \\t]*,([ \\t]*([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?(;([!#$%&'*+.^_`|~0-9A-Za-z-]+=([!#$%&'*+.^_`|~0-9A-Za-z-]+|\"([\\t \\x21\\x23-\\x5B\\x5D-\\x7E\\x80-\\xFF]|\\\\[\\t \\x21-\\x7E\\x80-\\xFF])*\"))?)*)?)*$" "$http_forwarded, $proxy_forwarded_elem";
-
-        # Otherwise, replace it
-        default "$proxy_forwarded_elem";
-    }
-
     map $upstream_http_x_xss_protection $x_xss_protection {
         default $upstream_http_x_xss_protection;
         "" "1; mode=block";

--- a/config/nginx/nginxconfig.io/proxy.conf
+++ b/config/nginx/nginxconfig.io/proxy.conf
@@ -8,7 +8,6 @@ proxy_ssl_server_name              on;
 proxy_set_header Upgrade           $http_upgrade;
 proxy_set_header Connection        $connection_upgrade;
 proxy_set_header X-Real-IP         $remote_addr;
-proxy_set_header Forwarded         $proxy_add_forwarded;
 proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
 proxy_set_header X-Forwarded-Proto $scheme;
 proxy_set_header X-Forwarded-Host  $host;

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -23,10 +23,6 @@ environment(ENV.fetch('RAILS_ENV', 'development'))
 #
 workers(ENV.fetch('WEB_CONCURRENCY', 0))
 
-# Set `env['REMOTE_ADDR']` (which will be used to determine `request.ip`) to the
-# `X-Forwarded-For` header value.
-set_remote_address(header: 'X-Forwarded-For')
-
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code
 # before forking the application. This takes advantage of Copy On Write


### PR DESCRIPTION
We noticed that rack-attack was blocking the Cloudflare IP that forwarded the bad request, rather than the originating client IP.

I figured out a fix for this: #4823. However, I have been wondering why that fix was even necessary.

I suspect that it might have been necessary because of the fact that Rack [prioritizes][1] the `Forwarded` header over `X-Forwarded-For`. I suspect that maybe the way that these headers are handled (maybe as they relate to `cloudflare-rails`?) is different, and/or maybe we aren't formatting the `Forwarded` header correctly. Maybe on Dokku (before our recent migration to raw Docker (Compose)) we weren't sending a `Forwarded` header at all, and that's why we didn't need #4823 when on Dokku.

[1]: https://github.com/rack/rack/blob/v3.1.7/lib/rack/request.rb#L43

Therefore, I am going to try reverting the #4823 change and also stop sending a `Forwarded` header. If, after this change, rack-attack continues to block the originating client IP rather than the Cloudflare IP, then my above theory is probably correct, and we'll leave things as they will at that point be. If we see a regression, then my theory is probably not correct, and we'll probably revert this PR. But I would like to try it and see what happens.

Unfortunately, it's sort of necessary to test this in production, because outside of a production environment it is difficult to simulate what the real request headers and environment etc will be when these requests are handled.

One nice thing about this change is that it allows us to delete a decent amount of NGINX code.