### PR TITLE
[log_formatter] Don't reference Rainbow in production

### DIFF
--- a/lib/logs/log_formatter.rb
+++ b/lib/logs/log_formatter.rb
@@ -36,6 +36,7 @@ class Logs::LogFormatter < Lograge::Formatters::KeyValue
   # rubocop:enable Metrics/CyclomaticComplexity
 
   # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   def call
     fields_to_display(@data).
       map do |key|
@@ -63,6 +64,7 @@ class Logs::LogFormatter < Lograge::Formatters::KeyValue
         end
       end
   end
+  # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity
 
   private

--- a/lib/logs/log_formatter.rb
+++ b/lib/logs/log_formatter.rb
@@ -42,7 +42,7 @@ class Logs::LogFormatter < Lograge::Formatters::KeyValue
         value = @data[key]
         key_value_string = format(key, value)
 
-        if Rails.env.development? || !Rainbow.enabled
+        if Rails.env.development? || (Rails.env.test? && !Rainbow.enabled)
           color, background, style = color_background_and_style(key, value)
 
           if defined?(Rainbow) # Rainbow won't be defined when running w/ Docker


### PR DESCRIPTION
It's not available there.

We are seeing this error in papertrail logs:

> Could not log "process_action.action_controller" event. NameError: uninitialized constant Logs::LogFormatter::Rainbow