### PR TITLE
[docker-compose/nginx] Shorten healthcheck interval from 60s to 30s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,8 +111,8 @@ services:
       test: curl --insecure -s -o /dev/null -w "%{http_code}" "https://$${HEALTHCHECK_HOSTNAME}/up" | grep -q "^200$" || false
       start_period: 60s
       start_interval: 2s
-      interval: 60s
-      timeout: 1s
+      interval: 30s
+      timeout: 3s
       retries: 1
     image: nginx:1.27.0-alpine
     logging: *default-logging


### PR DESCRIPTION
We have sometimes been seeing deployment failures where NGINX "is not ready", e.g.: https://github.com/davidrunger/david_runger/actions/runs/12850024770/job/35829282423

I am realizing that this probably is because the retry interval was so high. If one healthcheck failed, then it would be 60 seconds before the next healthcheck would be attempted. The problem is that we only wait 60 seconds for all services to boot. So, even one failure would mean that the healthcheck would not be attempted again before the deployment was considered a failure. This change will make it so that we will try again 30 seconds later after a failure before failing the deployment.

(Important context for this PR: for NGINX, in order to achieve zero downtime deployment, we do not actually restart the service when deploying. Therefore, the `start_interval` is almost never relevant, even during a fresh deployment.)

Also, now that we are going through the general Internet rather than simply pinging localhost (see #5845), I am increasing the timeout from 1 second to 3 seconds. Bear in mind that the server is likely to be slow due to having been freshly booted, and also due to the heavy CPU load during deployment. Hopefully this will help with the reliability of the healthcheck.