### PR TITLE
[docker-compose] Use a fake scheme for dummy syslog url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ x-rails-config: &default-rails-config
     driver: syslog
     options:
       # NOTE: The syslog-address value will be built into the image.
-      syslog-address: ${PAPERTRAIL_URL:-PAPERTRAIL_URL-was-not-set}
+      syslog-address: ${PAPERTRAIL_URL:-setpapertrailurl://it-was-not-set}
       tag: '{{.Name}}/{{.ID}}'
   networks:
     - external


### PR DESCRIPTION
Before, if `PAPERTRAIL_URL` was not set:

> Error response from daemon: unsupported scheme: ''

... and with no stack trace provided, making it pretty difficult to know/guess what the cause of this error is.

Now, if `PAPERTRAIL_URL` is not set:

> Error response from daemon: unsupported scheme: 'setpapertrailurl'

... making it relatively much easier to find the cause of this error.