### PR TITLE
Print all rake tasks at start of RunTypelizer test task

### DIFF
--- a/lib/test/tasks/run_typelizer.rb
+++ b/lib/test/tasks/run_typelizer.rb
@@ -2,7 +2,13 @@ class Test::Tasks::RunTypelizer < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    execute_rake_task('typelizer:generate', quiet: true)
+    pp(Rake::Task.tasks)
+    begin
+      execute_rake_task('typelizer:generate', quiet: true)
+    rescue => error
+      pp(error)
+      puts(error.backtrace)
+    end
     execute_system_command("! grep --quiet -RP '\\bunknown\\b' app/javascript/types/serializers/")
     execute_system_command('git diff --exit-code')
   end


### PR DESCRIPTION
Also, wrap it in a rescue block.

I'm trying to debug why this is [failing][1] on `main`.

[1]: https://github.com/davidrunger/david_runger/actions/runs/10512542496/job/29126254370#step:11:93