### PR TITLE
[assets:upload_vite_assets] Send stdout for zip command to /dev/null

### DIFF
--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -14,7 +14,7 @@ namespace :assets do
   def upload_zipped_assets(git_sha, directory_name)
     file_output_path = "tmp/#{directory_name}.zip"
     FileUtils.mkdir_p('tmp')
-    system("cd public && zip -r ../#{file_output_path} #{directory_name}")
+    system("cd public && zip -r ../#{file_output_path} #{directory_name} > /dev/null")
 
     Aws::S3::Resource.new(region: 'us-east-1').
       bucket('david-runger-test-uploads').


### PR DESCRIPTION
This will do what #5927 (building on #5926) was trying to do but failed to do (as seen in the deployment [here][1], where the undesired lines were still printed).

[1]: https://github.com/davidrunger/david_runger/actions/runs/12971882013/job/36178737181