### PR TITLE
Rename ReificationsPolicy => ReificationPolicy (singular) [DEV-152]

### DIFF
--- a/app/controllers/api/reifications_controller.rb
+++ b/app/controllers/api/reifications_controller.rb
@@ -2,7 +2,7 @@ class Api::ReificationsController < Api::BaseController
   def create
     @version = PaperTrail::Version.find(params[:paper_trail_version_id])
 
-    authorize(@version, :create?, policy_class: ReificationsPolicy)
+    authorize(@version, :create?, policy_class: ReificationPolicy)
 
     @version.reify.save!
 

--- a/app/policies/reification_policy.rb
+++ b/app/policies/reification_policy.rb
@@ -1,4 +1,4 @@
-class ReificationsPolicy < ApplicationPolicy
+class ReificationPolicy < ApplicationPolicy
   def create?
     own_record?
   end


### PR DESCRIPTION
All of our other policy classes are named with a singular noun. This change renames `ReificationsPolicy` (plural) to `ReificationPolicy` (singular), in order to be consistent with that pattern.