### PR TITLE
Track scrolling with http/ky/fetch (not sendBeacon) [HOME-15]

### DIFF
--- a/app/javascript/lib/composables/use_external_link_tracking.ts
+++ b/app/javascript/lib/composables/use_external_link_tracking.ts
@@ -37,10 +37,14 @@ export function trackExternalLinkClick(event: MouseEvent): void {
   const element = event.target;
 
   if (element instanceof HTMLAnchorElement) {
-    trackEvent('external_link_click', {
-      href: element.href,
-      page_url: window.location.href,
-      text: element.innerText,
-    });
+    trackEvent(
+      'external_link_click',
+      {
+        href: element.href,
+        page_url: window.location.href,
+        text: element.innerText,
+      },
+      { useSendBeacon: true },
+    );
   }
 }

--- a/app/javascript/lib/events.ts
+++ b/app/javascript/lib/events.ts
@@ -1,13 +1,22 @@
 import { routes } from '@/lib/routes';
+import { http } from '@/shared/http';
 
-export function trackEvent(type: string, data: object): void {
-  // NOTE: uBlock Origin (and probably others) block sendBeacon requests, so
-  // this tracking is not 100% reliable.
-  navigator.sendBeacon(
-    routes.api_events_path(),
-    JSON.stringify({
-      type,
-      data,
-    }),
-  );
+export function trackEvent(
+  type: string,
+  data: object,
+  options: { useSendBeacon?: boolean } = { useSendBeacon: false },
+): void {
+  const api_events_path = routes.api_events_path();
+  const payload = {
+    type,
+    data,
+  };
+
+  if (options.useSendBeacon) {
+    // NOTE: uBlock Origin (and probably others) block sendBeacon requests, so
+    // this tracking is not 100% reliable.
+    navigator.sendBeacon(api_events_path, JSON.stringify(payload));
+  } else {
+    http.post(api_events_path, payload);
+  }
 }

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -5,7 +5,7 @@
 
 # Enable parameter wrapping for JSON. You can disable this by setting :format to an empty array.
 ActiveSupport.on_load(:action_controller) do
-  wrap_parameters format: [:json]
+  wrap_parameters format: []
   ActionController::Parameters.action_on_unpermitted_parameters = false
 end
 

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -17,7 +17,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'groceries*.css' => (108..118),
     'groceries*.js' => (441..451),
     'home*.css' => (0..10),
-    'home*.js' => (239..249),
+    'home*.js' => (260..270),
     'logs*.css' => (95..105),
     'logs*.js' => (815..825),
     'quizzes*.js' => (123..133),


### PR DESCRIPTION
At least one ad blocker (uBlock Origin) blocks `sendBeacon`, but I doubt that any block `fetch`. We use `sendBeacon` for external link clicks because those need to be sent asynchronously (because otherwise the request might be cancelled as the user navigates away), but we don't really need that for scrolls. So, this change uses `fetch` (via ky, via our http wrapper library) to track scrolls, which should be more reliable.