### PR TITLE
Use my fork of typelizer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ group :development, :test do
   gem 'rubocop-rspec_rails', require: false
   gem 'runger_style', require: false
   gem 'spring-commands-rspec'
-  gem 'typelizer'
+  gem 'typelizer', github: 'davidrunger/typelizer'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,6 +6,13 @@ GIT
       msgpack
       redis (~> 5.0)
 
+GIT
+  remote: https://github.com/davidrunger/typelizer.git
+  revision: fc68af77ad08c84472567ff1f8050679793c74a1
+  specs:
+    typelizer (0.1.0)
+      railties (>= 6.0.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -626,8 +633,6 @@ GEM
     thor (1.3.1)
     tilt (2.4.0)
     timeout (0.4.1)
-    typelizer (0.1.0)
-      railties (>= 6.0.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
@@ -756,7 +761,7 @@ DEPENDENCIES
   sprockets-rails
   strip_attributes
   super_diff
-  typelizer
+  typelizer!
   vite_rails
   webmock
 

--- a/lib/test/task_helpers.rb
+++ b/lib/test/task_helpers.rb
@@ -85,6 +85,7 @@ module Test::TaskHelpers
       record_failure_and_log_message(
         "'#{task_name}' failed ('exited with 1', raised #{error.inspect}).",
       )
+      puts(error.backtrace)
     else
       record_success_and_log_message("'#{task_name}' succeeded (took #{time.round(3)}).")
     end


### PR DESCRIPTION
Also, print backtrace of errors that might occur in Test::TaskHelpers#execute_rake_task. This might be helpful to debug stuff (especially failures that might occur in CI, rather than locally).