### PR TITLE
Move listen gem from development-only to development & test group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ group :development, :test do
   gem 'immigrant'
   gem 'isolator'
   gem 'json-schema'
+  gem 'listen'
   gem 'pry-byebug', require: false
   gem 'rainbow'
   gem 'rubocop', require: false
@@ -80,7 +81,6 @@ group :development do
   gem 'binding_of_caller'
   gem 'http_logger'
   gem 'letter_opener'
-  gem 'listen'
   gem 'spring'
   gem 'spring-watcher-listen'
 end


### PR DESCRIPTION
Without this, the `Listen` reference in `lib/test/runner.rb` seems to be undefined (which throws an error if/when saying "n" to the suggested set of specs) when running `spec`, which is:

``` export RAILS_ENV=test DISABLE_SPRING=1 export POSTGRES_USER=david_runger POSTGRES_HOST=localhost set -x redis-cli -n 8 FLUSHDB bin/run-tests ```