### PR TITLE
[docker-compose/nginx] Lengthen healthcheck start period

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,8 +108,8 @@ services:
       - .env.nginx.local
     healthcheck:
       test: curl --insecure -s -o /dev/null -w "%{http_code}" "https://$${HEALTHCHECK_HOSTNAME}/up" | grep -q "^200$" || false
-      start_period: 20s
-      start_interval: 1s
+      start_period: 60s
+      start_interval: 2s
       interval: 60s
       timeout: 1s
       retries: 1
@@ -221,7 +221,7 @@ services:
     healthcheck:
       test: curl --silent --output /dev/null --fail localhost:3000/up
       start_period: 60s
-      start_interval: 1s
+      start_interval: 2s
       interval: 1m
       timeout: 1s
       retries: 1


### PR DESCRIPTION
(This change is similar to #5854, but now for `nginx`, rather than `web`.)

We [wait up to 60 seconds][1] for services to become healthy, so we should probably make the start period at least that long. Otherwise, I think that, once we go through the first 30 seconds of checks, then the remaining the 30 seconds are essentially wasted, if `nginx` wasn't healthy after those first 30 seconds, because it won't become healthy within that next 30 seconds (since the healthchecks aren't running anymore).

Also, increase the `web` and `nginx` start intervals to 2 seconds, so that we don't hammer DNS/Cloudflare too much / risk hitting rate limits that we might be imposing on ourselves. Also, since we only check for the services to be healthy [every two seconds][3], there is no real point in checking every 1 second for the services to be healthy, anyhow.

I'm hoping that this change might fix/avoid deployment failures like [this one][2].

[1]: https://github.com/davidrunger/david_runger/blob/8e1590df/bin/server/verify-expected-services.sh/#L7-L8
[2]: https://github.com/davidrunger/david_runger/actions/runs/12841641796/job/35811725080
[3]: https://github.com/davidrunger/david_runger/blob/8e1590df/bin/server/verify-expected-services.sh/#L8