### PR TITLE
[home] Add width and height for lazy-loaded images [HOME-6]

### DIFF
--- a/app/javascript/home/components/About.vue
+++ b/app/javascript/home/components/About.vue
@@ -8,6 +8,8 @@ HomeSection(section='about', title='About me', :renderHeadingManually='true')
             loading='lazy'
             src='~img/david.webp'
             alt='A picture of me'
+            width='235'
+            height='353'
           )
 
       .flex-3.p-4(class='sm:px-16')

--- a/app/javascript/home/components/Projects.vue
+++ b/app/javascript/home/components/Projects.vue
@@ -183,6 +183,8 @@ HomeSection(section='projects' title='Projects')
         loading='lazy'
         src='~img/serpent.webp'
         alt='Serpent Game'
+        width='239'
+        height='300'
       )
     template(v-slot:overview)
       div(slot='overview')
@@ -217,6 +219,8 @@ HomeSection(section='projects' title='Projects')
         loading='lazy'
         src='~img/simplecov-terminal.webp'
         alt='SimpleCov::Formatter::Terminal'
+        width='640'
+        height='386'
       )
     template(v-slot:overview)
       div(slot='overview')
@@ -253,6 +257,8 @@ HomeSection(section='projects' title='Projects')
         loading='lazy'
         src='~img/skedjewel.webp'
         alt='skedjewel.yml'
+        width='583'
+        height='208'
       )
     template(v-slot:overview)
       div(slot='overview')


### PR DESCRIPTION
I _think_ that this avoids at least one scenario where clicking the "Resume" nav link fails to go exactly to the resume section.