### PR TITLE
[sitemap] Add html suffix for privacy policy

### DIFF
--- a/public/root-sitemap.xml
+++ b/public/root-sitemap.xml
@@ -17,7 +17,7 @@
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://davidrunger.com/privacy-policy</loc>
+    <loc>https://davidrunger.com/privacy-policy.html</loc>
     <priority>0.5</priority>
   </url>
 </urlset>


### PR DESCRIPTION
It's needed (maybe since moving to serve static assets via NGINX?).

I'm not sure there's a lot of advantage in listing the privacy policy in the sitemap at all, but I guess it seems sort of like a good idea. Maybe it enhances credibility and makes search engines rank me higher.