### PR TITLE
Revert "Build Docker image on GitHub (not on server) [DEV-71] (#4903)"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -113,47 +113,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: davidrunger
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Set up Docker metadata
-        id: docker_metadata
-        uses: docker/metadata-action@v5
-        with:
-          images: |
-            davidrunger/david_runger
-          tags: |
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=sha,format=long
-
-      - name: Store build context
-        id: build_context
-        run: |
-          RUBY_VERSION=$(cat .ruby-version)
-          echo "RUBY_VERSION=${RUBY_VERSION}" >> $GITHUB_OUTPUT
-
-          GIT_REV="$(git rev-parse origin/main)"
-          echo "GIT_REV=${GIT_REV}" >> $GITHUB_OUTPUT
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build Docker image and push to Docker Hub
-        uses: docker/build-push-action@v6
-        with:
-          build-args: |
-            GIT_REV=${{ steps.build_context.outputs.GIT_REV }}
-            RAILS_ENV=production
-            RUBY_VERSION=${{ steps.build_context.outputs.RUBY_VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          labels: ${{ steps.meta.outputs.labels }}
-          push: true
-          tags: ${{ steps.docker_metadata.outputs.tags }}
-
       - name: Set up key for SSHing to server
         run: |
           mkdir -p ~/.ssh/

--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -21,10 +21,8 @@ fi
 # Run the install script.
 bin/server/install.sh
 
-# Pull the Docker image for the currently checked out Git SHA, and tag it as 'latest'.
-image_tag_for_sha="davidrunger/david_runger:sha-$(git rev-parse HEAD)"
-docker pull "$image_tag_for_sha"
-docker tag "$image_tag_for_sha" davidrunger/david_runger:latest
+# Rebuild the app.
+bin/build-docker production
 
 # Run release tasks.
 docker compose run --rm web bin/server/release-tasks

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,6 @@
 x-rails-config: &default-rails-config
+  build:
+    context: .
   depends_on:
     initialize_database:
       condition: service_completed_successfully
@@ -8,7 +10,6 @@ x-rails-config: &default-rails-config
   environment:
     MEMCACHED_PASSWORD: ''
     MEMCACHED_URL: memcached://memcached:11211
-  image: davidrunger/david_runger
   networks:
     - external
     - internal


### PR DESCRIPTION
This reverts commit 081c2d24eb328095952df9524367b8178a116098.

**Motivation:** `--mount=type=cache` does not work in GitHub Actions (https://github.com/moby/buildkit/issues/ 1512), which means we cannot cache gems between builds. We can still cache the overall Docker build step, so, as long as no gems change, the build is quick. However, a decent fraction of our PRs do involve gems changing, so this seems worth accounting for. Let's just try going back to building the images on the server.

Part of the motivation for building in GitHub Actions rather than on the server had been that we were running out of memory when trying to build the new image on the server and because the swap management process was using tons of CPU. However, now that I have allotted 2 GB of swap space (we had 0 before) and also increased the swappiness from 0 to currently 25 (and maybe I will go even higher, especially with this change), I'm optimistic that the server will now be able to handle building the images (and also having 2 web instances booted simultaneously, when we do our zero-downtime deployment rollout).

I guess that we'll have to try it out, and see what happens in production.

If the aforementioned Docker issue is ever addressed, then, at that time, it might be worth reverting this revert, i.e. going back to building the Docker image in a GitHub Action.