### PR TITLE
Use a named volume to store Prometheus data [DEV-159]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,6 +215,7 @@ services:
       - internal
     volumes:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
+      - prometheus-data:/prometheus
   rails_metrics:
     <<: *default-rails-config
     cpu_shares: 512
@@ -354,4 +355,5 @@ volumes:
   grafana-data:
   loki-data:
   postgres-data-v17:
+  prometheus-data:
   redis:


### PR DESCRIPTION
Currently, we are (inadvertently / without consideration) storing Prometheus metrics in the file system of the container itself. This is not great, because it means that if/when we recreate the prometheus service container, then the data will be lost.

To allow the data to persist even across recreations of the prometheus service container, this change moves to using a named volume as Prometheus's data storage location.

This does mean that, with this change, we will lose the data that we have so far accumulated in the container's file system, and we will "start fresh" with the blank data of the new named volume. That's alright. A month ago, we didn't even have any Prometheus metrics, at all, anyway, and we survived! So, I think it's safe to say that these metrics are not so essential that losing the ones accumulated so far would be a major loss.