### PR TITLE
[run-test-steps] Add zsh completions

### DIFF
--- a/bin/completions/_run-test-steps
+++ b/bin/completions/_run-test-steps
@@ -1,0 +1,8 @@
+#compdef run-test-steps
+
+_run-test-steps() {
+  test_steps=("${(f)$(rg 'class Test::Tasks::(\w+) < Pallets::Task' lib/test/tasks/ -r '$1' --no-line-number --no-filename | sort -u)}")
+  _describe 'test_steps' test_steps
+}
+
+compdef _run-test-steps run-test-steps

--- a/bin/run-test-steps
+++ b/bin/run-test-steps
@@ -7,6 +7,8 @@
 # Example 2:
 #   bin/run-test-steps CompileJavaScript RunFileSizeChecks
 
+# TIP: Run `bin/setup-completions` to install completions for this command.
+
 # https://stackoverflow.com/a/77655338/4009384
 if !defined?(Rails)
   exec('bin/rails', 'runner', __FILE__, '-e', 'test', *ARGV)

--- a/bin/setup-completions
+++ b/bin/setup-completions
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+for file in "$(pwd)/bin/completions/"_*; do
+  base=$(basename "$file")
+  target="$HOME/.oh-my-zsh/custom/completions/$base"
+
+  ln -sf "$file" "$target"
+  echo "Linked: $base"
+done
+
+echo "Completion installed! Restart your terminal or run 'compinit' to enable."


### PR DESCRIPTION
This assumes that the user has a `$HOME/.oh-my-zsh/custom/completions/` directory that is part of their `fpath`, and that they have `rg` (ripgrep) available.