### PR TITLE
[nignx] Reduce worker_rlimit_nofile and worker_connections to 1024

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -4,14 +4,14 @@
 user                 nginx;
 pid                  /var/run/nginx.pid;
 worker_processes     auto;
-worker_rlimit_nofile 65535;
+worker_rlimit_nofile 1024;
 
 # Load modules
 include              /etc/nginx/modules-enabled/*.conf;
 
 events {
     multi_accept       on;
-    worker_connections 65535;
+    worker_connections 1024;
 }
 
 http {

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -4,14 +4,14 @@
 user                 nginx;
 pid                  /var/run/nginx.pid;
 worker_processes     auto;
-worker_rlimit_nofile 512;
+worker_rlimit_nofile 1024;
 
 # Load modules
 include              /etc/nginx/modules-enabled/*.conf;
 
 events {
     multi_accept       on;
-    worker_connections 512;
+    worker_connections 1024;
 }
 
 http {

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -4,14 +4,14 @@
 user                 nginx;
 pid                  /var/run/nginx.pid;
 worker_processes     auto;
-worker_rlimit_nofile 1024;
+worker_rlimit_nofile 512;
 
 # Load modules
 include              /etc/nginx/modules-enabled/*.conf;
 
 events {
     multi_accept       on;
-    worker_connections 1024;
+    worker_connections 512;
 }
 
 http {


### PR DESCRIPTION
Testing this change temporarily on the server, it seems to reduce NGINX memory usage from ~30 MB to ~10 MB (per `docker stats`). A nice ~20 MB memory savings!, which can be put to good use elsewhere.