### PR TITLE
Bump strip_attributes from 1.13.0 to 1.14.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ ruby file: '.ruby-version'
 source 'https://rubygems.org'
 
 gem 'activeadmin'
-# Remove 'active_attr' after https://github.com/cgriego/active_attr/pull/ 205 is released.
-gem 'active_attr', github: 'davidrunger/active_attr', branch: 'leoarnold/rails-8'
 gem 'alba'
 gem 'aws-sdk-s3'
 gem 'bootsnap', require: false
@@ -49,8 +47,7 @@ gem 'runger_email_reply_trimmer'
 gem 'sassc' # used by ActiveAdmin asset pipeline
 gem 'sidekiq'
 gem 'sprockets-rails'
-# Source from RubyGems after https://github.com/rmm5t/strip_attributes/pull/ 73 is released.
-gem 'strip_attributes', github: 'davidrunger/strip_attributes', branch: 'leoarnold/rails-8'
+gem 'strip_attributes'
 gem 'typelizer', github: 'davidrunger/typelizer'
 gem 'vite_rails'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,14 +1,4 @@
 GIT
-  remote: https://github.com/davidrunger/active_attr.git
-  revision: d744e06d895f557dcdc6a14f96533c3bb7fc8a99
-  branch: leoarnold/rails-8
-  specs:
-    active_attr (0.17.0)
-      actionpack (>= 3.0.2, < 8.1)
-      activemodel (>= 3.0.2, < 8.1)
-      activesupport (>= 3.0.2, < 8.1)
-
-GIT
   remote: https://github.com/davidrunger/fixture_builder.git
   revision: b7b486c53e8c16904259ad176808ca37e2649c48
   specs:
@@ -24,14 +14,6 @@ GIT
     pallets (0.11.0)
       msgpack
       redis (~> 5.0)
-
-GIT
-  remote: https://github.com/davidrunger/strip_attributes.git
-  revision: b1a40de70c0e3360b761f82dbfb3bfdd40e2b539
-  branch: leoarnold/rails-8
-  specs:
-    strip_attributes (1.13.0)
-      activemodel (>= 3.0, < 8.1)
 
 GIT
   remote: https://github.com/davidrunger/typelizer.git
@@ -645,6 +627,8 @@ GEM
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
     stringio (3.1.2)
+    strip_attributes (1.14.0)
+      activemodel (>= 3.0, < 9.0)
     super_diff (0.13.0)
       attr_extras (>= 6.2.4)
       diff-lcs
@@ -686,7 +670,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  active_attr!
   activeadmin
   addressable
   alba
@@ -782,7 +765,7 @@ DEPENDENCIES
   spring-commands-rspec
   spring-watcher-listen
   sprockets-rails
-  strip_attributes!
+  strip_attributes
   super_diff
   typelizer!
   vite_rails


### PR DESCRIPTION
Also, remove `active_attr` (which I think we might not have needed to add, in the first place).

Also, go back to sourcing `strip_attributes` from RubyGems, now that a version has been released there that is compatible with Rails 8.0.