### PR TITLE
Include query counts (cached and uncached) in logs [DEV-101]

### DIFF
--- a/app/decorators/marriage_decorator.rb
+++ b/app/decorators/marriage_decorator.rb
@@ -5,6 +5,8 @@ class MarriageDecorator < Draper::Decorator
 
   memo_wise \
   def other_partner
-    partners.where.not(id: h.current_user).first
+    partner_ids = [partner_1_id, partner_2_id]
+    partner_id = (partner_ids - [h.current_user.id]).first
+    User.find(partner_id)
   end
 end

--- a/app/decorators/marriage_decorator.rb
+++ b/app/decorators/marriage_decorator.rb
@@ -7,6 +7,9 @@ class MarriageDecorator < Draper::Decorator
   def other_partner
     partner_ids = [partner_1_id, partner_2_id]
     partner_id = (partner_ids - [h.current_user.id]).first
-    User.find(partner_id)
+
+    if partner_id
+      User.find(partner_id)
+    end
   end
 end

--- a/lib/logs/log_builder.rb
+++ b/lib/logs/log_builder.rb
@@ -12,6 +12,8 @@ class Logs::LogBuilder
       exception: exception_log,
       params: params_log,
       status: status_code_log,
+      queries: payload[:queries_count],
+      cached_queries: payload[:cached_queries_count],
       ip: payload[:ip], # comes from ApplicationController#append_info_to_payload
       admin_user_id: payload[:admin_user_id], # from ApplicationController#append_info_to_payload
       user_id: payload[:user_id], # from ApplicationController#append_info_to_payload

--- a/lib/logs/log_formatter.rb
+++ b/lib/logs/log_formatter.rb
@@ -20,6 +20,8 @@ class Logs::LogFormatter < Lograge::Formatters::KeyValue
           when :format then 3
           when :params then 4
           when :status then 5
+          when :queries then 5.3
+          when :cached_queries then 5.6
           when :allocations then 6
           when :duration then 7
           when :db then 8
@@ -85,6 +87,16 @@ class Logs::LogFormatter < Lograge::Formatters::KeyValue
       when 3 then :yellow
       else %i[black red]
       end
+    when :queries
+      if value < 5
+        :green
+      elsif value < 12
+        :yellow
+      else
+        :red
+      end
+    when :cached_queries
+      :white
     when :allocations
       if value < 20_000
         :green


### PR DESCRIPTION
This was added in Rails 7.2: https://github.com/rails/rails/pull/ 51457

(I checked, and it seems that there are no other notable values included in the available log data that we are also (up to now) failing to log.)