### PR TITLE
[sidekiq] Delete outdated comments about server connection pool size

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -10,10 +10,6 @@ unless IS_DOCKER_BUILD
   end
 
   Sidekiq.configure_server do |config|
-    # Sidekiq Server Connection Pool size:
-    # This is `(max_)concurrency + 5`.
-    # For concurrency (3), see config/sidekiq.yml.
-    # For why we are adding 5, see https://github.com/sidekiq/sidekiq/wiki/Using-Redis#complete-control
     # :nocov:
     config.redis = { url: redis_options.url }
 


### PR DESCRIPTION
For one thing, we are no longer setting the size manually, anyway. We removed that in 2de177e7 / #1789.

Additionally, we no longer need to manage adding extra connections to the pool size. Now, Sidekiq has a dedicated pool for its own needs in addition to a separate pool for each Sidekiq capsule's connections:

> Before 7.0, the Sidekiq process would create one redis pool sized to `concurrency + 5`. Now Sidekiq will create multiple Redis pools: an internal pool of ten connections available to Sidekiq components along with a pool of **concurrency** for the job processors within each Capsule.

-- https://github.com/sidekiq/sidekiq/blob/c24525bc2aab8ce41c4767cd70410c4b27e0b132/docs/capsule.md#redis-pools