### PR TITLE
[docker-compose] Specify memory reservations for key services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,6 +78,10 @@ services:
   clock:
     <<: *default-rails-config
     command: ['bin/skedjewel']
+    deploy:
+      resources:
+        reservations:
+          memory: 6M
     healthcheck:
       test: ps -eo cmd | grep -P '^[b]in/skedjewel$'
       start_period: 10s
@@ -122,6 +126,10 @@ services:
     depends_on:
       vector:
         condition: service_started
+    deploy:
+      resources:
+        reservations:
+          memory: 10M
     entrypoint: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & /docker-entrypoint.sh nginx -g "daemon off;"'''
     env_file:
       - .env.nginx.local
@@ -158,6 +166,10 @@ services:
     depends_on:
       vector:
         condition: service_started
+    deploy:
+      resources:
+        reservations:
+          memory: 50M
     env_file:
       - .env.postgres.local
     healthcheck:
@@ -202,6 +214,10 @@ services:
       # - The ${variable:?message} syntax causes shell to exit with a non-zero
       #   code and print a message, when the variable is not set or empty
       - redis-server --requirepass "$${REDIS_PASSWORD:?REDIS_PASSWORD is required}"
+    deploy:
+      resources:
+        reservations:
+          memory: 12M
     env_file:
       - .env.redis-app.local
     volumes:
@@ -217,6 +233,10 @@ services:
       # - The ${variable:?message} syntax causes shell to exit with a non-zero
       #   code and print a message, when the variable is not set or empty
       - redis-server /usr/local/etc/redis/redis.conf --requirepass "$${REDIS_PASSWORD:?REDIS_PASSWORD is required}"
+    deploy:
+      resources:
+        reservations:
+          memory: 6M
     env_file:
       - .env.redis-cache.local
     volumes:
@@ -257,6 +277,10 @@ services:
   web:
     <<: *default-rails-config
     command: ['bin/rails', 'server', '--binding', '0.0.0.0']
+    deploy:
+      resources:
+        reservations:
+          memory: 230M
     expose:
       - '3000'
     healthcheck:
@@ -273,6 +297,10 @@ services:
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']
+    deploy:
+      resources:
+        reservations:
+          memory: 36M
     healthcheck:
       test: REDIS_URL="$$REDIS_URL/1" bin/sidekiqmon | grep --quiet "$$(hostname)"
       start_period: 60s


### PR DESCRIPTION
In this change, I am specifying memory reservations for all services that are actually potentially end-user-impacting: clock, nginx, postgres, redis-app, redis-cache, web, and worker.

To determine the memory reservation for each service, I started by looking at the mean total memory consumption (RAM + swap) and the RSS memory (i.e. RAM utilization) of that service over the past 24 hours (from the "Memory Usage Details" panel of the "Docker monitoring" dashboard). NOTE: That graph shows values in MiB, but in the table below I have converted them to MB, which is also the unit for the Docker Compose memory reservation.

```
             Total   RSS     Reservation (added in this change)
clock        1.17    0.35    6
nginx        4.35    1.18    10
postgres     39.43   2.46    50
redis-app    8.05    1.43    12
redis-cache  2.71    0.56    6
web          226.5   63.44   230
worker       187.7   52.74   36
```

In almost all cases, we are adding a little padding above the total mean memory usage (including swap). This will hopefully ensure that, for these services, usage of swap will be fairly minimal. In the case of clock and redis-cache, we are forced to add extra padding, because the minimum allowed reservation size is 6 MB. In some cases, like nginx, we are also adding a little extra padding, because the bang for buck (just a few extra MB of reserved memory) seems very good, in terms of making sure that NGINX can run fully in RAM.

The notable exception is worker, which wants to use ~188 MB of memory, but which we are only reserving 36 MB for. This is because worker's performance is not very critical. It tries to use significantly more memory than it is worth paying for. So, we are only going to reserve about 19% of the memory that it would like to use.

The total of the reservations is 350 MB. I'm not sure that we have a whole lot more than that available for use by our Docker services, after Debian's memory usage is accounted for.

Since we aren't specifying any memory limits or reservations for other services, I guess that this change will leave them/Docker to sort out how to allocate memory among them? I guess that I am going to deploy this, and look at the aforementioned graph to see how the memory usage of all of the Docker Compose services changes.
