### PR TITLE
Mark the root NGINX server block as the default

### DIFF
--- a/config/nginx/sites-enabled/davidrunger.com.conf
+++ b/config/nginx/sites-enabled/davidrunger.com.conf
@@ -1,6 +1,6 @@
 server {
-    listen                  443 ssl;
-    listen                  [::]:443 ssl;
+    listen                  443 ssl default_server;
+    listen                  [::]:443 ssl default_server;
     http2                   on;
     server_name             davidrunger.com;
 
@@ -41,8 +41,8 @@ server {
 
 # HTTP redirect
 server {
-    listen      80;
-    listen      [::]:80;
+    listen      80 default_server;
+    listen      [::]:80 default_server;
     server_name davidrunger.com;
 
     # logging


### PR DESCRIPTION
This way, we ensure that even if we later add subdomains (e.g. a `grafana` subdomain), requests simply to `https://localhost` will continue to go to the desired `server` block (i.e. the one modified herein, which proxies to the Rails app).