### PR TITLE
[emoji-picker] Tighten 'threshold' to 0.35 (from 0.6 default)

### DIFF
--- a/app/javascript/emoji_picker/EmojiPicker.vue
+++ b/app/javascript/emoji_picker/EmojiPicker.vue
@@ -52,6 +52,9 @@ const { highlightedSearchable, onArrowDown, onArrowUp, topRankedMatches } =
     query: queryDebounced,
     propertyToSearch: 'name',
     maxMatches: 10,
+    fuseOptions: {
+      threshold: 0.35,
+    },
   });
 
 function handleKeydown(event: KeyboardEvent) {

--- a/app/javascript/lib/composables/use_fuzzy_typeahead.ts
+++ b/app/javascript/lib/composables/use_fuzzy_typeahead.ts
@@ -1,4 +1,4 @@
-import Fuse from 'fuse.js';
+import Fuse, { IFuseOptions } from 'fuse.js';
 import { map } from 'lodash-es';
 import { computed, ComputedRef, ref, Ref, watch } from 'vue';
 
@@ -7,15 +7,20 @@ export function useFuzzyTypeahead<T extends object>({
   query,
   propertyToSearch,
   maxMatches,
+  fuseOptions,
 }: {
   searchables: Array<T>;
   query: Ref<string>;
   propertyToSearch: keyof T & string;
   maxMatches?: number;
+  fuseOptions?: IFuseOptions<T>;
 }) {
   const highlightedIndex = ref(0);
   const fuse = computed(() => {
-    return new Fuse(searchables, { keys: [propertyToSearch] });
+    return new Fuse(
+      searchables,
+      Object.assign({ keys: [propertyToSearch] }, fuseOptions),
+    );
   });
 
   const rankedMatches: ComputedRef<Array<T>> = computed(() => {


### PR DESCRIPTION
https://www.fusejs.io/api/options.html#threshold

I think that the results with the default threshold of 0.6 are too cluttered with low-value matches.

# Before

![image](https://github.com/user-attachments/assets/eb4cf711-44ae-4ec4-8131-d9d4bc4def70)

# After

![image](https://github.com/user-attachments/assets/b8b0443e-2440-41cc-856b-987b4c05c576)

It's interesting to note that this change actually removes some results from the list.