### PR TITLE
Move skedjewel download from assets:precompile to Dockerfile [DEV-85]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,13 @@ RUN --mount=type=cache,sharing=private,target=/var/lib/apt/lists \
   apt-get install --no-install-recommends -y \
   build-essential curl git libpq-dev unzip
 
+# Download skedjewel binary.
+ARG SKEDJEWEL_VERSION=v0.0.13
+RUN curl --fail -L "https://github.com/davidrunger/skedjewel/releases/download/$SKEDJEWEL_VERSION/skedjewel-$SKEDJEWEL_VERSION-linux" > skedjewel && \
+  mkdir -p /app/bin && \
+  mv skedjewel /app/bin/ && \
+  chmod a+x /app/bin/skedjewel
+
 # Configure bundler and install application gems
 RUN \
   bundle config set --local clean 1 && \
@@ -58,7 +65,7 @@ COPY . .
 
 ARG GIT_REV
 
-# Build public/assets/, download public/vite/ and public/vite-admin/, and download skedjewel.
+# Build public/assets/, download public/vite/ and public/vite-admin/.
 RUN DOCKER_BUILD=true \
   GIT_REV=${GIT_REV} \
   SECRET_KEY_BASE_DUMMY=1 \
@@ -74,7 +81,7 @@ RUN bin/bootsnap precompile app/ lib/
 # Return to base image for final stage of app image build
 FROM base
 
-# Copy built artifacts: gems, application code, compiled assets
+# Copy everything added to the app WORKDIR: gems, application code, skedjewel, compiled assets.
 COPY --from=build /app /app
 
 # Add GIT_REV env var permanently to the image

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -120,18 +120,6 @@ Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
   system('unzip -d public/ tmp/vite-admin.zip')
   FileUtils.rm('tmp/vite.zip')
   FileUtils.rm('tmp/vite-admin.zip')
-
-  # install skedjewel
-  bin_path = Rails.root.join('bin')
-  skedjewel_version = 'v0.0.13'
-  skedjewel_url =
-    'https://github.com/davidrunger/skedjewel/' \
-    "releases/download/#{skedjewel_version}/skedjewel-#{skedjewel_version}-linux"
-  system(<<~SH.squish, exception: true)
-    curl -L #{skedjewel_url} > skedjewel &&
-      mv skedjewel #{bin_path}/ &&
-      chmod a+x #{bin_path}/skedjewel
-  SH
 end
 
 if Rails.env.production?


### PR DESCRIPTION
This will allow cacheing of the skedjewel download and also avoids the hackiness of including it in `assets:precompile`.