### PR TITLE
Enable YJIT only for web (not for worker) [DEV-91]

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -37,6 +37,9 @@ class DavidRunger::Application < Rails::Application
   # Initialize configuration defaults for originally generated Rails version.
   config.load_defaults(7.2)
 
+  # We enable YJIT for the web server only in config/initializers/enable_yjit.rb.
+  config.yjit = false
+
   # Please, add to the `ignore` list any other `lib` subdirectories that do
   # not contain `.rb` files, or that should not be reloaded or eager loaded.
   # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/initializers/enable_yjit.rb
+++ b/config/initializers/enable_yjit.rb
@@ -4,7 +4,7 @@
 # If you are deploying to a memory constrained environment
 # you may want to delete this file, but otherwise it's free
 # performance.
-if defined?(RubyVM::YJIT.enable)
+if defined?(RubyVM::YJIT.enable) && defined?(Rails::Server)
   Rails.application.config.after_initialize do
     RubyVM::YJIT.enable
   end

--- a/config/initializers/enable_yjit.rb
+++ b/config/initializers/enable_yjit.rb
@@ -1,9 +1,4 @@
-# Automatically enable YJIT as of Ruby 3.3, as it brings very
-# sizeable performance improvements.
-
-# If you are deploying to a memory constrained environment
-# you may want to delete this file, but otherwise it's free
-# performance.
+# Enable YJIT on the server (for performance gains), but not on the worker (for memory savings).
 if defined?(RubyVM::YJIT.enable) && defined?(Rails::Server)
   Rails.application.config.after_initialize do
     RubyVM::YJIT.enable


### PR DESCRIPTION
This is intended to save memory on the server (for the Sidekiq processes not using YJIT), at the cost of processing speed.