### PR TITLE
[nginx] Format logs in logfmt style [DEV-129]

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -32,11 +32,35 @@ http {
     # Logging
     access_log             off;
     error_log              /dev/null;
+    log_format logfmt
+        '$time_iso8601 '
+        'ip=$remote_addr '
+        'method=$request_method '
+        'path=$uri '
+        'protocol=$server_protocol '
+        'https=$https_status '
+        'status=$status '
+        'size=$body_bytes_sent '
+        'user_agent="$http_user_agent"';
     # Define a format that adds a subdomain tag to logs. This seems helpful, in general, and it
     # makes it easy to distinguish subdomain requests in Vector transforms.
-    log_format with_subdomain '[$subdomain] $remote_addr - $remote_user [$time_local] '
-                                '"$request" $status $body_bytes_sent '
-                                '"$http_referer" "$http_user_agent"';
+    log_format logfmt_with_subdomain
+        '$time_iso8601 '
+        'subdomain=$subdomain '
+        'ip=$remote_addr '
+        'method=$request_method '
+        'path=$uri '
+        'protocol=$server_protocol '
+        'https=$https_status '
+        'status=$status '
+        'size=$body_bytes_sent '
+        'user_agent="$http_user_agent"';
+
+    # Define a map for https status
+    map $https $https_status {
+        default "off";   # If $https is not set (i.e., it's HTTP), use "off"
+        on      "on";    # If $https is set (i.e., it's HTTPS), use "on"
+    }
 
     # Map to detect if request is using hostname
     map $host $is_valid_host_name {

--- a/config/nginx/sites-enabled/davidrunger.com.conf
+++ b/config/nginx/sites-enabled/davidrunger.com.conf
@@ -14,7 +14,7 @@ server {
     include                 nginxconfig.io/enforce-host.conf;
 
     # logging
-    access_log              /var/log/nginx/access.log combined buffer=4k flush=1s;
+    access_log              /var/log/nginx/access.log logfmt buffer=4k flush=1s;
     error_log               /var/log/nginx/error.log warn;
 
     # Ownership verification when renewing SSL certificates
@@ -49,7 +49,7 @@ server {
     include     nginxconfig.io/enforce-host.conf;
 
     # logging
-    access_log  /var/log/nginx/access.log combined buffer=4k flush=1s;
+    access_log  /var/log/nginx/access.log logfmt buffer=4k flush=1s;
     error_log   /var/log/nginx/error.log warn;
 
     # Ownership verification when requesting SSL certificates

--- a/config/nginx/sites-enabled/grafana.davidrunger.com.conf
+++ b/config/nginx/sites-enabled/grafana.davidrunger.com.conf
@@ -15,7 +15,7 @@ server {
     include                 nginxconfig.io/enforce-host.conf;
 
     # logging
-    access_log             /dev/stdout with_subdomain buffer=4k flush=1s;
+    access_log             /dev/stdout logfmt_with_subdomain buffer=4k flush=1s;
     error_log              /dev/stderr warn;
 
     # Ownership verification when renewing SSL certificates
@@ -45,7 +45,7 @@ server {
     include     nginxconfig.io/enforce-host.conf;
 
     # logging
-    access_log  /dev/stdout with_subdomain buffer=4k flush=1s;
+    access_log  /dev/stdout logfmt_with_subdomain buffer=4k flush=1s;
     error_log   /dev/stderr warn;
 
     # Ownership verification when requesting SSL certificates

--- a/vector/vector.yaml
+++ b/vector/vector.yaml
@@ -9,7 +9,7 @@ transforms:
     inputs:
       - docker
     source: |
-      if .label."com.docker.compose.service" == "nginx" && match(string!(.message), r'^\[grafana\]') {
+      if .label."com.docker.compose.service" == "nginx" && contains(string!(.message), " subdomain=grafana ") {
         .label."com.docker.compose.service" = "nginx-grafana"
       }
 
@@ -42,11 +42,15 @@ sinks:
       - docker_with_grafana_nginx_separated
     endpoint: http://loki:3100
     encoding:
-      codec: json
+      codec: text
     healthcheck:
       enabled: false
     labels:
       service_name: '{{ .label."com.docker.compose.service" }}'
+    structured_metadata:
+      container_id: '{{ .container_id }}'
+      container_name: '{{ .container_name }}'
+      oneoff: '{{ .label."com.docker.compose.oneoff" }}'
 
   # Send logs to Papertrail
   papertrail:


### PR DESCRIPTION
Also, modify (versus the NGINX default log format) the set of which request attributes are logged.

Also, update the relevant Vector transform accordingly to now check for `subdomain=grafana` (rather than `[grafana]`, as before).

Also, change the codec for the Loki sink from JSON to text. This way, Grafana's "Explore Logs" feature will automatically parse as "Fields" the data from the logfmt-style logs (as opposed to using the JSON log properties is fields, which were mostly Docker-related, rather than related to the actual log lines). Some other aspects of the Grafana logs viewing experience will also be simpler/better (e.g. we will actually be able to see a meaningful preview of the actual log line content in the "Explore Logs" landing dashboard). I have added to `structured_metadata` the few bits of the JSON that are actually potentially valuable (`container_id`, `container_name`, and `oneoff`). Unfortunately, these don't show up as "Fields" in the Grafana "Explore Logs" view, but they are still available in the "Log line" view and to use in queries.