### PR TITLE
[runger-config/spec-commands] Don't set TERM=dumb

### DIFF
--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -3,7 +3,6 @@ javascript-watch-command: bin/vite dev
 spec-commands: |
   export RAILS_ENV=test DISABLE_SPRING=1
   export POSTGRES_USER=david_runger POSTGRES_HOST=localhost
-  export TERM=dumb
   set -x
   redis-cli -n 8 FLUSHDB
   bin/run-tests


### PR DESCRIPTION
I thought that this is needed to get tests to pass locally when run via `spec`, but instead I am going to modify `z.rb` not to load string monkeypatches except in development mode, which makes `TERM=dumb` unnecessary (if it ever even helped at all).

This undoes part of the changes recently made in #4859.