### PR TITLE
[Dockerfile] Add 'procps' (for 'ps' command) to installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN --mount=type=cache,sharing=private,target=/var/lib/apt/lists \
   --mount=type=cache,sharing=private,target=/var/cache/apt \
   apt-get update && \
   apt-get install --no-install-recommends -y \
-  curl libjemalloc2 postgresql-client
+  curl libjemalloc2 postgresql-client procps
 
 ARG RAILS_ENV
 RUN test -n "$RAILS_ENV"


### PR DESCRIPTION
We use `ps` for the healtcheck for the `clock` service. I guess maybe `ps` was removed in the Ruby 3.4.1 Docker image? I'm not totally clear on why/how this has still been working locally for me. I seem to have broken it with `docker system prune --force --all --volumes && docker volume prune --all --force`, though. This should fix it.

This change won't fix all of our issues. Docker builds (and, thus, deploys) are still broken until we merge #5797 .