### PR TITLE
[groceries] Render toast upon successful check-in [GROC-20]

### DIFF
--- a/app/javascript/groceries/components/CheckInModal.vue
+++ b/app/javascript/groceries/components/CheckInModal.vue
@@ -36,14 +36,19 @@ Modal(name='check-in-shopping-trip' width='85%' maxWidth='400px')
           @click='handleTripCheckinModalSubmit'
           type='primary'
           plain
-        ) Check in items in cart
+          :disabled="checkingIn"
+        )
+          span(v-if="checkingIn") Checking in...
+          span(v-else) Check in items in cart
 </template>
 
 <script setup lang="ts">
 import { storeToRefs } from 'pinia';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { TYPE } from 'vue-toastification';
 
 import { useGroceriesStore } from '@/groceries/store';
+import { vueToast } from '@/lib/vue_toasts';
 import { useModalStore } from '@/shared/modal/store';
 import type { Store } from '@/types';
 
@@ -51,6 +56,8 @@ import CheckInItemsList from './CheckInItemsList.vue';
 
 const groceriesStore = useGroceriesStore();
 const modalStore = useModalStore();
+
+const checkingIn = ref(false);
 
 const {
   neededSkippedCheckInItems,
@@ -64,8 +71,17 @@ const checkInStoreNames = computed((): string => {
     .join(', ');
 });
 
-function handleTripCheckinModalSubmit() {
-  groceriesStore.zeroItemsInCart();
+async function handleTripCheckinModalSubmit() {
+  checkingIn.value = true;
+
+  try {
+    await groceriesStore.zeroItemsInCart();
+    vueToast('Check-in successful!');
+  } catch {
+    vueToast('Something went wrong.', { type: TYPE.ERROR });
+  }
+
+  checkingIn.value = false;
   modalStore.hideModal({ modalName: 'check-in-shopping-trip' });
 }
 

--- a/app/javascript/lib/vue_toasts.ts
+++ b/app/javascript/lib/vue_toasts.ts
@@ -1,4 +1,4 @@
-import { POSITION, useToast } from 'vue-toastification';
+import { POSITION, TYPE, useToast } from 'vue-toastification';
 
 import 'css/vue_toastification_with_overrides.scss';
 
@@ -14,6 +14,7 @@ type ComponentOptions = {
 type VueToastificationOptions = {
   icon?: boolean;
   position?: POSITION;
+  type?: TYPE;
 };
 
 export function vueToast(

--- a/spec/features/account_deletion_spec.rb
+++ b/spec/features/account_deletion_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Account deletion' do
       accept_confirm { click_on('Delete Account') }
 
       expect(page).to have_current_path(root_path)
-      expect(page).to have_flash_message('We have deleted your account.', type: :notice)
+      expect(page).to have_flash_message('We have deleted your account.')
 
       expect(User.find_by(id: user.id)).to eq(nil)
     end

--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Check-Ins app' do
             wait_for { ActionMailer::Base.deliveries.size }.to eq(num_emails_before + 1)
           end
 
-          expect(page).to have_flash_message('Invitation sent.', type: :notice)
+          expect(page).to have_flash_message('Invitation sent.')
 
           # add an emotional need
           click_on('Click here')

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -99,7 +99,16 @@ RSpec.describe 'Groceries app' do
           expect(page).to have_text(needed_item.name)
           expect(page).not_to have_text(new_item_name)
         end
+
+        click_on('Check in items in cart')
+
+        expect(page).to have_vue_toast('Check-in successful!')
+        expect_needed(new_item_name, 0)
       end
     end
+  end
+
+  def expect_needed(item_name, needed)
+    expect(page).to have_text("#{item_name} (#{needed})")
   end
 end

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe 'proposing marriage to another user' do
             wait_for { ActionMailer::Base.deliveries.size }.to eq(num_emails_before + 1)
           end
 
-          expect(page).to have_flash_message('Invitation sent.', type: :notice)
+          expect(page).to have_flash_message('Invitation sent.')
 
           # log in proposee and accept the proposal
           Capybara.using_session('proposee') do

--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe 'Quizzes app' do
 
       accept_confirm { click_on('Delete') }
 
-      expect(page).to have_flash_message("Destroyed quiz '#{quiz_to_destroy.name}'.", type: :notice)
+      expect(page).to have_flash_message("Destroyed quiz '#{quiz_to_destroy.name}'.")
       expect(Quiz.find_by(id: quiz_to_destroy.id)).to eq(nil)
     end
   end

--- a/spec/support/matchers/capybara_page_matchers.rb
+++ b/spec/support/matchers/capybara_page_matchers.rb
@@ -1,4 +1,4 @@
-RSpec::Matchers.define(:have_flash_message) do |expected_text, type:|
+RSpec::Matchers.define(:have_flash_message) do |expected_text, type: :notice|
   match do |actual_page|
     expect(actual_page).to have_css(".flash__message--#{type}", text: expected_text)
   end
@@ -18,6 +18,30 @@ RSpec::Matchers.define(:have_flash_message) do |expected_text, type:|
     <<~MESSAGE.squish
       expected page ('#{actual_page.text}') not to have a(n) #{type} flash
       message with text '#{expected_text}'
+    MESSAGE
+  end
+end
+
+RSpec::Matchers.define(:have_vue_toast) do |expected_text|
+  match do |actual_page|
+    expect(actual_page).to have_css('.Vue-Toastification__toast-body', text: expected_text)
+  end
+
+  match_when_negated do |actual_page|
+    expect(actual_page).not_to have_css('.Vue-Toastification__toast-body', text: expected_text)
+  end
+
+  failure_message do |actual_page|
+    <<~MESSAGE.squish
+      expected page ('#{actual_page.text}') to have a Vue toast with text
+      '#{expected_text}'
+    MESSAGE
+  end
+
+  failure_message_when_negated do |actual_page|
+    <<~MESSAGE.squish
+      expected page ('#{actual_page.text}') not to have a Vue toast with text
+      '#{expected_text}'
     MESSAGE
   end
 end


### PR DESCRIPTION
Also, render an error message if the check-in errors. To support this, allow specifying a `type` for `vueToast`.

Also, disable the check-in button while the network request is in flight.

Also, make `:notice` the default expected type for the `have_flash_message` matcher.

Also, add a new `have_vue_toast` matcher. (I considered extending/renaming the existing `have_flash_message` matcher, instead, but decided against it, due to concerns about a combined approach potentially being complex and/or non-performant.)

Also, confirm in the groceries feature spec that the checked-in item is reduced to zero needed.