### PR TITLE
Remove sprockets-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,6 @@ gem 'runger_actions'
 gem 'runger_email_reply_trimmer'
 gem 'sassc' # used by ActiveAdmin asset pipeline
 gem 'sidekiq'
-gem 'sprockets-rails'
 gem 'strip_attributes'
 gem 'typelizer', github: 'davidrunger/typelizer'
 gem 'vite_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -619,13 +619,6 @@ GEM
     spring-watcher-listen (2.1.0)
       listen (>= 2.7, < 4.0)
       spring (>= 4)
-    sprockets (4.2.1)
-      concurrent-ruby (~> 1.0)
-      rack (>= 2.2.4, < 4)
-    sprockets-rails (3.5.2)
-      actionpack (>= 6.1)
-      activesupport (>= 6.1)
-      sprockets (>= 3.0.0)
     stringio (3.1.2)
     strip_attributes (1.14.0)
       activemodel (>= 3.0, < 9.0)
@@ -764,7 +757,6 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen
-  sprockets-rails
   strip_attributes
   super_diff
   typelizer!

--- a/config/application.rb
+++ b/config/application.rb
@@ -9,7 +9,6 @@ require 'action_mailer/railtie'
 require 'action_view/railtie'
 require 'active_job/railtie'
 require 'active_record/railtie'
-require 'sprockets/railtie'
 # rubocop:enable Style/RequireOrder
 
 # Require the gems listed in Gemfile, including any gems

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,7 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.
-Rails.application.config.assets.version = '1.0'
+# Rails.application.config.assets.version = '1.0'
 
 # Add additional assets to the asset load path.
 # Rails.application.config.assets.paths << Emoji.images_path


### PR DESCRIPTION
Do we need this anymore? I guess that Rails 8.0 transitions from sprockets to propshaft? We still have sprockets. Maybe we don't need it? Or, if we do, maybe it should be migrated to propshaft?