### PR TITLE
Import types explicitly as types

### DIFF
--- a/app/javascript/check_ins/types.ts
+++ b/app/javascript/check_ins/types.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   CheckIn,
   NeedSatisfactionRating as TypelizerNeedSatisfactionRating,
   UserSerializerBasic,

--- a/app/javascript/emoji_picker/EmojiPicker.vue
+++ b/app/javascript/emoji_picker/EmojiPicker.vue
@@ -33,7 +33,7 @@ import CopiedEmojiToast from '@/emoji_picker/components/CopiedEmojiToast.vue';
 import { emojiData } from '@/emoji_picker/emoji_data';
 import { useFuzzyTypeahead } from '@/lib/composables/use_fuzzy_typeahead';
 import { vueToast } from '@/lib/vue_toasts';
-import { EmojiData } from '@/types';
+import type { EmojiData } from '@/types';
 
 const query = ref('');
 const queryDebounced = refDebounced(query, 60, { maxWait: 180 });

--- a/app/javascript/emoji_picker/components/BoostsForm.vue
+++ b/app/javascript/emoji_picker/components/BoostsForm.vue
@@ -44,7 +44,7 @@ import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { routes } from '@/lib/routes';
 import { vueToast } from '@/lib/vue_toasts';
 import { http } from '@/shared/http';
-import { EmojiDataWithBoostedName } from '@/types';
+import type { EmojiDataWithBoostedName } from '@/types';
 
 const bootstrap = untypedBootstrap as Bootstrap;
 

--- a/app/javascript/emoji_picker/emoji_data.ts
+++ b/app/javascript/emoji_picker/emoji_data.ts
@@ -5,7 +5,7 @@ import { computed, reactive, ref } from 'vue';
 
 import { type Bootstrap } from '@/emoji_picker/types';
 import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
