### PR TITLE
Explicitly sort text log entries by created_at [LOG-30]

### DIFF
--- a/app/javascript/logs/components/data_renderers/TextLog.test.ts
+++ b/app/javascript/logs/components/data_renderers/TextLog.test.ts
@@ -1,0 +1,58 @@
+import { faker } from '@faker-js/faker';
+import { createTestingPinia } from '@pinia/testing';
+import { render, screen } from '@testing-library/vue';
+import { ElButton } from 'element-plus';
+
+import { Log } from '@/logs/types';
+import { logEntryFactory } from '@/test/factories/logEntryFactory';
+import { logFactory } from '@/test/factories/logFactory';
+
+import TextLog from './TextLog.vue';
+
+function renderOptions(specifiedProps: { log: Log }) {
+  return {
+    global: {
+      components: {
+        'el-button': ElButton,
+      },
+      plugins: [createTestingPinia()],
+    },
+    props: specifiedProps,
+  };
+}
+
+describe('when the log has log entries', () => {
+  test('renders the text of the log entries', () => {
+    const oldLogEntry = logEntryFactory.build({
+      created_at: faker.date
+        .between({
+          from: '2020-01-01T00:00:00.000Z',
+          to: '2021-01-01T00:00:00.000Z',
+        })
+        .toISOString(),
+    });
+
+    const newLogEntry = logEntryFactory.build({
+      created_at: faker.date
+        .between({
+          from: '2021-01-01T00:00:00.000Z',
+          to: '2022-01-01T00:00:00.000Z',
+        })
+        .toISOString(),
+    });
+
+    const log = logFactory.build({
+      log_entries: [newLogEntry, oldLogEntry],
+    });
+
+    render(TextLog, renderOptions({ log }));
+
+    assert(log.log_entries);
+
+    const oldLogEntryElement = screen.getByText(oldLogEntry.data);
+    const newLogEntryElement = screen.getByText(newLogEntry.data);
+    expect(
+      newLogEntryElement.compareDocumentPosition(oldLogEntryElement),
+    ).toEqual(4); // new log entry precedes the old log entry
+  });
+});

--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -15,12 +15,12 @@
 </template>
 
 <script setup lang="ts">
+import { sortBy } from 'lodash-es';
 import { computed, ref, type PropType } from 'vue';
 
 import { isArrayOfTextLogEntries } from '@/lib/type_predicates';
 import EditableTextLogRow from '@/logs/components/EditableTextLogRow.vue';
 import type { Log, TextLogEntry } from '@/logs/types';
