### PR TITLE
[docker-compose] Give worker 60 seconds (not 30) to boot up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
     command: ['bin/sidekiq']
     healthcheck:
       test: REDIS_URL="$$REDIS_URL/1" bin/sidekiqmon | grep --quiet "$$(hostname)"
-      start_period: 45s
+      start_period: 60s
       start_interval: 5s
       interval: 60s
       timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
     command: ['bin/sidekiq']
     healthcheck:
       test: REDIS_URL="$$REDIS_URL/1" bin/sidekiqmon | grep --quiet "$$(hostname)"
-      start_period: 30s
+      start_period: 45s
       start_interval: 5s
       interval: 60s
       timeout: 5s

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -165,9 +165,9 @@ services:
     healthcheck:
       test: REDIS_URL="$$REDIS_URL/1" bin/sidekiqmon | grep --quiet "$$(hostname)"
       start_period: 60s
-      start_interval: 5s
+      start_interval: 10s
       interval: 60s
-      timeout: 5s
+      timeout: 10s
       retries: 1
 
 networks:


### PR DESCRIPTION
... and increase the timeout and startup interval from 5 seconds to 10 seconds.

We recently had a [deploy failure][1] caused by the worker not booting up. I am guessing that it was just taking too long. Let's give it more time.

[1]: https://github.com/davidrunger/david_runger/actions/runs/10442469683/job/28914831734#step:5:598