### PR TITLE
[specs/feature] Write server log to file on spec failure [DEV-156]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,29 +44,37 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10 # this might cause issues if there are more than 10 commits in a PR (?)
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
+
       - uses: actions/setup-node@v4
         with:
           node-version-file: .node-version
+
       - name: Install pnpm
         run: npm install -g pnpm@9
+
       - name: Set pnpm store directory
         run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_ENV
+
       - uses: actions/cache@v4
         name: Set up pnpm cache
         with:
           path: ${{ env.PNPM_STORE_PATH }}
           key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: ${{ runner.os }}-pnpm-store-
+
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
           scandir: './bin'
+
       - name: Set GIT_REV environment variable
         uses: ./.github/actions/git_rev
+
       - name: Run tests & linters
         run: bin/run-tests
         env:
@@ -88,6 +96,15 @@ jobs:
           PERCY_TOKEN: '${{secrets.PERCY_TOKEN}}'
           CODECOV_TOKEN: '${{secrets.CODECOV_TOKEN}}'
           RAILS_MASTER_KEY: '${{secrets.RAILS_MASTER_KEY}}'
+
+      - name: Save failed feature spec logs
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: failed_feature_spec_logs
+          path: log/failed_feature_specs/
+          retention-days: 5
+
       - name: Save fixtures artifact
         uses: actions/upload-artifact@v4
         if: failure()
@@ -95,6 +112,7 @@ jobs:
           name: fixtures
           path: spec/fixtures/
           retention-days: 5
+
       - name: Upload Code Coverage
         uses: codecov/codecov-action@v5
         with:

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,15 +54,16 @@ Rails.application.configure do
   # Raise exceptions on deprecation notices.
   config.active_support.deprecation = :raise
 
-  if ENV.fetch('TEST_LOGGING', nil) == '1'
+  config.active_record.verbose_query_logs = true
+
+  config.log_level =
+    if ENV.fetch('TEST_LOGGING', nil) == '1'
+      # :nocov:
+      :debug
     # :nocov:
-    config.log_level = :debug
-    config.active_record.verbose_query_logs = true
-    # :nocov:
-  else
-    config.log_level = :warn
-    config.active_record.verbose_query_logs = false
-  end
+    else
+      :warn
+    end
 
   # Raises error for missing translations.
   # config.i18n.raise_on_missing_translations = true

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Groceries app' do
         click_on('Check in items in cart')
 
         expect(page).to have_vue_toast('Check-in successful!')
-        expect_needed(new_item_name, 0)
+        expect_needed(new_item_name, 10) # expect_needed(new_item_name, 0)
       end
     end
   end

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Groceries app' do
         click_on('Check in items in cart')
 
         expect(page).to have_vue_toast('Check-in successful!')
-        expect_needed(new_item_name, 10) # expect_needed(new_item_name, 0)
+        expect_needed(new_item_name, 0)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -213,7 +213,7 @@ RSpec.configure do |config|
 
     if example.exception
       # Prepare file name and directory
-      timestamp = example.execution_result.started_at.iso8601
+      timestamp = example.execution_result.started_at.in_time_zone.iso8601.tr(':', '-')
       description_as_brief_file_name =
         example.full_description.
           parameterize.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -198,14 +198,14 @@ RSpec.configure do |config|
     $test_log_string_io ||= StringIO.new
     $test_log_string_io.reopen
 
-    string_io_logger = ActiveSupport::Logger.new($test_log_string_io)
-    string_io_logger.formatter = Rails.logger.formatter.dup
-    string_io_logger.level = :debug
+    $string_io_logger ||= ActiveSupport::Logger.new($test_log_string_io)
+    $string_io_logger.formatter = Rails.logger.formatter.dup
+    $string_io_logger.level = :debug
 
-    Rails.with(logger: string_io_logger) do
-      Sidekiq.default_configuration.with(logger: string_io_logger) do
+    Rails.with(logger: $string_io_logger) do
+      Sidekiq.default_configuration.with(logger: $string_io_logger) do
         # We can't just do ActiveRecord::Base.with(...) because `with` is an ActiveRecord method.
-        Object.instance_method(:with).bind_call(ActiveRecord::Base, logger: string_io_logger) do
+        Object.instance_method(:with).bind_call(ActiveRecord::Base, logger: $string_io_logger) do
           example.run
         end
       end


### PR DESCRIPTION
This should be helpful to debug failing or (especially) flaking specs.

I ran the test suite 3 times on `main` and then 3 times on this branch. Results:

== main
1:29.49 total
1:23.02 total
1:20.45 total
Average: 1:24.3

== logs on failure
1:21.00 total
1:24.01 total
1:14.76 total
Average: 1:19.9

So, in those numbers, there's a 4.4 second speedup on this branch. I can't think of how/why this branch would really provide a speedup vs main, but the takeaway is that there does not appear to be a significant slowdown, at least.