### PR TITLE
Print stdout from Test::TaskHelpers#execute_rake_task if task fails

### DIFF
--- a/lib/test/tasks/run_typelizer.rb
+++ b/lib/test/tasks/run_typelizer.rb
@@ -2,7 +2,7 @@ class Test::Tasks::RunTypelizer < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    execute_rake_task('typelizer:generate', suppress_stdout: true)
+    execute_rake_task('typelizer:generate', log_stdout_only_on_failure: true)
     execute_system_command("! grep --quiet -RP '\\bunknown\\b' app/javascript/types/serializers/")
 
     if !execute_system_command('git diff --exit-code')


### PR DESCRIPTION
This code is absolutely hideous and complex. But I believe that it does what we want, and the result is that we might have access to more useful debugging information, in the event that a call to execute_rake_task that uses this option does fail.