### PR TITLE
[quizzes] Remove whitespace to avoid space before example questions

### DIFF
--- a/app/views/question_uploads/new.html.haml
+++ b/app/views/question_uploads/new.html.haml
@@ -27,7 +27,7 @@
 
   %h3 Example
 
-  %code.whitespace-pre-wrap
+  %code.whitespace-pre-wrap>
     :preserve
       Which is biggest?
       The earth


### PR DESCRIPTION
https://haml.info/docs/yardoc/file.REFERENCE.html#whitespace_removal__and_

Before:

![image](https://github.com/user-attachments/assets/d98b728b-3415-4fcd-a294-0225e5002aac)

After:

![image](https://github.com/user-attachments/assets/32e920cd-1a37-411d-910b-986fe79fa4da)