### PR TITLE
[prometheus] Only push metrics from web & sidekiq when run in Docker

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -19,7 +19,8 @@ Bundler.require(*Rails.groups)
 require 'freezolite/auto'
 
 IS_DOCKER_BUILD = ENV.key?('DOCKER_BUILD')
-IS_DOCKER = IS_DOCKER_BUILD || ENV.key?('DOCKER_BUILT')
+IS_DOCKER_BUILT = ENV.key?('DOCKER_BUILT')
+IS_DOCKER = IS_DOCKER_BUILD || IS_DOCKER_BUILT
 
 module DavidRunger
   CANONICAL_DOMAIN = 'davidrunger.com'

--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -1,4 +1,4 @@
-unless Rails.env.test?
+if IS_DOCKER_BUILT
   # :nocov:
   require 'prometheus_exporter/middleware'
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -17,19 +17,21 @@ unless IS_DOCKER_BUILD
     config[:job_logger] = SidekiqExt::JobLogger
 
     # Prometheus Exporter >>>
-    require 'prometheus_exporter/instrumentation'
+    if IS_DOCKER_BUILT
+      require 'prometheus_exporter/instrumentation'
 
-    config.server_middleware do |chain|
-      chain.add(PrometheusExporter::Instrumentation::Sidekiq)
-    end
+      config.server_middleware do |chain|
+        chain.add(PrometheusExporter::Instrumentation::Sidekiq)
+      end
 
-    config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
+      config.death_handlers << PrometheusExporter::Instrumentation::Sidekiq.death_handler
 
-    config.on(:startup) do
-      PrometheusExporter::Instrumentation::Process.start(type: 'sidekiq')
-      PrometheusExporter::Instrumentation::SidekiqProcess.start
-      PrometheusExporter::Instrumentation::SidekiqQueue.start
-      PrometheusExporter::Instrumentation::SidekiqStats.start
+      config.on(:startup) do
+        PrometheusExporter::Instrumentation::Process.start(type: 'sidekiq')
+        PrometheusExporter::Instrumentation::SidekiqProcess.start
+        PrometheusExporter::Instrumentation::SidekiqQueue.start
+        PrometheusExporter::Instrumentation::SidekiqStats.start
+      end
     end
     # <<< Prometheus Exporter
 


### PR DESCRIPTION
Otherwise, the Prometheus Exporter server will not be running, and, as a result, when run in development (outside of Docker, in which context `docker compose up` would have booted a Prometheus Exporter server), the `bin/rails server` and `bin/sidekiq` processes will print a log line every half second about being unable to connect to the Prometheus Exporter server.