### PR TITLE
[crontab] Rebuild the app after pruning docker

### DIFF
--- a/bin/server/prune-docker-and-rebuild.sh
+++ b/bin/server/prune-docker-and-rebuild.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+# Move to the application directory.
+cd /root/david_runger
+
+# Prune Docker.
+docker system prune --all --force
+
+# Rebuild Docker image(s).
+bin/build-docker production

--- a/config/server/crontab.txt
+++ b/config/server/crontab.txt
@@ -1,12 +1,12 @@
-# renice puma and nginx to have maximum CPU priority (each every other minute)
+# Renice puma and nginx to have maximum CPU priority (each every other minute).
 */2 * * * *  ps aux | grep [p]uma | awk {'print $2'} | xargs renice -n -20 -p
 1-59/2 * * * *  ps aux | grep -E '[n]ginx.*process' | awk {'print $2'} | xargs renice -n -20 -p
 
-# back up database (daily at 07:32 UTC, 1:32am or 2:32am CT)
+# Back up database (daily at 07:32 UTC, 1:32am or 2:32am CT).
 32 7 * * *  /root/david_runger/bin/server/back-up-db-to-s3.sh
 
-# trim docker images (Saturday at 08:55 UTC, 2:55am or 3:55am CT)
-55 8 * * 6  docker system prune --all --force
+# Trim docker images and rebuild the app (Saturday at 08:55 UTC, 2:55am or 3:55am CT).
+55 8 * * 6  /root/david_runger/bin/server/prune-docker-and-rebuild.sh
 
-# reboot server (Saturday at 09:22 UTC, 3:22am or 4:22am CT)
-22 9 * * 6  reboot
+# Reboot server (Saturday at 10:25 UTC, 4:25am or 5:25am CT).
+25 10 * * 6  reboot


### PR DESCRIPTION
Otherwise, I think that what can happen is this:
1. we prune the Docker cache
1. we reboot the app
1. the images are now considered stale because the cache was pruned (?)
1. Docker tries to build fresh images, but this fails because RUBY_VERSION is not provided
1. the app fails to boot

I think that I ran into this scenario after manually rebooting today (a Saturday, where no deploys i.e. builds have gone out yet today).

I'm not sure why this hasn't been happening every Saturday, when our crontab performs a scheduled reboot? Is it possible we were rebooting before the pruning actually completed? I guess not, because then why would I have experienced the issue after manually rebooting today? But, due to this possibility (even though it now seems relatively unlikely to me), I am moving back the reboot time further after the prune and rebuild.

It's actually possible that the reason that I ran into this issue is because I had just updated system packages on the server (probably including Docker itself)?

Hopefully this will avoid the problematic scenario detailed above.