### PR TITLE
Downgrade bundler from 2.5.17 to 2.5.11

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -763,4 +763,4 @@ RUBY VERSION
    ruby 3.3.4p94
 
 BUNDLED WITH
-   2.5.17
+   2.5.11


### PR DESCRIPTION
`bundle update --bundler 2.5.11`

Hopefully this will fix the following build error:

> Could not find 'bundler' (= 2.5.17) - did find: [bundler-2.5.11]

https://github.com/davidrunger/david_runger/actions/runs/10342375220/job/28625288615#step:5:250

I guess that 2.5.11 is installed on the `ruby:3.3.4-slim-bookworm` image (?), so let's just stick with that.