### PR TITLE
[nginx] Gzip 'text/html' and 'text/javascript' responses

### DIFF
--- a/config/nginx/nginxconfig.io/general.conf
+++ b/config/nginx/nginxconfig.io/general.conf
@@ -3,4 +3,4 @@ gzip            on;
 gzip_vary       on;
 gzip_proxied    any;
 gzip_comp_level 6;
-gzip_types      text/plain text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+gzip_types      text/plain text/html text/javascript text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;


### PR DESCRIPTION
We already have `application/javascript` in the list, but our JavaScript files are being served as `text/javascript`, which apparently is also a valid JavaScript MIME type, so here we add that to the list, as well.

Prior to this, I think that Cloudflare was compressing uncompressed files (of nontrivial size) with brotli, so for e.g. HTML files I think that we were uncompressed from our server to Cloudflare, but then compressed with brotli from Cloudflare to the user. Hopefully compressing the whole trip from our server with gzip will be faster overall? If it's not, we might want to disable all gzip compression on our server, and just let Cloudflare compress everything as brotli.

Unfortunately, it seems like brotli compression is not built into NGINX, but rather we'd have to use some sort of "NGINX Plus" addon.