### PR TITLE
[deploy] Add '--remove-orphans' to 'docker compose up' command

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -25,7 +25,7 @@ bin/server/install.sh
 bin/build-docker production
 
 # Launch fresh services.
-docker compose up --detach
+docker compose up --detach --remove-orphans
 
 # Run release tasks.
 docker compose exec web bin/server/release-tasks


### PR DESCRIPTION
This should hopefully prevent disk usage from growing whenever we deploy, and maybe eventually we will be able to do away with the `docker system prune --all --force` cron job.

The reason I initially hesitated to do this is because I didn't want to waste time/CPU deleting orphans when trying to boot up new containers. However, from using the `--remove-orphans` option locally, it doesn't feel like it adds a lot of time, and so I think it might be worth doing.