### PR TITLE
[specs] Confirm homepage redirect before proceeding to logs [DEV-39]

### DIFF
--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -15,6 +15,9 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
 
         expect { click_on(class: 'google-login') }.not_to change { User.count }
 
+        expect(page).to have_current_path(root_path)
+        expect(page).to have_text('David Runger Full stack web developer')
+
         visit(logs_path)
         expect(page).to have_text(user.email)
       end


### PR DESCRIPTION
Hypothesis: `visit(logs_path)` sometimes occurs quickly enough to cancel the browser request that is being made to log in the user.

Hoped for solution: confirm the path and page content of the home page (to which the user will be redirected after logging in). _Then_ visit the logs path (hopefully now with the assurance that the login request went to completion, rather than being cancelled).