### PR TITLE
[docker-compose] Add Grafana service to external network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,6 +74,7 @@ services:
       - '3000'
     image: grafana/grafana:latest
     networks:
+      - external # Allows Grafana to download plugins.
       - internal
     volumes:
       - grafana-data:/var/lib/grafana


### PR DESCRIPTION
This will allow Grafana to download plugins from the Internet (such as "Explore Logs", as documented here: https://grafana.com/docs/grafana-cloud/visualizations/simplified-exploration/logs/access/#install-via-environment-variable).