### PR TITLE
[gitignore] Ignore the whole 'log/' and 'tmp/' directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,12 +6,10 @@
 /.bundle
 
 # Logs
-/log/*
-!/log/.keep
+/log/
 
 # Temp
-/tmp/*
-!/tmp/.keep
+/tmp/
 
 # JavaScript packages
 /node_modules


### PR DESCRIPTION
I deleted the `.keep` files in these directories in dc151b9e9be67c1891a582dd405a0bbd5f18a478 . Insofar as that change makes sense, I probably should also have then made the changes that I'm making herein.

Part of my motivation is that this change makes VS Code show the `log/` and `tmp/` directories in a grayed out color in the explorer side bar, which is kind of nice.