### PR TITLE
Move success message from deploy script to verify-expected-services

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -35,4 +35,4 @@ git checkout main
 git reset --hard origin/main
 
 # Verify that all expected services are running.
-bin/server/verify-expected-services.sh && echo 'All expected services are running.'
+bin/server/verify-expected-services.sh

--- a/bin/server/verify-expected-services.sh
+++ b/bin/server/verify-expected-services.sh
@@ -13,6 +13,8 @@ for expected_service in "${expected_running_services[@]}" ; do
   fi
 done
 
-if [ "${#expected_services_not_running[@]}" -ne 0 ] ; then
+if [ "${#expected_services_not_running[@]}" -eq 0 ] ; then
+  echo 'All expected services are running.'
+else
   exit 1
 fi


### PR DESCRIPTION
This keeps the deploy script cleaner. Also, I think it will always be good to print this success message (e.g. when running it directly either on my local machine or on the server).