### PR TITLE
[docker-compose/nginx/healthcheck] Make HTTPS request to /up for 200

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
       vector:
         condition: service_started
     healthcheck:
-      test: curl --fail http://localhost/
+      test: curl --insecure -s -o /dev/null -w "%{http_code}" https://localhost/up | grep -q "^200$" || false
       start_period: 20s
       start_interval: 1s
       interval: 60s


### PR DESCRIPTION
Before, the response for our request to http://localhost/ was a 301 redirect to HTTPS. A more important thing to check is that an HTTPS request returns 200, which the `nginx` healthcheck will now do, as of this change.

Also, we will now make the healthcheck request to `/up`, since we already suppress web logs for that path (via `RequestRecordable::CONTROLLERS_NOT_TO_RECORD` and `config.lograge.ignore_actions`), and we don't want these healthcheck requests to appear as `Request`s or in the `web` logs.