### PR TITLE
[docker-compose] Add redis-overcommit-on-host service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@ x-rails-config: &default-rails-config
 
 x-redis-config: &redis
   depends_on:
+    redis-overcommit:
+      condition: service_started
     vector:
       condition: service_started
   healthcheck:
@@ -178,6 +180,11 @@ services:
       - .env.redis-cache.local
     volumes:
       - ./redis/redis-cache.conf:/usr/local/etc/redis/redis.conf
+  redis-overcommit:
+    build: https://raw.githubusercontent.com/bkuhl/redis-overcommit-on-host/09215f160d59a7289ab3f4734f235659cdb8d269/Dockerfile
+    restart: 'no'
+    volumes:
+      - /proc/sys/vm:/mnt/vm
   s3_db_backup:
     depends_on:
       vector:


### PR DESCRIPTION
This _sets the host system's_ `vm.overcommit_memory` setting to `1`.

Motivation: avoid the following Redis warning.

> 1:C 17 Jan 2025 07:43:16.137 # WARNING Memory overcommit must be enabled! Without it, a background save or replication may fail under low memory condition. Being disabled, it can also cause failures without low memory condition, see https://github.com/jemalloc/jemalloc/issues/1328. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.

-- https://grafana.davidrunger.com/goto/2u9O1CvNR?orgId=1