### PR TITLE
[gitignore] Add '.env'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # ENV secrets
+.env
 .env.*.local
 
 # Gems


### PR DESCRIPTION
I have long had this in my global gitignore file, but now we need to add it to this repo's gitignore file, because the server needs to have this file without it being considered a dirty file in the git working directory.