### PR TITLE
[logs] Refactor GET creation of log entries to a dedicated action

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,7 +9,6 @@ class ApplicationController < ActionController::Base
 
   AUTHORIZATION_ERROR_MESSAGES = {
     Pundit::NotAuthorizedError => 'You are not authorized to perform this action.',
-    TokenAuthenticatable::BlankToken => 'You did not provide a token.',
     TokenAuthenticatable::InvalidToken => 'Your token is not valid.',
   }.freeze
 

--- a/app/controllers/concerns/bootstrappable.rb
+++ b/app/controllers/concerns/bootstrappable.rb
@@ -13,9 +13,10 @@ module Bootstrappable
       # is useful because that ensures that turbo will always evaluate the
       # `<script>` tag(s) within which it's wrapped.
       @bootstrap_data ||= {
-        nonce: SecureRandom.uuid,
         current_user: current_user && UserSerializer::Basic.new(current_user),
-      }
+        nonce: SecureRandom.uuid,
+        toast_messages: flash[:toast_messages],
+      }.compact
 
       @bootstrap_data.merge!(data)
     end

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -2,7 +2,6 @@ module TokenAuthenticatable
   extend ActiveSupport::Concern
   prepend MemoWise
 
-  class BlankToken < StandardError ; end
   class InvalidToken < StandardError ; end
 
   private
@@ -28,10 +27,6 @@ module TokenAuthenticatable
   end
 
   def verify_valid_auth_token!
-    if auth_token_param.blank?
-      raise(BlankToken)
-    end
-
     if auth_token.blank?
       raise(InvalidToken)
     end

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -37,6 +37,7 @@ module TokenAuthenticatable
     end
 
     auth_token.update!(last_used_at: Time.current)
+
     true
   end
 end

--- a/app/controllers/log_entries_controller.rb
+++ b/app/controllers/log_entries_controller.rb
@@ -1,0 +1,28 @@
+class LogEntriesController < ApplicationController
+  prepend MemoWise
+
+  def create
+    if log && new_entry_param
+      authorize(log, :update?)
+      LogEntries::CreateFromParam.run!(log:, param: new_entry_param)
+      flash[:toast_messages] = ['Log entry created!']
+      redirect_to(log_path(log.slug))
+    else
+      skip_authorization
+      flash[:toast_messages] = ['There was something wrong with your request.']
+      redirect_to(logs_path)
+    end
+  end
+
+  private
+
+  memo_wise \
+  def log
+    auth_token_user&.logs&.find_by(slug: params[:slug].presence)
+  end
+
+  memo_wise \
+  def new_entry_param
+    params[:new_entry].presence
+  end
+end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -10,14 +10,6 @@ class LogsController < ApplicationController
     else
       current_user_logs = current_user.logs
       logs = current_user_logs.order(:created_at).includes(:log_shares)
-
-      new_entry = params[:new_entry].presence
-      if slug_param && new_entry
-        verify_valid_auth_token!
-        log = current_user_logs.find_by!(slug: slug_param)
-        LogEntries::CreateFromParam.run!(log:, param: new_entry)
-        bootstrap(toast_messages: ['New Log entry created!'])
-      end
     end
 
     @title = 'Logs'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
     resources :uploads, only: %i[new create]
   end
   get 'logs/:slug', to: 'logs#index', as: :log # routing to specific log will be done by Vue Router
+  get 'logs/:slug/log_entries/create', to: 'log_entries#create', as: :log_log_entries_create
 
   resources :users, only: [] do
     get 'logs/:slug', to: 'logs#index', as: :shared_log

