### PR TITLE
[specs] Bring back rspec-retry, only for Ferrum::ProcessTimeoutError

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,6 +104,7 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec-instafail', require: false
   gem 'rspec-rails'
+  gem 'rspec-retry'
   gem 'rspec-sidekiq'
   gem 'rspec-wait'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -518,6 +518,8 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
+    rspec-retry (0.6.2)
+      rspec-core (> 3.3)
     rspec-sidekiq (5.0.0)
       rspec-core (~> 3.0)
       rspec-expectations (~> 3.0)
@@ -736,6 +738,7 @@ DEPENDENCIES
   rollbar
   rspec-instafail
   rspec-rails
+  rspec-retry
   rspec-sidekiq
   rspec-wait
   rubocop

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,7 +151,7 @@ RSpec.configure do |config|
   config.display_try_failure_messages = true
   config.around(:each, type: :feature) do |example|
     example.run_with_retry(
-      # This actually means 'try: 2', i.e. retry just once
+      # This actually means 'try: 2', i.e. retry just once.
       retry: 2,
       exceptions_to_retry: [
         Ferrum::ProcessTimeoutError,

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,6 +146,27 @@ RSpec.configure do |config|
   config.include(MailSpecHelpers, type: :mailbox)
   config.include(MailSpecHelpers, type: :mailer)
 
+  # rspec-retry options >>>
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+  config.around(:each, type: :feature) do |example|
+    example.run_with_retry(
+      # This actually means 'try: 2', i.e. retry just once
+      retry: 2,
+      exceptions_to_retry: [
+        Ferrum::ProcessTimeoutError,
+      ],
+    )
+  end
+  config.retry_callback =
+    proc do |ex|
+      if ex.metadata[:type] == :feature
+        Capybara.reset!
+        page.driver.reset!
+      end
+    end
+  # <<< rspec-retry options
+
   config.before(:suite) do
     # Reset FactoryBot sequences to an arbitrarily high number to avoid collisions with
     # fixture_builder-built fixtures.


### PR DESCRIPTION
I don't really know of anything that we can do to avoid these `Ferrum::ProcessTimeoutError` exceptions that occur from time to time (not only in specs, but also in our prerenderer). When they do occur, let's retry (and log), rather than failing the build.

We had removed `rspec-retry` in #2417 (though noting that we might want to bring it back at some point).