### PR TITLE
Store logs in Loki and view them via Grafana (via NGINX) [DEV-120]

### DIFF
--- a/bin/server/bootstrap-letsencrypt.sh
+++ b/bin/server/bootstrap-letsencrypt.sh
@@ -5,7 +5,7 @@
 
 # shellcheck disable=SC2128
 
-domains=(davidrunger.com www.davidrunger.com)
+domains=(davidrunger.com grafana.davidrunger.com www.davidrunger.com)
 rsa_key_size=4096
 data_path="./ssl-data/certbot"
 email="davidjrunger@gmail.com" # Adding a valid address is strongly recommended

--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -32,6 +32,12 @@ http {
     # Logging
     access_log             off;
     error_log              /dev/null;
+    # Define a format that adds a subdomain tag to logs. This seems helpful, in general, and it
+    # makes it easy to distinguish subdomain requests in Vector transforms.
+    log_format with_subdomain '[$subdomain] $remote_addr - $remote_user [$time_local] '
+                                '"$request" $status $body_bytes_sent '
+                                '"$http_referer" "$http_user_agent"';
+
 
     # SSL
     ssl_session_timeout    1d;

--- a/config/nginx/sites-enabled/grafana.davidrunger.com.conf
+++ b/config/nginx/sites-enabled/grafana.davidrunger.com.conf
@@ -1,0 +1,54 @@
+server {
+    listen                  443 ssl;
+    listen                  [::]:443 ssl;
+    http2                   on;
+    server_name             grafana.localhost grafana.davidrunger.com;
+    set                     $subdomain 'grafana';
+
+    # SSL
+    ssl_certificate         /etc/letsencrypt/live/davidrunger.com/fullchain.pem;
+    ssl_certificate_key     /etc/letsencrypt/live/davidrunger.com/privkey.pem;
+    ssl_trusted_certificate /etc/letsencrypt/live/davidrunger.com/chain.pem;
+
+    # security
+    include                 nginxconfig.io/security.conf;
+
+    # logging
+    access_log             /dev/stdout with_subdomain buffer=4k flush=1s;
+    error_log              /dev/stderr warn;
+
+    # Ownership verification when renewing SSL certificates
+    include nginxconfig.io/letsencrypt.conf;
+
+    # Proxy to Grafana
+    location / {
+        # Use Docker's embedded DNS to resolve container names
+        resolver           127.0.0.11;
+        set                $grafana "grafana:3000";
+        proxy_pass         http://$grafana;
+        proxy_set_header   Host $host;
+        include            nginxconfig.io/proxy.conf;
+    }
+
+    # additional config
+    include nginxconfig.io/general.conf;
+}
+
+# HTTP redirect
+server {
+    listen      80;
+    listen      [::]:80;
+    server_name grafana.localhost grafana.davidrunger.com;
+    set         $subdomain 'grafana';
+
+    # logging
+    access_log  /dev/stdout with_subdomain buffer=4k flush=1s;
+    error_log   /dev/stderr warn;
+
+    # Ownership verification when requesting SSL certificates
+    include     nginxconfig.io/letsencrypt.conf;
+
+    location / {
+        return 301 https://$server_name$request_uri;
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,18 @@ services:
       interval: 5m
       timeout: 1s
       retries: 1
+  grafana:
+    depends_on:
+      - loki
+    env_file:
+      - .env.grafana.local
+    expose:
+      - '3000'
+    image: grafana/grafana:latest
+    networks:
+      - internal
+    volumes:
+      - grafana-data:/var/lib/grafana
   initialize_database:
     <<: *default-rails-config
     depends_on:
@@ -76,6 +88,14 @@ services:
         condition: service_healthy
       vector:
         condition: service_started
+  loki:
+    image: grafana/loki:latest
+    expose:
+      - '3100'
+    networks:
+      - internal
+    volumes:
+      - loki-data:/loki
   nginx:
     command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
     depends_on:
@@ -177,6 +197,9 @@ services:
     env_file:
       - .env.vector.local
     image: timberio/vector:latest-alpine
+    networks:
+      - external
+      - internal
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - ./vector/vector.yaml:/etc/vector/vector.yaml:ro
@@ -216,5 +239,7 @@ networks:
 
 volumes:
   app-public:
+  grafana-data:
+  loki-data:
   postgresql:
   redis:

--- a/vector/vector.yaml
+++ b/vector/vector.yaml
@@ -4,6 +4,15 @@ sources:
     type: docker_logs
 
 transforms:
+  docker_with_grafana_nginx_separated:
+    type: remap
+    inputs:
+      - docker
+    source: |
+      if .label."com.docker.compose.service" == "nginx" && match(string!(.message), r'^\[grafana\]') {
+        .label."com.docker.compose.service" = "nginx-grafana"
+      }
+
   # Filter to only the services that we want to send to Papertrail
   papertrail_services_filtered:
     type: filter
@@ -27,6 +36,18 @@ transforms:
       .brief_service_name = name_without_prefix_or_suffix
 
 sinks:
+  loki:
+    type: loki
+    inputs:
+      - docker_with_grafana_nginx_separated
+    endpoint: http://loki:3100
+    encoding:
+      codec: json
+    healthcheck:
+      enabled: false
+    labels:
+      service_name: '{{ .label."com.docker.compose.service" }}'
+
   # Send logs to Papertrail
   papertrail:
     encoding:


### PR DESCRIPTION
Docker's built-in json-file logging seems to not work very well, at least when also using log rotation. For example, `docker compose logs <service_name>` only shows logs for the current container, even if that container was just booted up recently. There are other problems. And we can't currently afford to send all logs (including NGINX) to Papertrail. So, we don't currently have a good solution that covers NGINX. Loki/Grafana will provide that.

A side benefit / win-win is that it would also be nice to have Grafana available for viewing metrics (aggregated/stored via StatsD, Graphite, and/or whatever), and this will lay some of the groundwork for that by setting up Grafana.