### PR TITLE
[admin] Remove "Admin" menu [ADM-3]

### DIFF
--- a/app/admin/asset_sizes.rb
+++ b/app/admin/asset_sizes.rb
@@ -1,6 +1,4 @@
 ActiveAdmin.register_page('Asset Sizes') do
-  menu parent: 'Admin'
-
   content do
     div(admin_ts_tag('charts.ts'))
 

--- a/app/admin/banned_path_fragments.rb
+++ b/app/admin/banned_path_fragments.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register(BannedPathFragment) do
-  menu parent: 'Admin'
   permit_params :value
 
   index do

--- a/app/admin/csp_reports.rb
+++ b/app/admin/csp_reports.rb
@@ -1,6 +1,5 @@
 ActiveAdmin.register(CspReport) do
   decorate_with CspReportDecorator
-  menu parent: 'Admin'
 
   index do
     id_column

--- a/app/admin/deploys.rb
+++ b/app/admin/deploys.rb
@@ -1,6 +1,5 @@
 ActiveAdmin.register(Deploy) do
   decorate_with DeployDecorator
-  menu parent: 'Admin'
 
   controller do
     def scoped_collection

--- a/app/admin/graphs.rb
+++ b/app/admin/graphs.rb
@@ -1,6 +1,4 @@
 ActiveAdmin.register_page('Graphs') do
-  menu parent: 'Admin'
-
   content do
     div(admin_ts_tag('charts.ts'))
 

--- a/app/admin/ip_blocks.rb
+++ b/app/admin/ip_blocks.rb
@@ -1,5 +1,4 @@
 ActiveAdmin.register(IpBlock) do
-  menu parent: 'Admin'
   permit_params :ip, :reason
 
   index do


### PR DESCRIPTION
Most of our models are turning out to be "Admin"-related. After all, I guess that's the point of having an admin app...

Rather than cramming all of this stuff into an "Admin" menu, this change removes the "Admin" menu and has everything now exist at the top level of the ActiveAdmin menu.

## Before

![image](https://github.com/user-attachments/assets/0884b0ba-7e4c-490a-a9e9-42db55021259)

## After

![image](https://github.com/user-attachments/assets/dac14dc0-3be5-4357-8e37-390d3cdf05ac)