### PR TITLE
[CompileJavaScript] Only print assets:upload_vite_assets on failure

### DIFF
--- a/lib/test/task_helpers.rb
+++ b/lib/test/task_helpers.rb
@@ -83,7 +83,7 @@ module Test::TaskHelpers
       time =
         Benchmark.measure do
           exception, captured_stdout =
-            capturing_stdout do
+            capturing_stdout_and_all_exceptions do
               Rake::Task[task_name].invoke(*args)
             end
         end.real
@@ -117,7 +117,7 @@ module Test::TaskHelpers
   # rubocop:enable Metrics/MethodLength
   # rubocop:enable Metrics/PerceivedComplexity
 
-  def capturing_stdout
+  def capturing_stdout_and_all_exceptions
     original_stdout = $stdout
     captured = StringIO.new
     $stdout = captured

--- a/lib/test/tasks/compile_java_script.rb
+++ b/lib/test/tasks/compile_java_script.rb
@@ -21,7 +21,10 @@ class Test::Tasks::CompileJavaScript < Pallets::Task
     )
 
     if ENV.fetch('CI', nil) == 'true' && ENV.fetch('GITHUB_REF_NAME') == 'main'
-      execute_rake_task('assets:upload_vite_assets')
+      execute_rake_task(
+        'assets:upload_vite_assets',
+        log_stdout_only_on_failure: true,
+      )
     end
   end
 end


### PR DESCRIPTION
The output when this succeeds is pretty verbose (currently about 70 lines), and it's not very useful. This will keep the logs of test runs on `main` more concise/readable.

Also, change a method name to reflect the important fact that the method rescues all exceptions (not just ones inheriting from StandardError).