### PR TITLE
Don't require Rails master key during docker build

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,8 @@ Bundler.require(*Rails.groups)
 
 require 'freezolite/auto'
 
-IS_DOCKER = %w[DOCKER_BUILD DOCKER_BUILT].any? { ENV.key?(_1) }
+IS_DOCKER_BUILD = ENV.key?('DOCKER_BUILD')
+IS_DOCKER = IS_DOCKER_BUILD || ENV.key?('DOCKER_BUILT')
 
 module DavidRunger
   CANONICAL_DOMAIN = 'davidrunger.com'.freeze

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -23,7 +23,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  config.require_master_key = true
+  config.require_master_key = !IS_DOCKER_BUILD
 
   config.public_file_server.enabled = true
 
@@ -74,7 +74,7 @@ Rails.application.configure do
   # you want to log everything, set the level to "debug".
   config.log_level = ENV.fetch('RAILS_LOG_LEVEL', 'info')
 
-  unless ENV.key?('DOCKER_BUILD')
+  unless IS_DOCKER_BUILD
     # Use a different cache store in production.
     config.cache_store =
       :mem_cache_store,

--- a/config/initializers/omni_auth.rb
+++ b/config/initializers/omni_auth.rb
@@ -2,7 +2,7 @@
 OmniAuth.config.logger = Rails.logger
 
 Rails.application.config.middleware.use(OmniAuth::Builder) do
-  unless ENV.key?('DOCKER_BUILD')
+  unless IS_DOCKER_BUILD
     provider(
       :google_oauth2,
       ENV.fetch('GOOGLE_OAUTH_CLIENT_ID'),

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,4 +1,4 @@
-unless ENV.key?('DOCKER_BUILD')
+unless IS_DOCKER_BUILD
   redis_options = RedisOptions.new
 
   redis_config = RedisClient.config(url: redis_options.url)

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -70,7 +70,7 @@ Rollbar.configure do |config|
   config.environment = ENV.fetch('ROLLBAR_ENV', Rails.env)
 
   client_token = Rails.application.credentials.rollbar&.dig(:post_client_item_access_token)
-  config.js_enabled = ENV.key?('DOCKER_BUILD') ? false : Flipper.enabled?(:rollbar_js)
+  config.js_enabled = IS_DOCKER_BUILD ? false : Flipper.enabled?(:rollbar_js)
   config.js_options = {
     accessToken: client_token,
     captureUncaught: true,

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,4 +1,4 @@
-unless ENV.key?('DOCKER_BUILD')
+unless IS_DOCKER_BUILD
   Sidekiq.strict_args!
 
   # We'll give Sidekiq db 1 (by default). The app uses db 0 for its direct uses.


### PR DESCRIPTION
I am hoping that this will fix errors like this:

https://github.com/davidrunger/david_runger/actions/runs/10329183156/job/28596726423#step:5:92

> ActiveSupport::EncryptedFile::MissingKeyError: Missing encryption > key to decrypt file with. Ask your team for your master key and > write it to /app/config/master.key or put it in the > ENV['RAILS_MASTER_KEY']. > (ActiveSupport::EncryptedFile::MissingKeyError)

Also, dry up `DOCKER_BUILD` env var references with a new `IS_DOCKER_BUILD` constant.