### PR TITLE
[ErrorSubscriber] Handle uncaught errors, as well

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -492,7 +492,7 @@ GEM
       railties (>= 5.2)
     rexml (3.3.6)
       strscan
-    rollbar (3.5.2)
+    rollbar (3.6.0)
     rouge (4.3.0)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)

--- a/config/initializers/error_subscriber.rb
+++ b/config/initializers/error_subscriber.rb
@@ -14,12 +14,7 @@ class ErrorSubscriber
       write_log_line(error.cause, **kwargs)
     else
       write_log_line(error, **kwargs)
-
-      # Unhandled errors will be picked up by Rollbar integrations, so don't send them here, too.
-      # Here, we will only report _handled_ (manually sent) errors.
-      if kwargs[:handled]
-        send_to_rollbar(error, **kwargs)
-      end
+      send_to_rollbar(error, **kwargs)
     end
   end
 

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,5 +1,5 @@
 Rollbar.configure do |config|
-  code_version = ENV.fetch('GIT_REV', nil)
+  code_version = ENV.fetch('GIT_REV', `git log --format=format:%H | head -n 1`.rstrip)
 
   access_token =
     case Rails.env
@@ -22,6 +22,10 @@ Rollbar.configure do |config|
   if Rails.env.in?(%w[development test])
     config.enabled = access_token.present?
   end
+
+  # NOTE: Instead of having Rollbar send uncaught errors on its own, we will
+  # send them to Rollbar via our Rails ErrorSubscriber.
+  config.capture_uncaught = false
 
   # By default, Rollbar will try to call the `current_user` controller method
   # to fetch the logged-in user object, and then call that object's `id`,

--- a/spec/config/initializers/error_subscriber_spec.rb
+++ b/spec/config/initializers/error_subscriber_spec.rb
@@ -63,9 +63,14 @@ RSpec.describe ErrorSubscriber do
         context 'when the error class is StandardError' do
           let(:error_class) { StandardError }
 
-          it 'does not send anything to Rollbar' do
-            expect(Rollbar).not_to receive(:log)
-            expect(Rollbar).not_to receive(:error)
+          it 'sends the error to Rollbar' do
+            expect(Rollbar).
+              to receive(:log).with(
+                :error,
+                an_instance_of(StandardError),
+                { handled: false },
+              ).
+              exactly(:once)
 
             report
           end


### PR DESCRIPTION
Also, bump Rollbar from 3.5.2 to 3.6.0. Version 3.6.0 includes support for using Rollbar via a Rails error subscriber class. We ultimately aren't using this functionality, though, and instead are still rolling our own error subscriber, so that we can also write the errors to the logs. The key thing that I took away from the Rollbar PR implementing that functionality ( https://github.com/rollbar/rollbar-gem/pull/ 1161 ), though, is its use of the `capture_uncaught` Rollbar configuration option, which I am using in this PR (and which I think I wasn't previously aware of), so that we can now have the Rails error subscriber handle both caught and uncaught exceptions, without Rollbar also sending any uncaught exceptions.

Also, use `git` to determine a SHA for Rollbar as a fallback if `GIT_REV` is not present. This makes it easier to test in development without setting `GIT_REV`, and is probably not a bad idea to have available as a fallback in other contexts, too.