### PR TITLE
[workout] Permit non-integer default workout time in bootstrap data

### DIFF
--- a/app/javascript/types/bootstrap/WorkoutsIndexBootstrap.ts
+++ b/app/javascript/types/bootstrap/WorkoutsIndexBootstrap.ts
@@ -62,7 +62,7 @@ const schema = {
       "additionalProperties": false,
       "properties": {
         "minutes": {
-          "type": "integer"
+          "type": "number"
         },
         "exercises": {
           "type": "array",

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -19,7 +19,10 @@ class JsonSchemaValidator
     )
       copy_data_to_clipboard
 
-      raise(NonconformingData, schema_validation_errors.to_s)
+      raise(
+        NonconformingData,
+        "Violation of #{relative_schema_path} : #{schema_validation_errors}",
+      )
     else
       @data
     end
@@ -56,14 +59,15 @@ class JsonSchemaValidator
 
   memo_wise \
   def absolute_schema_path
+    Rails.root.join(relative_schema_path).to_s
+  end
+
+  memo_wise \
+  def relative_schema_path
     if api?
-      Rails.root.join(
-        "spec/support/schemas/#{@controller_action}.json",
-      ).to_s
+      "spec/support/schemas/#{@controller_action}.json"
     else
-      Rails.root.join(
-        "spec/support/schemas/bootstrap/#{@controller_action}.json",
-      ).to_s
+      "spec/support/schemas/bootstrap/#{@controller_action}.json"
     end
   end
 

--- a/spec/support/schemas/bootstrap/workouts/index.json
+++ b/spec/support/schemas/bootstrap/workouts/index.json
@@ -58,7 +58,7 @@
       "additionalProperties": false,
       "properties": {
         "minutes": {
-          "type": "integer"
+          "type": "number"
         },
         "exercises": {
           "type": "array",


### PR DESCRIPTION
Also, make the error message more useful (easier to fix) by beginning it with the path of the schema that has been violated.

Also, DRY up `Rails.root.join` repetition in `JsonSchemaValidator`.