### PR TITLE
[spec/logs] Sleep 0.8 seconds before publishing new log entry [LOG-8]

### DIFF
--- a/app/javascript/logs/components/Log.vue
+++ b/app/javascript/logs/components/Log.vue
@@ -145,7 +145,12 @@ function subscribeToLogEntriesChannel() {
       log_id: log.id,
     },
     {
-      received: (data: LogEntryBroadcast) => {
+      connected() {
+        // NOTE: This is for tests, so that we can wait until the WebSocket is connected.
+        window.davidrunger.connectedToLogEntriesChannel = true;
+      },
+
+      received(data: LogEntryBroadcast) {
         if (Cookies.get('browser_uuid') === data.acting_browser_uuid) return;
 
         const { action, model } = data;

--- a/app/javascript/shared/index.d.ts
+++ b/app/javascript/shared/index.d.ts
@@ -4,6 +4,7 @@ declare global {
   interface Window {
     davidrunger: {
       bootstrap: object;
+      connectedToLogEntriesChannel?: boolean;
       env: 'development' | 'test' | 'production';
       modalKeydownListenerRegistered: boolean;
     };

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -194,6 +194,12 @@ RSpec.describe 'Logs app' do
 
           expect(page).to have_text(log.log_entries.first!.data)
 
+          wait_for do
+            page.evaluate_script('window.davidrunger?.connectedToLogEntriesChannel')
+          end.to eq(true)
+
+          sleep(0.5) # Give JavaScript even more time to be ready to receive WebSocket events.
+
           publish_new_log_entry
 
           expect(page).to have_text(new_log_entry_text)


### PR DESCRIPTION
This change aims to fix a flaky spec. See a failure [here][1].

**Hypothesis:** It's possible that the log entry is published via ActionCable before the ActionCable JavaScript in the browser has had time to subscribe to the relevant WebSocket.

**Solution:** Modify application code (sad) to add a globally accessible marker (`window.davidrunger.connectedToLogEntriesChannel`) when the ActionCable subscription has been created.

I actually saw this flake while working on this branch, after having added the `wait_for` to wait for `window.davidrunger.connectedToLogEntriesChannel` to be true, so apparently that alone is not sufficient. Therefore, let's also add a 0.5 second sleep after the ActionCable consumer has connected.

Hopefully these two changes together will eliminate the flakiness that we have seen in this spec.

[1]: https://github.com/davidrunger/david_runger/actions/runs/9737531169/job/26869781563#step:9:319