### PR TITLE
[vector] Don't send host/system to Papertrail

### DIFF
--- a/vector/vector.yaml
+++ b/vector/vector.yaml
@@ -13,11 +13,13 @@ transforms:
       match(string!(.container_name), r'-(clock|initialize_database|web|worker)-\d+')
 
   # Add brief service name to log data
-  papertrail_services_with_brief_service_name:
+  papertrail_services_remapped:
     type: remap
     inputs:
       - papertrail_services
     source: |
+      del(.host)
+
       name_without_prefix = replace(string!(.container_name), r'^david_runger-', "")
       name_without_prefix_or_suffix = replace(name_without_prefix, r'-\d+$', "")
       .brief_service_name = name_without_prefix_or_suffix
@@ -27,7 +29,7 @@ sinks:
   papertrail:
     type: papertrail
     inputs:
-      - papertrail_services_with_brief_service_name
+      - papertrail_services_remapped
     endpoint: '${PAPERTRAIL_HOST_AND_PORT}'
     encoding:
       codec: text


### PR DESCRIPTION
Previously, the container id of the vector container was being sent as the host/system, which is not particularly helpful, and which I think might have some downsides. When no host/system is provided, I think Papertrail will just log the sending IP address as the system, which I think actually works pretty well, so this change should bring up back to that.