### PR TITLE
Add extra CSP sources in test when not in CI [QUIZ-4]

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
     extra_sources = []
     extra_connect_sources = []
     # :nocov:
-    if Rails.env.development?
+    if Rails.env.development? || (Rails.env.test? && !ENV.key?('CI'))
       extra_sources << DavidRunger::CANONICAL_URL # allow assets from prod for local prerenders
       extra_connect_sources << 'ws://localhost:3000' # actioncable connections
       local_hostname = ENV.fetch('LOCAL_HOSTNAME', nil)

--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe 'Quizzes app' do
       # quiz show page expectations without participant
       expect(page).not_to have_text(participant_name)
 
+      # NOTE: Sleeping for 1 second here makes the login below about 10 seconds
+      # faster, and it might also help these specs not to flake on my machine.
+      sleep(1)
+
       # a participant joins
       using_session('Quiz participant session') do
         wait(20.seconds).for do

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -6,6 +6,7 @@ class CupriteLogger
   JSON_EXTRACTION_REGEX = /\A\s*[▶◀]\s+\d+\.\d+ ({.*})\n?\z/
   LOG_MESSAGES_TO_IGNORE = [
     /\A\[vite\] connecting\.\.\.\z/,
+    /\A\[vite\] connected\.\z/,
   ].freeze
   RUNTIME_CONSOLE_API_CALLED = '"Runtime.consoleAPICalled"'.freeze
   RUNTIME_EXCEPTION_THROWN = '"Runtime.exceptionThrown"'.freeze


### PR DESCRIPTION
Otherwise, when running tests locally while using the Vite development server, we sometimes get CSP errors, and these can cause problems (such as flaky specs).

Also, suppress Vite "connected" message, since we are now able to connect successfully, since the CSP is no longer a blocker.

Also, add a one second `sleep` to a quizzes feature spec. Without this, the login takes about 10 seconds, for some reason. Also, I think that this `sleep` makes these spec much more reliable when run on my machine (though it already seem reliable in CI).