### PR TITLE
[verify-expected-services] Increase retry delay to 2 seconds (from 1)

### DIFF
--- a/bin/server/verify-expected-services.sh
+++ b/bin/server/verify-expected-services.sh
@@ -5,7 +5,7 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 expected_running_services=(certbot clock nginx postgres redis-app redis-cache web worker)
 expected_services_not_running=()
 max_retries=30
-retry_delay=1
+retry_delay=2
 
 check_services() {
   running_services=$(docker ps --filter='status=running' --format='table {{.Names}} {{.Status}}' | tail -n +2)


### PR DESCRIPTION
In #4962, we increased the startup time for the `worker` service from 30 seconds to 60 seconds. Accordingly, we should also give `verify-expected-services` up to 60 seconds to start up. In this change, we accomplish that by increasing the retry delay from 1 second to 2 seconds.