### PR TITLE
[spec_helper] Don't focus specs in CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -387,7 +387,9 @@ RSpec.configure do |config|
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  config.filter_run_when_matching(:focus)
+  if !is_ci
+    config.filter_run_when_matching(:focus)
+  end
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend


### PR DESCRIPTION
This should protect us against accidentally committing focused specs, and thereby only running a tiny fraction of our test suite. (We are also protected by a RuboCop rule against this, but it's good to have redundancy.)