### PR TITLE
[home] Import SectionHeader with relative path

### DIFF
--- a/app/javascript/home/components/HomeSection.vue
+++ b/app/javascript/home/components/HomeSection.vue
@@ -7,9 +7,8 @@
 </template>
 
 <script setup lang="ts">
-import SectionHeader from '@/home/components/SectionHeader.vue';
-
 import ScrollHook from './ScrollHook.vue';
+import SectionHeader from './SectionHeader.vue';
 
 defineProps({
   renderHeadingManually: {


### PR DESCRIPTION
I think that I import all other home components using relative paths, so let's follow that precedent here, as well.