### PR TITLE
[deploy] Run release tasks on a fresh web container

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -25,7 +25,7 @@ bin/server/install.sh
 bin/build-docker production
 
 # Run release tasks.
-docker compose exec web bin/server/release-tasks
+docker compose run --rm web bin/server/release-tasks
 
 # Perform zero downtime, rolling deploy of web/nginx.
 bin/server/roll-out-web.sh

--- a/bin/server/release-tasks
+++ b/bin/server/release-tasks
@@ -60,17 +60,19 @@ runner.run_task('Registering deploy with Sidekiq') do
   end
 end
 
-runner.run_task('Notifying Rollbar of deploy') do
-  access_token = Rails.application.credentials.rollbar!.access_token!
-  Faraday.json_connection.post(
-    'https://api.rollbar.com/api/1/deploy/',
-    {
-      'environment' => Rails.env,
-      'revision' => ENV.fetch('GIT_REV'),
-      'rollbar_username' => 'davidjrunger',
-    },
-    {
-      'X-Rollbar-Access-Token' => access_token,
-    },
-  )
+if Rails.env.production?
+  runner.run_task('Notifying Rollbar of deploy') do
+    access_token = Rails.application.credentials.rollbar!.access_token!
+    Faraday.json_connection.post(
+      'https://api.rollbar.com/api/1/deploy/',
+      {
+        'environment' => Rails.env,
+        'revision' => ENV.fetch('GIT_REV'),
+        'rollbar_username' => 'davidjrunger',
+      },
+      {
+        'X-Rollbar-Access-Token' => access_token,
+      },
+    )
+  end
 end

--- a/bin/server/release-tasks
+++ b/bin/server/release-tasks
@@ -63,6 +63,7 @@ end
 if Rails.env.production?
   runner.run_task('Notifying Rollbar of deploy') do
     access_token = Rails.application.credentials.rollbar!.access_token!
+
     Faraday.json_connection.post(
       'https://api.rollbar.com/api/1/deploy/',
       {


### PR DESCRIPTION
Otherwise, I think that what happens is that the release tasks (including database migrations) execute on one of the older web containers. Since these don't have the latest code, they won't execute freshly deployed migrations. Also, the GIT_REV is outdated, and so (I'm pretty sure) we actually have been creating deploy markers with the wrong Git SHA. By running the release-tasks on a fresh container (with `run` rather than `exec`), we should boot a fresh container that will have the latest code (including migrations) and `GIT_REV`.