### PR TITLE
Fix "Sass @import rules are deprecated" warning

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,3 +1,2 @@
 //= link_tree ../images
-//= link_directory ../stylesheets .css
 //= link_tree ../javascripts

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../stylesheets/rails_views .css
 //= link_tree ../javascripts

--- a/app/assets/stylesheets/rails_views/marriage.scss
+++ b/app/assets/stylesheets/rails_views/marriage.scss
@@ -9,7 +9,7 @@ form.button_to {
     font-family: inherit;
     font-size: inherit;
     background: none;
-    color: rgb(0, 0, 238);
+    color: rgb(37, 99, 235);
     cursor: pointer;
   }
 }

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1,4 +1,4 @@
-@use "sass:meta";
+@use 'sass:meta';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -1,22 +1,23 @@
+@use "sass:meta";
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 /* stylelint-disable no-invalid-position-at-import-rule */
-@import 'tailwind_overrides';
-@import 'rails_overrides';
-@import 'element_plus_overrides';
-@import 'variables';
-@import 'animations/appear_vertically';
-@import 'components/spinner';
-@import 'components/toastify';
-@import 'elements/input';
-@import 'flash';
-@import 'utils/flex';
-@import 'utils/font_family';
-@import 'utils/font_size';
-@import 'utils/font_weight';
-@import 'utils/opacity';
-@import 'ui_framework/button';
+@include meta.load-css('tailwind_overrides');
+@include meta.load-css('rails_overrides');
+@include meta.load-css('element_plus_overrides');
+@include meta.load-css('variables');
+@include meta.load-css('animations/appear_vertically');
+@include meta.load-css('components/spinner');
+@include meta.load-css('components/toastify');
+@include meta.load-css('elements/input');
+@include meta.load-css('flash');
+@include meta.load-css('utils/flex');
+@include meta.load-css('utils/font_family');
+@include meta.load-css('utils/font_size');
+@include meta.load-css('utils/font_weight');
+@include meta.load-css('utils/opacity');
+@include meta.load-css('ui_framework/button');
 /* stylelint-enable no-invalid-position-at-import-rule */
 
 html,

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -1,4 +1,7 @@
-@import './variables/colors';
+$blue-light: #9acbff;
+$gray-light: #b8b8b8;
+$gray-lighter: #ddd;
+$white-dark: #f0f0f0;
 
 $header-height: 56px;
 $small-screen-breakpoint: 766px;

--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -2,6 +2,5 @@ $blue-light: #9acbff;
 $gray-light: #b8b8b8;
 $gray-lighter: #ddd;
 $white-dark: #f0f0f0;
-
 $header-height: 56px;
 $small-screen-breakpoint: 766px;

--- a/app/assets/stylesheets/variables/colors.scss
+++ b/app/assets/stylesheets/variables/colors.scss
@@ -1,4 +1,0 @@
-$blue-light: #9acbff;
-$gray-light: #b8b8b8;
-$gray-lighter: #ddd;
-$white-dark: #f0f0f0;

--- a/app/javascript/home/Home.vue
+++ b/app/javascript/home/Home.vue
@@ -64,7 +64,7 @@ function setScrollToFragmentTimeouts() {
 </script>
 
 <style lang="scss">
-@import 'css/variables';
+@use 'css/variables' as *;
 
 #app-root {
   letter-spacing: 0.2px;

--- a/app/javascript/home/components/HomeHeader.vue
+++ b/app/javascript/home/components/HomeHeader.vue
@@ -60,7 +60,7 @@ function collapseMobileMenu() {
 </script>
 
 <style lang="scss" scoped>
-@import 'css/variables';
+@use 'css/variables' as *;
 
 #header {
   position: fixed;

--- a/app/javascript/home/components/HomeHero.vue
+++ b/app/javascript/home/components/HomeHero.vue
@@ -34,7 +34,7 @@ useIntersectionObserver(homeRef, ([{ isIntersecting }]) => {
 </script>
 
 <style lang="scss" scoped>
-@import 'css/variables';
+@use 'css/variables' as *;
 
 #headline-name {
   font-size: 80px;

--- a/app/javascript/home/components/HomeSection.vue
+++ b/app/javascript/home/components/HomeSection.vue
@@ -27,7 +27,7 @@ defineProps({
 </script>
 
 <style lang="scss" scoped>
-@import 'css/variables';
+@use 'css/variables' as *;
 
 section {
   width: 100%;

--- a/app/javascript/home/components/NavLink.vue
+++ b/app/javascript/home/components/NavLink.vue
@@ -37,7 +37,7 @@ const prettyName = computed((): string => {
 </script>
 
 <style lang="scss" scoped>
-@import 'css/variables';
+@use 'css/variables' as *;
 
 a.nav-link.nav-link {
   color: $gray-light;

--- a/app/javascript/home/components/SkillRow.vue
+++ b/app/javascript/home/components/SkillRow.vue
@@ -52,7 +52,7 @@ const devIconClass = computed(() => {
 </script>
 
 <style lang="scss" scoped>
-@import 'css/variables';
+@use 'css/variables' as *;
 
 i[class^='devicon-'] {
   font-size: 65px;

--- a/app/views/marriages/show.html.haml
+++ b/app/views/marriages/show.html.haml
@@ -2,7 +2,7 @@
   = ts_tag('ujs')
 
 - content_for(:extra_css) do
-  = stylesheet_link_tag('marriage')
+  = stylesheet_link_tag('rails_views/marriage')
 
 = link_to('Back to check-ins', check_ins_path)
 %h1


### PR DESCRIPTION
Example of deprecation warning: https://github.com/davidrunger/david_runger/actions/runs/11598363996/job/32294058277#step:11:150

Fix from https://sass-lang.com/documentation/breaking-changes/import/

```
npm install -g sass-migrator
sass-migrator module --migrate-deps app/assets/stylesheets/styles.scss
```

... plus other changes.