### PR TITLE
Suppress assets:precompile and unzip output during deploy [DEV-146]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN DOCKER_BUILD=true \
   GIT_REV=${GIT_REV} \
   SECRET_KEY_BASE_DUMMY=1 \
   VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true \
-  bundle exec rails assets:precompile
+  bundle exec rails assets:precompile > /dev/null 2>&1
 
 # Precompile bootsnap code for faster boot times
 RUN bin/bootsnap precompile app/ lib/


### PR DESCRIPTION
It's too much output. Not worth the clutter/scrolling that it creates in the deploy output. This somewhat parallels the recent suppression of the output when zipping the assets: https://github.com/davidrunger/david_runger/pull/5928 .