### PR TITLE
Bump pry-byebug from f6f73023 to 3ac27ef7 [DEV-157]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,11 +8,11 @@ GIT
 
 GIT
   remote: https://github.com/davidrunger/pry-byebug.git
-  revision: f6f73023ba081630ddee32ae4399fb31706f074f
+  revision: 3ac27ef70a1b16a461db9f7572d3fe1a205effd4
   specs:
     pry-byebug (3.10.1)
-      byebug (>= 11.0)
       pry (>= 0.13)
+      runger_byebug (>= 11.0)
 
 GIT
   remote: https://github.com/davidrunger/typelizer.git
@@ -157,7 +157,6 @@ GEM
     bullet (8.0.0)
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
-    byebug (11.1.3)
     capybara (3.40.0)
       addressable
       matrix
@@ -608,6 +607,7 @@ GEM
       memo_wise (>= 1.7)
       rails (>= 6)
       shaped (>= 0.9)
+    runger_byebug (11.2.0)
     runger_config (5.2.0)
       activesupport (>= 7.1.2)
     runger_email_reply_trimmer (0.3.0)
@@ -855,7 +855,6 @@ CHECKSUMS
   browser (6.2.0) sha256=281d5295788825c9396427c292c2d2be0a5c91875c93c390fde6e5d61a5ace2d
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bullet (8.0.0) sha256=77f02fde19a1dfef028db42535e581b2b7b49906be5aa934494f1365a478de4d
-  byebug (11.1.3) sha256=2485944d2bb21283c593d562f9ae1019bf80002143cc3a255aaffd4e9cf4a35b
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   capybara-email (3.0.2) sha256=ab65dd9b15c096b1ebe24308d18d790eb08814f916883ebccbc1cf46f760696f
   capybara-screenshot (1.0.26) sha256=816b9370a07752097c82a05f568aaf5d3b7f45c3db5d3aab2014071e1b3c0c77
@@ -1045,6 +1044,7 @@ CHECKSUMS
   ruby-progressbar (1.13.0) sha256=80fc9c47a9b640d6834e0dc7b3c94c9df37f08cb072b7761e4a71e22cff29b33
   ruby2_keywords (0.0.5) sha256=ffd13740c573b7301cf7a2e61fc857b2a8e3d3aff32545d6f8300d8bae10e3ef
   runger_actions (0.24.0) sha256=727c8a11b544ec94739028cc9123ee6692175472486a1a5223bf2ad5804ca9b9
+  runger_byebug (11.2.0) sha256=b0aa26d5997bca1c060242b405eeb2a66cff30ad4266689fd60dcf434176a057
   runger_config (5.2.0) sha256=9b76d767a2daa63f6f8f2c52a8183f3f09a877cd35bcaee692d25377f4dd4558
   runger_email_reply_trimmer (0.3.0) sha256=068aa90311da474065f604cf29704785bb36d511a5d5e4031fc87fef8bbd9ac7
   runger_style (4.3.0) sha256=543c2414626d9084fef8fd057bf561c702e395f35e7af4ee6ee403276cf60614


### PR DESCRIPTION
This should fix these warnings that we see when dropping into byebug:

> /home/david/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/bundler/gems/pry-byebug-f6f73023ba08/lib/byebug/processors/pry_processor.rb:17: warning: undefining the allocator of T_DATA class Byebug::ThreadsTable

> /home/david/.rbenv/versions/3.4.1/lib/ruby/gems/3.4.0/bundler/gems/pry-byebug-f6f73023ba08/lib/byebug/processors/pry_processor.rb:17: warning: undefining the allocator of T_DATA class Byebug::Context