-import { assert } from '@/shared/helpers';
 
 const props = defineProps({
   log: {
@@ -32,7 +32,7 @@ const props = defineProps({
 const showAllEntries = ref(false);
 
 const sortedLogEntries = computed((): Array<TextLogEntry> => {
-  const logEntries = assert(props.log.log_entries);
+  const logEntries = sortBy(props.log.log_entries, 'created_at');
 
   if (isArrayOfTextLogEntries(logEntries)) {
     let logEntriesToShow;

--- a/app/javascript/test/factories/logEntryFactory.ts
+++ b/app/javascript/test/factories/logEntryFactory.ts
@@ -1,0 +1,12 @@
+import { faker } from '@faker-js/faker';
+import { Factory } from 'fishery';
+
+import { LogEntry } from '@/types';
+
+export const logEntryFactory = Factory.define<LogEntry>(({ sequence }) => ({
+  id: sequence,
+  log_id: 1,
+  note: null,
+  created_at: faker.date.past().toISOString(),
+  data: faker.commerce.productDescription(),
+}));

--- a/app/javascript/test/factories/logFactory.ts
+++ b/app/javascript/test/factories/logFactory.ts
@@ -1,0 +1,14 @@
+import { Factory } from 'fishery';
+
+import { Log } from '@/logs/types';
+import { userFactory } from '@/test/factories/userFactory';
+
+export const logFactory = Factory.define<Log>(({ sequence }) => ({
+  data_label: 'Dream content',
+  data_type: 'text',
+  description: null,
+  id: sequence,
+  name: 'Dream Journal',
+  slug: 'dream-journal',
+  user: userFactory.build(),
+}));

--- a/app/javascript/test/factories/userFactory.ts
+++ b/app/javascript/test/factories/userFactory.ts
@@ -1,0 +1,11 @@
+import { faker } from '@faker-js/faker';
+import { Factory } from 'fishery';
+
+import { UserSerializerBasic } from '@/types';
+
+export const userFactory = Factory.define<UserSerializerBasic>(
+  ({ sequence }) => ({
+    id: sequence,
+    email: faker.internet.email(),
+  }),
+);

--- a/package.json
+++ b/package.json
@@ -49,8 +49,10 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.18.0",
+    "@faker-js/faker": "^9.4.0",
     "@ianvs/prettier-plugin-sort-imports": "^4.4.1",
     "@percy/cli": "^1.30.6",
+    "@pinia/testing": "^0.1.7",
     "@tailwindcss/postcss": "^4.0.0",
     "@testing-library/vue": "^8.1.0",
     "@types/js-cookie": "^3.0.6",
@@ -66,6 +68,7 @@
     "eslint-config-prettier": "^10.0.1",
     "eslint-import-resolver-typescript": "^3.7.0",
     "eslint-plugin-import": "^2.31.0",
+    "fishery": "^2.2.2",
     "globals": "^15.14.0",
     "jsdom": "^26.0.0",
     "postcss": "^8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 9.18.0(jiti@2.4.2)
       eslint-import-resolver-custom-alias:
         specifier: ^1.3.2
-        version: 1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2)))
+        version: 1.3.2(eslint-plugin-import@2.31.0)
       eslint-plugin-vue:
         specifier: ^9.32.0
         version: 9.32.0(eslint@9.18.0(jiti@2.4.2))
@@ -123,12 +123,18 @@ importers:
       '@eslint/js':
         specifier: ^9.18.0
         version: 9.18.0
+      '@faker-js/faker':
+        specifier: ^9.4.0
+        version: 9.4.0
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.4.1
         version: 4.4.1(@vue/compiler-sfc@3.5.13)(prettier@3.4.2)
       '@percy/cli':
         specifier: ^1.30.6
         version: 1.30.6(typescript@5.7.3)
+      '@pinia/testing':
+        specifier: ^0.1.7
+        version: 0.1.7(pinia@2.3.1(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))(vue@3.5.13(typescript@5.7.3))
       '@tailwindcss/postcss':
         specifier: ^4.0.0
         version: 4.0.0
@@ -174,6 +180,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.31.0
         version: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2))
+      fishery:
+        specifier: ^2.2.2
+        version: 2.2.2
       globals:
         specifier: ^15.14.0
         version: 15.14.0
@@ -525,6 +534,10 @@ packages:
     resolution: {integrity: sha512-lB05FkqEdUg2AA0xEbUz0SnkXT1LcCTa438W4IWTUh4hdOnVbQyOJ81OrDXsJk/LSiJHubgGEFoR5EHq1NsH1A==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@faker-js/faker@9.4.0':
+    resolution: {integrity: sha512-85+k0AxaZSTowL0gXp8zYWDIrWclTbRPg/pm/V0dSFZ6W6D4lhcG3uuZl4zLsEKfEvs69xDbLN2cHQudwp95JA==}
+    engines: {node: '>=18.0.0', npm: '>=9.0.0'}
+
   '@floating-ui/core@1.4.1':
     resolution: {integrity: sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==}
 
@@ -762,6 +775,11 @@ packages:
   '@percy/webdriver-utils@1.30.6':
     resolution: {integrity: sha512-B1M9HWP3ZEM5CuDSMUx+68mrrKm9/JjJ0KO/OLztRh+v7TOsgOWpHMHalurwEIfoNf/olduQ4/Vv9TPrTSj72Q==}
     engines: {node: '>=14'}
+
+  '@pinia/testing@0.1.7':
+    resolution: {integrity: sha512-xcDq6Ry/kNhZ5bsUMl7DeoFXwdume1NYzDggCiDUDKoPQ6Mo0eH9VU7bJvBtlurqe6byAntWoX5IhVFqWzRz/Q==}
+    peerDependencies:
+      pinia: '>=2.2.6'
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1961,6 +1979,9 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
+  fishery@2.2.2:
+    resolution: {integrity: sha512-jeU0nDhPHJkupmjX+r9niKgVMTBDB8X+U/pktoGHAiWOSyNlMd0HhmqnjrpjUOCDPJYaSSu4Ze16h6dZOKSp2w==}
+
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
@@ -2562,6 +2583,9 @@ packages:
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
+
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
 
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
@@ -3954,6 +3978,8 @@ snapshots:
       '@eslint/core': 0.10.0
       levn: 0.4.1
 
+  '@faker-js/faker@9.4.0': {}
+
   '@floating-ui/core@1.4.1':
     dependencies:
       '@floating-ui/utils': 0.1.1
@@ -4257,6 +4283,14 @@ snapshots:
       '@percy/sdk-utils': 1.30.6
     transitivePeerDependencies:
       - typescript
+
+  '@pinia/testing@0.1.7(pinia@2.3.1(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3)))(vue@3.5.13(typescript@5.7.3))':
+    dependencies:
+      pinia: 2.3.1(typescript@5.7.3)(vue@3.5.13(typescript@5.7.3))
+      vue-demi: 0.14.10(vue@3.5.13(typescript@5.7.3))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -5406,7 +5440,7 @@ snapshots:
     dependencies:
       eslint: 9.18.0(jiti@2.4.2)
 
-  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2))):
+  eslint-import-resolver-custom-alias@1.3.2(eslint-plugin-import@2.31.0):
     dependencies:
       eslint-plugin-import: 2.31.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2))
       glob-parent: 6.0.2
@@ -5436,7 +5470,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@2.4.2)))(eslint@9.18.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5458,7 +5492,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.18.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.18.0(jiti@2.4.2)))(eslint@9.18.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.21.0(eslint@9.18.0(jiti@2.4.2))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.18.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3
@@ -5641,6 +5675,10 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  fishery@2.2.2:
+    dependencies:
+      lodash.mergewith: 4.6.2
 
   flat-cache@4.0.1:
     dependencies:
@@ -6278,6 +6316,8 @@ snapshots:
       lodash-es: 4.17.21
 
   lodash.merge@4.6.2: {}
+
+  lodash.mergewith@4.6.2: {}
 
   lodash.truncate@4.4.2: {}
 

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -44,5 +44,10 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    server: {
+      deps: {
+        inline: ['element-plus'],
+      },
+    },
   },
 });


### PR DESCRIPTION
I think that we have been relying on the server-side ordering of the text log entries, but that is insufficient if a new text log entry is created that is backdated to be older than the most recent text log entry. Prior to this change, that log entry would appear at the top of the list. With this change, that log entry will enter the list of entries in the proper chronological order.

Testing this was pretty brutal, and makes me question my decision to reintroduce JavaScript testing in #5925 . The test actually seems to take ridiculously long to run (between 2 and 3 seconds on my machine). For now, though, I will continue ahead, and see if I find value in having a JavaScript test harness available. Maybe it will not be so painful, now that I have figured out some of the sticking points / added some necessary and/or helpful supplemental libraries.