### PR TITLE
[deploy] Print a success message if all expected services are running

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -35,4 +35,4 @@ git checkout main
 git reset --hard origin/main
 
 # Verify that all expected services are running.
-bin/server/verify-expected-services.sh
+bin/server/verify-expected-services.sh && echo 'All expected services are running.'


### PR DESCRIPTION
It will give us a lot more justified confidence to see this explicit confirmation in the deploy logs, rather than just to see an absence of logged failure.