### PR TITLE
Don't enqueue SaveRequest workers that won't save anyway [DEV-140]

### DIFF
--- a/app/poros/save_request/skip_checker.rb
+++ b/app/poros/save_request/skip_checker.rb
@@ -1,0 +1,21 @@
+class SaveRequest::SkipChecker
+  def initialize(params:)
+    @controller = params['controller'].presence!
+    @action = params['action'].presence!
+    @params = params.presence!
+  end
+
+  def skip?
+    case [@controller, @action, @params.symbolize_keys]
+    in (
+      ['health_checks', _, _] |
+      ['anonymous', _, _] |
+      ['blog', 'assets', _] |
+      [_, _, { uptime_robot: _ }]
+    )
+      true
+    else
+      false
+    end
+  end
+end

--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -21,9 +21,7 @@ class SaveRequest
     return if Request.exists?(request_id: @request_id)
 
     if can_save_request?
-      if !should_save_request?
-        delete_request_data
-      elsif ban_reasons.present?
+      if ban_reasons.present?
         ban_requesting_ip
         delete_request_data
       else
@@ -36,13 +34,6 @@ class SaveRequest
   end
 
   private
-
-  def should_save_request?
-    return false if params['uptime_robot'].present?
-    return false if stashed_data['handler'] == 'blog#assets'
-
-    true
-  end
 
   memo_wise \
   def ban_reasons

--- a/config/initializers/monkeypatches/object.rb
+++ b/config/initializers/monkeypatches/object.rb
@@ -1,10 +1,12 @@
 module PresenceBangMonkeypatch
+  class ObjectNotPresent < StandardError ; end
+
   def presence!(error_message = nil)
     if present?
       self
     else
       error_message ||= "Expected object to be `present?` but was #{inspect}"
-      raise(error_message)
+      raise(ObjectNotPresent, error_message)
     end
   end
 end

--- a/spec/controllers/concerns/request_recordable_spec.rb
+++ b/spec/controllers/concerns/request_recordable_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe RequestRecordable, :without_verifying_authorization do
-  controller(ApplicationController) do
+  controller(HomeController) do
     def index
       render(plain: 'This is the #index action.')
     end
@@ -66,13 +66,8 @@ RSpec.describe RequestRecordable, :without_verifying_authorization do
         end
       end
 
-      context 'when the controller name is in CONTROLLERS_NOT_TO_RECORD' do
-        before do
-          stub_const(
-            'RequestRecordable::CONTROLLERS_NOT_TO_RECORD',
-            ["#{controller.controller_name.capitalize}Controller"],
-          )
-        end
+      context 'when there is an uptime_robot param' do
+        let(:params) { { 'uptime_robot' => '1' } }
 
         it 'does not stash initial request data in Redis' do
           perform_request

--- a/spec/poros/save_request/skip_checker_spec.rb
+++ b/spec/poros/save_request/skip_checker_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe SaveRequest::SkipChecker do
+  subject(:skip_checker) { described_class.new(params:) }
+
+  describe '#initialize' do
+    subject(:call_initialize) { skip_checker }
+
+    context 'when params does not include a controller' do
+      let(:params) { { 'action' => 'index' } }
+
+      it 'raises an error' do
+        expect { call_initialize }.to raise_error(PresenceBangMonkeypatch::ObjectNotPresent)
+      end
+    end
+
+    context 'when params does not include an action' do
+      let(:params) { { 'controller' => 'home' } }
+
+      it 'raises an error' do
+        expect { call_initialize }.to raise_error(PresenceBangMonkeypatch::ObjectNotPresent)
+      end
+    end
+
+    context 'when params includes a controller and action' do
+      let(:params) { { 'controller' => 'home', 'action' => 'index' } }
+
+      it 'does not raise an error' do
+        expect { call_initialize }.not_to raise_error
+      end
+    end
+  end
+
+  describe '#skip?' do
+    subject(:skip?) { skip_checker.skip? }
+
+    context 'when the controller is health_checks' do
+      let(:params) { { 'controller' => 'health_checks', 'action' => 'anything' } }
+
+      it 'returns true' do
+        expect(skip?).to eq(true)
+      end
+    end
+
+    context 'when the controller is anonymous' do
+      let(:params) { { 'controller' => 'anonymous', 'action' => 'anything' } }
+
+      it 'returns true' do
+        expect(skip?).to eq(true)
+      end
+    end
+
+    context 'when the controller is blog and the action is assets' do
+      let(:params) { { 'controller' => 'blog', 'action' => 'assets' } }
+
+      it 'returns true' do
+        expect(skip?).to eq(true)
+      end
+    end
+
+    context 'when uptime_robot is among the params keys' do
+      let(:params) { { 'controller' => 'home', 'action' => 'index', 'uptime_robot' => '1' } }
+
+      it 'returns true' do
+        expect(skip?).to eq(true)
+      end
+    end
+
+    context 'when controller is home, action is index, and params does not include uptime_robot' do
+      let(:params) { { 'controller' => 'home', 'action' => 'index', 'a_query_param' => 'true' } }
+
+      it 'returns true' do
+        expect(skip?).to eq(false)
+      end
+    end
+  end
+end

--- a/spec/workers/save_request_spec.rb
+++ b/spec/workers/save_request_spec.rb
@@ -108,34 +108,6 @@ RSpec.describe SaveRequest do
           end
         end
 
-        context 'when the request was an UptimeRobot ping' do
-          let(:stubbed_additional_data) { super().merge('params' => { 'uptime_robot' => '1' }) }
-
-          it 'does not create a request' do
-            expect { perform }.not_to change { Request.count }
-          end
-
-          it 'deletes the stashed data' do
-            perform
-            expect(stubbed_data_manager).to have_received(:delete_request_data)
-          end
-        end
-
-        context 'when the request was for a blog asset' do
-          let(:stubbed_additional_data) do
-            super().merge('handler' => 'blog#assets')
-          end
-
-          it 'does not create a request' do
-            expect { perform }.not_to change { Request.count }
-          end
-
-          it 'deletes the stashed data' do
-            perform
-            expect(stubbed_data_manager).to have_received(:delete_request_data)
-          end
-        end
-
         context 'when there is an auth_token_id in the initial stashed JSON' do
           let(:stubbed_initial_stashed_json) { super().merge('auth_token_id' => auth_token.id) }
           let(:auth_token) { AuthToken.first! }


### PR DESCRIPTION
Background: We have been storing request data in Redis and running SaveRequest workers for requests with an uptime_robot query param and for blog#assets requests. However, this is wasteful, since we ultimately won't create Request records for these requests.

This change stops storing data for such requests in Redis and stops running SaveRequest workers for these requests. The motivation is essentially to avoid wasted Redis requests, logs, Sidekiq queue consumption, etc.

As part of this change, I have refactored some existing checks for certain other requests that we already have been proactively skipping (specifically, requests to HealthChecksController and AnonymousController). I have now rolled up all such checks into a unified PORO, which leverages pattern matching for what I think is a pretty clean way to describe the conditions in which we want to skip saving a Request record.