### PR TITLE
[logs] Allow previewing shared log view from own account

### DIFF
--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -26,7 +26,7 @@ const bootstrap = untypedBootstrap as Bootstrap;
 const logsStore = useLogsStore();
 const modalStore = useModalStore();
 
-const { isSharedLog, isSharedLogView, selectedLog } = storeToRefs(logsStore);
+const { isSharedLogView, selectedLog } = storeToRefs(logsStore);
 
 const currentUser = computed(() => {
   return bootstrap.current_user;

--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -36,7 +36,7 @@ removeQueryParams(); // remove query params such as `new_entry` and `auth_token`
 renderBootstrappedToasts();
 
 onMounted(() => {
-  if (!isSharedLog.value) {
+  if (!isSharedLogView.value) {
     // If we are viewing a specific log, we want to ensure that the log entries for that log are
     // fetched first, so delay 10ms.
     // Otherwise (i.e. if viewing index), fetch all entries immediately.
@@ -44,9 +44,8 @@ onMounted(() => {
     setTimeout(() => {
       logsStore.fetchAllLogEntries();
     }, delayBeforeFetchingAllLogs);
-  }
 
-  document.addEventListener('keydown', (event) => {
+    document.addEventListener('keydown', (event) => {
     if (
       event.key === 'k' &&
       (event.metaKey === true || event.ctrlKey === true) // Meta for macOS, Ctrl for Windows/Linux
@@ -55,6 +54,7 @@ onMounted(() => {
       modalStore.showModal({ modalName: 'log-selector' });
     }
   });
+  }
 });
 </script>
 

--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -46,14 +46,14 @@ onMounted(() => {
     }, delayBeforeFetchingAllLogs);
 
     document.addEventListener('keydown', (event) => {
-    if (
-      event.key === 'k' &&
-      (event.metaKey === true || event.ctrlKey === true) // Meta for macOS, Ctrl for Windows/Linux
-    ) {
-      event.preventDefault(); // Prevent default behavior for the shortcut
-      modalStore.showModal({ modalName: 'log-selector' });
-    }
-  });
+      if (
+        event.key === 'k' &&
+        (event.metaKey === true || event.ctrlKey === true) // Meta for macOS, Ctrl for Windows/Linux
+      ) {
+        event.preventDefault(); // Prevent default behavior for the shortcut
+        modalStore.showModal({ modalName: 'log-selector' });
+      }
+    });
   }
 });
 </script>

--- a/app/javascript/logs/components/EditLogSharingSettingsModal.vue
+++ b/app/javascript/logs/components/EditLogSharingSettingsModal.vue
@@ -7,7 +7,7 @@ Modal(name='edit-log-sharing-settings' width='85%' maxWidth='600px' backgroundCl
         v-model='publiclyViewable'
         @change='savePubliclyViewableChange'
       ) Publicly viewable
-    div(v-if='isOwnLog && !publiclyViewable')
+    div(v-if='!publiclyViewable')
       el-tag(
         :key='logShare.email'
         v-for='logShare in logSharesSortedByLowercasedEmail'
@@ -37,7 +37,6 @@ Modal(name='edit-log-sharing-settings' width='85%' maxWidth='600px' backgroundCl
 
 <script setup lang="ts">
 import { ElInput } from 'element-plus';
-import { storeToRefs } from 'pinia';
 import { computed, nextTick, ref } from 'vue';
 
 import { bootstrap } from '@/lib/bootstrap';
@@ -51,7 +50,6 @@ const logsStore = useLogsStore();
 const modalStore = useModalStore();
 
 const log = assert(logsStore.selectedLog);
-const { isOwnLog } = storeToRefs(logsStore);
 
 const inputValue = ref('');
 const inputVisible = ref(false);

--- a/app/javascript/logs/components/Log.vue
+++ b/app/javascript/logs/components/Log.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 div
   h1.text-2xl.mb-2 {{log.name}}
-  h2.h5.text-neutral-400(v-if='!isOwnLog') shared by {{log.user.email}}
+  h2.h5.text-neutral-400(v-if='isSharedLogView') shared by {{log.user.email}}
   p.h5.mb-4.description {{log.description}}
   NewLogEntryForm(:log='log' v-if='renderInputAtTop')
   div.mb-4(v-if='log.log_entries === undefined').
@@ -14,7 +14,7 @@ div
     :logEntries='log.log_entries'
   )
   .my-8(v-else) There are no log entries for this log.
-  .controls(v-if='isOwnLog')
+  .controls(v-if='!isSharedLogView')
     NewLogEntryForm(
       v-if='!renderInputAtTop'
       :log='log'
@@ -98,7 +98,7 @@ const log = assert(logsStore.selectedLog);
 
 useTitle(`${log.name} - Logs - David Runger`);
 
-const { isOwnLog } = storeToRefs(logsStore);
+const { isOwnLog, isSharedLogView } = storeToRefs(logsStore);
 
 const renderInputAtTop = computed((): boolean => {
   return log.data_type === 'text';

--- a/app/javascript/logs/components/Log.vue
+++ b/app/javascript/logs/components/Log.vue
@@ -98,7 +98,7 @@ const log = assert(logsStore.selectedLog);
 
 useTitle(`${log.name} - Logs - David Runger`);
 
-const { isOwnLog, isSharedLogView } = storeToRefs(logsStore);
+const { isSharedLogView } = storeToRefs(logsStore);
 
 const renderInputAtTop = computed((): boolean => {
   return log.data_type === 'text';

--- a/app/javascript/logs/store.ts
+++ b/app/javascript/logs/store.ts
@@ -278,12 +278,6 @@ export const useLogsStore = defineStore('logs', {
   },
 
   getters: {
-    isOwnLog(): boolean {
-      if (!this.selectedLog) return false;
-
-      return this.selectedLog.user.id === this.current_user.id;
-    },
-
     isSharedLogView(): boolean {
       return !!this.router.currentRoute.value.meta.sharedView;
     },

--- a/app/javascript/logs/store.ts
+++ b/app/javascript/logs/store.ts
@@ -284,13 +284,6 @@ export const useLogsStore = defineStore('logs', {
       return this.selectedLog.user.id === this.current_user.id;
     },
 
-    // eslint-disable-next-line no-shadow
-    isSharedLog() {
-      const logIsPresent = !!this.selectedLog;
-      const isNotOwnLog = !this.isOwnLog;
-      return logIsPresent && isNotOwnLog;
-    },
-
     isSharedLogView(): boolean {
       return !!this.router.currentRoute.value.meta.sharedView;
     },

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -6,6 +6,51 @@ RSpec.describe 'Logs app' do
 
     let(:delete_last_entry_text) { 'Delete last entry' }
 
+    context 'when user has at least one log' do
+      let(:log) { user.logs.first! }
+
+      describe 'aspects of the view pertaining to sharing or not sharing' do
+        before do
+          visit(page_path)
+        end
+
+        let(:shared_by_text) { "shared by #{user.email}" }
+        let(:log_control_text_fragments) do
+          [
+            'Delete last entry',
+            'Sharing settings',
+            'Reminder settings',
+            'Delete log',
+            'open the log selector',
+          ]
+        end
+
+        context 'when user is not viewing a log sharing preview' do
+          let(:page_path) { log_path(slug: log.slug) }
+
+          it 'does not mention the email of the sharing user and shows log control buttons' do
+            expect(page).not_to have_text(shared_by_text)
+
+            log_control_text_fragments.each do |log_control_text_fragment|
+              expect(page).to have_text(log_control_text_fragment)
+            end
+          end
+        end
+
+        context 'when user views a log sharing preview' do
+          let(:page_path) { user_shared_log_path(user_id: user.id, slug: log.slug) }
+
+          it 'mentions the email of the sharing user and does not show log control buttons' do
+            expect(page).to have_text(shared_by_text)
+
+            log_control_text_fragments.each do |log_control_text_fragment|
+              expect(page).not_to have_text(log_control_text_fragment)
+            end
+          end
+        end
+      end
+    end
+
     context 'when user has multiple logs' do
       before { expect(user.logs.size).to be >= 2 }
 


### PR DESCRIPTION
Without these changes, exception(s) would occur when trying to view a sharing link (e.g. `/users/1/logs/4-mile-run`) while logged in as the owner of that log.