### PR TITLE
Don't validate JSON schemas when running in Docker

### DIFF
--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -12,7 +12,9 @@ class JsonSchemaValidator
   # https://jsonformatter.org/json-to-jsonschema .
   def validated_data
     if (
-      Rails.env.local? && !(defined?(Runger.config) && Runger.config.skip_schema_validation?) &&
+      Rails.env.local? &&
+        !IS_DOCKER &&
+        !(defined?(Runger.config) && Runger.config.skip_schema_validation?) &&
         schema_validation_errors.present?
     )
       copy_data_to_clipboard


### PR DESCRIPTION
The `json-schema` gem is a development and test dependency only. In our Dockerfile, we only install production gems. Therefore, the `json-schema` gem is not available when running Docker (even when running it locally in development mode). Thus, we need this condition to avoid an error about JSON::Schema being undefined when accessing a path that would otherwise attempt to validate a JSON response.