### PR TITLE
[Exit] Log some ENV vars, ci_step_results payload, and error response

### DIFF
--- a/lib/test/tasks/exit.rb
+++ b/lib/test/tasks/exit.rb
@@ -51,6 +51,9 @@ class Test::Tasks::Exit < Pallets::Task
   def post_ci_step_result(task_name, result_hash)
     print("#{task_name}:")
 
+    puts(%(ENV['GITHUB_HEAD_REF']: #{ENV['GITHUB_HEAD_REF'].inspect}))
+    puts(%(ENV['GITHUB_REF_NAME']: #{ENV['GITHUB_REF_NAME'].inspect}))
+    puts(%(ENV['GIT_REV']: #{ENV['GIT_REV'].inspect}))
     response =
       Faraday.json_connection.post(
         "#{ci_step_results_host}/api/ci_step_results",
@@ -66,10 +69,11 @@ class Test::Tasks::Exit < Pallets::Task
             github_run_attempt: ENV.fetch('GITHUB_RUN_ATTEMPT'),
             branch: ENV.fetch('GITHUB_HEAD_REF') { ENV.fetch('GITHUB_REF_NAME') },
             sha: ENV.fetch('GITHUB_SHA'),
-          },
+          }.tap { pp(it) },
         },
       )
 
+    puts(response.body)
     print("#{response.status} ... ")
   end
 


### PR DESCRIPTION
Pushing the results failed on `main` https://github.com/davidrunger/david_runger/actions/runs/13214710802/job/36892603965

> Posting CiStepResults ... WallClockTime:422 ... CpuTime:422 ... Test::Tasks::CheckVersions:422 ... Test::Tasks::PnpmInstall:422 ... Test::Tasks::SetupDb:422 ... Test::Tasks::BuildRouteHelpers:422 ... Test::Tasks::BuildFixtures:422 ... Test::Tasks::CompileJavaScript:422 ... Test::Tasks::ConvertSchemasToTs:422 ... Test::Tasks::CreateDbCopies:422 ... Test::Tasks::RunTypelizer:422 ... Test::Tasks::RunApiControllerTests:422 ... Test::Tasks::RunUnitTests:422 ... Test::Tasks::RunFileSizeChecks:422 ... Test::Tasks::RunHtmlControllerTests:422 ... Test::Tasks::RunFeatureTests:422 ... done.

I am guessing that is because something isn't as expected / hoped with the env vars and so we are failing a validation.