### PR TITLE
Stop adding .env.{development,production}.local files to docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 .env*
-!.env.development.local
-!.env.production.local
 .git
 .github
 .ruby-lsp

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -80,7 +80,16 @@ Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
   end
 
   def s3_bucket
-    @s3_bucket ||= Aws::S3::Resource.new(region: 'us-east-1').bucket('david-runger-test-uploads')
+    @s3_bucket ||=
+      Aws::S3::Resource.new(
+        region: 'us-east-1',
+        # NOTE: Here we are using the undocumented `unsigned_operations` feature
+        # (subject to breaking changes) to request public resources in this
+        # bucket without needing an AWS access key and secret.
+        # https://github.com/aws/aws-sdk-ruby/issues/
+        # 1149#issuecomment-2007175332
+        unsigned_operations: [:get_object],
+      ).bucket('david-runger-test-uploads')
   end
 
   begin


### PR DESCRIPTION
As of this change, it's no longer necessary to add the `.env.{development,production}.local` files to the image; it's sufficient for one or both of these env files just to exist on the host machine. (In development, we actually need both, so that the correct DATABASE_URL is defined, for example, though it will be connected to my local almost-empty "production" Docker database, rather than to the real production database.)

Prior to this change, we did need these files to be added to the image, so that they would be available during the Dockerfile build process when we run `assets:precompile`, so that we'd have access to an AWS access key and secret, so that we could download the precompiled frontend assets.

To avoid this need, this change uses an undocumented `unsigned_operations` AWS SDK option (https://github.com/aws/aws-sdk-ruby/issues/ 1149#issuecomment-2007175332), which makes it so that the AWS SDK doesn't attempt to sign the request for the publicly accessible build assets, which makes it so that no AWS access key and/or secret are needed during the Dockerfile build process (and nor are any other secrets needed).

**Motivation:** By making it so that no secrets are required in order to build the image for our Rails app, we'll be able to transition to building the images via GitHub Actions, rather than on the server (DEV~71).