### PR TITLE
Disallow ActiveRecord::Base.connection [DEV-110]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,7 +96,7 @@ group :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'ferrum'
-  gem 'fixture_builder'
+  gem 'fixture_builder', github: 'davidrunger/fixture_builder'
   gem 'launchy'
   gem 'pallets', github: 'davidrunger/pallets'
   gem 'percy-capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/davidrunger/fixture_builder.git
-  revision: d1a48104b59409ff6b4ae8a21123e43dfce541c5
+  revision: 06ec00445196d4382e301e4e0b22aec2822ddc52
   specs:
     fixture_builder (0.5.3.rc3)
       activerecord (>= 2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/davidrunger/fixture_builder.git
+  revision: d1a48104b59409ff6b4ae8a21123e43dfce541c5
+  specs:
+    fixture_builder (0.5.3.rc3)
+      activerecord (>= 2)
+      activesupport (>= 2)
+      hashdiff
+
+GIT
   remote: https://github.com/davidrunger/pallets.git
   revision: 3362ed2c3f3d33c856c8ce06640cbf9a89bb5b90
   specs:
@@ -228,10 +237,6 @@ GEM
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
     ffi (1.17.0)
-    fixture_builder (0.5.2)
-      activerecord (>= 2)
-      activesupport (>= 2)
-      hashdiff
     flipper (1.3.1)
       concurrent-ruby (< 2)
     flipper-redis (1.3.1)
@@ -692,7 +697,7 @@ DEPENDENCIES
   faraday
   faraday-multipart
   ferrum
-  fixture_builder
+  fixture_builder!
   flipper
   flipper-redis
   flipper-ui

--- a/app/controllers/api/log_entries_controller.rb
+++ b/app/controllers/api/log_entries_controller.rb
@@ -79,48 +79,52 @@ class Api::LogEntriesController < Api::BaseController
     datum_table_name = datum_class.table_name
     datum_class_name = datum_class.name
 
-    ApplicationRecord.connection.select_values(<<~SQL.squish)
-      SELECT row_to_json(log_entry)
-      FROM (
-        SELECT
-          log_entries.id,
-          to_char(log_entries.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
-          data,
-          log_entries.log_id,
-          log_entries.note
-        FROM #{datum_table_name}
-        INNER JOIN log_entries
-          ON log_entries.log_entry_datum_id = #{datum_table_name}.id
-          AND log_entries.log_entry_datum_type = '#{datum_class_name}'
-        WHERE log_entries.log_id = #{log.id}
-      ) log_entry;
-    SQL
+    ApplicationRecord.with_connection do |connection|
+      connection.select_values(<<~SQL.squish)
+        SELECT row_to_json(log_entry)
+        FROM (
+          SELECT
+            log_entries.id,
+            to_char(log_entries.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"') AS created_at,
+            data,
+            log_entries.log_id,
+            log_entries.note
+          FROM #{datum_table_name}
+          INNER JOIN log_entries
+            ON log_entries.log_entry_datum_id = #{datum_table_name}.id
+            AND log_entries.log_entry_datum_type = '#{datum_class_name}'
+          WHERE log_entries.log_id = #{log.id}
+        ) log_entry;
+      SQL
+    end
   end
 
   def log_entry_json_strings_for_user_and_datum_class(user:, datum_class:)
     datum_table_name = datum_class.table_name
     datum_class_name = datum_class.name
 
-    ApplicationRecord.connection.select_values(<<~SQL.squish)
-      SELECT row_to_json(log_entry)
-      FROM (
-        SELECT
-          log_entries.id,
-          to_char(
-            log_entries.created_at AT TIME ZONE 'UTC',
-            'YYYY-MM-DD"T"HH24:MI:SS"Z"'
-          ) AS created_at,
-          #{datum_table_name}.data,
-          log_entries.log_id,
-          log_entries.note
-        FROM #{datum_table_name}
-        INNER JOIN log_entries
-          ON log_entries.log_entry_datum_id = #{datum_table_name}.id
-          AND log_entries.log_entry_datum_type = '#{datum_class_name}'
-        INNER JOIN logs
-          ON logs.id = log_entries.log_id
-        WHERE logs.user_id = #{user.id}
-      ) log_entry;
-    SQL
+    ApplicationRecord.with_connection do |connection|
+      connection.select_values(<<~SQL.squish)
+        SELECT row_to_json(log_entry)
+        FROM (
+          SELECT
+            log_entries.id,
+            to_char(
+              log_entries.created_at AT TIME ZONE 'UTC',
+              'YYYY-MM-DD"T"HH24:MI:SS"Z"'
+            ) AS created_at,
+            #{datum_table_name}.data,
+            log_entries.log_id,
+            log_entries.note
+          FROM #{datum_table_name}
+          INNER JOIN log_entries
+            ON log_entries.log_entry_datum_id = #{datum_table_name}.id
+            AND log_entries.log_entry_datum_type = '#{datum_class_name}'
+          INNER JOIN logs
+            ON logs.id = log_entries.log_id
+          WHERE logs.user_id = #{user.id}
+        ) log_entry;
+      SQL
+    end
   end
 end

--- a/app/workers/truncate_tables.rb
+++ b/app/workers/truncate_tables.rb
@@ -12,7 +12,9 @@ class TruncateTables
   end
 
   def self.execute_sql(sql)
-    ApplicationRecord.connection.execute(sql)
+    ApplicationRecord.with_connection do |connection|
+      connection.execute(sql)
+    end
   end
 
   def self.print_row_counts

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,8 @@ class DavidRunger::Application < Rails::Application
   config.time_zone = ENV.fetch('TIME_ZONE', 'America/Chicago')
   config.active_record.default_timezone = :utc
 
+  config.active_record.permanent_connection_checkout = :deprecated
+
   # config.eager_load_paths << Rails.root.join("extras")
 
   config.generators.helper = nil

--- a/config/application.rb
+++ b/config/application.rb
@@ -56,7 +56,7 @@ class DavidRunger::Application < Rails::Application
   config.time_zone = ENV.fetch('TIME_ZONE', 'America/Chicago')
   config.active_record.default_timezone = :utc
 
-  config.active_record.permanent_connection_checkout = :deprecated
+  config.active_record.permanent_connection_checkout = :disallowed
 
   # config.eager_load_paths << Rails.root.join("extras")
 


### PR DESCRIPTION
https://edgeguides.rubyonrails.org/configuring.html#config-active-record-permanent-connection-checkout

Unfortunately, `fixture_builder` uses `ActiveRecord::Base.connection` directly, so I forked it and switched those usages to use `with_connection` instead; this change moves to using that fork.