### PR TITLE
[Procfile.dev.all] Use $HOME variable and add bin/ to skedjewel path

### DIFF
--- a/Procfile.dev.all
+++ b/Procfile.dev.all
@@ -1,4 +1,4 @@
 web: bin/rails server -p 3000
 js: bin/vite dev
 worker: bin/sidekiq
-clock: /Users/david/code/skedjewel/skedjewel
+clock: $HOME/code/skedjewel/bin/skedjewel


### PR DESCRIPTION
The $HOME variable is not to be system dependent. For example, on MacOS and Linux, my home directory path is different.

The `bin/` is because that is where the `skedjewel` executable is compiled to when running `shards build --production --release --no-debug --static` in the `skedjewel` repo.