### PR TITLE
Wrap 'MemoWise' in a generically named 'Memoization' class [DEV-112]

### DIFF
--- a/app/actions/proposals/accept.rb
+++ b/app/actions/proposals/accept.rb
@@ -1,5 +1,5 @@
 class Proposals::Accept < ApplicationAction
-  prepend MemoWise
+  prepend Memoization
 
   requires :encoded_token, String
   requires :proposee, User
@@ -15,17 +15,17 @@ class Proposals::Accept < ApplicationAction
     Marriage.where(partner_1: proposee).where(partner_2: nil).find_each(&:destroy!)
   end
 
-  memo_wise \
+  memoize \
   def marriage
     proposer.marriage || Marriage.build(partner_1: proposer)
   end
 
-  memo_wise \
+  memoize \
   def proposer
     User.find(proposer_id)
   end
 
-  memo_wise \
+  memoize \
   def proposer_id
     JWT.decode(
       encoded_token,

--- a/app/controllers/api/csp_reports_controller.rb
+++ b/app/controllers/api/csp_reports_controller.rb
@@ -1,5 +1,5 @@
 class Api::CspReportsController < Api::BaseController
-  prepend MemoWise
+  prepend Memoization
 
   IGNORED_USER_AGENTS = [
     /DuckDuckBot/,
@@ -37,12 +37,12 @@ class Api::CspReportsController < Api::BaseController
 
   private
 
-  memo_wise \
+  memoize \
   def csp_report_params
     JSON(request.raw_post)['csp-report']
   end
 
-  memo_wise \
+  memoize \
   def send_csp_violation_to_rollbar?
     IGNORED_USER_AGENTS.none? { request.user_agent.match?(_1) }
   end

--- a/app/controllers/concerns/browser_support_checkable.rb
+++ b/app/controllers/concerns/browser_support_checkable.rb
@@ -1,6 +1,6 @@
 module BrowserSupportCheckable
   extend ActiveSupport::Concern
-  prepend MemoWise
+  prepend Memoization
 
   included do
     helper_method :browser_support_checker
@@ -8,7 +8,7 @@ module BrowserSupportCheckable
 
   private
 
-  memo_wise \
+  memoize \
   def browser_support_checker
     BrowserSupportChecker.new(browser)
   end

--- a/app/controllers/concerns/request_recordable.rb
+++ b/app/controllers/concerns/request_recordable.rb
@@ -1,6 +1,6 @@
 module RequestRecordable
   extend ActiveSupport::Concern
-  prepend MemoWise
+  prepend Memoization
 
   # The number of seconds to store request data in Redis (to later turn into a `Request`). Set to
   # 21.days because that's ~ how long Sidekiq (which processes this data) will attempt retries for.
@@ -28,7 +28,7 @@ module RequestRecordable
     "request_data:#{request.request_id.presence!('No request_id')}:initial"
   end
 
-  memo_wise \
+  memoize \
   def request_data
     SaveRequest::RequestDataBuilder.new(
       request:,

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -1,19 +1,19 @@
 module TokenAuthenticatable
   extend ActiveSupport::Concern
-  prepend MemoWise
+  prepend Memoization
 
   class InvalidToken < StandardError ; end
 
   private
 
-  memo_wise \
+  memoize \
   def auth_token
     return nil if auth_token_param.blank?
 
     AuthToken.find_by(secret: auth_token_param)
   end
 
-  memo_wise \
+  memoize \
   def auth_token_param
     auth_token_param = params[:auth_token]
     # For AuthTokensController requests, the top-level `auth_token` param might be a hash, which we
@@ -21,7 +21,7 @@ module TokenAuthenticatable
     auth_token_param.is_a?(String) ? auth_token_param : nil
   end
 
-  memo_wise \
+  memoize \
   def auth_token_user
     auth_token&.user
   end

--- a/app/controllers/log_entries_controller.rb
+++ b/app/controllers/log_entries_controller.rb
@@ -1,5 +1,5 @@
 class LogEntriesController < ApplicationController
-  prepend MemoWise
+  prepend Memoization
 
   def create
     if log && new_entry_param
@@ -16,12 +16,12 @@ class LogEntriesController < ApplicationController
 
   private
 
-  memo_wise \
+  memoize \
   def log
     auth_token_user&.logs&.find_by(slug: params[:slug].presence)
   end
 
-  memo_wise \
+  memoize \
   def new_entry_param
     params[:new_entry].presence
   end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -1,5 +1,5 @@
 class QuizzesController < ApplicationController
-  prepend MemoWise
+  prepend Memoization
   include CspDisableable
 
   self.container_classes = %w[py-2 px-8]
@@ -101,7 +101,7 @@ class QuizzesController < ApplicationController
 
   # rubocop:disable Style/MethodCallWithArgsParentheses
   helper_method \
-  memo_wise \
+  memoize \
   def current_user_participation
     @quiz.participations.find_by(participant_id: current_user)
   end

--- a/app/decorators/check_in_decorator.rb
+++ b/app/decorators/check_in_decorator.rb
@@ -1,44 +1,44 @@
 class CheckInDecorator < Draper::Decorator
-  prepend MemoWise
+  prepend Memoization
 
   delegate_all
 
-  memo_wise \
+  memoize \
   def check_in_number
     marriage.check_ins.where(check_ins: { created_at: ..created_at }).size
   end
 
-  memo_wise \
+  memoize \
   def submitted_by_both_partners?
     submitted_by_partner? && submitted_by_self?
   end
 
-  memo_wise \
+  memoize \
   def all_ratings_scored_by_self?
     own_ratings.completed.size == emotional_needs_for_check_in.size
   end
 
-  memo_wise \
+  memoize \
   def submitted_by_partner?
     marriage.decorate.other_partner.check_in_submissions.exists?(check_in_id: id)
   end
 
-  memo_wise \
+  memoize \
   def submitted_by_self?
     h.current_user.check_in_submissions.exists?(check_in_id: id)
   end
 
-  memo_wise \
+  memoize \
   def emotional_needs_for_check_in
     marriage.emotional_needs.where(emotional_needs: { created_at: ..created_at })
   end
 
-  memo_wise \
+  memoize \
   def pretty_created_at
     object.created_at.strftime('%-m/%-d/%y')
   end
 
-  memo_wise \
+  memoize \
   def own_ratings
     need_satisfaction_ratings.where(user: h.current_user)
   end

--- a/app/decorators/concerns/user_agent_decoratable.rb
+++ b/app/decorators/concerns/user_agent_decoratable.rb
@@ -1,5 +1,5 @@
 module UserAgentDecoratable
-  prepend MemoWise
+  prepend Memoization
 
   def pretty_user_agent
     if good_browser_data?
@@ -16,7 +16,7 @@ module UserAgentDecoratable
       browser_name != 'Unknown Browser'
   end
 
-  memo_wise \
+  memoize \
   def browser
     Browser.new(user_agent)
   end

--- a/app/decorators/marriage_decorator.rb
+++ b/app/decorators/marriage_decorator.rb
@@ -1,9 +1,9 @@
 class MarriageDecorator < Draper::Decorator
-  prepend MemoWise
+  prepend Memoization
 
   delegate_all
 
-  memo_wise \
+  memoize \
   def other_partner
     partner_ids = [partner_1_id, partner_2_id]
     partner_id = (partner_ids - [h.current_user.id]).first

--- a/app/decorators/quiz_decorator.rb
+++ b/app/decorators/quiz_decorator.rb
@@ -1,9 +1,9 @@
 class QuizDecorator < Draper::Decorator
-  prepend MemoWise
+  prepend Memoization
 
   delegate_all
 
-  memo_wise \
+  memoize \
   def current_user_participation!
     h.current_user_participation.presence!
   end
@@ -40,7 +40,7 @@ class QuizDecorator < Draper::Decorator
       end
   end
 
-  memo_wise \
+  memoize \
   def question_count
     questions.count
   end

--- a/app/decorators/quiz_participation_decorator.rb
+++ b/app/decorators/quiz_participation_decorator.rb
@@ -1,9 +1,9 @@
 class QuizParticipationDecorator < Draper::Decorator
-  prepend MemoWise
+  prepend Memoization
 
   delegate_all
 
-  memo_wise \
+  memoize \
   def correct_answer_count
     correct_answer_selections.length
   end

--- a/app/decorators/request_decorator.rb
+++ b/app/decorators/request_decorator.rb
@@ -1,5 +1,5 @@
 class RequestDecorator < Draper::Decorator
-  prepend MemoWise
+  prepend Memoization
   include UserAgentDecoratable
 
   delegate_all

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -5,9 +5,9 @@ class ApplicationRecord < ActiveRecord::Base
   strip_attributes
 
   class << self
-    prepend MemoWise
+    prepend Memoization
 
-    memo_wise \
+    memoize \
     def serializer_class
       "#{name}Serializer".constantize
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,7 @@
 #  index_users_on_email  (email) UNIQUE
 #
 class User < ApplicationRecord
-  prepend MemoWise
+  prepend Memoization
 
   validates :email, presence: true, uniqueness: true, format: { with: /\A\S+@\S+\.\S+\z/ }
 
@@ -68,12 +68,12 @@ class User < ApplicationRecord
     %w[created_at email id updated_at]
   end
 
-  memo_wise \
+  memoize \
   def marriage
     Marriage.where(partner_1_id: id).or(Marriage.where(partner_2_id: id)).first
   end
 
-  memo_wise \
+  memoize \
   def spouse
     [marriage&.partner_1, marriage&.partner_2].compact.reject { _1.id == id }.first
   end

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -1,7 +1,7 @@
 class JsonSchemaValidator
   class NonconformingData < StandardError ; end
 
-  prepend MemoWise
+  prepend Memoization
 
   def initialize(data, controller_action:)
     @data = data
@@ -35,7 +35,7 @@ class JsonSchemaValidator
 
   private
 
-  memo_wise \
+  memoize \
   def schema_validation_errors
     JSON::Validator.fully_validate(
       absolute_schema_path,
@@ -62,23 +62,23 @@ class JsonSchemaValidator
     @data.is_a?(String) ? @data : @data.to_json
   end
 
-  memo_wise \
+  memoize \
   def universal_bootstrap_data?
     @data.is_a?(Hash) &&
       (@data.keys - %i[current_user nonce toast_messages]).empty?
   end
 
-  memo_wise \
+  memoize \
   def schema_file_exists?
     File.exist?(absolute_schema_path)
   end
 
-  memo_wise \
+  memoize \
   def absolute_schema_path
     Rails.root.join(relative_schema_path).to_s
   end
 
-  memo_wise \
+  memoize \
   def relative_schema_path
     if api?
       "spec/support/schemas/#{@controller_action}.json"
@@ -87,7 +87,7 @@ class JsonSchemaValidator
     end
   end
 
-  memo_wise \
+  memoize \
   def api?
     @controller_action.start_with?('api/')
   end

--- a/app/poros/redis_options.rb
+++ b/app/poros/redis_options.rb
@@ -1,18 +1,18 @@
 class RedisOptions
-  prepend MemoWise
+  prepend Memoization
 
   def initialize(db: nil)
     @db = db || default_db_number
   end
 
-  memo_wise \
+  memoize \
   def url
     "#{url_without_db}/#{@db}"
   end
 
   private
 
-  memo_wise \
+  memoize \
   def url_without_db
     case ENV.fetch('RAILS_ENV')
     when 'development', 'test' then ENV.fetch('REDIS_URL', 'redis://localhost:6379')
@@ -20,7 +20,7 @@ class RedisOptions
     end
   end
 
-  memo_wise \
+  memoize \
   def default_db_number
     if defined?(Rails) && Rails.env.test?
       # piggyback on the Postgres DB_SUFFIX ENV variable to choose a Redis DB number

--- a/app/poros/save_request/request_data_builder.rb
+++ b/app/poros/save_request/request_data_builder.rb
@@ -1,5 +1,5 @@
 class SaveRequest::RequestDataBuilder
-  prepend MemoWise
+  prepend Memoization
 
   # params not worth logging in `Request`s
   BORING_PARAMS = %w[
@@ -31,7 +31,7 @@ class SaveRequest::RequestDataBuilder
     @request_time = request_time
   end
 
-  memo_wise \
+  memoize \
   def request_data
     @request_data = {
       admin_user_id: @admin_user&.id,
@@ -51,7 +51,7 @@ class SaveRequest::RequestDataBuilder
 
   private
 
-  memo_wise \
+  memoize \
   def raw_user_agent
     @request.user_agent&.encode('UTF-8', invalid: :replace, undef: :replace, replace: '')
   end

--- a/app/poros/save_request/stashed_data_manager.rb
+++ b/app/poros/save_request/stashed_data_manager.rb
@@ -1,41 +1,41 @@
 class SaveRequest::StashedDataManager
-  prepend MemoWise
+  prepend Memoization
 
   def initialize(request_id)
     @request_id = request_id
   end
 
-  memo_wise \
+  memoize \
   def stashed_data
     initial_stashed_data.merge(final_stashed_data)
   end
 
-  memo_wise \
+  memoize \
   def initial_request_data_redis_key
     "request_data:#{@request_id}:initial"
   end
 
-  memo_wise \
+  memoize \
   def initial_stashed_json
     $redis_pool.with { |conn| conn.call('get', initial_request_data_redis_key) }
   end
 
-  memo_wise \
+  memoize \
   def initial_stashed_data
     JSON.parse(initial_stashed_json)
   end
 
-  memo_wise \
+  memoize \
   def final_request_data_redis_key
     "request_data:#{@request_id}:final"
   end
 
-  memo_wise \
+  memoize \
   def final_stashed_json
     $redis_pool.with { |conn| conn.call('get', final_request_data_redis_key) }
   end
 
-  memo_wise \
+  memoize \
   def final_stashed_data
     JSON.parse(final_stashed_json)
   end

--- a/app/poros/sitemap_crawler.rb
+++ b/app/poros/sitemap_crawler.rb
@@ -1,11 +1,11 @@
 class SitemapCrawler
-  prepend MemoWise
+  prepend Memoization
 
   def initialize(sitemap_url)
     @sitemap_url = sitemap_url
   end
 
-  memo_wise \
+  memoize \
   def urls
     urls_from_sitemap_doc(nokogiri_sitemap_doc(@sitemap_url))
   end

--- a/app/poros/track_asset_sizes.rb
+++ b/app/poros/track_asset_sizes.rb
@@ -1,8 +1,8 @@
 class TrackAssetSizes
-  prepend MemoWise
+  prepend Memoization
 
   class << self
-    prepend MemoWise
+    prepend Memoization
 
     def all_globs
       new.track_all_asset_sizes(dry_run: true).keys.sort
@@ -54,7 +54,7 @@ class TrackAssetSizes
     manifest[asset]['file']
   end
 
-  memo_wise \
+  memoize \
   def asset_and_js_dependencies(asset)
     asset_manifest = manifest.fetch(asset)
 
@@ -67,7 +67,7 @@ class TrackAssetSizes
     ).uniq
   end
 
-  memo_wise \
+  memoize \
   def entrypoints
     manifest.
       filter_map do |path, info|
@@ -78,12 +78,12 @@ class TrackAssetSizes
       sort
   end
 
-  memo_wise \
+  memoize \
   def manifest
     JSON.parse(manifest_json)
   end
 
-  memo_wise \
+  memoize \
   def manifest_json
     File.read('public/vite/.vite/manifest.json')
   end

--- a/app/poros/urls_at_url.rb
+++ b/app/poros/urls_at_url.rb
@@ -1,11 +1,11 @@
 class UrlsAtUrl
-  prepend MemoWise
+  prepend Memoization
 
   def initialize(page_url)
     @page_url = page_url
   end
 
-  memo_wise \
+  memoize \
   def urls
     links.filter_map do |link|
       href = link.attr('href')
@@ -19,17 +19,17 @@ class UrlsAtUrl
     href&.match?(%r{\A(https?:)?//})
   end
 
-  memo_wise \
+  memoize \
   def links
     nokogiri_document.css('a')
   end
 
-  memo_wise \
+  memoize \
   def nokogiri_document
     Nokogiri::HTML(page_content)
   end
 
-  memo_wise \
+  memoize \
   def page_content
     Faraday.get(@page_url).body
   end

--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -1,7 +1,7 @@
 require 'digest/sha1'
 
 module ApplicationWorker
-  prepend MemoWise
+  prepend Memoization
   include Sidekiq::Worker # rubocop:disable CustomCops/DontIncludeSidekiqWorker
   include SpacedLaunching
 
@@ -79,7 +79,7 @@ module ApplicationWorker
     end
   end
 
-  memo_wise \
+  memoize \
   def lock_key(args)
     "sidekiq-unique:#{self.class.name}:#{Digest::SHA1.hexdigest(JSON.dump(args))}"
   end

--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -1,5 +1,5 @@
 class CheckLinks::Checker
-  prepend MemoWise
+  prepend Memoization
   prepend ApplicationWorker
 
   LINK_CHECK_CACHE_KEY_PREFIX = 'link-check'
@@ -71,12 +71,12 @@ class CheckLinks::Checker
 
   private
 
-  memo_wise \
+  memoize \
   def redis_failure_key(url)
     "link_check:#{url}:failed"
   end
 
-  memo_wise \
+  memoize \
   def response(url)
     Rails.cache.fetch(cache_key(url), expires_in: 6.hours) do
       Rails.error.handle(severity: :info, context: { url: }) do
@@ -88,7 +88,7 @@ class CheckLinks::Checker
     end
   end
 
-  memo_wise \
+  memoize \
   def cache_key(url)
     [LINK_CHECK_CACHE_KEY_PREFIX, url]
   end

--- a/app/workers/concerns/throttleable.rb
+++ b/app/workers/concerns/throttleable.rb
@@ -1,5 +1,5 @@
 module Throttleable
-  prepend MemoWise
+  prepend Memoization
 
   private
 
@@ -14,7 +14,7 @@ module Throttleable
     end
   end
 
-  memo_wise \
+  memoize \
   def lock_manager
     Redlock::Client.new([$redis_pool], retry_count: 0)
   end

--- a/app/workers/data_monitors/home_index_requests.rb
+++ b/app/workers/data_monitors/home_index_requests.rb
@@ -1,5 +1,5 @@
 class DataMonitors::HomeIndexRequests < DataMonitors::Base
-  prepend MemoWise
+  prepend Memoization
   prepend ApplicationWorker
 
   def perform
@@ -23,7 +23,7 @@ class DataMonitors::HomeIndexRequests < DataMonitors::Base
     home_requests_in_past_day.size
   end
 
-  memo_wise \
+  memoize \
   def median_response_time_in_past_day
     home_requests_in_past_day.
       where.not(total: nil).

--- a/app/workers/fetch_ip_info_for_record.rb
+++ b/app/workers/fetch_ip_info_for_record.rb
@@ -1,5 +1,5 @@
 class FetchIpInfoForRecord
-  prepend MemoWise
+  prepend Memoization
   prepend ApplicationWorker
 
   LOCAL_IPS = %w[::1 127.0.0.1].map(&:freeze).freeze
@@ -24,7 +24,7 @@ class FetchIpInfoForRecord
     "ip-info:#{ip}"
   end
 
-  memo_wise \
+  memoize \
   def ip_info_from_api(ip)
     Rails.logger.info("Querying ip-api.com for info about IP address '#{ip}'")
     # we'd have to pay to use https :( so just use http

--- a/app/workers/save_request.rb
+++ b/app/workers/save_request.rb
@@ -1,7 +1,7 @@
 # This Sidekiq worker class converts data that has been stashed in Redis at two stages in the
 # request lifecycle into `Request` records saved to the Postgres database.
 class SaveRequest
-  prepend MemoWise
+  prepend Memoization
   prepend ApplicationWorker
 
   unique_while_executing!
@@ -35,7 +35,7 @@ class SaveRequest
 
   private
 
-  memo_wise \
+  memoize \
   def ban_reasons
     ban_reasons = []
 
@@ -46,7 +46,7 @@ class SaveRequest
     ban_reasons
   end
 
-  memo_wise \
+  memoize \
   def params
     stashed_data['params']
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -17,6 +17,8 @@ Bundler.require(*Rails.groups)
 
 require 'freezolite/auto'
 
+require_relative '../lib/memoization.rb'
+
 IS_DOCKER_BUILD = ENV.key?('DOCKER_BUILD')
 IS_DOCKER_BUILT = ENV.key?('DOCKER_BUILT')
 IS_DOCKER = IS_DOCKER_BUILD || IS_DOCKER_BUILT

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -18,15 +18,15 @@ class Rack::Attack
   # rubocop:enable Style/SymbolProc
 
   class << self
-    prepend MemoWise
+    prepend Memoization
 
-    memo_wise \
+    memoize \
     def banned_path_fragments
       # rescue because sometimes the database might not even exist yet, e.g. during tests
       Set.new((BannedPathFragment.pluck(:value) rescue []).map(&:freeze)).freeze
     end
 
-    memo_wise \
+    memoize \
     def blocked_ips
       # rescue because sometimes the database might not even exist yet, e.g. during tests
       Set.new((IpBlock.pluck(:ip) rescue []).map(&:freeze)).freeze

--- a/lib/email/mailgun_via_http.rb
+++ b/lib/email/mailgun_via_http.rb
@@ -1,7 +1,7 @@
 # rubocop:disable Style/ClassAndModuleChildren
 module Email
   class MailgunViaHttp
-    prepend MemoWise
+    prepend Memoization
 
     DEVELOPER_EMAILS = Set['davidjrunger@gmail.com'].freeze
     MAILGUN_URL = 'https://api.mailgun.net/v3/mg.davidrunger.com'
@@ -31,7 +31,7 @@ module Email
 
     private
 
-    memo_wise \
+    memoize \
     def connection
       Faraday.new(MAILGUN_URL) do |conn|
         conn.request(:multipart)
@@ -45,13 +45,13 @@ module Email
       end
     end
 
-    memo_wise \
+    memoize \
     def attachments_tmp_directory
       # use random directory for thread safety (so users' emails don't conflict w/ each other)
       "tmp/attachments/#{Time.zone.today.iso8601}/#{SecureRandom.alphanumeric(5)}"
     end
 
-    memo_wise \
+    memoize \
     def post_body(mail)
       body = {
         to: safe_to_value(mail),

--- a/lib/memoization.rb
+++ b/lib/memoization.rb
@@ -1,0 +1,11 @@
+module MemoWisePatches
+  def prepended(target)
+    super
+
+    target.singleton_class.alias_method(:memoize, :memo_wise)
+  end
+end
+
+MemoWise.singleton_class.prepend(MemoWisePatches)
+
+Memoization = MemoWise

--- a/lib/test/diff_helpers.rb
+++ b/lib/test/diff_helpers.rb
@@ -1,5 +1,5 @@
 module DiffHelpers
-  prepend MemoWise
+  prepend Memoization
 
   SPECIAL_RUBY_FILES = %w[
     .irbrc
@@ -13,24 +13,24 @@ module DiffHelpers
     files_changed.include?(filename)
   end
 
-  memo_wise \
+  memoize \
   def db_schema_changed?
     file_changed?('db/schema.rb')
   end
 
-  memo_wise \
+  memoize \
   def dotfile_changed?
     files_changed.any? { _1.match?(/(^|\/)\./) }
   end
 
-  memo_wise \
+  memoize \
   def diff
     ensure_master_is_present
     `git log main..HEAD --full-diff --source --format="" --unified=0 -p . \
       | grep -Ev "^(diff |index |--- a/|\\+\\+\\+ b/|@@ )"`
   end
 
-  memo_wise \
+  memoize \
   def diff_mentions?(phrase)
     diff.match?(%r{#{phrase}}i)
   end
@@ -43,51 +43,51 @@ module DiffHelpers
     end
   end
 
-  memo_wise \
+  memoize \
   def files_added_in?(directory)
     ensure_master_is_present
     `git diff --name-only --diff-filter=A main HEAD #{directory}`.rstrip.split("\n").any?
   end
 
-  memo_wise \
+  memoize \
   def files_changed
     ensure_master_is_present
     `git diff --name-only $(git merge-base HEAD main)`.rstrip.split("\n")
   end
 
-  memo_wise \
+  memoize \
   def file_extensions_changed
     files_changed.filter_map do |file_name|
       file_name.include?('.') && file_name.split('.').last
     end.uniq.sort
   end
 
-  memo_wise \
+  memoize \
   def all_changed_file_extensions_are_among?(file_extensions)
     (file_extensions_changed - file_extensions).empty?
   end
 
-  memo_wise \
+  memoize \
   def files_with_css_changed?
     Dir['app/**/*.{css,scss,vue}'].intersect?(files_changed)
   end
 
-  memo_wise \
+  memoize \
   def files_with_js_changed?
     Dir['app/javascript/**/*.{js,ts,vue}'].intersect?(files_changed)
   end
 
-  memo_wise \
+  memoize \
   def haml_files_changed?
     Dir['app/**/*.haml'].intersect?(files_changed)
   end
 
-  memo_wise \
+  memoize \
   def rubocop_files_changed?
     files_changed.any? { |file| file.include?('rubocop') } # e.g. `.rubocop.yml`
   end
 
-  memo_wise \
+  memoize \
   def ruby_files_changed?
     ruby_files =
       Dir['*.rb'] +

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -1,13 +1,13 @@
 class Test::RequirementsResolver
-  prepend MemoWise
+  prepend Memoization
   include DiffHelpers
 
   class << self
-    prepend MemoWise
+    prepend Memoization
 
     # rubocop:disable Metrics/MethodLength, Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
-    memo_wise \
+    memoize \
     def dependency_map
       base_dependency_map = {
         # NB: Tasks that are better to run earlier are listed first.
@@ -126,7 +126,7 @@ class Test::RequirementsResolver
       global_config['run_all']
     end
 
-    memo_wise \
+    memoize \
     def config
       YAML.load_file('lib/test/.tests.yml') rescue Hash.new { |hash, key| hash[key] = {} }
     end
@@ -151,7 +151,7 @@ class Test::RequirementsResolver
       config['tasks'].transform_values { _1 || 'default' }
     end
 
-    memo_wise \
+    memoize \
     def task_config_groups
       task_config.group_by { |_key, value| value }.transform_values { _1.map(&:first) }
     end
@@ -282,7 +282,7 @@ class Test::RequirementsResolver
     end
   end
 
-  memo_wise \
+  memoize \
   def running_locally?
     !ENV.key?('CI')
   end

--- a/lib/test/runner.rb
+++ b/lib/test/runner.rb
@@ -14,7 +14,7 @@ Rails.application.load_tasks
 
 class Test::Runner < Pallets::Workflow
   class << self
-    prepend MemoWise
+    prepend Memoization
 
     attr_accessor :exit_code
     attr_reader :start_time
@@ -35,7 +35,7 @@ class Test::Runner < Pallets::Workflow
       end
     end
 
-    memo_wise \
+    memoize \
     def required_tasks
       Test::RequirementsResolver.new.required_tasks
     end

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -1,7 +1,7 @@
 require Rails.root.join('app/poros/track_asset_sizes.rb')
 
 class Test::Tasks::RunFileSizeChecks < Pallets::Task
-  prepend MemoWise
+  prepend Memoization
   include Test::TaskHelpers
 
   # file size constraints in kilobytes
@@ -48,19 +48,19 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
 
   private
 
-  memo_wise \
+  memoize \
   def tracker
     TrackAssetSizes.new
   end
 
-  memo_wise \
+  memoize \
   def assets_and_size_in_kb
     tracker.
       track_all_asset_sizes(dry_run: true).
       transform_values { _1.fdiv(1024).round(2) }
   end
 
-  memo_wise \
+  memoize \
   def file_size_violations
     assets_and_size_in_kb.reject do |asset_name, file_size_in_kb|
       constraint = CONSTRAINTS[asset_name]
@@ -68,7 +68,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     end
   end
 
-  memo_wise \
+  memoize \
   def readable_file_size_violations
     file_size_violations.map do |file_name, actual_size|
       constraint = CONSTRAINTS[file_name]
@@ -81,12 +81,12 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     end.join(', ')
   end
 
-  memo_wise \
+  memoize \
   def unspecified_files
     assets_and_size_in_kb.keys - CONSTRAINTS.keys
   end
 
-  memo_wise \
+  memoize \
   def nonexistent_files
     CONSTRAINTS.keys - assets_and_size_in_kb.keys
   end


### PR DESCRIPTION
This will make it easier to swap out MemoWise for a different memoization library, in the future, if we ever want/need to, as we have done in the past [once][1] and [twice][2] before. For this reason, in general, I think it often makes sense to "own" a light wrapper around services being used -- i.e. "[wrap your dependencies][3]" -- whether that is memoization or HTTP calls or a payment gateway.

Additionally, I don't really like the name `MemoWise`/`memo_wise`. It's trying to be cute, but (not intending offense, and grateful for the library) I personally find it a little annoying and cringe. I will prefer just reading/writing `Memoization` and `memoize`.

[1]: https://github.com/davidrunger/david_runger/pull/2833
[2]: https://github.com/davidrunger/david_runger/pull/2834
[3]: https://thoughtbot.com/blog/wrap-your-dependencies