### PR TITLE
Add 'json' to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'freezolite'
 gem 'haml'
 gem 'haml-rails'
 gem 'hashid-rails'
+gem 'json'
 gem 'js-routes', require: false
 gem 'jwt'
 gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -716,6 +716,7 @@ DEPENDENCIES
   immigrant
   isolator
   js-routes
+  json
   json-schema
   jwt
   launchy


### PR DESCRIPTION
This probably should have been done in #5696 (?).

This doesn't fix any substantive problem (since we have other gems that require the `json` gem, so it was already available), but it's a good idea to have it explicitly listed in the Gemfile.