### PR TITLE
Merely log emails when running via Docker in development

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -90,7 +90,13 @@ Rails.application.configure do
   # Email
   config.action_mailer.perform_deliveries = true
   config.action_mailer.raise_delivery_errors = true
-  config.action_mailer.delivery_method = :letter_opener
+  config.action_mailer.delivery_method =
+    if Rails.env.development? && IS_DOCKER
+      # Merely log, because letter_opener is a development dependency (so not available in Docker).
+      Mail::LoggerDelivery
+    else
+      :letter_opener
+    end
 
   local_hostname = ENV.fetch('LOCAL_HOSTNAME', nil)
   if local_hostname && !local_hostname.empty? # rubocop:disable Rails/Present


### PR DESCRIPTION
`letter_opener` is not available in Docker (because we only install production gems in Docker, and `letter_opener` is in the `development` group). Therefore, when running in development mode in Docker, with this change, we will instead now use `Mail::LoggerDelivery` (which is provided by the `mail` gem) as the `delivery_method`, rather than `letter_opener`.