### PR TITLE
Bump postgres from 16.3 to 17.2 [DEV-113]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -199,13 +199,13 @@ services:
       interval: 5m
       timeout: 1s
       retries: 1
-    image: postgres:16.3-alpine
+    image: postgres:17.2-alpine
     logging: *default-logging
     memswap_limit: 99G
     networks:
       - internal
     volumes:
-      - postgresql:/var/lib/postgresql/data
+      - postgres-data-v17:/var/lib/postgresql/data
   prometheus:
     cpu_shares: 512
     expose:
@@ -353,5 +353,5 @@ volumes:
   app-public:
   grafana-data:
   loki-data:
-  postgresql:
+  postgres-data-v17:
   redis:

--- a/docs/postgres-16-to-17-upgrade.sh
+++ b/docs/postgres-16-to-17-upgrade.sh
@@ -16,15 +16,6 @@ docker compose exec postgres psql -U david_runger david_runger_production -c 'SE
 # [ON LOCAL] Create database backup in S3.
 bin/qr
 
-# Create database backup on server.
-docker compose exec postgres pg_dumpall -U david_runger > backup.sql
-
-# Check git status.
-git status
-
-# Check that the backup file is approximately the expected size.
-ls -lah backup.sql
-
 # Update Postgres from 16.3 to 17.2 in docker-compose.yml.
 sed -i 's/postgres:16.3-alpine/postgres:17.2-alpine/g' docker-compose.yml
 
@@ -45,6 +36,15 @@ docker images postgres
 
 # Stop services that access the database.
 docker compose stop clock nginx web worker
+
+# Create database backup on server.
+docker compose exec postgres pg_dumpall -U david_runger > backup.sql
+
+# Check git status.
+git status
+
+# Check that the backup file is approximately the expected size.
+ls -lah backup.sql
 
 # Bring down the database.
 docker compose down postgres

--- a/docs/postgres-16-to-17-upgrade.sh
+++ b/docs/postgres-16-to-17-upgrade.sh
@@ -16,6 +16,9 @@ docker compose exec postgres psql -U david_runger david_runger_production -c 'SE
 # Check data (to have a point of comparison later).
 docker compose exec postgres psql -U david_runger david_runger_production -c 'SELECT COUNT(*) FROM users; SELECT * FROM text_log_entry_data ORDER BY created_at DESC LIMIT 1;'
 
+# [ON LOCAL] Create database backup in S3.
+bin/qr
+
 # Update Postgres from 16.3 to 17.2 in docker-compose.yml.
 sed -i 's/postgres:16.3-alpine/postgres:17.2-alpine/g' docker-compose.yml
 
@@ -33,9 +36,6 @@ docker compose pull postgres
 
 # Check that the Postgres 17 image is available.
 docker images postgres
-
-# [ON LOCAL] Create database backup in S3.
-bin/qr
 
 # Stop services that access the database.
 docker compose stop clock nginx web worker

--- a/docs/postgres-16-to-17-upgrade.sh
+++ b/docs/postgres-16-to-17-upgrade.sh
@@ -16,9 +16,6 @@ docker compose exec postgres psql -U david_runger david_runger_production -c 'SE
 # Check data (to have a point of comparison later).
 docker compose exec postgres psql -U david_runger david_runger_production -c 'SELECT COUNT(*) FROM users; SELECT * FROM text_log_entry_data ORDER BY created_at DESC LIMIT 1;'
 
-# [ON LOCAL] Create database backup in S3.
-bin/qr
-
 # Update Postgres from 16.3 to 17.2 in docker-compose.yml.
 sed -i 's/postgres:16.3-alpine/postgres:17.2-alpine/g' docker-compose.yml
 
@@ -36,6 +33,9 @@ docker compose pull postgres
 
 # Check that the Postgres 17 image is available.
 docker images postgres
+
+# [ON LOCAL] Create database backup in S3.
+bin/qr
 
 # Stop services that access the database.
 docker compose stop clock nginx web worker

--- a/docs/postgres-16-to-17-upgrade.sh
+++ b/docs/postgres-16-to-17-upgrade.sh
@@ -52,7 +52,7 @@ ls -lah backup.sql
 # Bring down the database.
 docker compose down postgres
 
-# Check Docker processes. Expect not to see the services just taken down.
+# Check Docker processes. Expect not to see the stopped / down services.
 docker ps
 
 # Bring up the database (version 17).

