### PR TITLE
[docker-compose] Add '--watch-config' to vector command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -175,7 +175,11 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./vector/vector.yaml:/etc/vector/vector.yaml:ro
     command:
-      ['--config', '/etc/vector/vector.yaml', '--require-healthy', 'true']
+      - '--config'
+      - '/etc/vector/vector.yaml'
+      - '--require-healthy'
+      - 'true'
+      - '--watch-config'
   web:
     <<: *default-rails-config
     command: ['bin/rails', 'server', '--binding', '0.0.0.0']


### PR DESCRIPTION
This way, the service will reload itself if/when the configuration file is changed. (This doesn't happen automatically, because the file is not part of a Dockerfile definition, but rather is provided to the service via a Docker volume.)