### PR TITLE
[docker-compose/certbot] Tweak healthcheck timings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,9 +64,9 @@ services:
     healthcheck:
       test: certbot --version
       start_period: 30s
-      start_interval: 3s
-      interval: 1h
-      timeout: 3s
+      start_interval: 5s
+      interval: 1m
+      timeout: 10s
       retries: 1
     image: certbot/certbot
     logging: *default-logging


### PR DESCRIPTION
Goal: avoid deployment failures like this one: https://github.com/davidrunger/david_runger/actions/runs/12879215907/job/35906435637

Hypothesis: certbot was becoming unhealthy because the healthcheck was not completing within the timeout limit. Then, certbot was not becoming healthy again before an attempted deployment went out, thus failing the deploy.

Try to fix "the healthcheck was not completing within the timeout limit" by increasing the timeout limit from 3s to 10s.

Try to fix "certbot was not becoming healthy again before an attempted deployment went out" by shortening the interval from 1h to 1m.

(Probably unrelated to the deployment failure, but somewhat relevant to this general theme:) try to put less load on the server during certbot startup by increasing the start_interval from 3s to 5s.