### PR TITLE
Remove indexes on ip_blocks.isp and requests.isp [DEV-151]

### DIFF
--- a/app/models/ip_block.rb
+++ b/app/models/ip_block.rb
@@ -12,8 +12,7 @@
 #
 # Indexes
 #
-#  index_ip_blocks_on_ip   (ip) UNIQUE
-#  index_ip_blocks_on_isp  (isp)
+#  index_ip_blocks_on_ip  (ip) UNIQUE
 #
 class IpBlock < ApplicationRecord
   validates :ip,

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -29,7 +29,6 @@
 #  index_requests_on_auth_token_id  (auth_token_id)
 #  index_requests_on_handler        (handler)
 #  index_requests_on_ip             (ip)
-#  index_requests_on_isp            (isp)
 #  index_requests_on_request_id     (request_id) UNIQUE
 #  index_requests_on_requested_at   (requested_at)
 #  index_requests_on_user_id        (user_id)

--- a/db/migrate/20250202225737_remove_isp_indexes.rb
+++ b/db/migrate/20250202225737_remove_isp_indexes.rb
@@ -1,0 +1,6 @@
+class RemoveIspIndexes < ActiveRecord::Migration[8.0]
+  def change
+    remove_index :ip_blocks, :isp
+    remove_index :requests, :isp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_02_174557) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_02_225737) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -159,7 +159,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_02_174557) do
     t.string "isp"
     t.string "location"
     t.index ["ip"], name: "index_ip_blocks_on_ip", unique: true
-    t.index ["isp"], name: "index_ip_blocks_on_isp"
   end
 
   create_table "items", force: :cascade do |t|
@@ -314,7 +313,6 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_02_174557) do
     t.index ["auth_token_id"], name: "index_requests_on_auth_token_id"
     t.index ["handler"], name: "index_requests_on_handler"
     t.index ["ip"], name: "index_requests_on_ip"
-    t.index ["isp"], name: "index_requests_on_isp"
     t.index ["request_id"], name: "index_requests_on_request_id", unique: true
     t.index ["requested_at"], name: "index_requests_on_requested_at"
     t.index ["user_id"], name: "index_requests_on_user_id"

--- a/spec/factories/ip_blocks.rb
+++ b/spec/factories/ip_blocks.rb
@@ -12,8 +12,7 @@
 #
 # Indexes
 #
-#  index_ip_blocks_on_ip   (ip) UNIQUE
-#  index_ip_blocks_on_isp  (isp)
+#  index_ip_blocks_on_ip  (ip) UNIQUE
 #
 FactoryBot.define do
   factory :ip_block do

--- a/spec/factories/requests.rb
+++ b/spec/factories/requests.rb
@@ -29,7 +29,6 @@
 #  index_requests_on_auth_token_id  (auth_token_id)
 #  index_requests_on_handler        (handler)
 #  index_requests_on_ip             (ip)
-#  index_requests_on_isp            (isp)
 #  index_requests_on_request_id     (request_id) UNIQUE
 #  index_requests_on_requested_at   (requested_at)
 #  index_requests_on_user_id        (user_id)


### PR DESCRIPTION
I don't think that I ever use these indexes, so they're just wasting disk space and making inserts slower.