### PR TITLE
[docker-compose] Don't execute s3_db_backup service by default

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,8 @@ services:
     image: dokku/s3backup
     networks:
       - external
+    profiles:
+      - nondefault
   web:
     <<: *default-rails-config
     command: ['bin/rails', 'server', '--binding', '0.0.0.0']


### PR DESCRIPTION
By putting the `s3_db_backup` service into a profile called anything other than `default` (I'm going with `nondefault`), now that service won't be executed when we run `docker compose up` without specifying any services.