### PR TITLE
Delete dangling reference to BLOG_ROOT_URL in Content Security Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -6,7 +6,7 @@
 
 Rails.application.configure do
   config.content_security_policy do |policy|
-    extra_sources = [ENV.fetch('BLOG_ROOT_URL', nil)].compact # bridgetown blog server
+    extra_sources = []
     extra_connect_sources = []
     # :nocov:
     if Rails.env.development?


### PR DESCRIPTION
As of #4869, we no longer serve the blog by proxying to another server (and so we no longer use `BLOG_ROOT_URL`). Instead, to develop locally using the blog, a command like the following should be run from the `blog` repository:

`BRIDGETOWN_ENV=production bin/bridgetown deploy && rmrf ~/code/david_runger/blog && mv output blog && cp -r blog ~/code/david_runger && rmrf blog`

Then, http://localhost:3000/blog/ (from this `david_runger` Rails app) should work.