### PR TITLE
[vector] Only send logs to Papertrail if HOST/PORT env var is present

### DIFF
--- a/vector/vector.yaml
+++ b/vector/vector.yaml
@@ -30,7 +30,7 @@ sinks:
     encoding:
       codec: text
     endpoint: '${PAPERTRAIL_HOST_AND_PORT}'
-    if: '${PAPERTRAIL_HOST_AND_PORT:-false}' # Defaults to false if env var not set.
+    if: '${PAPERTRAIL_HOST_AND_PORT:-false}'
     inputs:
       - papertrail_services_remapped
     process: '{{ .brief_service_name }}'

--- a/vector/vector.yaml
+++ b/vector/vector.yaml
@@ -27,10 +27,11 @@ transforms:
 sinks:
   # Send logs to Papertrail
   papertrail:
-    type: papertrail
-    inputs:
-      - papertrail_services_remapped
-    endpoint: '${PAPERTRAIL_HOST_AND_PORT}'
     encoding:
       codec: text
+    endpoint: '${PAPERTRAIL_HOST_AND_PORT}'
+    if: '${PAPERTRAIL_HOST_AND_PORT:-false}' # Defaults to false if env var not set.
+    inputs:
+      - papertrail_services_remapped
     process: '{{ .brief_service_name }}'
+    type: papertrail

--- a/vector/vector.yaml
+++ b/vector/vector.yaml
@@ -5,18 +5,20 @@ sources:
 
 transforms:
   # Filter to only the services that we want to send to Papertrail
-  papertrail_services:
+  papertrail_services_filtered:
     type: filter
     inputs:
       - docker
     condition: |
-      match(string!(.container_name), r'-(clock|initialize_database|web|worker)-\d+')
+      _, env_var_error = get_env_var("PAPERTRAIL_HOST_AND_PORT")
+
+      env_var_error == null && match(string!(.container_name), r'-(clock|initialize_database|web|worker)-\d+')
 
   # Add brief service name to log data
   papertrail_services_remapped:
     type: remap
     inputs:
-      - papertrail_services
+      - papertrail_services_filtered
     source: |
       del(.host)
 
@@ -30,7 +32,6 @@ sinks:
     encoding:
       codec: text
     endpoint: '${PAPERTRAIL_HOST_AND_PORT}'
-    if: '${PAPERTRAIL_HOST_AND_PORT:-false}'
     inputs:
       - papertrail_services_remapped
     process: '{{ .brief_service_name }}'


### PR DESCRIPTION
This will make it more straightforward to run Docker containers locally without sending logs to Papertrail (e.g. by simply commenting out PAPERTRAIL_HOST_AND_PORT in `.env.vector.local`).