### PR TITLE
[nginx] Try serving static files by adding a .html suffix

### DIFF
--- a/config/nginx/sites-enabled/davidrunger.com.conf
+++ b/config/nginx/sites-enabled/davidrunger.com.conf
@@ -19,7 +19,8 @@ server {
     # Serve static files from the public directory
     location / {
         root /var/www/david-runger-public;
-        try_files $uri @rails_app;  # Try to serve the file; if not found, forward to Rails app
+        # Try to serve the file (and try adding .html suffix). If not found, forward to Rails app.
+        try_files $uri $uri.html @rails_app;
     }
 
     location @rails_app {


### PR DESCRIPTION
This will make NGINX serve the `public/privacy-policy.html` file via https://davidrunger.com/privacy-policy . Currently, that path 404s (and one must go to https://davidrunger.com/privacy-policy.html ). With this change, both URLs will work.