### PR TITLE
[typelizer] Only configure in initializer if defined

### DIFF
--- a/config/initializers/typelizer.rb
+++ b/config/initializers/typelizer.rb
@@ -1,6 +1,8 @@
-Typelizer.reject_class =
-  proc do |serializer:|
-    serializer.in?([
-      LogEntrySerializer, # This model is not backed by a single database table.
-    ])
-  end
+if defined?(Typelizer)
+  Typelizer.reject_class =
+    proc do |serializer:|
+      serializer.in?([
+        LogEntrySerializer, # This model is not backed by a single database table.
+      ])
+    end
+end


### PR DESCRIPTION
This should fix `NameError: uninitialized constant Typelizer` errors occurring during production deployments. (Those errors are occurring because `typelizer` is in the `group :development, :test` Gemfile block.)

https://github.com/davidrunger/david_runger/actions/runs/10524178379/job/29160503039#step:5:125