### PR TITLE
Remove route aliasing for user and admin login paths [DEV-145]

### DIFF
--- a/app/controllers/admin/omniauth_callbacks_controller.rb
+++ b/app/controllers/admin/omniauth_callbacks_controller.rb
@@ -13,7 +13,7 @@ class Admin::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       redirect_to(session.delete('admin_user_return_to') || admin_root_path)
     else
       flash[:alert] = "#{email} is not authorized to access admin"
-      redirect_to(admin_login_path)
+      redirect_to(new_admin_user_session_path)
     end
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -107,7 +107,7 @@ class ApplicationController < ActionController::Base
     else
       flash[:alert] = 'You must sign in first.'
       session['user_return_to'] = request.path
-      redirect_to(login_path)
+      redirect_to(new_user_session_path)
     end
   end
 
@@ -116,7 +116,7 @@ class ApplicationController < ActionController::Base
 
     flash[:alert] = 'You must sign in as an admin user first.'
     session['admin_user_return_to'] = request.path
-    redirect_to(admin_login_path)
+    redirect_to(new_admin_user_session_path)
   end
 
   # override Rails's built-in #verify_authenticity_token method to allow for `auth_token` use

--- a/app/javascript/emoji_picker/EmojiPicker.vue
+++ b/app/javascript/emoji_picker/EmojiPicker.vue
@@ -25,8 +25,8 @@
     .mt-8.max-w-sm
       b Tip:
       span.
-        #[a(href='/login')  log in] to customize which search keywords are associated
-        with which emojis.
+        #[a(:href='routes.new_user_session_path()')  log in] to customize
+        which search keywords are associated with which emojis.
 </template>
 
 <script setup lang="ts">
@@ -40,6 +40,7 @@ import { emojiData } from '@/emoji_picker/emoji_data';
 import { type Bootstrap } from '@/emoji_picker/types';
 import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { useFuzzyTypeahead } from '@/lib/composables/use_fuzzy_typeahead';
+import { routes } from '@/lib/routes';
 import { vueToast } from '@/lib/vue_toasts';
 import type { EmojiData } from '@/types';
 

