### PR TITLE
[rollbar] Use 'git' in block variant of ENV.fetch

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,5 +1,5 @@
 Rollbar.configure do |config|
-  code_version = ENV.fetch('GIT_REV', `git log --format=format:%H | head -n 1`.rstrip)
+  code_version = ENV.fetch('GIT_REV') { `git log --format=format:%H | head -n 1`.rstrip }
 
   access_token =
     case Rails.env


### PR DESCRIPTION
Otherwise, we try to call out to `git`, even if we don't actually need it (and it might not be available).

I think this will fix complaints such as `fatal: not a git repository (or any of the parent directories): .git` (https://github.com/davidrunger/david_runger/actions/runs/10650392835/job/29521750853#step:5:94) and `sh: 1: git: not found` (https://github.com/davidrunger/david_runger/actions/runs/10650392835/job/29521750853#step:5:466).

This issue was introduced in https://github.com/davidrunger/david_runger/pull/5061 .