### PR TITLE
Stop inserting Rack::Deflater middleware

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -62,7 +62,6 @@ class DavidRunger::Application < Rails::Application
     g.factory_bot(dir: 'spec/factories')
   end
 
-  config.middleware.insert_after(ActionDispatch::Static, Rack::Deflater) # gzip all responses
   initializer(
     'move Browser middleware after Rack::Attack',
     after: 'rack-attack.middleware',


### PR DESCRIPTION
Motivation for deleting: "No such middleware to insert after: ActionDispatch::Static" https://github.com/davidrunger/david_runger/actions/runs/10337699081/job/28614892505#step:5:873

Cause of error: https://github.com/davidrunger/david_runger/pull/4884/files#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eR31

Rationale for deleting: I think that, in production, [NGINX will handle gzipping][1] for us. In other environments, gzipping shouldn't be needed or relevant.

[1]: https://github.com/davidrunger/david_runger/blob/272f6f112b3f80dc928272f0942a13d1b18a08c2/config/nginx/nginxconfig.io/general.conf#L1-L6