### PR TITLE
[specs] Raise error if ApplicationRecord::Base.connection is called

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ ruby file: '.ruby-version'
 
 source 'https://rubygems.org'
 
-gem 'activeadmin'
+gem 'activeadmin', github: 'davidrunger/activeadmin'
 gem 'alba'
 gem 'aws-sdk-s3'
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,19 @@
 GIT
+  remote: https://github.com/davidrunger/activeadmin.git
+  revision: ccbbe57a903fe6a6d5a804951a73d89b1a54db38
+  specs:
+    activeadmin (3.2.5)
+      arbre (~> 1.2, >= 1.2.1)
+      csv
+      formtastic (>= 3.1)
+      formtastic_i18n (>= 0.4)
+      inherited_resources (~> 1.7)
+      jquery-rails (>= 4.2)
+      kaminari (>= 1.2.1)
+      railties (>= 6.1)
+      ransack (>= 4.0)
+
+GIT
   remote: https://github.com/davidrunger/fixture_builder.git
   revision: 06ec00445196d4382e301e4e0b22aec2822ddc52
   specs:
@@ -69,16 +84,6 @@ GEM
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activeadmin (3.2.4)
-      arbre (~> 1.2, >= 1.2.1)
-      csv
-      formtastic (>= 3.1)
-      formtastic_i18n (>= 0.4)
-      inherited_resources (~> 1.7)
-      jquery-rails (>= 4.2)
-      kaminari (>= 1.2.1)
-      railties (>= 6.1)
-      ransack (>= 4.0)
     activejob (7.2.1)
       activesupport (= 7.2.1)
       globalid (>= 0.3.6)
@@ -667,7 +672,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activeadmin
+  activeadmin!
   addressable
   alba
   amazing_print

--- a/config/initializers/monkeypatches/active_record_connection_handling.rb
+++ b/config/initializers/monkeypatches/active_record_connection_handling.rb
@@ -1,0 +1,36 @@
+if Rails.env.test?
+  # Code being patched:
+  # https://github.com/rails/rails/blob/v7.2.1/activerecord/lib/active_record/connection_handling.rb#L259-L281
+  module Runger::ConnectionHandlingMonkeypatch
+    def connection
+      pool = connection_pool
+      check_calling_connection_allowed
+      if pool.permanent_lease?
+        pool.lease_connection
+      else
+        pool.active_connection
+      end
+    end
+
+    def check_calling_connection_allowed
+      case ActiveRecord.permanent_connection_checkout
+      when :deprecated
+        ActiveRecord.deprecator.warn(<<~MESSAGE)
+          Called deprecated `ActiveRecord::Base.connection` method.
+
+          Either use `with_connection` or `lease_connection`.
+        MESSAGE
+      when :disallowed
+        raise(ActiveRecord::ActiveRecordError, <<~MESSAGE)
+          Called deprecated `ActiveRecord::Base.connection` method.
+
+          Either use `with_connection` or `lease_connection`.
+        MESSAGE
+      end
+    end
+  end
+
+  ActiveSupport.on_load(:active_record) do
+    ActiveRecord::ConnectionHandling.prepend(Runger::ConnectionHandlingMonkeypatch)
+  end
+end

--- a/config/initializers/monkeypatches/active_record_connection_handling.rb
+++ b/config/initializers/monkeypatches/active_record_connection_handling.rb
@@ -15,11 +15,13 @@ if Rails.env.test?
     def check_calling_connection_allowed
       case ActiveRecord.permanent_connection_checkout
       when :deprecated
+        # :nocov:
         ActiveRecord.deprecator.warn(<<~MESSAGE)
           Called deprecated `ActiveRecord::Base.connection` method.
 
           Either use `with_connection` or `lease_connection`.
         MESSAGE
+        # :nocov:
       when :disallowed
         raise(ActiveRecord::ActiveRecordError, <<~MESSAGE)
           Called deprecated `ActiveRecord::Base.connection` method.

--- a/config/initializers/monkeypatches/active_record_connection_handling.rb
+++ b/config/initializers/monkeypatches/active_record_connection_handling.rb
@@ -5,11 +5,13 @@ if Rails.env.test?
     def connection
       pool = connection_pool
       check_calling_connection_allowed
+      # :nocov:
       if pool.permanent_lease?
         pool.lease_connection
       else
         pool.active_connection
       end
+      # :nocov:
     end
 
     def check_calling_connection_allowed

--- a/spec/config/initializers/monkeypatches/active_record/base_spec.rb
+++ b/spec/config/initializers/monkeypatches/active_record/base_spec.rb
@@ -1,0 +1,9 @@
+RSpec.describe(ActiveRecord::Base) do
+  describe '::connection' do
+    subject(:connection) { ActiveRecord::Base.connection }
+
+    it 'raises an error' do
+      expect { connection }.to raise_error(ActiveRecord::ActiveRecordError)
+    end
+  end
+end

--- a/spec/workers/truncate_tables_spec.rb
+++ b/spec/workers/truncate_tables_spec.rb
@@ -1,19 +1,27 @@
 RSpec.describe TruncateTables do
   subject(:worker) { TruncateTables.new }
 
+  # rubocop:disable RSpec/InstanceVariable
   describe '#perform' do
     subject(:perform) { worker.perform }
+
+    around do |spec|
+      ApplicationRecord.with_connection do |connection|
+        @connection = connection
+        spec.run
+      end
+    end
 
     context 'when there is at least one row in the `requests` table' do
       before { expect(Request.count).to be > 0 }
 
       it 'issues a DELETE command against the `requests` table' do
-        expect(ApplicationRecord.connection).to receive(:execute).
+        expect(@connection).to receive(:execute).
           with(/DELETE FROM requests/).
           and_call_original
 
         # pass other calls through
-        allow(ApplicationRecord.connection).to receive(:execute).and_call_original
+        allow(@connection).to receive(:execute).and_call_original
 
         perform
       end
@@ -23,15 +31,16 @@ RSpec.describe TruncateTables do
       before { Request.delete_all }
 
       it 'does not issue a DELETE command against the `requests` table' do
-        expect(ApplicationRecord.connection).
+        expect(@connection).
           not_to receive(:execute).
           with(/DELETE FROM requests/i)
 
         # pass other calls through
-        allow(ApplicationRecord.connection).to receive(:execute).and_call_original
+        allow(@connection).to receive(:execute).and_call_original
 
         perform
       end
     end
   end
+  # rubocop:enable RSpec/InstanceVariable
 end


### PR DESCRIPTION
fixes https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/672

Unfortunately, I think that this requires monkeypatching ActiveRecord. At least, that's the only solution that I can think of. So, that's what I'm doing. Fortunately, it's only in test that we need to do it. The reason is that something about how tests set up their database connection (which I think then gets used by the application code) causes the error to not occur in some situations when it would actually occur in development or production. In the original ActiveRecord code, the `permanent_connection_checkout` config is only checked if `pool.permanent_lease?` is truthy. It's falsy in test, though. This monkeypatch changes the code to check the `permanent_connection_checkout` config whether `pool.permanent_lease?` is truthy or falsy.

This also requires forking `activeadmin`, because currently the upstream `activeadmin` uses `ActiveRecord::Base.connection` (via `resource_class.connection`) in one place. I have submitted a PR to upstream my fork: https://github.com/activeadmin/activeadmin/pull/ 8474 .