### PR TITLE
[StackTraceFilter] Simplify filtering logic and handle Docker paths

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -34,7 +34,9 @@ class Event < ApplicationRecord
   class << self
     def create_with_stack_trace!(attributes)
       create!(attributes.merge(
-        stack_trace: StackTraceFilter.new.application_stack_trace,
+        stack_trace:
+          StackTraceFilter.new.
+            application_stack_trace(ignore: [__FILE__]),
       ))
     end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -34,9 +34,7 @@ class Event < ApplicationRecord
   class << self
     def create_with_stack_trace!(attributes)
       create!(attributes.merge(
-        stack_trace:
-          StackTraceFilter.new(caller).
-            application_stack_trace(ignore: [__FILE__]),
+        stack_trace: StackTraceFilter.new.application_stack_trace,
       ))
     end
 

--- a/app/poros/stack_trace_filter.rb
+++ b/app/poros/stack_trace_filter.rb
@@ -1,20 +1,10 @@
 class StackTraceFilter
-  def initialize(stack_trace)
-    @stack_trace = stack_trace
-  end
-
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/PerceivedComplexity
-  def application_stack_trace(ignore: [])
-    @stack_trace.select do |caller_line|
-      caller_line.include?('/david_runger/') &&
-        caller_line.exclude?('/gems/') &&
+  def application_stack_trace
+    caller.drop(1).select do |caller_line|
+      caller_line.exclude?('/gems/') &&
         caller_line.exclude?('/lib/ruby/') &&
         caller_line.exclude?('/middleware/') &&
-        caller_line.exclude?(__FILE__) &&
-        ignore.all? { caller_line.exclude?(it) }
+        caller_line.exclude?(__FILE__)
     end.presence || caller
   end
-  # rubocop:enable Metrics/PerceivedComplexity
-  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/app/poros/stack_trace_filter.rb
+++ b/app/poros/stack_trace_filter.rb
@@ -1,10 +1,13 @@
 class StackTraceFilter
-  def application_stack_trace
-    caller.drop(1).select do |caller_line|
+  # rubocop:disable Metrics/CyclomaticComplexity
+  def application_stack_trace(ignore: [])
+    caller.select do |caller_line|
       caller_line.exclude?('/gems/') &&
         caller_line.exclude?('/lib/ruby/') &&
         caller_line.exclude?('/middleware/') &&
-        caller_line.exclude?(__FILE__)
+        caller_line.exclude?(__FILE__) &&
+        ignore.all? { caller_line.exclude?(it) }
     end.presence || caller
   end
+  # rubocop:enable Metrics/CyclomaticComplexity
 end

--- a/spec/poros/stack_trace_filter_spec.rb
+++ b/spec/poros/stack_trace_filter_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe(StackTraceFilter) do
+  subject(:stack_trace_filter) { StackTraceFilter.new }
+
+  describe '#application_stack_trace' do
+    subject(:application_stack_trace) { stack_trace_filter.application_stack_trace }
+
+    context 'when the caller has Dockerized file paths' do
+      before do
+        expect(stack_trace_filter).to receive(:caller).and_return(mocked_stack_trace)
+      end
+
+      let(:mocked_stack_trace) do
+        # rubocop:disable Layout/LineLength
+        [
+          "/app/app/models/event.rb:37:in 'Event.create_with_stack_trace!'",
+          expected_line_of_interest,
+          "/app/vendor/bundle/ruby/3.4.0/gems/actionpack-8.0.1/lib/action_controller/metal/basic_implicit_render.rb:8:in 'ActionController::BasicImplicitRender#send_action'",
+          "/app/lib/middleware/early.rb:11:in 'Middleware::Early#call'",
+        ]
+        # rubocop:enable Layout/LineLength
+      end
+      let(:expected_line_of_interest) do
+        "/app/app/controllers/api/events_controller.rb:11:in 'Api::EventsController#create'"
+      end
+
+      it 'returns only the lines of application code (and not the filter itself)' do
+        expect(application_stack_trace).to eq([expected_line_of_interest])
+      end
+    end
+  end
+end

--- a/spec/poros/stack_trace_filter_spec.rb
+++ b/spec/poros/stack_trace_filter_spec.rb
@@ -2,7 +2,9 @@ RSpec.describe(StackTraceFilter) do
   subject(:stack_trace_filter) { StackTraceFilter.new }
 
   describe '#application_stack_trace' do
-    subject(:application_stack_trace) { stack_trace_filter.application_stack_trace }
+    subject(:application_stack_trace) do
+      stack_trace_filter.application_stack_trace(ignore: [file_to_ignore])
+    end
 
     context 'when the caller has Dockerized file paths' do
       before do
@@ -12,13 +14,14 @@ RSpec.describe(StackTraceFilter) do
       let(:mocked_stack_trace) do
         # rubocop:disable Layout/LineLength
         [
-          "/app/app/models/event.rb:37:in 'Event.create_with_stack_trace!'",
+          "#{file_to_ignore}:37:in 'Event.create_with_stack_trace!'",
           expected_line_of_interest,
           "/app/vendor/bundle/ruby/3.4.0/gems/actionpack-8.0.1/lib/action_controller/metal/basic_implicit_render.rb:8:in 'ActionController::BasicImplicitRender#send_action'",
           "/app/lib/middleware/early.rb:11:in 'Middleware::Early#call'",
         ]
         # rubocop:enable Layout/LineLength
       end
+      let(:file_to_ignore) { '/app/app/models/event.rb' }
       let(:expected_line_of_interest) do
         "/app/app/controllers/api/events_controller.rb:11:in 'Api::EventsController#create'"
       end

--- a/spec/poros/stack_trace_filter_spec.rb
+++ b/spec/poros/stack_trace_filter_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe(StackTraceFilter) do
         "/app/app/controllers/api/events_controller.rb:11:in 'Api::EventsController#create'"
       end
 
-      it 'returns only the lines of application code (and not the filter itself)' do
+      it 'returns only unignored lines of application code' do
         expect(application_stack_trace).to eq([expected_line_of_interest])
       end
     end


### PR DESCRIPTION
Without this, in production, the whole stack trace was being included, because everything was being filtered out, because no paths included `/david_runger/`.