### PR TITLE
[logs] Pass only 'log' prop to data renderers

### DIFF
--- a/app/javascript/lib/type_predicates.ts
+++ b/app/javascript/lib/type_predicates.ts
@@ -1,6 +1,15 @@
+import { TextLogEntry } from '@/logs/types';
+import { LogEntry } from '@/types';
+
 export function isArrayOfStrings(object: unknown): object is Array<string> {
   return (
     Array.isArray(object) &&
     object.every((element) => typeof element === 'string')
   );
+}
+
+export function isArrayOfTextLogEntries(
+  logEntries: Array<LogEntry>,
+): logEntries is Array<TextLogEntry> {
+  return logEntries.every((logEntry) => typeof logEntry.data === 'string');
 }

--- a/app/javascript/logs/components/Log.vue
+++ b/app/javascript/logs/components/Log.vue
@@ -8,10 +8,7 @@ div
     Loading...
   LogDataDisplay(
     v-else-if='log.log_entries.length'
-    :dataLabel='log.data_label'
-    :dataType='log.data_type'
     :log='log'
-    :logEntries='log.log_entries'
   )
   .my-8(v-else) There are no log entries for this log.
   .controls(v-if='!isSharedLogView')
@@ -77,20 +74,14 @@ const PUBLIC_TYPE_TO_DATA_RENDERER_MAPPING = {
   text: TextLog,
 };
 
