### PR TITLE
[GitHub Actions] Increase deployment timeout from 15 minutes to 20

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -106,7 +106,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     needs: test
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - name: Clone repo
         uses: actions/checkout@v4


### PR DESCRIPTION
A recent deployment timed out: https://github.com/davidrunger/david_runger/actions/runs/12991176984/attempts/1 . It looks like another 5 minutes would have been enough for it to succeed.