### PR TITLE
[docker-compose/web] Shorten healthcheck interval from 1m to 12s

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -263,8 +263,8 @@ services:
       test: curl --silent --output /dev/null --fail localhost:3000/up
       start_period: 60s
       start_interval: 2s
-      interval: 1m
-      timeout: 1s
+      interval: 12s
+      timeout: 3s
       retries: 1
     profiles:
       - nondefault


### PR DESCRIPTION
Also, increase the timeout from 1s to 3s, to account for possibly slow responses resulting from the freshness of the newly launched web server and especially from the heavy demand on system resources as other containers also are booted up during a deployment.

Motivation: try to avoid deployment failures like [this one][1].

It looks like the `web` service was _initially_ healthy, but then it became unhealthy while we were waiting for the `worker` service to become healthy. Then, due to the (previously) long healthcheck interval, the `web` service never became healthy again within the remaining time allotted for services to become healthy, and so the deployment failed.

[1]: https://github.com/davidrunger/david_runger/actions/runs/12858457583/job/35847651250