### PR TITLE
[RunTypelizer] Suppress 'typelizer:generate' rake task output

### DIFF
--- a/lib/test/tasks/run_typelizer.rb
+++ b/lib/test/tasks/run_typelizer.rb
@@ -2,7 +2,7 @@ class Test::Tasks::RunTypelizer < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    execute_rake_task('typelizer:generate')
+    execute_rake_task('typelizer:generate', suppress_stdout: true)
     execute_system_command("! grep --quiet -RP '\\bunknown\\b' app/javascript/types/serializers/")
 
     if !execute_system_command('git diff --exit-code')


### PR DESCRIPTION
The output is a bit verbose, as seen here: https://github.com/davidrunger/david_runger/actions/runs/11599094922/job/32296470000?pr=5394#step:11:149

So, this change suppresses the output.