### PR TITLE
Add nginx and web to 'nondefault' Docker Compose profile [DEV-65]

### DIFF
--- a/bin/build-docker
+++ b/bin/build-docker
@@ -12,8 +12,16 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 rails_env=$1
 
-docker compose build \
-  --build-arg GIT_REV="$(git rev-parse origin/main)" \
-  --build-arg RUBY_VERSION="$(cat .ruby-version)" \
-  --build-arg RAILS_ENV="$rails_env" \
-  --progress=plain
+build() {
+  docker compose build ${1:-} \
+    --build-arg GIT_REV="$(git rev-parse origin/main)" \
+    --build-arg RUBY_VERSION="$(cat .ruby-version)" \
+    --build-arg RAILS_ENV="$rails_env" \
+    --progress=plain
+}
+
+# Build web. (We must invoke it specifically because it's in the `nondefault` compose profile.)
+build web
+
+# Build non-web images. (The build steps should all be cached, since they're no different from web).
+build

--- a/bin/build-docker
+++ b/bin/build-docker
@@ -13,6 +13,8 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 rails_env=$1
 
 build() {
+  # Quotes would break this when there is no argument.
+  # shellcheck disable=SC2086
   docker compose build ${1:-} \
     --build-arg GIT_REV="$(git rev-parse origin/main)" \
     --build-arg RUBY_VERSION="$(cat .ruby-version)" \

--- a/bin/server/roll-out-web.sh
+++ b/bin/server/roll-out-web.sh
@@ -19,7 +19,7 @@ reload_nginx() {
 scale_web() {
   scale=$1
   echo_iso8601 "Scaling web to $scale."
-  docker compose up --detach --no-deps --scale web="$scale" --no-recreate web
+  docker compose up --detach --no-deps --scale web="$scale" --no-recreate --remove-orphans web
 }
 
 old_container_id=$(docker ps --filter name=web --quiet | tail -1)

--- a/config/nginx/nginxconfig.io/proxy.conf
+++ b/config/nginx/nginxconfig.io/proxy.conf
@@ -15,6 +15,6 @@ proxy_set_header X-Forwarded-Port  $server_port;
 proxy_set_header X-Request-Start   $msec;
 
 # Proxy timeouts
-proxy_connect_timeout              60s;
-proxy_send_timeout                 60s;
-proxy_read_timeout                 60s;
+proxy_connect_timeout              10s;
+proxy_send_timeout                 30s;
+proxy_read_timeout                 30s;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,11 +47,6 @@ services:
       - internal
   nginx:
     command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
-    depends_on:
-      certbot:
-        condition: service_started
-      web:
-        condition: service_started
     image: nginx:1.27.0-alpine
     networks:
       - external
@@ -59,6 +54,8 @@ services:
     ports:
       - 80:80
       - 443:443
+    profiles:
+      - nondefault
     volumes:
       - ./config/nginx/:/etc/nginx/
       - ./ssl-data/certbot/conf:/etc/letsencrypt
@@ -114,6 +111,8 @@ services:
     command: ['bin/rails', 'server', '--binding', '0.0.0.0']
     expose:
       - '3000'
+    profiles:
+      - nondefault
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']


### PR DESCRIPTION
This will avoid these services being restarted when we call `docker compose up --detach --remove-orphans` in `deploy.sh`. (If these services are restarted by that command, then we get a significant chunk of downtime, which we don't want. Instead, we want to manage the rollout of `web` only via the `roll-out-web.sh` script.)

It still happens sometimes that some requests get caught in the transition, and I believe that they hang for the duration of the NGINX `proxy_connect_timeout`. I am therefore going to lower that timeout, so that these requests fail more quickly. I'm also lowering the `proxy_send_timeout` and `proxy_read_timeout` while I'm at it.