--- a/docs/postgres-16-to-17-upgrade.sh
+++ b/docs/postgres-16-to-17-upgrade.sh
@@ -7,6 +7,9 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 # Check git status.
 git status
 
+# Check git HEAD.
+git show
+
 # Check version (expect PostgreSQL 16.3).
 docker compose exec postgres psql -U david_runger david_runger_production -c 'SELECT VERSION();'
 

--- a/docs/postgres-16-to-17-upgrade.sh
+++ b/docs/postgres-16-to-17-upgrade.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+# Make sure that PR to update docker-compose.yml to Postgres 17 is ready to merge.
+
+# Check git status.
+git status
+
+# Check version (expect PostgreSQL 16.3).
+docker compose exec postgres psql -U david_runger david_runger_production -c 'SELECT VERSION();'
+
+# Check data (to have a point of comparison later).
+docker compose exec postgres psql -U david_runger david_runger_production -c 'SELECT COUNT(*) FROM users; SELECT * FROM text_log_entry_data ORDER BY created_at DESC LIMIT 1;'
+
+# [ON LOCAL] Create database backup in S3.
+bin/qr
+
+# Create database backup on server.
+docker compose exec postgres pg_dumpall -U david_runger > backup.sql
+
+# Check git status.
+git status
+
+# Check that the backup file is approximately the expected size.
+ls -lah backup.sql
+
+# Update Postgres from 16.3 to 17.2 in docker-compose.yml.
+sed -i 's/postgres:16.3-alpine/postgres:17.2-alpine/g' docker-compose.yml
+
+# Switch to new Postgres data volume in docker-compose.yml.
+sed -i 's/postgresql:/postgres-data-v17:/g' docker-compose.yml
+
+# Check git status.
+git status
+
+# View git diff.
+git diff
+
+# Pull the new Postgres 17 image (to minimize downtime).
+docker compose pull postgres
+
+# Check that the Postgres 17 image is available.
+docker images postgres
+
+# Stop services that access the database.
+docker compose stop clock nginx web worker
+
+# Bring down the database.
+docker compose down postgres
+
+# Check Docker processes. Expect not to see the services just taken down.
+docker ps
+
+# Bring up the database (version 17).
+docker compose up --detach postgres
+
+# Check version (expect PostgreSQL 17.2).
+docker compose exec postgres psql -U david_runger -c 'SELECT VERSION();'
+
+# Restore data from dump.
+docker compose exec --no-TTY postgres psql -U david_runger < backup.sql
+
+# Check data.
+docker compose exec postgres psql -U david_runger david_runger_production -c 'SELECT COUNT(*) FROM users; SELECT * FROM text_log_entry_data ORDER BY created_at DESC LIMIT 1;'
+
+# Boot services.
+bin/server/boot-services.sh
+
+# Verify services.
+bin/server/verify-expected-services.sh
+
+# Check git status.
+git status
+
+# Delete dump.
+rm backup.sql
+
+# Undo changes to docker-compose.yml.
+git checkout .
+
+# Check git status.
+git status
+
+# Check git HEAD.
+git show
+
+# Remove old data volume.
+docker volume rm david_runger_postgresql
+
+# Merge PR to update Postgres version and reference postgres v17 volume in docker-compose.yml.
+# Wait for it to deploy.
+
+# Check version (expect PostgreSQL 17.2).
+docker compose exec postgres psql -U david_runger david_runger_production -c 'SELECT VERSION();'
+
+# Check data is still good.
+docker compose exec postgres psql -U david_runger david_runger_production -c 'SELECT COUNT(*) FROM users; SELECT * FROM text_log_entry_data ORDER BY created_at DESC LIMIT 1;'
+
+# Check git status.
+git status
+
+# Check git HEAD.
+git show


### PR DESCRIPTION
Also, add script documenting upgrade plan.

Also, change the name of the volume that we are attaching to the postgres service. This will give us a "fresh start", which we sort of need, because otherwise Postgres will complain/error that the data was created with Postgres 16 but we are now running on Postgres 17. The data will be copied from the old volume to the new volume by dumping a backup from version 16 and then restoring from that backup after we are on version 17.

NOTE: The `docs/postgres-16-to-17-upgrade.sh` script being added here is not for execution as a script. Rather, this is a playbook of commands that I plan to manually copy-paste for execution on the server. I am adding the script for documentation (hence why it is in `docs/`) and so that hopefully I can reuse it (maybe with some tweaks) when doing future Postgres upgrades.