### PR TITLE
[docker-compose/rails] Remove hardcoded 'production' RAILS_ENV

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       - external
   web:
     <<: *default-rails-config
-    command: ['bin/rails', 'server']
+    command: ['bin/rails', 'server', '--binding', '0.0.0.0']
     expose:
       - '3000'
   worker:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ x-rails-config: &default-rails-config
   environment:
     MEMCACHED_PASSWORD: ''
     MEMCACHED_URL: memcached://memcached:11211
-    RAILS_ENV: production
   networks:
     - external
     - internal


### PR DESCRIPTION
In #4815, we intended to make it possible to build the Docker app in either development mode or production mode.

However, due to the hardcoded `RAILS_ENV` of `production` that is being removed in this PR, we actually were still booting the app in a production Rails environment, when booting the app via Docker Compose.

This change makes it so that when we build the app for development (`bin/build-docker development`) and run it with Docker Compose (`docker compose up --detach --remove-orphans`), the app will run with `RAILS_ENV=development`, as intended.

(I noticed the need for this change because I got some data monitor emails while I had the app running locally in what I thought was development mode, but actually `Rails.env` was production, and so it was loading my production Mailgun key and sending a real email.)