### PR TITLE
[bootstrap-letsencrypt] Comment out problematic lines for subdomains

### DIFF
--- a/bin/server/bootstrap-letsencrypt.sh
+++ b/bin/server/bootstrap-letsencrypt.sh
@@ -43,7 +43,7 @@ docker compose run --rm --entrypoint "\
 echo
 
 echo "### Temporarily commenting out problematic line ..."
-sed -i 's|^\s\+\(ssl_trusted_certificate\s\)|    # \1|' config/nginx/sites-enabled/davidrunger.com.conf
+sed -i 's|^\s\+\(ssl_trusted_certificate\s\)|    # \1|' config/nginx/sites-enabled/*davidrunger.com.conf
 echo
 
 echo "### Starting nginx ..."
@@ -85,7 +85,7 @@ docker compose run --rm --entrypoint "\
 echo
 
 echo "### Uncommenting temporarily commented-out line ..."
-sed -i 's|^\s\+# \(ssl_trusted_certificate\s\)|    \1|' config/nginx/sites-enabled/davidrunger.com.conf
+sed -i 's|^\s\+# \(ssl_trusted_certificate\s\)|    \1|' config/nginx/sites-enabled/*davidrunger.com.conf
 echo
 
 echo "### Reloading nginx ..."


### PR DESCRIPTION
This is relevant now that we also have grafana.davidrunger.com.conf (added in #5827). I already made this change temporarily on the server, in order to get fresh SSL certificates for the new set of domains, including grafana.davidrunger.com . I am committing this change here now so that future runs of the `bin/server/bootstrap-letsencrypt.sh` script will work smoothly.