### PR TITLE
[roll-out-web] Remove 'status=waiting' log lines

### DIFF
--- a/bin/server/roll-out-web.sh
+++ b/bin/server/roll-out-web.sh
@@ -68,7 +68,6 @@ while [ $attempt -le $max_attempts ] ; do
       exit 1
     fi
 
-    echo_iso8601 "status=waiting delay=$delay"
     sleep $delay
     attempt=$((attempt + 1))
   fi

--- a/bin/server/roll-out-web.sh
+++ b/bin/server/roll-out-web.sh
@@ -52,15 +52,15 @@ while [ $attempt -le $max_attempts ] ; do
 
   # Validate status code is a number and in range
   if [ $exit_code -eq 0 ] && [[ "$status_code" =~ ^[0-9]+$ ]] && [ "$status_code" -ge 200 ] && [ "$status_code" -lt 300 ] ; then
-    echo_iso8601 "status=success attempt=$attempt status_code=$status_code"
+    echo_iso8601 "attempt=$attempt status=success status_code=$status_code"
     break
   else
     if [ $exit_code -eq 7 ] ; then
-      echo_iso8601 "status=error attempt=$attempt error=connection_refused"
+      echo_iso8601 "attempt=$attempt status=error error=connection_refused"
     elif [ $exit_code -eq 28 ] ; then
-      echo_iso8601 "status=error attempt=$attempt error=connection_timeout"
+      echo_iso8601 "attempt=$attempt status=error error=connection_timeout"
     else
-      echo_iso8601 "status=error attempt=$attempt status_code=$status_code error_msg=\"$error_msg\" exit_code=$exit_code"
+      echo_iso8601 "attempt=$attempt status=error status_code=$status_code error_msg=\"$error_msg\" exit_code=$exit_code"
     fi
 
     if [ $attempt -eq $max_attempts ] ; then


### PR DESCRIPTION
They are not worth it and they clutter up the output too much.

Also, move the attempt number to beginning of curl result log lines. This way, it will align with the opening log line about the request that is about to be made, which also starts with the attempt number.