### PR TITLE
[SaveRequest::SkipChecker] Don't save api/events#create requests

### DIFF
--- a/app/poros/save_request/skip_checker.rb
+++ b/app/poros/save_request/skip_checker.rb
@@ -11,6 +11,7 @@ class SaveRequest::SkipChecker
       ['health_checks', _, _] |
       ['anonymous', _, _] |
       ['blog', 'assets', _] |
+      ['api/events', 'create', _] |
       [_, _, { uptime_robot: _ }]
     )
       true

--- a/spec/poros/save_request/skip_checker_spec.rb
+++ b/spec/poros/save_request/skip_checker_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe SaveRequest::SkipChecker do
       end
     end
 
+    context 'when the controller is api/events and the action is create' do
+      let(:params) { { 'controller' => 'api/events', 'action' => 'create' } }
+
+      it 'returns true' do
+        expect(skip?).to eq(true)
+      end
+    end
+
     context 'when uptime_robot is among the params keys' do
       let(:params) { { 'controller' => 'home', 'action' => 'index', 'uptime_robot' => '1' } }
 


### PR DESCRIPTION
These requests are largely redundant with the `Event` records that will also be created (and, in this case, we prefer to have the `Event` records rather than `Request` records).