### PR TITLE
Remove :admin User factory trait & rename relevant fixture [DEV-153]

### DIFF
--- a/spec/actions/quiz_questions/create_from_list_spec.rb
+++ b/spec/actions/quiz_questions/create_from_list_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe QuizQuestions::CreateFromList do
       questions_list:,
     }
   end
-  let(:quiz) { create(:quiz, owner: users(:admin)) }
+  let(:quiz) { create(:quiz, owner: users(:married_user)) }
   let(:questions_list) do
     <<~QUESTIONS_LIST
       What's your Hogwarts house?

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -15,8 +15,14 @@ RSpec.describe ApplicationController, :without_verifying_authorization do
         context 'when no User is logged in' do
           before { controller.sign_out_all_scopes }
 
-          it 'returns the User with email "davidjrunger@gmail.com"' do
-            expect(current_user.email).to eq('davidjrunger@gmail.com')
+          context 'when there is a user with email "davidjrunger@gmail.com"' do
+            before { User.find_or_create_by!(email: david_runger_email) }
+
+            let(:david_runger_email) { 'davidjrunger@gmail.com' }
+
+            it 'returns the User with email "davidjrunger@gmail.com"' do
+              expect(current_user.email).to eq(david_runger_email)
+            end
           end
         end
       end

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe(ProposalsController) do
         ),
       }
     end
-    let(:proposer) { users(:admin) }
+    let(:proposer) { users(:single_user) }
     let(:proposee) { users(:user) }
 
     context 'when JWT_SECRET is set' do

--- a/spec/controllers/question_uploads_controller_spec.rb
+++ b/spec/controllers/question_uploads_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe QuestionUploadsController do
   before { sign_in(user) }
 
-  let(:user) { users(:admin) }
+  let(:user) { users(:married_user) }
   let(:quiz) { user.quizzes.first! }
 
   describe '#new' do

--- a/spec/controllers/quizzes_controller_spec.rb
+++ b/spec/controllers/quizzes_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe QuizzesController do
   before { sign_in(user) }
 
-  let(:user) { users(:admin) }
+  let(:user) { users(:married_user) }
 
   describe '#index' do
     subject(:get_index) { get(:index) }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -14,9 +14,5 @@
 FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
-
-    trait :admin do
-      email { 'davidjrunger@gmail.com' }
-    end
   end
 end

--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -7,14 +7,16 @@ RSpec.describe 'Logging in as an AdminUser via Google auth' do
 
     it 'allows the AdminUser to log in via Google' do
       visit(new_admin_user_session_path)
+
       expect(page).to have_css('button.google-login')
 
       expect { click_on(class: 'google-login') }.not_to change { AdminUser.count }
 
       visit(admin_root_path)
+
       expect(page).to have_text('David Runger')
       expect(page).to have_text('Dashboard')
-      expect(page).to have_text(admin_user.email)
+      expect(page).to have_text(/Recent Users.*#{User.last!.email}/)
     end
   end
 

--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Quizzes app' do
-  let(:quiz_owner) { users(:admin) }
+  let(:quiz_owner) { users(:married_user) }
   let(:existing_quiz) { quiz_owner.quizzes.first! }
   let(:participant) { users(:user) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe User do
 
     context 'when the user is married' do
       it "returns the user's spouse" do
-        expect(spouse).to eq(users(:admin))
+        expect(spouse).to eq(users(:married_user))
       end
     end
 

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -13,10 +13,10 @@ FixtureBuilder.configure do |fbuilder|
   fbuilder.factory do
     # users
     user = name(:user, create(:user)).first
-    admin = name(:admin, create(:user, :admin)).first
+    married_user = name(:married_user, create(:user)).first
     name(:single_user, create(:user))
 
-    # admin users
+    # AdminUsers
     admin_user = name(:admin_user, create(:admin_user, email: 'davidjrunger@gmail.com')).first
 
     # groceries
@@ -33,7 +33,7 @@ FixtureBuilder.configure do |fbuilder|
 
     create(
       :log,
-      user: admin,
+      user: married_user,
       name: 'Chinups',
       data_label: '# of chinups',
       data_type: 'counter',
@@ -76,11 +76,11 @@ FixtureBuilder.configure do |fbuilder|
     create(:banned_path_fragment, value: 'wordpress')
 
     # quizzes
-    quiz = create(:quiz, owner: admin)
+    quiz = create(:quiz, owner: married_user)
 
     # quiz participations
     participation = create(:quiz_participation, quiz:, participant: user)
-    participation_2 = create(:quiz_participation, quiz:, participant: admin)
+    participation_2 = create(:quiz_participation, quiz:, participant: married_user)
 
     # quiz questions
     quiz_question_1 = create(:quiz_question, quiz:)
@@ -101,7 +101,7 @@ FixtureBuilder.configure do |fbuilder|
     create(:quiz_question_answer_selection, answer: answer_2, participation: participation_2)
 
     # marriages
-    marriage = create(:marriage, partner_1: user, partner_2: admin)
+    marriage = create(:marriage, partner_1: user, partner_2: married_user)
 
     # emotional needs
     emotional_need = create(:emotional_need, marriage:)
@@ -111,7 +111,7 @@ FixtureBuilder.configure do |fbuilder|
 
     # need satisfaction ratings
     create(:need_satisfaction_rating, emotional_need:, check_in:, user:, score: 3)
-    create(:need_satisfaction_rating, emotional_need:, check_in:, user: admin, score: -3)
+    create(:need_satisfaction_rating, emotional_need:, check_in:, user: married_user, score: -3)
 
     # JSON Preferences
     create(:json_preference, :emoji_boosts, user:)
@@ -125,7 +125,7 @@ FixtureBuilder.configure do |fbuilder|
     # Events
     name(:event, create(:event, user:, admin_user:))
     create(:event, user:, admin_user: nil)
-    create(:event, user: admin, admin_user:)
+    create(:event, user: married_user, admin_user:)
     create(:event, user: nil, admin_user: nil)
   end
 end


### PR DESCRIPTION
This User factory trait is not relevant anymore, since https://github.com/davidrunger/david_runger/commit/3f50818b ("Check for AdminUser (not User#admin?) to authorize Sidekiq & Flipper"), which deleted `User::ADMIN_EMAILS` and User#admin? .