-const LogDataDisplay = (props: {
-  dataType: LogDataType;
-  log: Log;
-  logEntries: Array<LogEntry>;
-  dataLabel: string;
-}) => {
-  const DataRenderer = PUBLIC_TYPE_TO_DATA_RENDERER_MAPPING[props.dataType];
+const LogDataDisplay = (props: { log: Log }) => {
+  const DataRenderer =
+    PUBLIC_TYPE_TO_DATA_RENDERER_MAPPING[props.log.data_type];
   return h(DataRenderer, {
     log: props.log,
-    logEntries: props.logEntries,
-    dataLabel: props.dataLabel,
   });
 };
-LogDataDisplay.props = ['dataType', 'log', 'logEntries', 'dataLabel'];
+LogDataDisplay.props = ['log'];
 
 const logsStore = useLogsStore();
 const modalStore = useModalStore();

--- a/app/javascript/logs/components/Log.vue
+++ b/app/javascript/logs/components/Log.vue
@@ -51,11 +51,10 @@ import { computed, h } from 'vue';
 
 import actionCableConsumer from '@/channels/consumer';
 import { useLogsStore } from '@/logs/store';
-import type { Log, LogDataType, LogEntryBroadcast } from '@/logs/types';
+import type { Log, LogEntryBroadcast } from '@/logs/types';
 import * as RoutesType from '@/rails_assets/routes';
 import { assert } from '@/shared/helpers';
 import { useModalStore } from '@/shared/modal/store';
-import type { LogEntry } from '@/types';
 
 import CounterBarGraph from './data_renderers/CounterBarGraph.vue';
 import DurationTimeseries from './data_renderers/DurationTimeseries.vue';

--- a/app/javascript/logs/components/data_renderers/CounterBarGraph.vue
+++ b/app/javascript/logs/components/data_renderers/CounterBarGraph.vue
@@ -10,15 +10,12 @@
 import { computed, type PropType } from 'vue';
 
 import BarGraph from '@/components/charts/BarGraph.vue';
-import type { LogEntry } from '@/types';
+import type { Log } from '@/logs/types';
+import { assert } from '@/shared/helpers';
 
 const props = defineProps({
-  dataLabel: {
-    type: String,
-    required: true,
-  },
-  logEntries: {
-    type: Array as PropType<Array<LogEntry>>,
+  log: {
+    type: Object as PropType<Log>,
     required: true,
   },
 });
@@ -26,7 +23,7 @@ const props = defineProps({
 const logEntriesToChartData = computed(() => {
   const countByDate: { [key: string]: number } = {};
 
-  for (const logEntry of props.logEntries) {
+  for (const logEntry of assert(props.log.log_entries)) {
     const date = new Date(logEntry.created_at);
     const dateIsoStringInLocalTime = new Date(
       date.getTime() - date.getTimezoneOffset() * 60 * 1000,
@@ -49,7 +46,7 @@ const chartMetadata = computed(() => {
   return {
     datasets: [
       {
-        label: props.dataLabel,
+        label: props.log.data_label,
         data: logEntriesToChartData.value,
       },
     ],

--- a/app/javascript/logs/components/data_renderers/DurationTimeseries.vue
+++ b/app/javascript/logs/components/data_renderers/DurationTimeseries.vue
@@ -13,6 +13,7 @@ import { sortBy } from 'lodash-es';
 import { computed, type PropType } from 'vue';
 
 import LineChart from '@/components/charts/LineChart.vue';
+import type { Log } from '@/logs/types';
 import type { LogEntry } from '@/types';
 
 function epochMsToHhMmSs(epochMs: number) {
@@ -48,8 +49,8 @@ type ChartData = {
 };
 
 const props = defineProps({
-  logEntries: {
-    type: Array as PropType<Array<LogEntry>>,
+  log: {
+    type: Object as PropType<Log>,
     required: true,
   },
 });
@@ -84,7 +85,7 @@ const CHART_OPTIONS = {
 };
 
 const logEntriesToChartData = computed((): Array<ChartData> => {
-  return sortBy(props.logEntries, 'created_at').map(
+  return sortBy(props.log.log_entries, 'created_at').map(
     (logEntry: LogEntry): ChartData => ({
       x: logEntry.created_at,
       y: new Date(

--- a/app/javascript/logs/components/data_renderers/IntegerTimeseries.vue
+++ b/app/javascript/logs/components/data_renderers/IntegerTimeseries.vue
@@ -11,21 +11,17 @@ import { sortBy } from 'lodash-es';
 import { computed, type PropType } from 'vue';
 
 import LineChart from '@/components/charts/LineChart.vue';
-import type { LogEntry } from '@/types';
+import type { Log } from '@/logs/types';
 
 const props = defineProps({
-  dataLabel: {
-    type: String,
-    required: true,
-  },
-  logEntries: {
-    type: Array as PropType<Array<LogEntry>>,
+  log: {
+    type: Object as PropType<Log>,
     required: true,
   },
 });
 
 const logEntriesToChartData = computed(() => {
-  return sortBy(props.logEntries, 'created_at').map((logEntry) => ({
+  return sortBy(props.log.log_entries, 'created_at').map((logEntry) => ({
     x: logEntry.created_at,
     y: logEntry.data,
     note: logEntry.note,
@@ -36,7 +32,7 @@ const chartMetadata = computed(() => {
   return {
     datasets: [
       {
-        label: props.dataLabel,
+        label: props.log.data_label,
         data: logEntriesToChartData.value,
       },
     ],

--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -25,20 +25,18 @@ const props = defineProps({
     type: Object as PropType<Log>,
     required: true,
   },
-  logEntries: {
-    type: Array as PropType<Array<TextLogEntry>>,
-    required: true,
-  },
 });
 
 const showAllEntries = ref(false);
 
 const sortedLogEntries = computed((): Array<TextLogEntry> => {
+  const logEntries = props.log.log_entries;
   let logEntriesToShow;
-  if (showAllEntries.value || props.logEntries.length <= 3) {
-    logEntriesToShow = props.logEntries;
+
+  if (showAllEntries.value || logEntries.length <= 3) {
+    logEntriesToShow = logEntries;
   } else {
-    logEntriesToShow = props.logEntries.slice(props.logEntries.length - 3);
+    logEntriesToShow = logEntries.slice(logEntries.length - 3);
   }
 
   return logEntriesToShow.slice().reverse();

--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -17,8 +17,10 @@
 <script setup lang="ts">
 import { computed, ref, type PropType } from 'vue';
 
+import { isArrayOfTextLogEntries } from '@/lib/type_predicates';
 import EditableTextLogRow from '@/logs/components/EditableTextLogRow.vue';
 import type { Log, TextLogEntry } from '@/logs/types';
+import { assert } from '@/shared/helpers';
 
 const props = defineProps({
   log: {
@@ -30,16 +32,21 @@ const props = defineProps({
 const showAllEntries = ref(false);
 
 const sortedLogEntries = computed((): Array<TextLogEntry> => {
-  const logEntries = props.log.log_entries;
-  let logEntriesToShow;
+  const logEntries = assert(props.log.log_entries);
 
-  if (showAllEntries.value || logEntries.length <= 3) {
-    logEntriesToShow = logEntries;
+  if (isArrayOfTextLogEntries(logEntries)) {
+    let logEntriesToShow;
+
+    if (showAllEntries.value || logEntries.length <= 3) {
+      logEntriesToShow = logEntries;
+    } else {
+      logEntriesToShow = logEntries.slice(logEntries.length - 3);
+    }
+
+    return logEntriesToShow.slice().reverse();
   } else {
-    logEntriesToShow = logEntries.slice(logEntries.length - 3);
+    return [];
   }
-
-  return logEntriesToShow.slice().reverse();
 });
 </script>
 


### PR DESCRIPTION
It seems sort of counterproductive / requires more typing / makes things sort of confusing when we "destructure" a `log` into some of its constituent properties (including `data_type`, `log_entries`, and `data_label`), when there probably is no case where we would want to pass a `log` object and then pass other `data_type`, `log_entries`, and/or `data_label` that are not associated with that `log`. This gives me the feeling that we should just use the single, unified `log` prop, and destructure it as needed _within_ the data renderer components, rather than destructuring as separate props to pass _to_ the component. This changes the implementation from the destructured props approach to the unified `log` prop approach.