### PR TITLE
[nginx] Relax Referrer-Policy to strict-origin-when-cross-origin

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -65,7 +65,7 @@ http {
 
     map $upstream_http_referrer_policy $referrer_policy {
         default $upstream_http_referrer_policy;
-        "" "no-referrer";
+        "" "strict-origin-when-cross-origin";
     }
 
     # Load configs


### PR DESCRIPTION
I think/hope that this will fix this issue that I am seeing in the logs when trying to create a Flipper feature flag: