### PR TITLE
[blog] Link 'blog/' to web container via a Docker volume

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -113,6 +113,8 @@ services:
       - '3000'
     profiles:
       - nondefault
+    volumes:
+      - ./blog:/app/blog
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']


### PR DESCRIPTION
Otherwise, the built container won't see newly deployed blog content.

fixes https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/649