### PR TITLE
[.rubocop.yml] Set 'StringLiteralsFrozenByDefault: true' for all cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,7 @@ AllCops:
   <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
     - <%= path.sub(/^!! /, '').sub(/\/$/, '/**/*').rstrip %>
   <% end %>
+  StringLiteralsFrozenByDefault: true
 
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never

--- a/app/models/json_preference.rb
+++ b/app/models/json_preference.rb
@@ -15,8 +15,8 @@
 #
 class JsonPreference < ApplicationRecord
   module Types
-    DEFAULT_WORKOUT = 'default_workout'.freeze
-    EMOJI_BOOSTS = 'emoji_boosts'.freeze
+    DEFAULT_WORKOUT = 'default_workout'
+    EMOJI_BOOSTS = 'emoji_boosts'
   end
 
   JsonPreference::Types.constants.each do |constant_name|

--- a/app/models/quiz_question.rb
+++ b/app/models/quiz_question.rb
@@ -14,8 +14,8 @@
 #  index_quiz_questions_on_quiz_id  (quiz_id)
 #
 class QuizQuestion < ApplicationRecord
-  OPEN = 'open'.freeze
-  CLOSED = 'closed'.freeze
+  OPEN = 'open'
+  CLOSED = 'closed'
   STATUSES = [OPEN, CLOSED].freeze
 
   validates :content, presence: true

--- a/app/workers/check_links/launch_page_fetches.rb
+++ b/app/workers/check_links/launch_page_fetches.rb
@@ -1,7 +1,7 @@
 class CheckLinks::LaunchPageFetches
   prepend ApplicationWorker
 
-  SITEMAP_URL = 'https://davidrunger.com/sitemap.xml'.freeze
+  SITEMAP_URL = 'https://davidrunger.com/sitemap.xml'
 
   def perform
     sitemap_urls.each do |url|

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,7 +22,7 @@ IS_DOCKER_BUILD = ENV.key?('DOCKER_BUILD')
 IS_DOCKER = IS_DOCKER_BUILD || ENV.key?('DOCKER_BUILT')
 
 module DavidRunger
-  CANONICAL_DOMAIN = 'davidrunger.com'.freeze
+  CANONICAL_DOMAIN = 'davidrunger.com'
 
   class << self
     def canonical_url(path)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,6 +1,6 @@
 class Rack::Attack
   PATH_FRAGMENT_SEPARATOR_REGEX = %r{/|\.|\?|-|_|=}
-  PENTESTERS_PREFIX = 'pentesters-'.freeze
+  PENTESTERS_PREFIX = 'pentesters-'
   PENTESTING_FINDTIME = 1.day.freeze
   WHITELISTED_PATH_PREFIXES = %w[
     /auth/google_oauth2?

--- a/lib/email/mailgun_via_http.rb
+++ b/lib/email/mailgun_via_http.rb
@@ -4,9 +4,9 @@ module Email
     prepend MemoWise
 
     DEVELOPER_EMAILS = Set['davidjrunger@gmail.com'].freeze
-    MAILGUN_URL = 'https://api.mailgun.net/v3/mg.davidrunger.com'.freeze
+    MAILGUN_URL = 'https://api.mailgun.net/v3/mg.davidrunger.com'
     # must _not_ start with a slash! ( https://github.com/lostisland/faraday/issues/293/ )
-    MESSAGES_PATH = 'messages'.freeze
+    MESSAGES_PATH = 'messages'
 
     # rubocop:disable Lint/UselessMethodDefinition, Lint/RedundantCopDisableDirective
     # rubocop:disable Style/RedundantInitialize

--- a/lib/redis_config.rb
+++ b/lib/redis_config.rb
@@ -1,5 +1,5 @@
 module RedisConfig
-  REDIS_NAMESPACE = 'redis-config'.freeze
+  REDIS_NAMESPACE = 'redis-config'
   TYPES = %w[integer].map(&:freeze).freeze
 
   def add(key_name, type)

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -8,8 +8,8 @@ class CupriteLogger
     /\A\[vite\] connecting\.\.\.\z/,
     /\A\[vite\] connected\.\z/,
   ].freeze
-  RUNTIME_CONSOLE_API_CALLED = '"Runtime.consoleAPICalled"'.freeze
-  RUNTIME_EXCEPTION_THROWN = '"Runtime.exceptionThrown"'.freeze
+  RUNTIME_CONSOLE_API_CALLED = '"Runtime.consoleAPICalled"'
+  RUNTIME_EXCEPTION_THROWN = '"Runtime.exceptionThrown"'
 
   def self.javascript_errors
     @javascript_errors ||= []

--- a/tools/custom_cops/dont_include_sidekiq_worker.rb
+++ b/tools/custom_cops/dont_include_sidekiq_worker.rb
@@ -5,7 +5,7 @@ module CustomCops
 
     MSG =
       'Use `prepend ApplicationWorker` rather than `include Sidekiq::Worker` ' \
-      'or `include Sidekiq::Job`'.freeze
+      'or `include Sidekiq::Job`'
 
     def_node_matcher :including_sidekiq_worker?, <<~PATTERN
       (send ... :include (const (const ... :Sidekiq) ${:Worker :Job}))

--- a/tools/json_schemas_to_typescript.rb
+++ b/tools/json_schemas_to_typescript.rb
@@ -1,5 +1,5 @@
 module JsonSchemasToTypescript
-  SCHEMA_DIRECTORY = 'spec/support/schemas'.freeze
+  SCHEMA_DIRECTORY = 'spec/support/schemas'
   API_SCHEMA_DIRECTORY = "#{SCHEMA_DIRECTORY}/api".freeze
   BOOTSTRAP_SCHEMA_DIRECTORY = "#{SCHEMA_DIRECTORY}/bootstrap".freeze
 


### PR DESCRIPTION
Since we are using `freezolite`, our string literals should be frozen by default. This makes RuboCop aware of that.