### PR TITLE
[vue] Enable "whitespace: 'preserve'" option [DEV-98]

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -18,7 +18,13 @@ export default defineConfig({
     ]),
     RubyPlugin(),
     ElementPlus(),
-    vue(),
+    vue({
+      template: {
+        compilerOptions: {
+          whitespace: 'preserve',
+        },
+      },
+    }),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
NOTE: I am usually working in pug templates, and pug has its own issues with whitespace. So, this setting won't have any impact on most of my work. However, I still think that this is a good and worthwhile change, since I do occasionally work with plain HTML templates, especially in `Playground.vue`, and, in those cases, I think that `whitespace: 'preserve'` is my preferred option.