### PR TITLE
Track length of CI build time steps [DEV-160]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -93,6 +93,8 @@ jobs:
           # The hostname used to communicate with the Redis service container
           REDIS_HOST: redis
           REDIS_PORT: 6379
+          CI_STEP_RESULTS_HOST: '${{secrets.CI_STEP_RESULTS_HOST}}'
+          CI_STEP_RESULTS_AUTH_TOKEN: '${{secrets.CI_STEP_RESULTS_AUTH_TOKEN}}'
           PERCY_TOKEN: '${{secrets.PERCY_TOKEN}}'
           CODECOV_TOKEN: '${{secrets.CODECOV_TOKEN}}'
           RAILS_MASTER_KEY: '${{secrets.RAILS_MASTER_KEY}}'

--- a/app/controllers/api/ci_step_results_controller.rb
+++ b/app/controllers/api/ci_step_results_controller.rb
@@ -1,0 +1,32 @@
+class Api::CiStepResultsController < Api::BaseController
+  def create
+    authorize(CiStepResult)
+
+    @ci_step_result =
+      current_or_auth_token_user.
+        ci_step_results.
+        build(ci_step_result_params)
+
+    if @ci_step_result.save
+      head :created
+    else
+      render json: { errors: @ci_step_result.errors.to_hash }, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def ci_step_result_params
+    params.expect(ci_step_result: %i[
+      name
+      seconds
+      started_at
+      stopped_at
+      passed
+      github_run_id
+      github_run_attempt
+      branch
+      sha
+    ])
+  end
+end

--- a/app/controllers/ci_step_results_controller.rb
+++ b/app/controllers/ci_step_results_controller.rb
@@ -1,0 +1,12 @@
+class CiStepResultsController < ApplicationController
+  self.container_classes = %w[p-8]
+
+  def index
+    authorize(CiStepResult)
+
+    @title = 'CI Timings'
+    @chart_data = CiStepResultsPresenter.new(current_user).data
+
+    render :index
+  end
+end

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -22,6 +22,11 @@ module TokenAuthenticatable
   end
 
   memoize \
+  def current_or_auth_token_user
+    current_user || auth_token_user
+  end
+
+  memoize \
   def auth_token_user
     auth_token&.user
   end

--- a/app/models/ci_step_result.rb
+++ b/app/models/ci_step_result.rb
@@ -1,0 +1,36 @@
+# == Schema Information
+#
+# Table name: ci_step_results
+#
+#  branch             :string           not null
+#  created_at         :datetime         not null
+#  github_run_attempt :integer          not null
+#  github_run_id      :bigint           not null
+#  id                 :bigint           not null, primary key
+#  name               :string           not null
+#  passed             :boolean          default(FALSE), not null
+#  seconds            :float            not null
+#  sha                :string           not null
+#  started_at         :datetime         not null
+#  stopped_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint           not null
+#
+# Indexes
+#
+#  idx_on_name_github_run_id_github_run_attempt_96ff2b0b91  (name,github_run_id,github_run_attempt) UNIQUE
+#  index_ci_step_results_on_user_id                         (user_id)
+#
+class CiStepResult < ApplicationRecord
+  belongs_to :user
+
+  validates :name, presence: true, uniqueness: { scope: %i[github_run_id github_run_attempt] }
+  validates :seconds, presence: true
+  validates :started_at, presence: true
+  validates :stopped_at, presence: true
+  validates :passed, inclusion: { in: [true, false] }
+  validates :github_run_id, presence: true
+  validates :github_run_attempt, presence: true
+  validates :branch, presence: true
+  validates :sha, presence: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,7 @@ class User < ApplicationRecord
   has_many :check_in_submissions, dependent: :destroy
   has_many :json_preferences, dependent: :destroy
   has_many :events, dependent: :destroy
+  has_many :ci_step_results, dependent: :destroy
 
   JsonPreference::Types.constants.each do |constant_name|
     scope_name = JsonPreference::Types.const_get(constant_name).to_sym

--- a/app/policies/ci_step_result_policy.rb
+++ b/app/policies/ci_step_result_policy.rb
@@ -1,0 +1,2 @@
+class CiStepResultPolicy < ApplicationPolicy
+end

