### PR TITLE
[check_links/checker] Expect possible 403 status for termsfeed URLs

### DIFF
--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -26,6 +26,8 @@ class CheckLinks::Checker
   STATUS_EXPECTATIONS = {
     'https://www.commonlit.org/' => [200, 403],
     'https://www.linkedin.com/in/davidrunger/' => [200, 429, 999],
+    'https://www.termsfeed.com/privacy-policy-generator/' => [200, 403],
+    'https://www.termsfeed.com/blog/cookies/#What_Are_Cookies' => [200, 403],
   }
   STATUS_EXPECTATIONS.default_proc =
     proc do |_hash, url|


### PR DESCRIPTION
We have been receiving 403s for these two URLs for the past several days. I guess maybe they blocked DigitalOcean or something (where this app is currently hosted).