### PR TITLE
Decrease Cuprite process timeout from 20 seconds to 10 seconds

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -65,7 +65,7 @@ Capybara.register_driver(:cuprite) do |app|
     app,
     window_size: [1200, 800],
     headless: !use_headful_chrome,
-    process_timeout: 20,
+    process_timeout: 10,
     logger: CupriteLogger.new,
   )
 end


### PR DESCRIPTION
Now that we [retry on `Ferrum::ProcessTimeoutError`][1], I think that this long process timeout is not really helpful, and is probably counterproductive, on net (since we wait up to 20 seconds when something goes wrong with the browser, but I think we are unlikely to have success between seconds 10 and 20).

[1]: https://github.com/davidrunger/david_runger/blob/2fcf7747135a011c1a7fb26f8a3e16535f8125d0/spec/spec_helper.rb/#L156-L164