### PR TITLE
[docker-compose/nginx] Provide host for healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -126,7 +126,8 @@ services:
     env_file:
       - .env.nginx.local
     healthcheck:
-      test: curl -s -o /dev/null -w "%{http_code}" "http://localhost/nginx-health" | grep -q "^200$" || false
+      test: |-
+        curl -s -o /dev/null -w "%{http_code}" --header 'Host: davidrunger.com' http://localhost/nginx-health | grep -q "^200$" || false
       start_period: 60s
       start_interval: 2s
       interval: 10s


### PR DESCRIPTION
Without this, the request will be rejected by NGINX due to [this][1] and [this][2].

[1]: https://github.com/davidrunger/david_runger/blob/c7e93885/config/nginx/nginx.conf/#L76-L79
[2]: https://github.com/davidrunger/david_runger/blob/c7e93885/config/nginx/nginxconfig.io/enforce-host.conf/#L1-L2