-import { EmojiData, EmojiDataWithBoostedName } from '@/types';
+import type { EmojiData, EmojiDataWithBoostedName } from '@/types';
 
 const originalEmojilibData = flatMap(EmojiLibData, (names, symbol) => {
   return names.map((name) => {

--- a/app/javascript/emoji_picker/types.ts
+++ b/app/javascript/emoji_picker/types.ts
@@ -1,4 +1,4 @@
-import { UserSerializerWithEmojiBoosts } from '@/types';
+import type { UserSerializerWithEmojiBoosts } from '@/types';
 
 export interface Bootstrap {
   current_user?: UserSerializerWithEmojiBoosts;

--- a/app/javascript/groceries/components/CheckInModal.vue
+++ b/app/javascript/groceries/components/CheckInModal.vue
@@ -45,7 +45,7 @@ import { computed } from 'vue';
 
 import { useGroceriesStore } from '@/groceries/store';
 import { useModalStore } from '@/shared/modal/store';
-import { Store } from '@/types';
+import type { Store } from '@/types';
 
 import CheckInItemsList from './CheckInItemsList.vue';
 

--- a/app/javascript/groceries/components/CheckInStoreList.vue
+++ b/app/javascript/groceries/components/CheckInStoreList.vue
@@ -17,7 +17,7 @@ ul
 import type { PropType } from 'vue';
 
 import { useGroceriesStore } from '@/groceries/store';
-import { Store } from '@/types';
+import type { Store } from '@/types';
 
 defineProps({
   stores: {

--- a/app/javascript/groceries/components/Store.vue
+++ b/app/javascript/groceries/components/Store.vue
@@ -79,7 +79,7 @@ import { helpers, useGroceriesStore } from '@/groceries/store';
 import type { Item as ItemType } from '@/groceries/types';
 import { isMobileDevice } from '@/lib/is_mobile_device';
 import { useModalStore } from '@/shared/modal/store';
-import { Store } from '@/types';
+import type { Store } from '@/types';
 
 import CheckInModal from './CheckInModal.vue';
 import Item from './Item.vue';

--- a/app/javascript/groceries/components/StoreListEntry.vue
+++ b/app/javascript/groceries/components/StoreListEntry.vue
@@ -19,7 +19,7 @@ import type { PropType } from 'vue';
 import { LockIcon } from 'vue-tabler-icons';
 
 import { useGroceriesStore } from '@/groceries/store';
-import { Store } from '@/types';
+import type { Store } from '@/types';
 
 defineProps({
   store: {

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -10,7 +10,7 @@ import * as RoutesType from '@/rails_assets/routes';
 import { http } from '@/shared/http';
 import { kyApi } from '@/shared/ky';
 import { getById, safeGetById } from '@/shared/store_helpers';
-import { Store } from '@/types';
+import type { Store } from '@/types';
 
 declare const Routes: typeof RoutesType;
 

--- a/app/javascript/groceries/types.ts
+++ b/app/javascript/groceries/types.ts
@@ -1,5 +1,5 @@
 import { JsonBroadcast } from '@/shared/types';
-import { Store, Item as TypelizerItem, UserSerializerBasic } from '@/types';
+import type { Store, Item as TypelizerItem, UserSerializerBasic } from '@/types';
 
 export type CheckInStatus = 'needed' | 'in-cart' | 'skipped';
 

--- a/app/javascript/groceries/types.ts
+++ b/app/javascript/groceries/types.ts
@@ -1,5 +1,9 @@
 import { JsonBroadcast } from '@/shared/types';
-import type { Store, Item as TypelizerItem, UserSerializerBasic } from '@/types';
+import type {
+  Store,
+  Item as TypelizerItem,
+  UserSerializerBasic,
+} from '@/types';
 
 export type CheckInStatus = 'needed' | 'in-cart' | 'skipped';
 

--- a/app/javascript/logs/components/EditLogSharingSettingsModal.vue
+++ b/app/javascript/logs/components/EditLogSharingSettingsModal.vue
@@ -43,7 +43,7 @@ import { computed, nextTick, ref } from 'vue';
 import { bootstrap } from '@/lib/bootstrap';
 import { assert } from '@/shared/helpers';
 import { useModalStore } from '@/shared/modal/store';
-import { LogShare } from '@/types';
+import type { LogShare } from '@/types';
 
 import { useLogsStore } from '../store';
 import type { Bootstrap } from '../types';

--- a/app/javascript/logs/store.ts
+++ b/app/javascript/logs/store.ts
@@ -6,7 +6,7 @@ import * as RoutesType from '@/rails_assets/routes';
 import { assert } from '@/shared/helpers';
 import { kyApi } from '@/shared/ky';
 import { getById } from '@/shared/store_helpers';
-import { LogShare } from '@/types';
+import type { LogShare } from '@/types';
 
 import { Bootstrap, Log, LogEntry, LogEntryDataValue } from './types';
 

--- a/app/javascript/logs/types.ts
+++ b/app/javascript/logs/types.ts
@@ -1,5 +1,5 @@
 import { JsonBroadcast } from '@/shared/types';
-import { Log as TypelizerLog, UserSerializerBasic } from '@/types';
+import type { Log as TypelizerLog, UserSerializerBasic } from '@/types';
 
 export type LogEntryDataValue = string | number;
 export type LogDataType = 'counter' | 'duration' | 'number' | 'text';

--- a/app/javascript/packs/quizzes.ts
+++ b/app/javascript/packs/quizzes.ts
@@ -4,7 +4,7 @@ import Rails from '@rails/ujs';
 import actionCableConsumer from '@/channels/consumer';
 import { loadAsyncPartials } from '@/lib/async_partial';
 import { assert } from '@/shared/helpers';
-import { Quiz, UserSerializerBasic } from '@/types';
+import type { Quiz, UserSerializerBasic } from '@/types';
 
 // https://github.com/hotwired/turbo-rails/issues/135#issuecomment-814413558
 Rails.delegate(

--- a/app/javascript/workout/Workout.vue
+++ b/app/javascript/workout/Workout.vue
@@ -18,7 +18,7 @@ div(v-if='workoutIsInProgress')
 import { storeToRefs } from 'pinia';
 import { computed } from 'vue';
 
-import { WorkoutPlan as WorkoutPlanType } from '@/types';
+import type { WorkoutPlan as WorkoutPlanType } from '@/types';
 import NewWorkoutForm from '@/workout/components/NewWorkoutForm.vue';
 import WorkoutPlan from '@/workout/components/WorkoutPlan.vue';
 import WorkoutsTable from '@/workout/components/WorkoutsTable.vue';

--- a/app/javascript/workout/components/WorkoutPlan.vue
+++ b/app/javascript/workout/components/WorkoutPlan.vue
@@ -73,7 +73,7 @@ import { computed, onBeforeMount, ref, type PropType } from 'vue';
 
 import { assert } from '@/shared/helpers';
 import { useModalStore } from '@/shared/modal/store';
-import { Exercise } from '@/types';
+import type { Exercise } from '@/types';
 
 import ConfirmWorkoutModal from './ConfirmWorkoutModal.vue';
 

--- a/app/javascript/workout/components/WorkoutsTable.vue
+++ b/app/javascript/workout/components/WorkoutsTable.vue
@@ -27,7 +27,7 @@ import strftime from 'strftime';
 import { computed, type PropType } from 'vue';
 
 import { toast } from '@/lib/toasts';
-import { Workout } from '@/types';
+import type { Workout } from '@/types';
 import { useWorkoutsStore } from '@/workout/store';
 
 const props = defineProps({

--- a/app/javascript/workout/store.ts
+++ b/app/javascript/workout/store.ts
@@ -4,7 +4,7 @@ import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import * as RoutesType from '@/rails_assets/routes';
 import { http } from '@/shared/http';
 import { kyApi } from '@/shared/ky';
-import { Workout, WorkoutPlan } from '@/types';
+import type { Workout, WorkoutPlan } from '@/types';
 
 import { Bootstrap, NewWorkoutAttributes } from './types';
 

--- a/app/javascript/workout/types.ts
+++ b/app/javascript/workout/types.ts
@@ -1,4 +1,8 @@
-import type { RepTotals, UserSerializerWithDefaultWorkout, Workout } from '@/types';
+import type {
+  RepTotals,
+  UserSerializerWithDefaultWorkout,
+  Workout,
+} from '@/types';
 
 export type NewWorkoutAttributes = {
   publiclyViewable: boolean;

--- a/app/javascript/workout/types.ts
+++ b/app/javascript/workout/types.ts
@@ -1,4 +1,4 @@
-import { RepTotals, UserSerializerWithDefaultWorkout, Workout } from '@/types';
+import type { RepTotals, UserSerializerWithDefaultWorkout, Workout } from '@/types';
 
 export type NewWorkoutAttributes = {
   publiclyViewable: boolean;


### PR DESCRIPTION
Not explicitly importing the types as types doesn't seem to break the compiled JavaScript code (as evidenced by specs and production still working), but it does seem to break the Vite server. This change fixes the issue by explicitly importing types as types.