### PR TITLE
Don't stash initial request data in Redis for HealthChecksController

### DIFF
--- a/app/controllers/concerns/request_recordable.rb
+++ b/app/controllers/concerns/request_recordable.rb
@@ -2,6 +2,9 @@ module RequestRecordable
   extend ActiveSupport::Concern
   prepend MemoWise
 
+  CONTROLLERS_NOT_TO_RECORD = [
+    'HealthChecksController', # don't log these frequent, low-value requests
+  ].freeze
   # The number of seconds to store request data in Redis (to later turn into a `Request`). Set to
   # 21.days because that's ~ how long Sidekiq (which processes this data) will attempt retries for.
   REQUEST_DATA_TTL = Integer(21.days)
@@ -14,8 +17,10 @@ module RequestRecordable
   private
 
   def store_initial_request_data_in_redis
-    $redis_pool.with do |conn|
-      conn.call('setex', initial_request_data_redis_key, REQUEST_DATA_TTL, request_data.to_json)
+    unless self.class.name.in?(CONTROLLERS_NOT_TO_RECORD)
+      $redis_pool.with do |conn|
+        conn.call('setex', initial_request_data_redis_key, REQUEST_DATA_TTL, request_data.to_json)
+      end
     end
   rescue JSON::GeneratorError
     Rails.logger.info("[RequestRecordable][JSON::GeneratorError] #{request_data.inspect}")

--- a/config/initializers/request_logging.rb
+++ b/config/initializers/request_logging.rb
@@ -3,10 +3,8 @@ ActiveSupport::Notifications.subscribe('process_action.action_controller') do |*
 
   controller_name = payload[:controller]
 
-  next if controller_name.in?([
-    'AnonymousController', # this occurs in tests
-    'HealthChecksController', # don't log these frequent, low-value requests
-  ])
+  next if controller_name.in?(RequestRecordable::CONTROLLERS_NOT_TO_RECORD)
+  next if controller_name == 'AnonymousController' # This occurs in tests.
 
   controller_klass = controller_name.constantize
   # We won't log requests to non-ApplicationController controllers (e.g. Flipper & Sidekiq engines)


### PR DESCRIPTION
The requests to `/up` were using up a nontrivial amount of storage (~90 MB or so, IIRC) in the application's Redis database. I believe that the requests were sitting in Redis for their full 21 day TTL. This change will make it so that we don't store that data in Redis for any period of time, which should make Redis use notably less memory overall.