### PR TITLE
Switch back to 'config.public_file_server.enabled = true'

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -62,6 +62,7 @@ class DavidRunger::Application < Rails::Application
     g.factory_bot(dir: 'spec/factories')
   end
 
+  config.middleware.insert_after(ActionDispatch::Static, Rack::Deflater) # gzip all responses
   initializer(
     'move Browser middleware after Rack::Attack',
     after: 'rack-attack.middleware',

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -28,7 +28,7 @@ Rails.application.configure do
   config.require_master_key = !IS_DOCKER_BUILD
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
-  config.public_file_server.enabled = false
+  config.public_file_server.enabled = true
 
   # Compress CSS using a preprocessor.
   # config.assets.css_compressor = :sass


### PR DESCRIPTION
I think I was wrong to think that NGINX server our `public/` directory. (Maybe it should, but I think it currently doesn't? At least, that's what the current errors in production suggest.)