### PR TITLE
Make RunTypelizer depend on BuildFixtures

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -27,7 +27,7 @@ class Test::RequirementsResolver
         Test::Tasks::RunStylelint => Test::Tasks::PnpmInstall,
         Test::Tasks::RunEslint => Test::Tasks::PnpmInstall,
         Test::Tasks::RunAnnotate => Test::Tasks::SetupDb,
-        Test::Tasks::RunTypelizer => Test::Tasks::SetupDb,
+        Test::Tasks::RunTypelizer => Test::Tasks::BuildFixtures,
         Test::Tasks::RunBrakeman => nil,
         Test::Tasks::RunDatabaseConsistency => Test::Tasks::SetupDb,
         Test::Tasks::RunImmigrant => Test::Tasks::SetupDb,

--- a/lib/test/tasks/run_typelizer.rb
+++ b/lib/test/tasks/run_typelizer.rb
@@ -2,13 +2,7 @@ class Test::Tasks::RunTypelizer < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    pp(Rake::Task.tasks)
-    begin
-      execute_rake_task('typelizer:generate')
-    rescue => error
-      pp(error)
-      puts(error.backtrace)
-    end
+    execute_rake_task('typelizer:generate')
     execute_system_command("! grep --quiet -RP '\\bunknown\\b' app/javascript/types/serializers/")
     execute_system_command('git diff --exit-code')
   end


### PR DESCRIPTION
Also, remove debugging code.

I'm not sure if this will resolve the spec failures that we are seeing on `main` ([example][1]), but it might.

[1]: https://github.com/davidrunger/david_runger/actions/runs/10513097780/job/29127904630#step:11:215