### PR TITLE
Don't require certbot, nginx healthchecks for deploy; tweak web check

### DIFF
--- a/bin/server/roll-out-web.sh
+++ b/bin/server/roll-out-web.sh
@@ -35,7 +35,7 @@ echo_iso8601 "Curling new container IP until success."
 attempt=1
 max_attempts=30
 delay=2
-url="http://$new_container_ip:3000/"
+url="http://$new_container_ip:3000/up"
 
 while [ $attempt -le $max_attempts ] ; do
   echo_iso8601 "attempt=$attempt max_attempts=$max_attempts url=$url"

--- a/bin/server/verify-expected-services.sh
+++ b/bin/server/verify-expected-services.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
-expected_running_services=(certbot clock nginx postgres redis-app redis-cache web worker)
+expected_running_services=(clock postgres redis-app redis-cache web worker)
 expected_services_not_running=()
 max_retries=30
 retry_delay=2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       test: certbot --version
       start_period: 30s
       start_interval: 5s
-      interval: 1m
+      interval: 1h
       timeout: 10s
       retries: 1
     image: certbot/certbot
@@ -130,7 +130,7 @@ services:
         curl -s -o /dev/null -w "%{http_code}" --header 'Host: davidrunger.com' http://localhost/nginx-health | grep -q "^200$" || false
       start_period: 60s
       start_interval: 2s
-      interval: 10s
+      interval: 5m
       timeout: 3s
       retries: 1
     image: nginx:1.27.0-alpine
@@ -263,8 +263,8 @@ services:
       test: curl --silent --output /dev/null --fail localhost:3000/up
       start_period: 60s
       start_interval: 2s
-      interval: 12s
-      timeout: 3s
+      interval: 5m
+      timeout: 5s
       retries: 1
     profiles:
       - nondefault


### PR DESCRIPTION
Our CPU is nowadays has a higher baseline load than I would like. I think that, partially as a result of this, the median response time in the past day has been ~180 ms (which is much higher than normal), although memory pressure and swap usage is also probably a factor. Therefore, I want to reduce the CPU load created by healthchecks.

To this end, I want to increase all healthcheck intervals to at least 5m.

However, this risks breaking deploys, if we require a healthcheck for deployment, but it has an infrequent interval (and so cannot recover quickly). To avoid this issue, I am removing certbot and nginx from services that are required to have a healthy status during deployment.

Regarding certbot, it's not super vital that certbot be running at all times. If there are issues, then I can address them when I get an email from LetsEncrypt about the SSL certificates needing renewal.

Regarding nginx, we don't even restart the `nginx` service during deploys, and if there is an nginx issue then I expect to receive notice about it from UptimeRobot.

This change increases the `web` healthcheck `interval` from 12s to 5m. We recently decreased it from 1m to 12s in #5865 (and increased the timeout from 1s to 3s), but I don't know that we can afford that amount of CPU usage. This change goes back past 1m all the way to 5m. To compensate (i.e. to hopefully make the healthcheck really unlikely to fail when it does run at these relatively infrequent intervals), we'll further increase the timeout to 5s.

Also, for the web rollout, we'll now curl the `/up` endpoint instead of the root. I think that the root endpoint might be slower than `/up` during a web rollout, because there won't be any prerenders yet, and, so, when making requests to `/`, we will be making requests to S3 looking for prerenders, which will never be there. `/up` won't have this issue.

Now, all `interval`s are at least 5m, which should not create too much CPU load.