### PR TITLE
Remove z.rb from dockerignore [DEV-95]

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 app/javascript/rails_assets
 bin/skedjewel
 config/credentials/production.key
-config/initializers/z.rb
 docs
 log
 node_modules


### PR DESCRIPTION
Since this is a personal concern, I don't like having it in `.dockerignore`. Instead, I will add an `unless IS_DOCKER` wrapper around the file's whole current contents, in order to avoid the errors that occur when attempting to load this file when running via Docker (which doesn't install development or test gems).