### PR TITLE
Copy public/ directory to volume used by NGINX after building

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -33,6 +33,11 @@ bin/build-docker production
 # Run release tasks.
 docker compose run --rm web bin/server/release-tasks
 
+# Copy fully built out public/ directory from web to nginx via app-public volume.
+docker run --rm \
+  --mount source=david_runger_app-public,target=/app-public \
+  --entrypoint cp david_runger-web -r /app/public/. /app-public/
+
 # Perform zero downtime, rolling deploy of web/nginx.
 bin/server/roll-out-web.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,7 +122,6 @@ services:
       - nondefault
     volumes:
       - ./blog:/app/blog
-      - app-public:/app/public
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']


### PR DESCRIPTION
Otherwise, the NGINX volume won't see updated `public/` files.

Also, remove the volume from the `web` Docker Compose service because we want to ensure that the `web` image has the latest version of `public/` (copied from the host) rather than using potentially outdated volume content.