### PR TITLE
Change timeseries.measurements column from json to jsonb [DEV-150]

### DIFF
--- a/app/models/timeseries.rb
+++ b/app/models/timeseries.rb
@@ -4,7 +4,7 @@
 #
 #  created_at   :datetime         not null
 #  id           :bigint           not null, primary key
-#  measurements :json             not null
+#  measurements :jsonb            not null
 #  name         :text             not null
 #  updated_at   :datetime         not null
 #

--- a/db/migrate/20250202174557_change_timeseries_measurements_to_jsonb.rb
+++ b/db/migrate/20250202174557_change_timeseries_measurements_to_jsonb.rb
@@ -1,0 +1,11 @@
+class ChangeTimeseriesMeasurementsToJsonb < ActiveRecord::Migration[8.0]
+  def up
+    # Change column type from json to jsonb
+    change_column :timeseries, :measurements, 'jsonb USING measurements::jsonb'
+  end
+
+  def down
+    # Rollback from jsonb to json
+    change_column :timeseries, :measurements, 'json USING measurements::json'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_02_071217) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_02_174557) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -339,7 +339,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_02_071217) do
 
   create_table "timeseries", force: :cascade do |t|
     t.text "name", null: false
-    t.json "measurements", default: [], null: false
+    t.jsonb "measurements", default: [], null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end


### PR DESCRIPTION
I think jsonb is probably somewhat better for our use case, and we use jsonb (rather than json) for all other JSON columns. To remain consistent and to enjoy the advantages of jsonb, this change converts the timeseries.measurements column from json to jsonb.