### PR TITLE
[docker-compose] Add health check for certbot service

### DIFF
--- a/bin/server/verify-expected-services.sh
+++ b/bin/server/verify-expected-services.sh
@@ -13,7 +13,7 @@ check_services() {
 
   for expected_service in "${expected_running_services[@]}" ; do
     # Make sure that the service is running and that the healthcheck (if there is one) is healthy.
-    if ! grep -q -P "^david_runger-$expected_service-\d+ Up [^(]+($| \(healthy\)$)" <<< "$running_services" ; then
+    if ! grep -q -P "^david_runger-$expected_service-\d+ Up [^(]+ \(healthy\)$" <<< "$running_services" ; then
       echo "$expected_service is not running!"
       expected_services_not_running+=("$expected_service")
     fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,13 @@ x-redis-config: &redis
 services:
   certbot:
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
+    healthcheck:
+      test: certbot --version
+      start_period: 10s
+      start_interval: 1s
+      interval: 1h
+      timeout: 1s
+      retries: 1
     image: certbot/certbot
     networks:
       - external


### PR DESCRIPTION
This doesn't really check that certbot is actually doing it's certbot work or even that it's running at all (which, it usually won't be; it will just be sleeping). This just checks that `certbot --version` is available. Better than nothing, though, I guess. And `certbot` was the only service without a health check; now all services have one.