### PR TITLE
[enable_yjit] Also initialize YJIT in CI

### DIFF
--- a/config/initializers/enable_yjit.rb
+++ b/config/initializers/enable_yjit.rb
@@ -1,8 +1,6 @@
 # Enable YJIT on the server (for performance gains), but not on the worker (for memory savings).
-if defined?(RubyVM::YJIT.enable)
+if defined?(RubyVM::YJIT.enable) && (defined?(Rails::Server) || ENV.key?('CI'))
   Rails.application.config.after_initialize do
-    if defined?(Rails::Server)
-      RubyVM::YJIT.enable
-    end
+    RubyVM::YJIT.enable
   end
 end

--- a/config/initializers/enable_yjit.rb
+++ b/config/initializers/enable_yjit.rb
@@ -1,6 +1,8 @@
 # Enable YJIT on the server (for performance gains), but not on the worker (for memory savings).
-if defined?(RubyVM::YJIT.enable) && defined?(Rails::Server)
+if defined?(RubyVM::YJIT.enable)
   Rails.application.config.after_initialize do
-    RubyVM::YJIT.enable
+    if defined?(Rails::Server)
+      RubyVM::YJIT.enable
+    end
   end
 end


### PR DESCRIPTION
This way, we have the YJIT lines under test coverage. Also, maybe this will make CI run a little faster than it will with YJIT enabled? I like not enabling YJIT for my tests locally, because I am pretty memory constrained on my current machine.