--- a/spec/controllers/log_entries_controller_spec.rb
+++ b/spec/controllers/log_entries_controller_spec.rb
@@ -1,0 +1,78 @@
+RSpec.describe LogEntriesController do
+  before { sign_in(user) }
+
+  let(:user) { users(:user) }
+
+  describe '#create' do
+    subject(:get_create) { get(:create, params:) }
+
+    let(:params) { { slug: log.slug } }
+    let(:log) { user.logs.number.first! }
+
+    context 'when there is a non-blank `new_entry` query param' do
+      let(:params) { super().merge(new_entry: '199.8') }
+
+      context 'when the user has an auth_token whose secret is the submitted auth token param' do
+        let(:params) { super().merge(auth_token: user.auth_tokens.first!.secret) }
+
+        it 'creates a log entry with the value of the `new_entry` query param' do
+          expect { get_create }.to change { log.log_entries.size }.by(1)
+          log_entry = log.log_entries.order(:created_at).last!
+          expect(log_entry.data).to eq(Float(params[:new_entry]))
+        end
+
+        context 'when the log is a number log' do
+          before { expect(log.data_type).to eq('number') }
+
+          context 'when the `new_entry` param has a space' do
+            before { expect(params[:new_entry]).to include(' ') }
+
+            let(:new_entry_data) { 280.4 }
+            let(:new_entry_note) { 'yikes! 😬 not good!' }
+            let(:params) { super().merge(new_entry: "#{new_entry_data} #{new_entry_note}") }
+
+            it 'creates a new log entry by splitting the `new_entry` param into data and note' do
+              expect { get_create }.to change { log.log_entries.size }.by(1)
+              log_entry = log.log_entries.order(:created_at).last!
+
+              expect(log_entry.data).to eq(new_entry_data)
+              expect(log_entry.note).to eq(new_entry_note)
+            end
+          end
+        end
+      end
+
+      context "when there is an `auth_token` param but it is not the user's `auth_token`" do
+        let(:params) { super().merge(auth_token: SecureRandom.uuid) }
+
+        it 'raises an error and does not create a log entry' do
+          expect { get_create }.not_to change { log.reload.log_entries.size }
+        end
+      end
+
+      context 'when there is no `auth_token` param' do
+        let(:params) { super().merge(auth_token: '') }
+
+        it 'does not create a log entry' do
+          expect { get_create }.not_to change { log.reload.log_entries.size }
+        end
+      end
+    end
+
+    context 'when there is a blank string `new_entry` param' do
+      let(:params) { super().merge(new_entry: '') }
+
+      context "when there is an auth_token param that is one of the user's auth_token secrets" do
+        let(:params) { super().merge(auth_token: user.auth_tokens.first!.secret) }
+
+        it 'does not create a log_entry' do
+          expect { get_create }.not_to change { log.reload.log_entries.size }
+        end
+
+        it 'redirects to the logs index page' do
+          expect(get_create).to redirect_to(logs_path)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/logs_controller_spec.rb
+++ b/spec/controllers/logs_controller_spec.rb
@@ -76,56 +76,6 @@ RSpec.describe LogsController do
         expect(response.body).to include(log.name)
       end
 
-      context 'when there is a non-blank `new_entry` query param' do
-        let(:params) { super().merge(new_entry: '199.8') }
-
-        context 'when the user has an auth_token whose secret is the submitted auth token param' do
-          let(:params) { super().merge(auth_token: user.auth_tokens.first!.secret) }
-
-          it 'creates a log entry with the value of the `new_entry` query param' do
-            expect { get_index }.to change { log.log_entries.size }.by(1)
-            log_entry = log.log_entries.order(:created_at).last!
-            expect(log_entry.data).to eq(Float(params[:new_entry]))
-          end
-
-          context 'when the log is a number log' do
-            before { expect(log.data_type).to eq('number') }
-
-            context 'when the `new_entry` param has a space' do
-              before { expect(params[:new_entry]).to include(' ') }
-
-              let(:new_entry_data) { 280.4 }
-              let(:new_entry_note) { 'yikes! 😬 not good!' }
-              let(:params) { super().merge(new_entry: "#{new_entry_data} #{new_entry_note}") }
-
-              it 'creates a new log entry by splitting the `new_entry` param into data and note' do
-                expect { get_index }.to change { log.log_entries.size }.by(1)
-                log_entry = log.log_entries.order(:created_at).last!
-
-                expect(log_entry.data).to eq(new_entry_data)
-                expect(log_entry.note).to eq(new_entry_note)
-              end
-            end
-          end
-        end
-
-        context "when there is an `auth_token` param but it is not the user's `auth_token`" do
-          let(:params) { super().merge(auth_token: SecureRandom.uuid) }
-
-          it 'raises an error and does not create a log entry' do
-            expect { get_index }.not_to change { log.reload.log_entries.size }
-          end
-        end
-
-        context 'when there is no `auth_token` param' do
-          let(:params) { super().merge(auth_token: '') }
-
-          it 'does not create a log entry' do
-            expect { get_index }.not_to change { log.reload.log_entries.size }
-          end
-        end
-      end
-
       context 'when there is a blank string `new_entry` param' do
         let(:params) { super().merge(new_entry: '') }
 


### PR DESCRIPTION
This change adds a new route like this: `GET /logs/:slug/log_entries/create?auth_token=<token>&new_entry=<value>`

Having this functionality crammed into logs#index was complicating that action too much.