### PR TITLE
Give certbot health check test 3 seconds (not 1)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,10 @@ services:
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
     healthcheck:
       test: certbot --version
-      start_period: 10s
-      start_interval: 1s
+      start_period: 30s
+      start_interval: 3s
       interval: 1h
-      timeout: 1s
+      timeout: 3s
       retries: 1
     image: certbot/certbot
     networks:


### PR DESCRIPTION
Also, extend the start_period from 10 seconds to 30 seconds.

During a recent deployment attempt ([link][1]), `certbot` had "unhealthy" status, resulting in a deployment failure. I'm not sure why this would be, since the health check `test` passes on my machine and in production when executed with `docker compose exec certbot certbot --version`. Maybe we aren't giving it enough time? So, this PR gives more time.

[1]: https://github.com/davidrunger/david_runger/actions/runs/10438815683/job/28906610003#step:5:601