--- a/app/javascript/lib/sign_out.ts
+++ b/app/javascript/lib/sign_out.ts
@@ -5,5 +5,5 @@ declare const Routes: typeof RoutesType;
 
 export async function signOut() {
   await kyApi.delete(Routes.destroy_user_session_path({ format: 'json' }));
-  window.location.assign('/login');
+  window.location.assign(Routes.new_user_session_path());
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,12 +9,7 @@ Rails.application.routes.draw do
     get '/users/auth/google_oauth2/callback' => 'users/omniauth_callbacks#google_oauth2'
     delete 'sign_out', to: 'devise/sessions#destroy', as: :destroy_user_session
   end
-  get 'login', to: 'sessions#new'
-  # https://stackoverflow.com/a/46218826/4009384
-  Rails.application.routes.named_routes.tap do |named_routes|
-    named_routes['new_session'] = named_routes['login']
-    named_routes['new_user_session'] = named_routes['login']
-  end
+  get 'login', to: 'sessions#new', as: :new_user_session
   resource :my_account, controller: :my_account, only: %i[destroy edit show]
 
   get 'blog', to: 'blog#index'
@@ -93,13 +88,7 @@ Rails.application.routes.draw do
     get '/admin_users/auth/google_oauth2/callback' => 'admin/omniauth_callbacks#google_oauth2'
     delete '/admin_users/sign_out', to: 'devise/sessions#destroy', as: :destroy_admin_user_session
   end
-  get '/admin/login', to: 'admin/sessions#new'
-  # https://stackoverflow.com/a/46218826/4009384
-  Rails.application.routes.named_routes.tap do |named_routes|
-    # Devise calls `#new_admin_user_session_url` to determine where to redirect an AdminUser to log
-    # in, so we need to alias `#admin_login` to that name.
-    named_routes['new_admin_user_session'] = named_routes['admin_login']
-  end
+  get '/admin/login', to: 'admin/sessions#new', as: :new_admin_user_session
   ActiveAdmin.routes(self)
 
   authenticate :admin_user do

--- a/lib/tasks/rails_assets.rake
+++ b/lib/tasks/rails_assets.rake
@@ -11,7 +11,7 @@ task build_js_routes: :environment do
   routes_path = 'rails_assets/routes.js'
   routes_full_path = "app/javascript/#{routes_path}"
 
-  options = { exclude: /admin|google|login|rails|sidekiq/ }
+  options = { exclude: /admin|google|rails|sidekiq/ }
   JsRoutes.generate!(routes_path, **options)
   File.write(routes_full_path.sub('.js', '.d.ts'), JsRoutes.definitions(**options))
 

--- a/spec/controllers/admin/dashboard_controller_spec.rb
+++ b/spec/controllers/admin/dashboard_controller_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Admin::DashboardController do
 
       it 'redirects to the admin login page with a flash message' do
         get_index
-        expect(response.status).to redirect_to(admin_login_path)
+        expect(response.status).to redirect_to(new_admin_user_session_path)
         expect(flash[:alert]).to eq('You must sign in as an admin user first.')
       end
     end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Admin::UsersController do
 
       it 'redirects to the admin login page' do
         get_become
-        expect(response).to redirect_to(admin_login_path)
+        expect(response).to redirect_to(new_admin_user_session_path)
       end
     end
   end

--- a/spec/controllers/workouts_controller_spec.rb
+++ b/spec/controllers/workouts_controller_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe WorkoutsController do
       it 'redirects to the login page' do
         get_index
 
-        expect(response).to redirect_to(login_path)
+        expect(response).to redirect_to(new_user_session_path)
       end
     end
   end

--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Logging in as an AdminUser via Google auth' do
     let(:admin_user) { admin_users(:admin_user) }
 
     it 'allows the AdminUser to log in via Google' do
-      visit(admin_login_path)
+      visit(new_admin_user_session_path)
       expect(page).to have_css('button.google-login')
 
       expect { click_on(class: 'google-login') }.not_to change { AdminUser.count }
@@ -24,7 +24,7 @@ RSpec.describe 'Logging in as an AdminUser via Google auth' do
     before { expect(AdminUser.where(email: stubbed_admin_user_email)).not_to exist }
 
     it 'does not create an AdminUser' do
-      visit(admin_login_path)
+      visit(new_admin_user_session_path)
       expect(page).to have_css('button.google-login')
 
       expect { click_on(class: 'google-login') }.not_to change { AdminUser.count }

--- a/spec/features/flipper_spec.rb
+++ b/spec/features/flipper_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Flipper web UI', :rack_test_driver do
 
     it 'redirects to the root path', :prerendering_disabled do
       visit_flipper_web_ui
-      expect(page).to have_current_path(admin_login_path)
+      expect(page).to have_current_path(new_admin_user_session_path)
     end
   end
 
@@ -25,7 +25,7 @@ RSpec.describe 'Flipper web UI', :rack_test_driver do
 
     it 'redirects to the root path', :prerendering_disabled do
       visit_flipper_web_ui
-      expect(page).to have_current_path(admin_login_path)
+      expect(page).to have_current_path(new_admin_user_session_path)
     end
   end
 end

--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
       let(:user) { users(:user) }
 
       it 'allows a user to log in with Google' do
-        visit(login_path)
+        visit(new_user_session_path)
         expect(page).to have_css('button.google-login')
 
         expect { click_on(class: 'google-login') }.not_to change { User.count }
@@ -29,7 +29,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
       before { expect(User.where(email: stubbed_user_email)).not_to exist }
 
       it 'allows a user to sign up (and log in) with Google' do
-        visit(login_path)
+        visit(new_user_session_path)
         expect(page).to have_css('button.google-login')
 
         expect { click_on(class: 'google-login') }.to change { User.count }.by(1)
@@ -69,7 +69,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
       end
 
       it "renders Google's response" do
-        visit(login_path)
+        visit(new_user_session_path)
         expect(page).to have_css('button.google-login')
 
         click_on(class: 'google-login')

--- a/spec/features/vue_playground_spec.rb
+++ b/spec/features/vue_playground_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Vue Playground' do
     it 'redirects to the root path', :prerendering_disabled do
       visit_vue_playground_path
 
-      expect(page).to have_current_path(admin_login_path)
+      expect(page).to have_current_path(new_admin_user_session_path)
     end
   end
 
@@ -27,7 +27,7 @@ RSpec.describe 'Vue Playground' do
     it 'redirects to the root path', :prerendering_disabled do
       visit_vue_playground_path
 
-      expect(page).to have_current_path(admin_login_path)
+      expect(page).to have_current_path(new_admin_user_session_path)
     end
   end
 end


### PR DESCRIPTION
Our route "aliasing" in `config/routes.rb` for user and admin login paths causes problems with `js-routes`. (https://davidrunger.atlassian.net/browse/NEW-23 is to fix those issues upstream.) But, I think that our route aliasing is not really needed / worth it, in the first place. Therefore, this change removes those route aliases, which allows us to use a `new_user_session_path` helper on the frontend to refer to the `/login` path.