### PR TITLE
[docker-compose] Comment out logging temporarily

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,13 @@ x-rails-config: &default-rails-config
   env_file:
     # NOTE: We need this to have DATABASE_URL in bin/docker-entrypoint.
     - .env.production.local
-  logging:
-    driver: syslog
-    options:
-      # NOTE: The syslog-address value will be built into the image.
-      syslog-address: ${PAPERTRAIL_URL:-setpapertrailurl://it-was-not-set}
-      tag: '{{.Name}}/{{.ID}}'
+  # Uncomment this on 2024-09-17 or after.
+  # logging:
+  #   driver: syslog
+  #   options:
+  #     # NOTE: The syslog-address value will be built into the image.
+  #     syslog-address: ${PAPERTRAIL_URL:-setpapertrailurl://it-was-not-set}
+  #     tag: '{{.Name}}/{{.ID}}'
   networks:
     - external
     - internal


### PR DESCRIPTION
We have hit our papertrail log limit for the month (due to an issue where we were logging a bunch of stack traces, fixed in #5053). Unfortunately, I think that this means that papertrail refuses to even connect, resulting in deployment failures. Comment out this logging temporarily, until the monthly quote resets on 2024-09-17.