--- a/app/presenters/ci_step_results_presenter.rb
+++ b/app/presenters/ci_step_results_presenter.rb
@@ -1,0 +1,53 @@
+class CiStepResultsPresenter
+  prepend Memoization
+
+  FIELDS_TO_PLUCK = %i[name github_run_id github_run_attempt created_at seconds].freeze
+
+  def initialize(user)
+    @user = user
+  end
+
+  def data
+    results_grouped_by_name.map do |name, rows|
+      {
+        name:,
+        data:
+          rows.to_h do |_name, github_run_id, github_run_attempt, _created_at, seconds|
+            # Lines will only appear if each series has dots at the exact same
+            # time, so we will standardize on the earliest created_at.
+            # https://github.com/ankane/chartkick/issues/ 137#issuecomment-58734647
+            [earliest_created_at(github_run_id:, github_run_attempt:), seconds]
+          end,
+      }
+    end
+  end
+
+  private
+
+  memoize \
+  def ci_step_results_row_data
+    @user.
+      ci_step_results.
+      pluck(*FIELDS_TO_PLUCK)
+  end
+
+  def results_grouped_by_name
+    name_index = FIELDS_TO_PLUCK.index(:name)
+
+    ci_step_results_row_data.group_by { |row| row[name_index] }
+  end
+
+  def earliest_created_at(github_run_id:, github_run_attempt:)
+    results_grouped_by_run_id_and_attempt[[github_run_id, github_run_attempt]].
+      pluck(FIELDS_TO_PLUCK.index(:created_at)).
+      min
+  end
+
+  memoize \
+  def results_grouped_by_run_id_and_attempt
+    ci_step_results_row_data.
+      group_by do |_name, github_run_id, github_run_attempt, _created_at, _seconds|
+        [github_run_id, github_run_attempt]
+      end
+  end
+end

--- a/app/views/ci_step_results/index.html.haml
+++ b/app/views/ci_step_results/index.html.haml
@@ -1,0 +1,6 @@
+- content_for(:page_assets) do
+  = ts_tag('charts')
+
+%h1= @title
+
+= line_chart(@chart_data, curve: false)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,10 +66,13 @@ Rails.application.routes.draw do
   end
   resources :quiz_questions, only: %i[update]
 
+  resources :ci_step_results, only: %i[index]
+
   namespace :api, defaults: { format: :json } do
     resources :check_ins, only: [] do
       resources :check_in_submissions, only: %i[create]
     end
+    resources :ci_step_results, only: %i[create]
     resources :events, only: %i[create]
     resources :need_satisfaction_ratings, only: %i[update]
     resources :csp_reports, only: %i[create]

--- a/db/migrate/20250208054141_create_ci_step_results.rb
+++ b/db/migrate/20250208054141_create_ci_step_results.rb
@@ -1,0 +1,17 @@
+class CreateCiStepResults < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ci_step_results do |t|
+      t.string :name, null: false
+      t.float :seconds, null: false
+      t.datetime :started_at, null: false
+      t.datetime :stopped_at, null: false
+      t.boolean :passed, default: false, null: false
+      t.bigint :github_run_id, null: false
+      t.integer :github_run_attempt, null: false
+      t.string :branch, null: false
+      t.string :sha, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250208064333_add_user_id_to_ci_step_results.rb
+++ b/db/migrate/20250208064333_add_user_id_to_ci_step_results.rb
@@ -1,0 +1,5 @@
+class AddUserIdToCiStepResults < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :ci_step_results, :user, null: false, foreign_key: true
+  end
+end

--- a/db/migrate/20250208092554_add_unique_index_to_ci_step_results.rb
+++ b/db/migrate/20250208092554_add_unique_index_to_ci_step_results.rb
@@ -1,0 +1,5 @@
+class AddUniqueIndexToCiStepResults < ActiveRecord::Migration[8.0]
+  def change
+    add_index :ci_step_results, %i[name github_run_id github_run_attempt], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_02_225737) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_08_092554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -104,6 +104,23 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_02_225737) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["marriage_id"], name: "index_check_ins_on_marriage_id"
+  end
+
+  create_table "ci_step_results", force: :cascade do |t|
+    t.string "name", null: false
+    t.float "seconds", null: false
+    t.datetime "started_at", null: false
+    t.datetime "stopped_at", null: false
+    t.boolean "passed", default: false, null: false
+    t.bigint "github_run_id", null: false
+    t.integer "github_run_attempt", null: false
+    t.string "branch", null: false
+    t.string "sha", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", null: false
+    t.index ["name", "github_run_id", "github_run_attempt"], name: "idx_on_name_github_run_id_github_run_attempt_96ff2b0b91", unique: true
+    t.index ["user_id"], name: "index_ci_step_results_on_user_id"
   end
 
   create_table "csp_reports", force: :cascade do |t|
