### PR TITLE
[docker-compose/vector] Alphabetize configuration keys

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,18 +168,18 @@ services:
     profiles:
       - nondefault
   vector:
-    env_file:
-      - .env.vector.local
-    image: timberio/vector:latest-alpine
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock:ro
-      - ./vector/vector.yaml:/etc/vector/vector.yaml:ro
     command:
       - '--config'
       - '/etc/vector/vector.yaml'
       - '--require-healthy'
       - 'true'
       - '--watch-config'
+    env_file:
+      - .env.vector.local
+    image: timberio/vector:latest-alpine
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./vector/vector.yaml:/etc/vector/vector.yaml:ro
   web:
     <<: *default-rails-config
     command: ['bin/rails', 'server', '--binding', '0.0.0.0']


### PR DESCRIPTION
This is a non-substantive change.

Although it can be nice to have the keys ordered by importance (high to low), I find it generally simpler to find things when the keys are simply ordered alphabetically.