### PR TITLE
Fix more things for production Docker builds without secrets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ ARG GIT_REV
 # Build public/assets/, download public/vite/ and public/vite-admin/, and download skedjewel.
 RUN DOCKER_BUILD=true \
   GIT_REV=${GIT_REV} \
+  SECRET_KEY_BASE_DUMMY=1 \
   VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true \
   bundle exec rails assets:precompile
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,7 +45,7 @@ Rails.application.configure do
     Rails.application.credentials.aws&.dig(:secret_access_key),
   ].all?(&:present?)
     config.active_storage.service = :amazon
-  else
+  elsif !IS_DOCKER_BUILD
     raise(':amazon storage cannot be enabled because not all required credentials are present')
   end
 

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -4,7 +4,12 @@ Rollbar.configure do |config|
   access_token =
     case Rails.env
     # :nocov:
-    when 'production' then Rails.application.credentials.rollbar!.access_token!
+    when 'production'
+      if IS_DOCKER_BUILD
+        nil
+      else
+        Rails.application.credentials.rollbar!.access_token!
+      end
     # :nocov:
     else ENV.fetch('ROLLBAR_ACCESS_TOKEN', nil)
     end


### PR DESCRIPTION
See the latest build failure here: https://github.com/davidrunger/david_runger/actions/runs/10329351334/job/28597050353

I believe that this finally works out all the kinks (based on running `bin/build-docker production` locally, which is now successful).