### PR TITLE
[logs] Always require old enough log for ::needing_reminder [LOG-31]

### DIFF
--- a/spec/workers/send_log_reminder_emails_spec.rb
+++ b/spec/workers/send_log_reminder_emails_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe SendLogReminderEmails do
 
       before do
         log = Log.number.joins(:log_entries).first!
-        log.update!(reminder_time_in_seconds: 3600, reminder_last_sent_at: nil)
+        log.update!(
+          created_at: 3.hours.ago,
+          reminder_last_sent_at: nil,
+          reminder_time_in_seconds: Integer(1.hour),
+        )
         log.log_entries.find_each { _1.update!(created_at: 2.hours.ago) }
       end
 


### PR DESCRIPTION
This change fixes a potential bug. I don't know if the bug would ever have really occurred; I think it mostly was just at risk of occurring due to the way that we artificially construct spec setup data, sometimes without perfect realism.

Anyway, the bug is that if there were a log with a recent `created_at` time but somehow the bug had an older-than-the-`created_at` `reminder_last_sent_at` that was old enough that the log should be sent again (if we were to ignore the recent created_at timestamp), then the log would be included in the `needing_reminder` scope. But it shouldn't be, because we should respect the recency of the `created_at` timestamp, even if the `reminder_last_sent_at` timestamp is old. This situation can occur if the fixture data is more than ~[3 days old][1], as happened to me recently with the fixtures on my local machine.

This change fixes the bug by essentially respecting the `created_at` timestamp _in addition to_ the `reminder_last_sent_at` timestamp in the case where the log has log entries (in addition to respecting it in the case where the log has no log entries, as we had already been doing before).

[1]: https://github.com/davidrunger/david_runger/blob/c973bae1/spec/models/log_spec.rb/#L20