### PR TITLE
Stop truncating the requests table [DEV-142]

### DIFF
--- a/app/workers/truncate_tables.rb
+++ b/app/workers/truncate_tables.rb
@@ -81,7 +81,6 @@ class TruncateTables
     self.class.print_row_counts
     Rails.logger.info
 
-    self.class.truncate(table: 'requests', timestamp: 'requested_at')
     self.class.truncate(
       table: 'ip_blocks',
       timestamp: 'created_at',

--- a/app/workers/truncate_tables.rb
+++ b/app/workers/truncate_tables.rb
@@ -26,8 +26,8 @@ class TruncateTables
   def self.truncate(
     table:,
     timestamp:,
-    max_allowed_rows: self.max_allowed_rows,
-    min_surviving_timestamp: nil
+    min_surviving_timestamp:,
+    max_allowed_rows: self.max_allowed_rows
   )
     log_truncation_plan(table:, max_allowed_rows:, min_surviving_timestamp:)
 
@@ -45,7 +45,7 @@ class TruncateTables
     return if min_surviving_timestamp_based_on_count.nil?
 
     min_surviving_timestamp =
-      [min_surviving_timestamp_based_on_count, min_surviving_timestamp].compact.max
+      [min_surviving_timestamp_based_on_count, min_surviving_timestamp].max
 
     delete_old_rows_sql = <<~SQL.squish
       DELETE
@@ -60,14 +60,10 @@ class TruncateTables
   end
 
   def self.log_truncation_plan(table:, max_allowed_rows:, min_surviving_timestamp:)
-    if min_surviving_timestamp.present?
-      Rails.logger.info(<<~LOG.squish)
-        Truncating `#{table}` with a minimum surviving timestamp of #{min_surviving_timestamp} and
-        #{max_allowed_rows} rows (whichever leaves fewer rows in the table).
-      LOG
-    else
-      Rails.logger.info("Truncating `#{table}` with a max of #{max_allowed_rows} rows.")
-    end
+    Rails.logger.info(<<~LOG.squish)
+      Truncating `#{table}` with a minimum surviving timestamp of #{min_surviving_timestamp} and
+      #{max_allowed_rows} rows (whichever leaves fewer rows in the table).
+    LOG
   end
 
   def self.num_rows(table)

--- a/spec/workers/truncate_tables_spec.rb
+++ b/spec/workers/truncate_tables_spec.rb
@@ -12,28 +12,27 @@ RSpec.describe TruncateTables do
       end
     end
 
-    context 'when there is at least one row in the `requests` table' do
-      before { expect(Request.count).to be > 0 }
+    context 'when there is at least one row in the `ip_blocks` table' do
+      before { expect(IpBlock.count).to be > 0 }
 
-      it 'issues a DELETE command against the `requests` table' do
-        expect(@connection).to receive(:execute).
-          with(/DELETE FROM requests/).
-          and_call_original
-
-        # pass other calls through
+      it 'issues a DELETE command against the `ip_blocks` table' do
         allow(@connection).to receive(:execute).and_call_original
 
         perform
+
+        expect(@connection).
+          to have_received(:execute).
+          with(/DELETE FROM ip_blocks/)
       end
     end
 
-    context 'when there are no rows in the `requests` table' do
-      before { Request.delete_all }
+    context 'when there are no rows in the `ip_blocks` table' do
+      before { IpBlock.delete_all }
 
-      it 'does not issue a DELETE command against the `requests` table' do
+      it 'does not issue a DELETE command against the `ip_blocks` table' do
         expect(@connection).
           not_to receive(:execute).
-          with(/DELETE FROM requests/i)
+          with(/DELETE FROM ip_blocks/i)
 
         # pass other calls through
         allow(@connection).to receive(:execute).and_call_original


### PR DESCRIPTION
I think that the truncation of the `requests` table is mostly a legacy from when the app was deployed to Heroku using a free Heroku database that limited us to a total of 10,000 rows. Now that we are running the app on a VPS with 25 GiB of storage, we have no fixed row limit and the space considerations at this time are not significantly concerning. And there is upside in being able to search over an indefinitely long history of requests. So, this change removes the `requests` table from the set of tables truncated by the `TruncateTables` worker.