### PR TITLE
Use RubyGems-hosted `fixture_builder`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,7 @@ group :test do
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'ferrum'
-  gem 'fixture_builder', github: 'davidrunger/fixture_builder'
+  gem 'fixture_builder'
   gem 'launchy'
   gem 'pallets', github: 'davidrunger/pallets'
   gem 'percy-capybara'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/davidrunger/fixture_builder.git
-  revision: 1edc864a575cddbae6d7ab473f567dc57e3dca03
-  specs:
-    fixture_builder (0.5.3.rc3)
-      activerecord (>= 2)
-      activesupport (>= 2)
-      hashdiff
-
-GIT
   remote: https://github.com/davidrunger/pallets.git
   revision: 3362ed2c3f3d33c856c8ce06640cbf9a89bb5b90
   specs:
@@ -239,6 +230,10 @@ GEM
       webrick (~> 1.7)
       websocket-driver (~> 0.7)
     ffi (1.17.1)
+    fixture_builder (0.5.3.rc2)
+      activerecord (>= 2)
+      activesupport (>= 2)
+      hashdiff
     flipper (1.3.2)
       concurrent-ruby (< 2)
     flipper-redis (1.3.2)
@@ -706,7 +701,7 @@ DEPENDENCIES
   faraday
   faraday-multipart
   ferrum
-  fixture_builder!
+  fixture_builder
   flipper
   flipper-redis
   flipper-ui


### PR DESCRIPTION
This probably should have been done as part of #5471 , since that basically reverted the change that motivated the initial move away from the RubyGems fixture_builder. So, doing it now.