### PR TITLE
[specs] Consolidate error-handling examples and suppress actual logs

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -59,6 +59,7 @@ class ApplicationController < ActionController::Base
 
   def set_controller_action_in_context
     ActiveSupport::ExecutionContext[:controller_action] =
+      ActiveSupport::ExecutionContext.to_h[:controller_action] ||
       "#{params['controller']}##{params['action']}"
   end
 

--- a/spec/features/error_handling_spec.rb
+++ b/spec/features/error_handling_spec.rb
@@ -47,7 +47,10 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
             handled=false source=application.action_dispatch
             controller_action="home#upgrade_browser"
           ERROR_LOG
-          expect(Rails.logger).to have_received(:add).with(Logger::ERROR, /StandardError \(#{error_message}\)/)
+          expect(Rails.logger).to have_received(:add).with(
+            Logger::ERROR,
+            /StandardError \(#{error_message}\)/,
+          )
         end
       end
     end

--- a/spec/features/error_handling_spec.rb
+++ b/spec/features/error_handling_spec.rb
@@ -16,19 +16,27 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
       context 'when a non-RoutingError is raised' do
         before do
           expect(BrowserSupportChecker).to receive(:new).and_raise(StandardError.new(error_message))
+
+          # Don't actually write log messages for the error.
+          allow(Rails.logger).to receive(:error)
+          allow(Rails.logger).to receive(:add)
         end
 
         let(:error_message) { 'A BrowserSupportChecker instance could not be initialized!' }
 
-        it 'renders the 500 error page and responds with 500' do
+        it 'renders the 500 error page, responds with 500, does not expose the error message, and logs an error' do
           visit(upgrade_browser_path)
+
           expect(page).to have_css('h1', text: 'Sorry, something went wrong.')
           expect(page.status_code).to be(500)
-        end
-
-        it 'does not expose the error message' do
-          visit(upgrade_browser_path)
           expect(page).not_to have_text(error_message)
+          expect(Rails.logger).to have_received(:error).with(<<~ERROR_LOG.squish)
+            [error-report:error] StandardError : A BrowserSupportChecker
+            instance could not be initialized! |
+            handled=false source=application.action_dispatch
+            controller_action="home#upgrade_browser"
+          ERROR_LOG
+          expect(Rails.logger).to have_received(:add).with(Logger::ERROR, /#{error_message}/)
         end
       end
     end

--- a/spec/features/error_handling_spec.rb
+++ b/spec/features/error_handling_spec.rb
@@ -6,10 +6,21 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
       context 'when visiting a path that is not defined' do
         let(:nonexistent_path) { '/this-path-does-not-exist' }
 
+        before do
+          allow(Rails.logger).to receive(:warn)
+        end
+
         it 'says that the page does not exist and returns a 404' do
           visit(nonexistent_path)
           expect(page).to have_text("The page you were looking for doesn't exist.")
           expect(page.status_code).to be(404)
+          expect(Rails.logger).
+            to have_received(:warn).
+            with(%r{#{Regexp.escape(<<~WARN_LOG.squish)}})
+              [error-report:warning] ActionController::RoutingError :
+              No route matches [GET] "/this-path-does-not-exist" |
+              handled=true source=application controller_action="errors#not_found"
+            WARN_LOG
         end
       end
 

--- a/spec/features/error_handling_spec.rb
+++ b/spec/features/error_handling_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
 
         let(:error_message) { 'A BrowserSupportChecker instance could not be initialized!' }
 
-        fit 'renders the 500 error page, responds with 500, does not expose the error message, and logs an error' do
+        it 'renders the 500 error page, responds with 500, does not expose the error message, and logs an error' do
           visit(upgrade_browser_path)
 
           expect(page).to have_css('h1', text: 'Sorry, something went wrong.')

--- a/spec/features/error_handling_spec.rb
+++ b/spec/features/error_handling_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
 
         let(:error_message) { 'A BrowserSupportChecker instance could not be initialized!' }
 
-        it 'renders the 500 error page, responds with 500, does not expose the error message, and logs an error' do
+        it 'renders the 500 error page, responds with 500, does not expose the error message, and logs error messages' do
           visit(upgrade_browser_path)
 
           expect(page).to have_css('h1', text: 'Sorry, something went wrong.')
@@ -47,7 +47,7 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
             handled=false source=application.action_dispatch
             controller_action="home#upgrade_browser"
           ERROR_LOG
-          expect(Rails.logger).to have_received(:add).with(Logger::ERROR, /#{error_message}/)
+          expect(Rails.logger).to have_received(:add).with(Logger::ERROR, /StandardError \(#{error_message}\)/)
         end
       end
     end

--- a/spec/features/error_handling_spec.rb
+++ b/spec/features/error_handling_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
 
         let(:error_message) { 'A BrowserSupportChecker instance could not be initialized!' }
 
-        it 'renders the 500 error page, responds with 500, does not expose the error message, and logs an error' do
+        fit 'renders the 500 error page, responds with 500, does not expose the error message, and logs an error' do
           visit(upgrade_browser_path)
 
           expect(page).to have_css('h1', text: 'Sorry, something went wrong.')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,16 +71,16 @@ WebMock.disable_net_connect!(
 OmniAuth.config.test_mode = true
 
 if SpecHelper.is_ci?
-  # Capybara::Screenshot.s3_configuration = {
-  #   s3_client_credentials: {
-  #     access_key_id: Rails.application.credentials.aws![:access_key_id],
-  #     secret_access_key: Rails.application.credentials.aws![:secret_access_key],
-  #     region: 'us-east-1',
-  #   },
-  #   bucket_name: 'david-runger-test-uploads',
-  #   bucket_host: 'david-runger-test-uploads.s3.amazonaws.com',
-  #   key_prefix: 'failure-screenshots/',
-  # }
+  Capybara::Screenshot.s3_configuration = {
+    s3_client_credentials: {
+      access_key_id: Rails.application.credentials.aws![:access_key_id],
+      secret_access_key: Rails.application.credentials.aws![:secret_access_key],
+      region: 'us-east-1',
+    },
+    bucket_name: 'david-runger-test-uploads',
+    bucket_host: 'david-runger-test-uploads.s3.amazonaws.com',
+    key_prefix: 'failure-screenshots/',
+  }
 end
 
 Cuprite::CustomDrivers.register_with_capybara
@@ -403,9 +403,9 @@ RSpec.configure do |config|
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  # if !SpecHelper.is_ci?
+  if !SpecHelper.is_ci?
     config.filter_run_when_matching(:focus)
-  # end
+  end
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,16 +71,16 @@ WebMock.disable_net_connect!(
 OmniAuth.config.test_mode = true
 
 if SpecHelper.is_ci?
-  Capybara::Screenshot.s3_configuration = {
-    s3_client_credentials: {
-      access_key_id: Rails.application.credentials.aws![:access_key_id],
-      secret_access_key: Rails.application.credentials.aws![:secret_access_key],
-      region: 'us-east-1',
-    },
-    bucket_name: 'david-runger-test-uploads',
-    bucket_host: 'david-runger-test-uploads.s3.amazonaws.com',
-    key_prefix: 'failure-screenshots/',
-  }
+  # Capybara::Screenshot.s3_configuration = {
+  #   s3_client_credentials: {
+  #     access_key_id: Rails.application.credentials.aws![:access_key_id],
+  #     secret_access_key: Rails.application.credentials.aws![:secret_access_key],
+  #     region: 'us-east-1',
+  #   },
+  #   bucket_name: 'david-runger-test-uploads',
+  #   bucket_host: 'david-runger-test-uploads.s3.amazonaws.com',
+  #   key_prefix: 'failure-screenshots/',
+  # }
 end
 
 Cuprite::CustomDrivers.register_with_capybara

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -403,9 +403,9 @@ RSpec.configure do |config|
   # is tagged with `:focus`, all examples get run. RSpec also provides
   # aliases for `it`, `describe`, and `context` that include `:focus`
   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  if !SpecHelper.is_ci?
+  # if !SpecHelper.is_ci?
     config.filter_run_when_matching(:focus)
-  end
+  # end
 
   # Allows RSpec to persist some state between runs in order to support
   # the `--only-failures` and `--next-failure` CLI options. We recommend


### PR DESCRIPTION
With Cuprite-using feature specs, they are costly enough that it makes sense to consolidate multiple different expectations into a single example.

The spec(s) in question here are run with the `rack_test` driver, and so are much faster. However, I still don't know that the cost of splitting them up is justified. I don't think splitting these increases the clarity of the spec(s) very much, so I don't think there is much upside.

Also, this change suppresses logs from actually being written to `log/test.log` by stubbing some methods on `Rails.logger` (without `and_call_original`). Motivation: when looking at logs, these log lines seem concerning and like something that needs to be investigated, which is sort of a waste of time, because these log lines are expected. So, instead of actually writing the log lines, let's stub them.