@@ -377,6 +394,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_02_225737) do
   add_foreign_key "check_in_submissions", "check_ins"
   add_foreign_key "check_in_submissions", "users"
   add_foreign_key "check_ins", "marriages"
+  add_foreign_key "ci_step_results", "users"
   add_foreign_key "emotional_needs", "marriages"
   add_foreign_key "events", "admin_users"
   add_foreign_key "events", "users"

--- a/lib/test/middleware/task_result_tracking_middleware.rb
+++ b/lib/test/middleware/task_result_tracking_middleware.rb
@@ -6,14 +6,21 @@ class Test::Middleware::TaskResultTrackingMiddleware
       job_name = job['task_class']
       @job_results ||= Hash.new { |hash, key| hash[key] = {} }
 
+      start_time = Time.current
       # https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
-      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      start_time_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
 
       yield
 
-      stop_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      elapsed_time = stop_time - start_time
-      @job_results[job_name][:run_time] = elapsed_time
+      stop_time_monotonic = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      stop_time = Time.current
+
+      elapsed_time = stop_time_monotonic - start_time_monotonic
+
+      job_hash = @job_results[job_name]
+      job_hash[:start_time] = start_time
+      job_hash[:stop_time] = stop_time
+      job_hash[:run_time] = elapsed_time
     rescue => error
       puts(AmazingPrint::Colors.red(
         "Error occurred ('exited with 1') in Pallets runner: #{error.inspect}",

--- a/lib/test/tasks/exit.rb
+++ b/lib/test/tasks/exit.rb
@@ -45,6 +45,10 @@ class Test::Tasks::Exit < Pallets::Task
       puts('done.')
     else
       puts('ci_step_results_host is not present; not sending results.')
+      puts(%(ENV.fetch('GITHUB_RUN_ID'): #{ENV.fetch('GITHUB_RUN_ID')}))
+      puts(%(ENV.fetch('GITHUB_RUN_ATTEMPT'): #{ENV.fetch('GITHUB_RUN_ATTEMPT')}))
+      puts(%(ENV.fetch('GITHUB_HEAD_REF') { ENV.fetch('GITHUB_REF_NAME') }: #{ENV.fetch('GITHUB_HEAD_REF') { ENV.fetch('GITHUB_REF_NAME') }}))
+      puts(%(ENV.fetch('GITHUB_SHA'): #{ENV.fetch('GITHUB_SHA')}))
     end
   end
 

--- a/lib/test/tasks/exit.rb
+++ b/lib/test/tasks/exit.rb
@@ -45,10 +45,6 @@ class Test::Tasks::Exit < Pallets::Task
       puts('done.')
     else
       puts('ci_step_results_host is not present; not sending results.')
-      puts(%(ENV.fetch('GITHUB_RUN_ID'): #{ENV.fetch('GITHUB_RUN_ID')}))
-      puts(%(ENV.fetch('GITHUB_RUN_ATTEMPT'): #{ENV.fetch('GITHUB_RUN_ATTEMPT')}))
-      puts(%(ENV.fetch('GITHUB_HEAD_REF') { ENV.fetch('GITHUB_REF_NAME') }: #{ENV.fetch('GITHUB_HEAD_REF') { ENV.fetch('GITHUB_REF_NAME') }}))
-      puts(%(ENV.fetch('GITHUB_SHA'): #{ENV.fetch('GITHUB_SHA')}))
     end
   end
 

--- a/spec/controllers/api/ci_step_results_controller_spec.rb
+++ b/spec/controllers/api/ci_step_results_controller_spec.rb
@@ -1,0 +1,70 @@
+RSpec.describe(Api::CiStepResultsController) do
+  describe '#create' do
+    subject(:post_create) { post(:create, params:) }
+
+    context 'when no current_user is present' do
+      before { controller.sign_out_all_scopes }
+
+      let(:params) { ci_step_result_params }
+      let(:ci_step_result_params) { valid_ci_step_result_params }
+      let(:valid_ci_step_result_params) do
+        {
+          ci_step_result: {
+            name: 'RunUnitTests',
+            seconds: 18.984,
+            started_at: 1.minute.ago,
+            stopped_at: 10.seconds.ago,
+            passed: true,
+            github_run_id: 13_578_642,
+            github_run_attempt: 1,
+            branch: 'main',
+            sha: SecureRandom.hex(20),
+          },
+        }
+      end
+
+      context 'when no auth_token param is provided' do
+        before { expect(params[:auth_token]).to eq(nil) }
+
+        it 'does not create a CiStepResult and responds with a 401 status code and error message' do
+          expect { post_create }.not_to change { CiStepResult.count }
+          expect(response).to have_http_status(401)
+          expect(response.parsed_body).to eq('error' => 'Your request was not authenticated')
+        end
+      end
+
+      context 'when a valid auth_token param is provided' do
+        let(:user) { User.joins(:auth_tokens).first! }
+        let(:params) do
+          ci_step_result_params.merge(auth_token: user.auth_tokens.first!.secret)
+        end
+
+        context 'when the CiStepResult params are valid' do
+          let(:ci_step_result_params) { valid_ci_step_result_params }
+
+          it 'creates a CiStepResult for the user and returns a 201 status code' do
+            expect { post_create }.to change { user.reload.ci_step_results.size }.by(1)
+            expect(response).to have_http_status(201)
+          end
+        end
+
+        context 'when the CiStepResult params are invalid' do
+          let(:ci_step_result_params) do
+            valid_ci_step_result_params.deep_merge({
+              ci_step_result: {
+                name: nil,
+              },
+            })
+          end
+
+          it 'returns a 422 status code' do
+            post_create
+
+            expect(response).to have_http_status(422)
+            expect(response.parsed_body).to eq({ 'errors' => { 'name' => ["can't be blank"] } })
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/ci_step_results_controller_spec.rb
+++ b/spec/controllers/ci_step_results_controller_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe(CiStepResultsController) do
+  describe '#index' do
+    context 'when a user is signed in' do
+      before { sign_in(user) }
+
+      context 'when the user has some ci_step_results' do
+        let(:user) do
+          User.
+            joins(:ci_step_results).
+            group(users: :id).
+            having('COUNT(ci_step_results.id) >= 2').
+            first!
+        end
+
+        it 'responds with 200' do
+          get(:index)
+
+          expect(response).to have_http_status(200)
+        end
+      end
+    end
+  end
+end

--- a/spec/factories/ci_step_results.rb
+++ b/spec/factories/ci_step_results.rb
@@ -1,0 +1,51 @@
+# == Schema Information
+#
+# Table name: ci_step_results
+#
+#  branch             :string           not null
+#  created_at         :datetime         not null
+#  github_run_attempt :integer          not null
+#  github_run_id      :bigint           not null
+#  id                 :bigint           not null, primary key
+#  name               :string           not null
+#  passed             :boolean          default(FALSE), not null
+#  seconds            :float            not null
+#  sha                :string           not null
+#  started_at         :datetime         not null
+#  stopped_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  user_id            :bigint           not null
+#
+# Indexes
+#
+#  idx_on_name_github_run_id_github_run_attempt_96ff2b0b91  (name,github_run_id,github_run_attempt) UNIQUE
+#  index_ci_step_results_on_user_id                         (user_id)
+#
+FactoryBot.define do
+  factory :ci_step_result do
+    created_at_time = 10.days.ago
+    github_run_id_seed = Kernel.rand(100_000_000)
+
+    association(:user)
+
+    branch { 'main' }
+    created_at { created_at_time }
+    github_run_attempt { rand(1..2) }
+    sequence(:github_run_id) { |n| github_run_id_seed + n }
+    name { 'RunFeatureTests' }
+    passed { true }
+    seconds { rand(80..90) + rand }
+    sha { SecureRandom.hex(20) }
+    started_at { created_at_time - 90.seconds }
+    stopped_at { created_at_time - 5.seconds }
+    updated_at { created_at_time }
+
+    trait(:feature_tests) do
+      name { 'RunFeatureTests' }
+    end
+
+    trait(:unit_tests) do
+      name { 'RunUnitTests' }
+    end
+  end
+end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -128,5 +128,11 @@ FixtureBuilder.configure do |fbuilder|
     create(:event, user:, admin_user: nil)
     create(:event, user: married_user, admin_user:)
     create(:event, user: nil, admin_user: nil)
+
+    # CiStepResults
+    create(:ci_step_result, :feature_tests, user:)
+    create(:ci_step_result, :feature_tests, user:)
+    create(:ci_step_result, :unit_tests, user:)
+    create(:ci_step_result, :unit_tests, user:)
   end
 end


### PR DESCRIPTION
Motivation: CI build times are getting kind of slow. Accumulating data about the build times will be helpful to understand the problem(s) and also to monitor the effectiveness of performance improvements that we might attempt.

This change sort of undoes https://github.com/davidrunger/david_runger/pull/720 , but whereas that PR removed functionality that had leveraged the logs app and data model, this PR adds a whole new, separate data model, controllers, and view.