### PR TITLE
[Dockerfile] Remove redundant curl apt-get installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN --mount=type=cache,sharing=private,target=/var/lib/apt/lists \
   --mount=type=cache,sharing=private,target=/var/cache/apt \
   apt-get update -qq && \
   apt-get install --no-install-recommends -y \
-  build-essential curl git libpq-dev unzip
+  build-essential git libpq-dev unzip
 
 # Download skedjewel binary.
 ARG SKEDJEWEL_VERSION=v0.0.13


### PR DESCRIPTION
As of #4950, we are now installing `curl` on the `base` image, so we don't also need to try to install it on the `build` image.

This will avoid notes [like this][1] when building the image:

>  curl is already the newest version (7.88.1-10+deb12u6).

[1]: https://github.com/davidrunger/david_runger/actions/runs/10438074750/job/28905025826#step:5:223