### PR TITLE
[logs] Don't show log selector tip when in shared-log view

### DIFF
--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -5,7 +5,8 @@ div
   .text-center
     LogSelectorModal
     router-view(:key='$route.fullPath').m-8
-    footer.mb-4 Tip: {{ bootstrap.log_selector_keyboard_shortcut }} will open the log selector.
+    footer.mb-4(v-if="!isSharedLogView")
+      | Tip: {{ bootstrap.log_selector_keyboard_shortcut }} will open the log selector.
 </template>
 
 <script setup lang="ts">
@@ -25,7 +26,7 @@ const bootstrap = untypedBootstrap as Bootstrap;
 const logsStore = useLogsStore();
 const modalStore = useModalStore();
 
-const { isSharedLog, selectedLog } = storeToRefs(logsStore);
+const { isSharedLog, isSharedLogView, selectedLog } = storeToRefs(logsStore);
 
 const currentUser = computed(() => {
   return bootstrap.current_user;

--- a/app/javascript/logs/router.ts
+++ b/app/javascript/logs/router.ts
@@ -8,7 +8,12 @@ import LogsIndex from './components/LogsIndex.vue';
 const routes = [
   { path: '/logs', name: 'logs-index', component: LogsIndex },
   { path: '/logs/:slug', name: 'log', component: Log },
-  { path: '/users/:user_id/logs/:slug', name: 'shared_log', component: Log },
+  {
+    path: '/users/:user_id/logs/:slug',
+    name: 'shared_log',
+    component: Log,
+    meta: { sharedView: true },
+  },
 ];
 
 const router = createRouter({

--- a/app/javascript/logs/store.ts
+++ b/app/javascript/logs/store.ts
@@ -292,7 +292,7 @@ export const useLogsStore = defineStore('logs', {
     },
 
     isSharedLogView(): boolean {
-      return !!this.router.currentRoute.value.meta.sharedView
+      return !!this.router.currentRoute.value.meta.sharedView;
     },
 
     logById() {

--- a/app/javascript/logs/store.ts
+++ b/app/javascript/logs/store.ts
@@ -291,6 +291,10 @@ export const useLogsStore = defineStore('logs', {
       return logIsPresent && isNotOwnLog;
     },
 
+    isSharedLogView(): boolean {
+      return !!this.router.currentRoute.value.meta.sharedView
+    },
+
     logById() {
       return ({ logId }: { logId: number }): Log => getById(this.logs, logId);
     },


### PR DESCRIPTION
This applies whenever the path is a shared log path, regardless of whether a user is viewing their own shared log at that path (i.e. previewing the share view) or viewing someone else's shared log.

When viewing someone else's shared log, there are no other logs available to select, so we shouldn't suggest the log selector.

When viewing one's own log at a shared path, we want that "preview" view to accurately reflect what other user will see (which, as mentioned just above, won't include a tip about the log selector).