### PR TITLE
Serve SSL certificate renewal requests via HTTPS (not just HTTP)

### DIFF
--- a/config/nginx/sites-enabled/davidrunger.com.conf
+++ b/config/nginx/sites-enabled/davidrunger.com.conf
@@ -16,6 +16,9 @@ server {
     access_log              /var/log/nginx/access.log combined buffer=4k flush=1s;
     error_log               /var/log/nginx/error.log warn;
 
+    # SSL certificate renewals
+    include nginxconfig.io/letsencrypt.conf;
+
     # Serve static files from the public directory
     location / {
         root /var/www/david-runger-public;


### PR DESCRIPTION
Currently, attempts to renew our SSL certificate via certbot are failing. I think that the reason that they are failing is because the requests are made to a URL like https://davidrunger.com/.well-known/acme-challenge/Dcw_D--50Cj64bEKvTe_IM5juzxKzIYMRjUhzPy1P5M . Note the `https` scheme. Prior to this change, I think we weren't serving the ACME challenge responses via HTTPS, so the requests were failing. With this change, I think that we will now serve the responses via HTTPS, which hopefully will allow the renewals to succeed.