### PR TITLE
[SpacedLaunching] Refer to worker class constant (not string name)

### DIFF
--- a/app/workers/check_links/launch_link_checks_for_page.rb
+++ b/app/workers/check_links/launch_link_checks_for_page.rb
@@ -6,7 +6,7 @@ class CheckLinks::LaunchLinkChecksForPage
 
     if Faraday.head(url).headers['content-type'].include?('text/html')
       launch_with_spacing(
-        worker_name: CheckLinks::Checker.name,
+        worker: CheckLinks::Checker,
         arguments_list:,
         spacing_seconds: Rails.env.development? ? 1 : 10,
       )

--- a/app/workers/concerns/spaced_launching.rb
+++ b/app/workers/concerns/spaced_launching.rb
@@ -5,11 +5,11 @@ module SpacedLaunching
 
   private
 
-  def launch_with_spacing(worker_name:, arguments_list:, spacing_seconds:)
+  def launch_with_spacing(worker:, arguments_list:, spacing_seconds:)
     warn_if_total_spacing_too_large(arguments_list:, spacing_seconds:)
 
     arguments_list.each_with_index do |arguments, index|
-      worker_name.constantize.perform_in((index + 1) * spacing_seconds, *Array(arguments))
+      worker.perform_in((index + 1) * spacing_seconds, *Array(arguments))
     end
   end
 

--- a/spec/workers/concerns/spaced_launching_spec.rb
+++ b/spec/workers/concerns/spaced_launching_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SpacedLaunching do
     subject(:launch_with_spacing) do
       worker.send(
         :launch_with_spacing,
-        worker_name: 'FetchIpInfoForRecord',
+        worker_name: FetchIpInfoForRecord,
         arguments_list: ['Request', Faker::Internet.ip_v4_address] * 3,
         spacing_seconds:,
       )

--- a/spec/workers/concerns/spaced_launching_spec.rb
+++ b/spec/workers/concerns/spaced_launching_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe SpacedLaunching do
     subject(:launch_with_spacing) do
       worker.send(
         :launch_with_spacing,
-        worker_name: FetchIpInfoForRecord,
+        worker: FetchIpInfoForRecord,
         arguments_list: ['Request', Faker::Internet.ip_v4_address] * 3,
         spacing_seconds:,
       )


### PR DESCRIPTION
It seems pointless that we were serializing the worker class constant to a string and then converting back to a constant. Let's just pass the worker class constant directly.