### PR TITLE
Replace relative imports that go up a level (i.e. '../') w/ absolute

### DIFF
--- a/app/javascript/groceries/components/ManageCheckInStoresModal.vue
+++ b/app/javascript/groceries/components/ManageCheckInStoresModal.vue
@@ -19,9 +19,9 @@ Modal(name='manage-check-in-stores' width='80%' maxWidth='370px')
 </template>
 
 <script setup lang="ts">
+import { useGroceriesStore } from '@/groceries/store';
 import { useModalStore } from '@/shared/modal/store';
 
-import { useGroceriesStore } from '../store';
 import CheckInStoreList from './CheckInStoreList.vue';
 
 const groceriesStore = useGroceriesStore();

--- a/app/javascript/logs/components/EditLogSharingSettingsModal.vue
+++ b/app/javascript/logs/components/EditLogSharingSettingsModal.vue
@@ -41,12 +41,11 @@ import { storeToRefs } from 'pinia';
 import { computed, nextTick, ref } from 'vue';
 
 import { bootstrap } from '@/lib/bootstrap';
+import { useLogsStore } from '@/logs/store';
+import type { Bootstrap } from '@/logs/types';
 import { assert } from '@/shared/helpers';
 import { useModalStore } from '@/shared/modal/store';
 import type { LogShare } from '@/types';
-
-import { useLogsStore } from '../store';
-import type { Bootstrap } from '../types';
 
 const logsStore = useLogsStore();
 const modalStore = useModalStore();


### PR DESCRIPTION
It seems more stable/future-proof to use absolute imports, instead, and also I think more consistent, since in most places I am already using absolute imports in such cases.