### PR TITLE
[docker-compose] Increase various healthcheck intervals [DEV-123]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ x-redis-config: &redis
     test: ['CMD', 'redis-cli', 'ping']
     start_period: 20s
     start_interval: 1s
-    interval: 10s
+    interval: 5m
     timeout: 1s
     retries: 1
   image: redis:7.2.5-alpine
@@ -61,8 +61,8 @@ services:
     healthcheck:
       test: ps -eo cmd | grep -P '^[b]in/skedjewel$'
       start_period: 10s
-      start_interval: 1s
-      interval: 10s
+      start_interval: 2s
+      interval: 5m
       timeout: 1s
       retries: 1
   initialize_database:
@@ -113,7 +113,7 @@ services:
       test: ['CMD', 'pg_isready', '-U', 'david_runger']
       start_period: 20s
       start_interval: 1s
-      interval: 10s
+      interval: 5m
       timeout: 1s
       retries: 1
     image: postgres:16.3-alpine
@@ -189,7 +189,7 @@ services:
       test: curl --silent --output /dev/null --fail localhost:3000/up
       start_period: 30s
       start_interval: 1s
-      interval: 10s
+      interval: 1m
       timeout: 1s
       retries: 1
     profiles:
@@ -203,7 +203,7 @@ services:
       test: REDIS_URL="$$REDIS_URL/1" bin/sidekiqmon | grep --quiet "$$(hostname)"
       start_period: 60s
       start_interval: 10s
-      interval: 60s
+      interval: 5m
       timeout: 10s
       retries: 1
 


### PR DESCRIPTION
Many of these healthchecks cause a non-negligible spike in CPU usage that is sort of annoying. For example, I see regular little spikes in CPU usage when looking at `htop` or `docker stats`. This small CPU spikes also take away CPU that could be used for other work that is more likely to actually be time sensitive and/or useful.

I think that the main value of the healthchecks is really for the Docker compose startup process, anyway; I don't think we get much value from the ongoing healthchecks post-startup that are (mostly) what is being tweaked herein. For one thing, I don't think that the ongoing healthchecks are very likely at all to randomly fail after startup. Also, I don't know that such a failure would actually even trigger anything useful (like a restart of the service or a notification). So, checking frequently doesn't seem worth it, given the downside of spikes in CPU usage.

I have increased numerous intervals from 10 seconds to 5 minutes, plus a few other somewhat related tweaks increasing healthcheck intervals.