### PR TITLE
[verify-expected-services] Loosen regex for "Up About an hour" case

### DIFF
--- a/bin/server/verify-expected-services.sh
+++ b/bin/server/verify-expected-services.sh
@@ -13,7 +13,7 @@ check_services() {
 
   for expected_service in "${expected_running_services[@]}" ; do
     # Make sure that the service is running and that the healthcheck (if there is one) is healthy.
-    if ! grep -q -P "^david_runger-$expected_service-\d+ Up \d+ \S+($| \(healthy\)$)" <<< "$running_services" ; then
+    if ! grep -q -P "^david_runger-$expected_service-\d+ Up [^(]+($| \(healthy\)$)" <<< "$running_services" ; then
       echo "$expected_service is not running!"
       expected_services_not_running+=("$expected_service")
     fi


### PR DESCRIPTION
Currently, services are being [reported as not running][1] during deployment attempts, even though they are running, because our regex assumed a certain format of the container status that actually won't always be provided.

[1]: https://github.com/davidrunger/david_runger/actions/runs/10438463349/job/28905901338#step:5:532

```
root@debian:~/david_runger# docker ps
CONTAINER ID   IMAGE                  COMMAND                  CREATED             STATUS                       PORTS                                                                      NAMES
1ea52d4cd654   david_runger-web       "/app/bin/docker-ent…"   6 minutes ago       Up 6 minutes (healthy)       3000/tcp                                                                   david_runger-web-84
dde0f559bc93   david_runger-worker    "/app/bin/docker-ent…"   9 minutes ago       Up 9 minutes (healthy)                                                                                  david_runger-worker-1
f11c5e629d57   david_runger-clock     "/app/bin/docker-ent…"   9 minutes ago       Up 9 minutes                                                                                            david_runger-clock-1
b078d5a7412e   redis:7.2.5-alpine     "docker-entrypoint.s…"   About an hour ago   Up About an hour (healthy)                                                                              david_runger-redis-cache-1
d1b020c3a445   redis:7.2.5-alpine     "docker-entrypoint.s…"   About an hour ago   Up About an hour (healthy)                                                                              david_runger-redis-app-1
46d2e181211a   postgres:16.3-alpine   "docker-entrypoint.s…"   About an hour ago   Up About an hour (healthy)                                                                              david_runger-postgres-1
833a016b64aa   nginx:1.27.0-alpine    "/docker-entrypoint.…"   6 days ago          Up 4 days                    0.0.0.0:80->80/tcp, :::80->80/tcp, 0.0.0.0:443->443/tcp, :::443->443/tcp   david_runger-nginx-1
2f15cdcd4d64   certbot/certbot        "/bin/sh -c 'trap ex…"   2 weeks ago         Up 4 days                    80/tcp, 443/tcp                                                            david_runger-certbot-1
```