### PR TITLE
Update 'bundle' binstub

### DIFF
--- a/bin/bundle
+++ b/bin/bundle
@@ -8,6 +8,7 @@
 
 require 'rubygems'
 
+# rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Layout/LineLength
 m =
   Module.new do
     module_function
@@ -114,3 +115,4 @@ m.load_bundler!
 if m.invoked_as_script?
   load Gem.bin_path('bundler', 'bundle')
 end
+# rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Layout/LineLength

--- a/bin/bundle
+++ b/bin/bundle
@@ -20,7 +20,6 @@ m =
       ENV.fetch('BUNDLER_VERSION', nil)
     end
 
-    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
     def cli_arg_version
       return unless invoked_as_script? # don't want to hijack other binstubs
       return unless 'update'.start_with?(ARGV.first || ' ') # must be running `bundle update`
@@ -28,17 +27,16 @@ m =
       bundler_version = nil
       update_index = nil
       ARGV.each_with_index do |a, i|
-        if update_index && update_index.succ == i && a =~ Gem::Version::ANCHORED_VERSION_PATTERN
+        if update_index && update_index.succ == i && a.match?(Gem::Version::ANCHORED_VERSION_PATTERN)
           bundler_version = a
         end
         next unless a =~ /\A--bundler(?:[= ](#{Gem::Version::VERSION_PATTERN}))?\z/o
 
-        bundler_version = Regexp.last_match(1) || '>= 0.a'
+        bundler_version = Regexp.last_match(1)
         update_index = i
       end
       bundler_version
     end
-    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
 
     def gemfile
       gemfile = ENV.fetch('BUNDLE_GEMFILE', nil)
@@ -50,7 +48,7 @@ m =
     def lockfile
       lockfile =
         case File.basename(gemfile)
-        when 'gems.rb' then gemfile.sub(/\.rb$/, gemfile)
+        when 'gems.rb' then gemfile.sub(/\.rb$/, '.locked')
         else "#{gemfile}.lock"
         end
       File.expand_path(lockfile)
@@ -60,35 +58,36 @@ m =
       return unless File.file?(lockfile)
 
       lockfile_contents = File.read(lockfile)
-      unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/o
-        return
-      end
+      return unless lockfile_contents =~ /\n\nBUNDLED WITH\n\s{2,}(#{Gem::Version::VERSION_PATTERN})\n/o
 
       Regexp.last_match(1)
     end
 
-    def bundler_version
-      @bundler_version ||=
-        env_var_version || cli_arg_version || lockfile_version || "#{Gem::Requirement.default}.a"
+    def bundler_requirement
+      @bundler_requirement ||=
+        env_var_version ||
+        cli_arg_version ||
+        bundler_requirement_for(lockfile_version)
+    end
+
+    def bundler_requirement_for(version)
+      return "#{Gem::Requirement.default}.a" unless version
+
+      bundler_gem_version = Gem::Version.new(version)
+
+      bundler_gem_version.approximate_recommendation
     end
 
     def load_bundler!
       ENV['BUNDLE_GEMFILE'] ||= gemfile
 
-      # must dup string for RG < 1.8 compatibility
-      activate_bundler(bundler_version.dup)
+      activate_bundler
     end
 
-    def activate_bundler(bundler_version)
-      if (
-        Gem::Version.correct?(bundler_version) &&
-          Gem::Version.new(bundler_version).release < Gem::Version.new('2.0')
-      )
-        bundler_version = '< 2'
-      end
+    def activate_bundler
       gem_error =
         activation_error_handling do
-          gem 'bundler', bundler_version
+          gem 'bundler', bundler_requirement
         end
       return if gem_error.nil?
 
@@ -96,16 +95,9 @@ m =
         activation_error_handling do
           require 'bundler/version'
         end
-      if (
-        require_error.nil? &&
-          Gem::Requirement.new(bundler_version).satisfied_by?(Gem::Version.new(Bundler::VERSION))
-      )
-        return
-      end
+      return if require_error.nil? && Gem::Requirement.new(bundler_requirement).satisfied_by?(Gem::Version.new(Bundler::VERSION))
 
-      # rubocop:disable Layout/LineLength
-      warn("Activating bundler (#{bundler_version}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_version}'`")
-      # rubocop:enable Layout/LineLength
+      warn("Activating bundler (#{bundler_requirement}) failed:\n#{gem_error.message}\n\nTo install the version of bundler this project requires, run `gem install bundler -v '#{bundler_requirement}'`")
       exit(42)
     end
 


### PR DESCRIPTION
```
bundle binstubs bundler --force
bin/rubocop bin/bundle -A
```

It seems that somewhere in this diff there is a change that will avoid this error:

https://github.com/davidrunger/david_runger/actions/runs/10727609105/job/29750513266#step:5:690

```
[web build 10/10] RUN bin/bootsnap precompile app/ lib/
1.019 Activating bundler (2.5.18) failed:
1.019 Could not find 'bundler' (= 2.5.18) - did find: [bundler-2.5.16]
1.019 Checked in 'GEM_PATH=/root/.local/share/gem/ruby/3.3.0:/usr/local/lib/ruby/gems/3.3.0:/usr/local/bundle' , execute `gem env` for more information
1.019
1.019 To install the version of bundler this project requires, run `gem install bundler -v '2.5.18'`
```

I think that, with this change, bundler will now activate the version that is needed when running the `bin/bootsnap` binstub (and, hopefully, also all other binstubs), as bundler already does when running `bundle install` without the specified version of bundler yet being installed/activated.