### PR TITLE
[nginx] Add dedicated health check endpoint

### DIFF
--- a/config/nginx/sites-enabled/davidrunger.com.conf
+++ b/config/nginx/sites-enabled/davidrunger.com.conf
@@ -46,6 +46,12 @@ server {
     listen      [::]:80 default_server;
     server_name davidrunger.com;
 
+    location /nginx-health {
+        access_log          off;
+        add_header          'Content-Type' 'text/plain';
+        return              200 "Healthy! :)\n";
+    }
+
     include     nginxconfig.io/enforce-host.conf;
 
     # logging

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,10 +126,10 @@ services:
     env_file:
       - .env.nginx.local
     healthcheck:
-      test: curl --insecure -s -o /dev/null -w "%{http_code}" "https://$${HEALTHCHECK_HOSTNAME}/up" | grep -q "^200$" || false
+      test: curl -s -o /dev/null -w "%{http_code}" "http://localhost/nginx-health" | grep -q "^200$" || false
       start_period: 60s
       start_interval: 2s
-      interval: 30s
+      interval: 10s
       timeout: 3s
       retries: 1
     image: nginx:1.27.0-alpine


### PR DESCRIPTION
During deployments lately ([latest example][1]), `nginx` has been considered unhealthy, which is failing the deploy.

I think that this is because the heavy CPU usage during deployment maybe sometimes slows down the server response times to the point that the healthcheck fails.

This change adds a dedicated healthcheck that doesn't hit the Rails server or DNS / the general Internet, with the hope that it will therefore be more reliable.

Also, because we are not logging this request and because it is less costly than the previous healthcheck request (since it no longer hits the Rails app or uses SSL), I am reducing the healthcheck interval from 30s to 10s.

A nice side benefit of this is that it allows us to get rid of the HEALTHCHECK_HOSTNAME env var.

[1]: https://github.com/davidrunger/david_runger/actions/runs/12856260739/job/35842770187