### PR TITLE
Stop sending logs to Papertrail [DEV-139]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -280,11 +280,8 @@ services:
       - '--require-healthy'
       - 'true'
       - '--watch-config'
-    env_file:
-      - .env.vector.local
     image: timberio/vector:latest-alpine
     networks:
-      - external
       - internal
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro

--- a/vector/vector.yaml
+++ b/vector/vector.yaml
@@ -1,5 +1,4 @@
 sources:
-  # Read Docker container logs
   docker:
     type: docker_logs
 
@@ -12,28 +11,6 @@ transforms:
       if .label."com.docker.compose.service" == "nginx" && contains(string!(.message), " subdomain=grafana ") {
         .label."com.docker.compose.service" = "nginx-grafana"
       }
-
-  # Filter to only the services that we want to send to Papertrail
-  papertrail_services_filtered:
-    type: filter
-    inputs:
-      - docker
-    condition: |
-      papertrail_address, env_var_error = get_env_var("PAPERTRAIL_HOST_AND_PORT")
-
-      env_var_error == null && contains(papertrail_address, "papertrail") && match(string!(.container_name), r'-(clock|initialize_database|web|worker)-\d+')
-
-  # Add brief service name to log data
-  papertrail_services_remapped:
-    type: remap
-    inputs:
-      - papertrail_services_filtered
-    source: |
-      del(.host)
-
-      name_without_prefix = replace(string!(.container_name), r'^david_runger-', "")
-      name_without_prefix_or_suffix = replace(name_without_prefix, r'-\d+$', "")
-      .brief_service_name = name_without_prefix_or_suffix
 
 sinks:
   loki:
@@ -51,15 +28,3 @@ sinks:
       container_id: '{{ .container_id }}'
       container_name: '{{ .container_name }}'
       oneoff: '{{ .label."com.docker.compose.oneoff" }}'
-
-  # Send logs to Papertrail
-  papertrail:
-    encoding:
-      codec: text
-    endpoint: '${PAPERTRAIL_HOST_AND_PORT:-davidrunger.com:12345}'
-    healthcheck:
-      enabled: false
-    inputs:
-      - papertrail_services_remapped
-    process: '{{ .brief_service_name }}'
-    type: papertrail


### PR DESCRIPTION
I don't think I really am going to get much value out of Papertrail, now that I have my own logging set up via Vector and Loki, viewable via Grafana.

This might save some CPU and/or memory in Vector, and it is probably better not to be sending data out to an external service, all other things being equal.

A Papertrail-like search experience can be had by going to "Explore" in Grafana, selecting Loki as the data source, using a query like `{service_name=~".+"} |~ "your_query_here"`, and clicking the "Live" button.