### PR TITLE
Update vite config to avoid Sass deprecation warning

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -8,6 +8,14 @@ import FullReload from 'vite-plugin-full-reload';
 import RubyPlugin from 'vite-plugin-ruby';
 
 export default defineConfig({
+  // https://github.com/vitejs/vite/issues/ 18164#issuecomment-2365310242
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler',
+      },
+    },
+  },
   logLevel: process.env.CI ? 'warn' : undefined,
   plugins: [
     FullReload([


### PR DESCRIPTION
This change removes the following deprecation warning

```
Deprecation Warning: The legacy JS API is deprecated and will be removed in Dart Sass 2.0.0.

More info: https://sass-lang.com/d/legacy-js-api
```

which can be reproduced by running `bin/vite dev` (and `bin/rails server`) and going to http://localhost:3000/logs (or probably any other URL in the app).

For more details: https://github.com/vitejs/vite/issues/ 18164#issuecomment-2365310242 .

Apparently, this will be fixed on Vite's end in Vite 6, but for now I guess that this config change is required. (So, I guess we can remove this after upgrading to Vite 6?)