### PR TITLE
[home] Save scroll Events [HOME-13]

### DIFF
--- a/app/javascript/home/Home.vue
+++ b/app/javascript/home/Home.vue
@@ -29,6 +29,7 @@
 import { onMounted } from 'vue';
 
 import { useExternalLinkTracking } from '@/lib/composables/use_external_link_tracking';
+import { useScrollTracking } from '@/lib/composables/use_scroll_tracking';
 import { isMobileDevice } from '@/lib/is_mobile_device';
 
 import About from './components/About.vue';
@@ -40,6 +41,7 @@ import Resume from './components/Resume.vue';
 import Skills from './components/Skills.vue';
 
 useExternalLinkTracking();
+useScrollTracking();
 
 onMounted(() => {
   setScrollToFragmentTimeouts();

--- a/app/javascript/lib/composables/use_scroll_tracking.ts
+++ b/app/javascript/lib/composables/use_scroll_tracking.ts
@@ -1,0 +1,25 @@
+import { onMounted, onUnmounted } from 'vue';
+
+import { trackEvent } from '@/lib/events';
+
+let trackedScrollEvent = false
+
+function trackScrollEvent() {
+  if (!trackedScrollEvent) {
+    trackEvent('scroll', {
+      page_url: window.location.href,
+    });
+
+    trackedScrollEvent = true;
+  }
+}
+
+export function useScrollTracking() {
+  onMounted(() => {
+    window.addEventListener('scroll', trackScrollEvent);
+
+    onUnmounted(() => {
+      window.removeEventListener('scroll', trackScrollEvent);
+    });
+  });
+}

--- a/app/javascript/lib/composables/use_scroll_tracking.ts
+++ b/app/javascript/lib/composables/use_scroll_tracking.ts
@@ -2,7 +2,7 @@ import { onMounted, onUnmounted } from 'vue';
 
 import { trackEvent } from '@/lib/events';
 
-let trackedScrollEvent = false
+let trackedScrollEvent = false;
 
 function trackScrollEvent() {
   if (!trackedScrollEvent) {


### PR DESCRIPTION
This will probably be a decent indicator of a real human user, which is something that I am interested in.

This change only creates one scroll Event per page load. A user might trigger very many scroll events, but there's only really value in storing one.