### PR TITLE
[spec/quizzes] Add more page content expectations [QUIZ-4]

### DIFF
--- a/app/models/quiz_question_answer.rb
+++ b/app/models/quiz_question_answer.rb
@@ -28,4 +28,5 @@ class QuizQuestionAnswer < ApplicationRecord
   has_many(:answering_participations, through: :selections, source: :participation)
 
   scope :correct, -> { where(is_correct: true) }
+  scope :incorrect, -> { where(is_correct: false) }
 end

--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -69,6 +69,7 @@ RSpec.describe 'Quizzes app' do
 
       # start the quiz
       click_on('Start quiz!')
+      expect(page).to have_text('Question 1')
 
       first_question, second_question = QuizQuestion.order(:created_at).last(2)
 
@@ -76,20 +77,31 @@ RSpec.describe 'Quizzes app' do
       using_session('Quiz participant session') do
         choose(first_question.answers.correct.first!.content)
         click_on('Submit')
+        expect(page).to have_css('.font-bold', text: 'Jessica')
+        expect(page).to have_css('ol li:nth-of-type(1)', text: /\A\z/)
       end
 
       # close question (reveal answer) and move to next question
       click_on('Close question')
+      expect(page).to have_css('.text-lime-600', text: '(Jessica)')
+      expect(page).to have_text('Jessica (1/2)')
+
       click_on('Next question')
+      expect(page).to have_text('Question 2')
+      expect(page).to have_text('Jessica (1/2)')
 
       # participant chooses an incorrect answer
       using_session('Quiz participant session') do
-        choose(second_question.answers.first!.content)
+        choose(second_question.answers.incorrect.first!.content)
         click_on('Submit')
+        expect(page).to have_css('.font-bold', text: 'Jessica')
+        expect(page).to have_css('ol li:nth-of-type(1)', text: /\A✓\z/)
       end
 
       # close question (reveal answer)
       click_on('Close question')
+      expect(page).to have_css('.text-red-600', text: '(Jessica)')
+      expect(page).to have_text('Jessica (1/2)')
 
       # verify participant sees they got first question right and second question wrong
       using_session('Quiz participant session') do


### PR DESCRIPTION
It seems like maybe sometimes a response intended for the quiz owner gets processed in the session of the non-owner quiz participant? (If so, hopefully that's not something that can happen in real life, but rather is just a quirk of Capybara's session management.)

This change adds additional expectations about page content after taking actions in the browser. Hopefully this will slow things down a bit / keep things a bit more stable, so that responses are less likely to get mixed up as we move quickly back and forth between the two sessions.

I ran the test 60 times after making this change, and it flaked with the error that this change aims to fix (`TurboFrameMissingError`) zero times, whereas, when I did the same thing previously without this change, the spec flaked 5 times with `TurboFrameMissingError`. So, I think that's pretty encouraging.

Other flakiness remains in the spec being modified herein, but I think that I'll try to fix that in a separate PR.