### PR TITLE
[docker] Don't send development logs to Papertrail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@
 .byebug_history
 .irb_history
 
+# Docker
+docker-compose.override.yml
+
 # Generated JavaScript path helpers
 /app/javascript/rails_assets
 

--- a/bin/build-docker
+++ b/bin/build-docker
@@ -15,8 +15,7 @@ rails_env=$1
 build() {
   services=("$@")
 
-  bin/server/with-docker-compose-env \
-    docker compose build "${services[@]}" \
+  docker compose build "${services[@]}" \
     --build-arg GIT_REV="$(git rev-parse origin/main)" \
     --build-arg RUBY_VERSION="$(cat .ruby-version)" \
     --build-arg RAILS_ENV="$rails_env" \

--- a/bin/server/boot-services.sh
+++ b/bin/server/boot-services.sh
@@ -7,8 +7,7 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 boot_services() {
   services=("$@")
 
-  bin/server/with-docker-compose-env \
-    docker compose up --detach --remove-orphans "${services[@]}"
+  docker compose up --detach --remove-orphans "${services[@]}"
 }
 
 # Boot default services.

--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -21,12 +21,6 @@ fi
 # Run the install script.
 bin/server/install.sh
 
-# Source environment variables needed in docker-compose.yml.
-set -a
-# shellcheck disable=SC1091
-. .env.papertrail.local
-set +a
-
 # Rebuild the app.
 bin/build-docker production
 

--- a/bin/server/with-docker-compose-env
+++ b/bin/server/with-docker-compose-env
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
-
-env "$(cat .env.papertrail.local)" "$@"

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,13 @@
+x-rails-json-file-logging: &json-file-logging
+  logging:
+    driver: local
+
+services:
+  clock:
+    <<: *json-file-logging
+  initialize_database:
+    <<: *json-file-logging
+  web:
+    <<: *json-file-logging
+  worker:
+    <<: *json-file-logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ x-rails-config: &default-rails-config
     driver: syslog
     options:
       # NOTE: The syslog-address value will be built into the image.
-      syslog-address: ${PAPERTRAIL_URL}
+      syslog-address: ${PAPERTRAIL_URL:-PAPERTRAIL_URL-was-not-set}
       tag: '{{.Name}}/{{.ID}}'
   networks:
     - external


### PR DESCRIPTION
In development, developers can now avoid sending logs to Papertrail (and instead just have logs available locally, via the `local` driver) via `cp docker-compose.override.yml.example docker-compose.override.yml`. The `docker-compose.override.yml` is a special file name that is loaded automatically by Docker.

The reason that we are using a `docker-compose.override.yml.example` template (and gitignoring the actual `docker-compose.override.yml` file) is because we _do_ want to track at least a copy of this file via version control, but we _don't_ want this file to be sent to the server via git, because, on the server, we _do_ want logs to be sent to Papertrail.

Also, instead of using `.env.papertrail.local` to source `PAPERTRAIL_URL`, we will now use `.env`, which is sourced by Docker Compose automatically, which makes things a lot easier and which is a more complete/foolproof solution. For example, even the code being deleted in this PR that loads `.env.papertrail.local` manually in several cases doesn't help when e.g. running `docker compose run --rm web echo 'hi'` on the server; we'd still get warnings like this:

> WARN[0000] The "PAPERTRAIL_URL" variable is not set. Defaulting to a blank string.

Just using `.env` (on the server) should avoid these warnings in all cases.

Also, in order to avoid warnings in development if a `.env` file with `PAPERTRAIL_URL` is not present, we also now provide a default value for `PAPERTRAIL_URL` in `docker-compose.yml`.