### PR TITLE
Use cAdvisor to expose Docker metrics for Prometheus [DEV-135]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,22 @@ x-redis-config: &redis
     - internal
 
 services:
+  cadvisor:
+    command:
+      # Add options to lower CPU/memory use. https://github.com/google/cadvisor/issues/ 2523
+      - '--docker_only'
+      - '--housekeeping_interval=30s'
+      - '--enable_metrics'
+      - 'cpu,diskIO,memory,network'
+    expose:
+      - '8080'
+    image: gcr.io/cadvisor/cadvisor:v0.49.2
+    networks:
+      - internal
+    volumes:
+      - /sys:/sys:ro # Seems to be needed for CPU and Disk I/O usage.
+      - /var/lib/docker/:/var/lib/docker:ro # Seems to be needed for memory usage.
+      - /var/run/docker.sock:/var/run/docker.sock:ro # Seems to be needed for anything to work.
   certbot:
     depends_on:
       vector:

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -3,6 +3,10 @@ global:
   evaluation_interval: 20s
 
 scrape_configs:
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets: ['cadvisor:8080']
+
   # NOTE: This name is required for this dashboard:
   # https://grafana.com/grafana/dashboards/1860-node-exporter-full/ .
   - job_name: 'node'


### PR DESCRIPTION
This can surface info about CPU and memory usage per service, which I think is potentially pretty useful info. I'm going to view the data via this dashboard: https://grafana.com/grafana/dashboards/15798-docker-monitoring/

Without the `cadvisor` command line options provided herein, this was using way too much CPU (far more than any other service) and also way too much memory (comparable with our other most memory hungry services). With the CLI options here, it's much more reasonable.

Unfortunately, the network info currently seems not to be labelled with the service name?, making it essentially useless. This seems to be discussed in bugs like this one ( https://github.com/google/cadvisor/issues/ 3551 ), but it's not clear to me if there's a fix or workaround yet.