### PR TITLE
Log original client IP from CF-Connecting-IP header [DEV-136]

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -35,7 +35,7 @@ http {
     log_format logfmt
         '[$request_id] '
         '$time_iso8601 '
-        'ip=$remote_addr '
+        'ip=$original_client_ip '
         'method=$request_method '
         'path=$uri '
         'protocol=$server_protocol '
@@ -49,7 +49,7 @@ http {
         '[$request_id] '
         '$time_iso8601 '
         'subdomain=$subdomain '
-        'ip=$remote_addr '
+        'ip=$original_client_ip '
         'method=$request_method '
         'path=$uri '
         'protocol=$server_protocol '
@@ -57,6 +57,11 @@ http {
         'status=$status '
         'size=$body_bytes_sent '
         'user_agent="$http_user_agent"';
+
+    map $http_cf_connecting_ip $original_client_ip {
+        default   $http_cf_connecting_ip;
+        ""        $remote_addr; # Fallback to remote_addr if CF header is missing
+    }
 
     # Define a map for https status
     map $https $https_status {


### PR DESCRIPTION
This change uses the `CF-Connecting-IP` header to log the original client IP address (rather than the IP address of the connecting Cloudflare machine, as we are currently doing). In the event that no such header is present, we fall back to the `$remote_addr` value provided by NGINX.

This header can be trivially faked (as we do [in our own NGINX healthcheck][1], for example), but in the 99+% of cases where the request is not that malicious/deceitful, I think it will be helpful. Certainly, on net, I expect that we will be better off versus just logging the IP address of some Cloudflare box.

[1]: https://github.com/davidrunger/david_runger/blob/e4728c6e/docker-compose.yml/#L130