### PR TITLE
[nginx] Remove explicit 'text/html' gzipping

### DIFF
--- a/config/nginx/nginxconfig.io/general.conf
+++ b/config/nginx/nginxconfig.io/general.conf
@@ -3,4 +3,4 @@ gzip            on;
 gzip_vary       on;
 gzip_proxied    any;
 gzip_comp_level 6;
-gzip_types      text/plain text/html text/javascript text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;
+gzip_types      text/plain text/javascript text/css text/xml application/json application/javascript application/rss+xml application/atom+xml image/svg+xml;


### PR DESCRIPTION
```
~/david_runger# docker compose exec nginx nginx -s reload
2024/08/11 07:52:19 [warn] 35#35: duplicate MIME type "text/html" in /etc/nginx/nginxconfig.io/general.conf:6
nginx: [warn] duplicate MIME type "text/html" in /etc/nginx/nginxconfig.io/general.conf:6
2024/08/11 07:52:19 [notice] 35#35: signal process started
```

https://nginx.org/en/docs/http/ngx_http_gzip_module.html#gzip_types:

> Responses with the "text/html" type are always compressed.

Apparently it's considered a duplicate listing to list `text/html` explicitly. Therefore, remove it.