### PR TITLE
[Exit] Remove temp logging, fix GitHub ENV var access

### DIFF
--- a/lib/test/tasks/exit.rb
+++ b/lib/test/tasks/exit.rb
@@ -51,9 +51,6 @@ class Test::Tasks::Exit < Pallets::Task
   def post_ci_step_result(task_name, result_hash)
     print("#{task_name}:")
 
-    puts(%(ENV['GITHUB_HEAD_REF']: #{ENV['GITHUB_HEAD_REF'].inspect}))
-    puts(%(ENV['GITHUB_REF_NAME']: #{ENV['GITHUB_REF_NAME'].inspect}))
-    puts(%(ENV['GIT_REV']: #{ENV['GIT_REV'].inspect}))
     response =
       Faraday.json_connection.post(
         "#{ci_step_results_host}/api/ci_step_results",
@@ -67,13 +64,12 @@ class Test::Tasks::Exit < Pallets::Task
             passed: result_hash[:exit_code] == 0,
             github_run_id: ENV.fetch('GITHUB_RUN_ID'),
             github_run_attempt: ENV.fetch('GITHUB_RUN_ATTEMPT'),
-            branch: ENV.fetch('GITHUB_HEAD_REF') { ENV.fetch('GITHUB_REF_NAME') },
-            sha: ENV.fetch('GITHUB_SHA'),
-          }.tap { pp(it) },
+            branch: ENV.fetch('GITHUB_HEAD_REF', nil).presence || ENV.fetch('GITHUB_REF_NAME'),
+            sha: ENV.fetch('GIT_REV'),
+          },
         },
       )
 
-    puts(response.body)
     print("#{response.status} ... ")
   end
 


### PR DESCRIPTION
PR run https://github.com/davidrunger/david_runger/actions/runs/13214871445/job/36892919372?pr=6052 that illustrates why we want to switch from `sha: ENV.fetch('GITHUB_SHA')` to `sha: ENV.fetch('GIT_REV')`:

```
ENV['GITHUB_HEAD_REF']: "exit/log-env-vars-and-ci-step-results-payload"
ENV['GITHUB_REF_NAME']: "6052/merge"
ENV['GIT_REV']: "63fd1f237f5664f3ea13d288a8ac5e869ac64567"
{name: "WallClockTime",
 seconds: 125.82212649500002,
 started_at: "2025-02-08T10:40:35.544194Z",
 stopped_at: "2025-02-08T10:42:41.359297Z",
 passed: true,
 github_run_id: "13214871445",
 github_run_attempt: "1",
 branch: "exit/log-env-vars-and-ci-step-results-payload",
 sha: "141ce7c8af5857bf3f4154542484c1adb4310841"}
201
```

`main` run https://github.com/davidrunger/david_runger/actions/runs/13214893897/job/36892967485 that illustrates why we want to switch from `branch: ENV.fetch('GITHUB_HEAD_REF') { ENV.fetch('GITHUB_REF_NAME') }` to `branch: ENV.fetch('GITHUB_HEAD_REF', nil).presence || ENV.fetch('GITHUB_REF_NAME')`:

```
ENV['GITHUB_HEAD_REF']: ""
ENV['GITHUB_REF_NAME']: "main"
ENV['GIT_REV']: "4a94b3e9454ab146fb5dc5b234907a62a64851c5"
{name: "WallClockTime",
 seconds: 109.69665696199999,
 started_at: "2025-02-08T10:44:18.371961Z",
 stopped_at: "2025-02-08T10:46:08.061710Z",
 passed: true,
 github_run_id: "13214893897",
 github_run_attempt: "1",
 branch: "",
 sha: "4a94b3e9454ab146fb5dc5b234907a62a64851c5"}
{"errors" => {"branch" => ["can't be blank"]}}
422
```