### PR TITLE
[logs] Sort by name (not created_at)

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -9,7 +9,7 @@ class LogsController < ApplicationController
       logs = Log.where(id: shared_log)
     else
       current_user_logs = current_user.logs
-      logs = current_user_logs.order(:created_at).includes(:log_shares)
+      logs = current_user_logs.order(:name).includes(:log_shares)
     end
 
     @title = 'Logs'


### PR DESCRIPTION
The goal is to have an ordering that makes it easy for the user to find the log that he or she is looking for. I believe that `name` will be much more useful for this purpose than `created_at`.