### PR TITLE
[admin/deploys] Make Git SHAs GitHub commit links [ADM-1]

### DIFF
--- a/app/admin/deploys.rb
+++ b/app/admin/deploys.rb
@@ -4,7 +4,7 @@ ActiveAdmin.register(Deploy) do
 
   index do
     id_column
-    column :github_commit_link
+    column('Git SHA') { it.github_commit_link }
     column :created_at
     column :updated_at
     actions
@@ -13,7 +13,7 @@ ActiveAdmin.register(Deploy) do
   show do
     attributes_table do
       row :id
-      row :github_commit_link
+      row('Git SHA') { it.github_commit_link }
       row :created_at
       row :updated_at
     end

--- a/app/admin/deploys.rb
+++ b/app/admin/deploys.rb
@@ -1,3 +1,23 @@
 ActiveAdmin.register(Deploy) do
+  decorate_with DeployDecorator
   menu parent: 'Admin'
+
+  index do
+    id_column
+    column :github_commit_link
+    column :created_at
+    column :updated_at
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :id
+      row :github_commit_link
+      row :created_at
+      row :updated_at
+    end
+
+    active_admin_comments
+  end
 end

--- a/app/decorators/deploy_decorator.rb
+++ b/app/decorators/deploy_decorator.rb
@@ -1,0 +1,14 @@
+class DeployDecorator < Draper::Decorator
+  delegate_all
+
+  def github_commit_link
+    h.link_to(
+      git_sha,
+      "https://github.com/davidrunger/david_runger/commit/#{git_sha}",
+    )
+  end
+
+  def to_s
+    "Deploy of #{git_sha.first(8)}"
+  end
+end

--- a/spec/controllers/admin/deploys_controller_spec.rb
+++ b/spec/controllers/admin/deploys_controller_spec.rb
@@ -30,9 +30,9 @@ RSpec.describe Admin::DeploysController do
         expect(response).to have_http_status(200)
 
         expect(response.body).to have_link(
-            deploy.git_sha,
-            href: "https://github.com/davidrunger/david_runger/commit/#{deploy.git_sha}",
-          )
+          deploy.git_sha,
+          href: "https://github.com/davidrunger/david_runger/commit/#{deploy.git_sha}",
+        )
       end
     end
   end

--- a/spec/controllers/admin/deploys_controller_spec.rb
+++ b/spec/controllers/admin/deploys_controller_spec.rb
@@ -5,11 +5,16 @@ RSpec.describe Admin::DeploysController do
     describe '#index' do
       subject(:get_index) { get(:index) }
 
-      it 'lists deploys' do
+      it 'lists deploys with the commit SHA as a GitHub link' do
         get_index
 
+        expect(response).to have_http_status(200)
+
         Deploy.all.presence!.each do |deploy|
-          expect(response.body).to have_text(deploy.git_sha)
+          expect(response.body).to have_link(
+            deploy.git_sha,
+            href: "https://github.com/davidrunger/david_runger/commit/#{deploy.git_sha}",
+          )
         end
       end
     end
@@ -19,11 +24,15 @@ RSpec.describe Admin::DeploysController do
 
       let(:deploy) { deploys(:deploy) }
 
-      it 'responds with 200' do
+      it 'responds with 200 and links to the commit on GitHub' do
         get_show
 
         expect(response).to have_http_status(200)
-        expect(response.body).to have_text(deploy.git_sha)
+
+        expect(response.body).to have_link(
+            deploy.git_sha,
+            href: "https://github.com/davidrunger/david_runger/commit/#{deploy.git_sha}",
+          )
       end
     end
   end


### PR DESCRIPTION
This will make it more convenient / faster to see what a particular deploy was deploying.

A single deploy could include multiple new commits, and so a compare view from the previously deployed SHA to the SHA of each deploy in question would probably be a better approach. However, that would be somewhat difficult to do without an N + 1 query; at least, I don't think it would be straightforward to do while simply leveraging ActiveAdmin's capacity to automatically construct most of the view. So, for now, for simplicity, I am going to just ship this change. I think that hopefully this 20% of the work will still deliver 80% of the possible benefits.

Also, while looking at the show page and creating a decorator, make the main title prettier by defining a `to_s` method on the decorator.