### PR TITLE
[spec/features/logs] Refer to download location as Capybara.save_path

### DIFF
--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -184,13 +184,14 @@ RSpec.describe 'Logs app' do
         it 'allows the user to download a CSV with the log data' do
           visit(log_path(slug: log.slug))
 
-          Rails.root.glob('tmp/capybara/*.csv').each { FileUtils.rm(it) }
+          csv_glob = Capybara.save_path.join('*.csv')
+          Rails.root.glob(csv_glob).each { FileUtils.rm(it) }
 
           click_on('Download CSV')
 
-          wait_for { Rails.root.glob('tmp/capybara/*.csv') }.to be_present
+          wait_for { Rails.root.glob(csv_glob) }.to be_present
 
-          downloaded_csv_path = Rails.root.glob('tmp/capybara/*.csv').last
+          downloaded_csv_path = Rails.root.glob(csv_glob).last
           csv = CSV.read(downloaded_csv_path, headers: true)
 
           expect(csv.headers).to eq(['Time', log.data_label])


### PR DESCRIPTION
... rather than hardcoding it as `Rails.root` + `tmp/capybara`.

Also, DRY up the references to it.

This is just a refactor; not a substantive change.