### PR TITLE
[RequestRecordable] Handle invalid byte sequences in user agent

### DIFF
--- a/app/poros/save_request/request_data_builder.rb
+++ b/app/poros/save_request/request_data_builder.rb
@@ -53,6 +53,6 @@ class SaveRequest::RequestDataBuilder
 
   memo_wise \
   def raw_user_agent
-    @request.user_agent
+    @request.user_agent.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
   end
 end

--- a/app/poros/save_request/request_data_builder.rb
+++ b/app/poros/save_request/request_data_builder.rb
@@ -53,6 +53,6 @@ class SaveRequest::RequestDataBuilder
 
   memo_wise \
   def raw_user_agent
-    @request.user_agent.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
+    @request.user_agent&.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
   end
 end

--- a/spec/controllers/concerns/request_recordable_spec.rb
+++ b/spec/controllers/concerns/request_recordable_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe RequestRecordable, :without_verifying_authorization do
 
   describe '#store_initial_request_data_in_redis' do
     subject(:data_stashed_in_redis_after_request) do
+      request.headers['User-Agent'] = user_agent
       get(:index, params:)
 
       $redis_pool.with do |conn|
@@ -15,6 +16,7 @@ RSpec.describe RequestRecordable, :without_verifying_authorization do
     end
 
     let(:params) { {} }
+    let(:user_agent) { 'RequestRecordable spec user agent' }
 
     context 'when a user is not logged in' do
       before { controller.sign_out_all_scopes }
@@ -25,6 +27,14 @@ RSpec.describe RequestRecordable, :without_verifying_authorization do
 
         it 'includes the auth token id' do
           expect(data_stashed_in_redis_after_request).to include('auth_token_id' => auth_token.id)
+        end
+      end
+
+      context 'when the user agent has an invalid byte sequence' do
+        let(:user_agent) { "valid bytes\xA1\xE5)" }
+
+        it 'saves the data to Redis with the user agent string sanitized' do
+          expect(data_stashed_in_redis_after_request).to include('user_agent' => 'valid bytes)')
         end
       end
 

--- a/spec/controllers/concerns/request_recordable_spec.rb
+++ b/spec/controllers/concerns/request_recordable_spec.rb
@@ -38,6 +38,14 @@ RSpec.describe RequestRecordable, :without_verifying_authorization do
         end
       end
 
+      context 'when the user agent is nil' do
+        let(:user_agent) { nil }
+
+        it 'saves the data to Redis with the user agent as nil' do
+          expect(data_stashed_in_redis_after_request).to include('user_agent' => nil)
+        end
+      end
+
       context 'when a JSON::GeneratorError is raised' do
         before do
           # rubocop:disable RSpec/AnyInstance


### PR DESCRIPTION
fixes rb#666
https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/666

We were receiving requests with user agent `"Sogou Push Spider/3.0(+http://www.sogou.com/docs/help/webmasters.htm#07\xA1\xE5)"`.