### PR TITLE
Loosen href selector for devicons stylesheet in prerenderer [HOME-8]

### DIFF
--- a/bin/prerender
+++ b/bin/prerender
@@ -68,13 +68,11 @@ class Prerenderer
   end
 
   def remove_devicon_stylesheet!
-    # rubocop:disable Layout/LineLength
-    @html_doc.css(
-      'link[rel="stylesheet"]' \
-      '[href="https://cdn.jsdelivr.net/gh/konpa/devicon@df6431e323547add1b4cf45992913f15286456d3/devicon.min.css"]' \
-      '[data-lazyloader-state="spent"]',
-    ).remove
-    # rubocop:enable Layout/LineLength
+    @html_doc.
+      css(
+        'link[rel="stylesheet"][href*="devicon"][data-lazyloader-state="spent"]',
+      ).
+      remove
   end
 end
 


### PR DESCRIPTION
The previous selector wasn't matching, ever since we changed the devicons URL here https://github.com/davidrunger/david_runger/commit/f0c27b6f6b5178d7da2c48a052f4d36232219717#diff-1211700308b42367a41d399ab0cf8871eb97bf17664a4da78d578613f54edceaR4 .