### PR TITLE
[vector] Add fallback for PAPERTRAIL_HOST_AND_PORT

### DIFF
--- a/vector/vector.yaml
+++ b/vector/vector.yaml
@@ -10,9 +10,9 @@ transforms:
     inputs:
       - docker
     condition: |
-      _, env_var_error = get_env_var("PAPERTRAIL_HOST_AND_PORT")
+      papertrail_address, env_var_error = get_env_var("PAPERTRAIL_HOST_AND_PORT")
 
-      env_var_error == null && match(string!(.container_name), r'-(clock|initialize_database|web|worker)-\d+')
+      env_var_error == null && contains(papertrail_address, "papertrail") && match(string!(.container_name), r'-(clock|initialize_database|web|worker)-\d+')
 
   # Add brief service name to log data
   papertrail_services_remapped:
@@ -31,7 +31,9 @@ sinks:
   papertrail:
     encoding:
       codec: text
-    endpoint: '${PAPERTRAIL_HOST_AND_PORT}'
+    endpoint: '${PAPERTRAIL_HOST_AND_PORT:-davidrunger.com:12345}'
+    healthcheck:
+      enabled: false
     inputs:
       - papertrail_services_remapped
     process: '{{ .brief_service_name }}'


### PR DESCRIPTION
In #5814 , we tried to make it easier to avoid sending logs to Papertrail by simply commenting out the `PAPERTRAIL_HOST_AND_PORT` env var.

However, without a fallback/default value, I think that this actually then makes the Vector configuration invalid, and causes Vector to not do anything.

I didn't notice this before, because we currently only have the Papertrail sink. But now I am working on also adding a Loki sink, which brought to my attention the fact that having a blank PAPERTRAIL_HOST_AND_PORT not only disables logging to Papertrail, but it breaks Vector in general.

Somewhat similarly, if the PAPERTRAIL_HOST_AND_PORT is not an address with DNS set up and which responds, then Vector's health check for the Papertrail sink will fail if the health check is performed, which then I think breaks Vector overall. Therefore, we will disable the health check for the Papertrail sink.

This change will allow Vector to keep working overall (e.g. sending logs to Loki, in the future), even if there is no PAPERTRAIL_HOST_AND_PORT env var set in the environment.