### PR TITLE
[Dockerfile] Add 'libyaml-dev' to packages installed for build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN --mount=type=cache,sharing=private,target=/var/lib/apt/lists \
   --mount=type=cache,sharing=private,target=/var/cache/apt \
   apt-get update -qq && \
   apt-get install --no-install-recommends -y \
-  build-essential git libpq-dev unzip
+  build-essential git libpq-dev libyaml-dev unzip
 
 # Download skedjewel binary.
 ARG SKEDJEWEL_VERSION=v0.0.13


### PR DESCRIPTION
After running `docker system prune --force --all --volumes && docker volume prune --all --force`, I was getting an error when trying to build the Docker image for the project, specifically during the `bundle install` command.

I'm not sure why this issue has emerged now. Maybe it has to do with bumping Ruby to 3.4.1 relatively recently? Maybe that image doesn't include libyaml-dev by default, but previous Ruby images did?

Anyway, adding this seems to fix the issue (although there is at least one unresolved issue in a later build step, which I will try to fix in a subsequent PR).