### PR TITLE
[docker-compose/nginx] Make healthcheck request to env var hostname

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
     env_file:
       - .env.nginx.local
     healthcheck:
-      test: curl --insecure -s -o /dev/null -w "%{http_code}" https://localhost/up | grep -q "^200$" || false
+      test: curl --insecure -s -o /dev/null -w "%{http_code}" "https://$${HEALTHCHECK_HOSTNAME}/up" | grep -q "^200$" || false
       start_period: 20s
       start_interval: 1s
       interval: 60s


### PR DESCRIPTION
As of #5844, we can no longer make successful requests to our production NGINX that don't have a hostname of davidrunger.com.

Locally, though, we want to check localhost, not davidrunger.com.

Therefore, let's use an environment variable to specify the hostname for the healthcheck request.

In my local `.env.nginx.local` file, I'll set `HEALTHCHECK_HOSTNAME` to `localhost`. In the production file, I'll set it to `davidrunger.com`.