### PR TITLE
[home] Use h1 for main hero text and h2 for section headers

### DIFF
--- a/app/javascript/home/components/HomeHero.vue
+++ b/app/javascript/home/components/HomeHero.vue
@@ -3,8 +3,8 @@
   ref="homeRef"
 )
   .spacer.grow
-  #headline-container.grow(data-section='home')
-    #headline-name.monospace.text-blue-300.border-b-2.border-indigo-200.leading-normal
+  h1#headline-container.grow(data-section='home')
+    #headline-name.monospace.font-normal.text-blue-300.border-b-2.border-indigo-200.leading-normal
       | David Runger
     .pt-4.text-4xl.text-right.text-neutral-100
       | Full stack web developer

--- a/app/javascript/home/components/SectionHeader.vue
+++ b/app/javascript/home/components/SectionHeader.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-h1.text-3xl.font-bold.my-4 {{ title }}
+h2.text-3xl.font-bold.my-4 {{ title }}
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
There should be one, and only one, h1 per page. This change accomplishes that on the homepage.