### PR TITLE
[docker-compose/web] Increase start_period from 30s to 60s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,7 +220,7 @@ services:
       - '3000'
     healthcheck:
       test: curl --silent --output /dev/null --fail localhost:3000/up
-      start_period: 30s
+      start_period: 60s
       start_interval: 1s
       interval: 1m
       timeout: 1s


### PR DESCRIPTION
We [wait up to 60 seconds][1] for the service to become healthy, so we should probably make the start period at least that long. Otherwise, I think that one we go through the first 30 seconds of checks then the remaining the 30 seconds are essentially wasted, if `web` wasn't healthy after those first 30 seconds, because it won't become healthy within that next 30 seconds.

[1]: https://github.com/davidrunger/david_runger/blob/8e1590df/bin/server/verify-expected-services.sh/#L7-L8