### PR TITLE
[ConvertSchemasToTs] Remove puts printing the class name

### DIFF
--- a/lib/test/tasks/convert_schemas_to_ts.rb
+++ b/lib/test/tasks/convert_schemas_to_ts.rb
@@ -2,8 +2,6 @@ class Test::Tasks::ConvertSchemasToTs < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    puts("Running '#{AmazingPrint::Colors.yellow(self.class.name)}' ...")
-
     if !execute_system_command(<<~COMMAND)
       bin/json-schemas-to-typescript && git diff --exit-code
     COMMAND


### PR DESCRIPTION
I added this because I copied it from [here](https://github.com/davidrunger/david_runger/blob/acaf10000ba1ec74dceff2c78e5d2733da843c7b/lib/test/tasks/run_file_size_checks.rb/#L34), but I don't think it's useful here. This puts statement somewhat clutters and confuses the test output, and it breaks the pattern we have with other log lines that print in yellow which then should have a corresponding green or red follow-up log line. (The place from which I copied this `puts` statement does print a corresponding success message in green, so I think it's fine to leave.)