### PR TITLE
[LOG-25] Allow Ctrl+K also to open the log selector

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -25,6 +25,7 @@ class LogsController < ApplicationController
       current_user: UserSerializer::Basic.new(current_user),
       logs: LogSerializer.new(logs, params: { own_log: !shared_log? }),
       log_input_types:,
+      log_selector_keyboard_shortcut: LogSelectorKeyboardShortcut.new(browser).shortcut,
     )
     render :index
   end

--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -5,7 +5,7 @@ div
   .text-center
     LogSelectorModal
     router-view(:key='$route.fullPath').m-8
-    footer.mb-4 Tip: Super+k will open the log selector.
+    footer.mb-4 Tip: {{ bootstrap.log_selector_keyboard_shortcut }} will open the log selector.
 </template>
 
 <script setup lang="ts">
@@ -45,7 +45,11 @@ onMounted(() => {
   }
 
   document.addEventListener('keydown', (event) => {
-    if (event.key === 'k' && event.metaKey === true) {
+    if (
+      event.key === 'k' &&
+      (event.metaKey === true || event.ctrlKey === true) // Meta for macOS, Ctrl for Windows/Linux
+    ) {
+      event.preventDefault(); // Prevent default behavior for the shortcut
       modalStore.showModal({ modalName: 'log-selector' });
     }
   });

--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -12,7 +12,7 @@ div
 import { storeToRefs } from 'pinia';
 import { computed, onMounted } from 'vue';
 
-import { bootstrap } from '@/lib/bootstrap';
+import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { removeQueryParams } from '@/lib/remove_query_params';
 import { renderBootstrappedToasts } from '@/lib/toasts';
 import { useLogsStore } from '@/logs/store';
@@ -21,13 +21,14 @@ import { useModalStore } from '@/shared/modal/store';
 import LogSelectorModal from './components/LogSelectorModal.vue';
 import type { Bootstrap } from './types';
 
+const bootstrap = untypedBootstrap as Bootstrap;
 const logsStore = useLogsStore();
 const modalStore = useModalStore();
 
 const { isSharedLog, selectedLog } = storeToRefs(logsStore);
 
 const currentUser = computed(() => {
-  return (bootstrap as Bootstrap).current_user;
+  return bootstrap.current_user;
 });
 
 removeQueryParams(); // remove query params such as `new_entry` and `auth_token`

--- a/app/javascript/logs/types.ts
+++ b/app/javascript/logs/types.ts
@@ -28,6 +28,7 @@ export type Bootstrap = Intersection<
     current_user: UserSerializerBasic;
     logs: Array<Log>;
     log_input_types: Array<LogInput>;
+    log_selector_keyboard_shortcut: string;
     toast_messages: Array<string>;
   },
   LogsIndexBootstrap

--- a/app/javascript/types/bootstrap/LogsIndexBootstrap.ts
+++ b/app/javascript/types/bootstrap/LogsIndexBootstrap.ts
@@ -34,9 +34,18 @@ const schema = {
           "items": {
             "$ref": "#/definitions/LogInputType"
           }
+        },
+        "log_selector_keyboard_shortcut": {
+          "type": "string"
         }
       },
-      "required": ["current_user", "log_input_types", "logs", "nonce"],
+      "required": [
+        "current_user",
+        "log_input_types",
+        "log_selector_keyboard_shortcut",
+        "logs",
+        "nonce"
+      ],
       "title": "Root"
     },
     "User": {

--- a/app/poros/log_selector_keyboard_shortcut.rb
+++ b/app/poros/log_selector_keyboard_shortcut.rb
@@ -1,0 +1,13 @@
+class LogSelectorKeyboardShortcut
+  def initialize(browser)
+    @browser = browser
+  end
+
+  def shortcut
+    if @browser.platform.mac?
+      'Cmd+K'
+    else
+      'Ctrl+K'
+    end
+  end
+end

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -18,6 +18,9 @@ RSpec.describe 'Logs app' do
         end
         expect(page).to have_text('New Log')
 
+        # Check for (platform-specific) keyboard shortcut to open log-selector modal
+        expect(page).to have_text('Tip: Ctrl+K will open the log selector.')
+
         log = user.logs.first!
         other_log = user.logs.second!
         click_on(log.name)

--- a/spec/poros/log_selector_keyboard_shortcut_spec.rb
+++ b/spec/poros/log_selector_keyboard_shortcut_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe LogSelectorKeyboardShortcut do
+  subject(:log_selector_keyboard_shortcut) { described_class.new(browser) }
+
+  describe '#shortcut' do
+    subject(:shortcut) { log_selector_keyboard_shortcut.shortcut }
+
+    context 'when the browser platform is MacOS' do
+      let(:browser) do
+        Browser.new(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 ' \
+          '(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        )
+      end
+
+      it 'returns "Cmd+K"' do
+        expect(shortcut).to eq('Cmd+K')
+      end
+    end
+
+    context 'when the browser platform is Linux' do
+      let(:browser) do
+        Browser.new(
+          'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 ' \
+          '(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        )
+      end
+
+      it 'returns "Ctrl+K"' do
+        expect(shortcut).to eq('Ctrl+K')
+      end
+    end
+
+    context 'when the browser platform is Windows' do
+      let(:browser) do
+        Browser.new(
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' \
+          '(KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+        )
+      end
+
+      it 'returns "Ctrl+K"' do
+        expect(shortcut).to eq('Ctrl+K')
+      end
+    end
+  end
+end

--- a/spec/support/schemas/bootstrap/logs/index.json
+++ b/spec/support/schemas/bootstrap/logs/index.json
@@ -30,9 +30,18 @@
           "items": {
             "$ref": "#/definitions/LogInputType"
           }
+        },
+        "log_selector_keyboard_shortcut": {
+          "type": "string"
         }
       },
-      "required": ["current_user", "log_input_types", "logs", "nonce"],
+      "required": [
+        "current_user",
+        "log_input_types",
+        "log_selector_keyboard_shortcut",
+        "logs",
+        "nonce"
+      ],
       "title": "Root"
     },
     "User": {


### PR DESCRIPTION
Also, change the suggested keyboard shortcut, depending on which platform the user is on. On Windows and Linux, we will suggest Ctrl+K, while on macOS, we will suggest Cmd+K.