### PR TITLE
[runger-config] Add spec-commands (to run tests/linters via pallets)

### DIFF
--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -1,2 +1,9 @@
 expected-num-github-checks: 4
 javascript-watch-command: bin/vite dev
+spec-commands: |
+  export RAILS_ENV=test DISABLE_SPRING=1
+  export POSTGRES_USER=david_runger POSTGRES_HOST=localhost
+  export TERM=dumb
+  set -x
+  redis-cli -n 8 FLUSHDB
+  bin/run-tests


### PR DESCRIPTION
(Set `TERM=dumb` to make Rainbow color printing a no-op (specifically in LogFormatter), as one of our tests expect.)