### PR TITLE
[home] Shrink skill icons from 66px to 50px (mobile: 45px to 42px)

### DIFF
--- a/app/javascript/home/components/SkillRow.vue
+++ b/app/javascript/home/components/SkillRow.vue
@@ -56,8 +56,8 @@ watchEffect(() => {
 </style>
 
 <style lang="scss" scoped>
-$icon-size-normal: 66px;
-$icon-size-small: 45px;
+$icon-size-normal: 50px;
+$icon-size-small: 42px;
 
 .svg-container {
   height: $icon-size-normal;


### PR DESCRIPTION
This change follows #5946 , which introduced a somewhat more bold color palette for the skill icons. Probably partially because of that, I think that the icons are too prominent. This change shrinks them a little bit, so that they will be less prominent/distracting. The thing that we probably most want users to focus on is the names of the skills, not the pictures of them.

Before (from Percy):

![image](https://github.com/user-attachments/assets/af2e4a13-308f-4fa6-b2a3-0cc1cd6d5888)

After (from Percy):

![image](https://github.com/user-attachments/assets/25d1257f-b4e0-4a58-9e8e-cb5e6c095882)