### PR TITLE
[specs] Refresh page for quiz owner once participant submits [QUIZ-5]

### DIFF
--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -86,6 +86,10 @@ RSpec.describe 'Quizzes app' do
         expect(page).to have_css('ol li:nth-of-type(1)', text: /\A\z/)
       end
 
+      # refresh the page and check that the respondent's name is still bolded
+      visit(page.current_url)
+      expect(page).to have_css('.font-bold', text: participant_name)
+
       # close question (reveal answer) and move to next question
       click_on('Close question')
       expect(page).to have_css('.text-lime-600', text: "(#{participant_name})")


### PR DESCRIPTION
Sometimes, specs fail to hit this line: https://github.com/davidrunger/david_runger/blob/432caa6c/app/decorators/quiz_decorator.rb/#L27

I believe that cause of the flakiness in test coverage was basically a race condition. In order for the line in question to be covered, I believe that the quiz participant would need to submit their answer prior to the completion of [this 750 ms delay][1] (for at least one of the two quiz questions in the relevant feature spec that is being changed herein). That seems like something that should indeed usually happen -- but sometimes, I think it doesn't happen, and when that happens, I believe that the line in question doesn't get hit by any test.

With this change, we will now have the quiz owner refresh the page after the quiz participant has submitted their response to the first question. This will ensure that the line in question does get hit.

I suspect (but cannot really know for sure, I think) that this flakiness in test coverage _might_ be due to #5796. In that PR, I think that we effectively reduced our Puma thread concurrency from 3 threads to 2 threads. I believe concurrency might affect how likely we are to enter the scenario where the line in question is not covered. If so, then that PR might be relevant.

[1]: https://github.com/davidrunger/david_runger/blob/432caa6c/app/views/quiz_questions/_open.html.haml/#L14