### PR TITLE
Add Prometheus and node-exporter to track system metrics [DEV-121]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
   grafana:
     depends_on:
       - loki
+      - prometheus
     env_file:
       - .env.grafana.local
     expose:
@@ -128,6 +129,12 @@ services:
       - ./ssl-data/certbot/conf:/etc/letsencrypt
       - ./ssl-data/certbot/www:/var/www/_letsencrypt
       - app-public:/var/www/david-runger-public:ro
+  node_exporter:
+    expose:
+      - '9100'
+    image: prom/node-exporter:latest
+    networks:
+      - internal
   postgres:
     depends_on:
       vector:
@@ -150,6 +157,14 @@ services:
     environment:
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
       POSTGRES_USER: david_runger
+  prometheus:
+    expose:
+      - '9090'
+    image: prom/prometheus:latest
+    networks:
+      - internal
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
   redis-app:
     <<: *redis
     # https://stackoverflow.com/a/72593084/4009384

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 20s
+  evaluation_interval: 20s
+
+scrape_configs:
+  # NOTE: This name is required for this dashboard:
+  # https://grafana.com/grafana/dashboards/1860-node-exporter-full/ .
+  - job_name: 'node'
+    static_configs:
+      - targets: ['node_exporter:9100']


### PR DESCRIPTION
This was astonishingly easy and straightforward. When combined with [this dashboard][1], this provides pretty thorough visibility into pretty much any system metric that one might care about.

[1]: https://grafana.com/grafana/dashboards/1860-node-exporter-full/