### PR TITLE
Respond with JSON for 404 JSON requests [DEV-167]

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -16,7 +16,7 @@ class ErrorsController < ApplicationController
 
     respond_to do |format|
       format.html { render file: 'public/404.html', status: :not_found, layout: false }
-      format.json { render json: { error: 'Resource not found' }, status: :not_found }
+      format.json { render json: { error: 'Not Found' }, status: :not_found }
       format.any { render plain: 'Not found' }
     end
   end

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe ErrorsController do
 
       it %(says "The page you were looking for doesn't exist.") do
         get_not_found
-        expect(json_response).to eq({ 'error' => 'Resource not found' })
+        expect(json_response).to eq({ 'error' => 'Not Found' })
       end
     end
 

--- a/spec/requests/404_handling_spec.rb
+++ b/spec/requests/404_handling_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe 'handling 404s' do # rubocop:disable RSpec/DescribeClass
+  subject(:request_nonexistent_route) do
+    get('/not-there', headers:)
+  end
+
+  context 'when production error handling is enabled', :production_like_error_handling do
+    context 'when exceptions_app is set to routes' do
+      before { expect(Rails.application.config.exceptions_app).to eq(Rails.application.routes) }
+
+      context 'when the request includes a JSON-prioritizing Accept header (while also accepting other content types)' do
+        let(:headers) { { 'Accept' => 'application/json, */*;q=0.5' } }
+
+        it 'responds with a 404 status code and JSON content' do
+          request_nonexistent_route
+
+          expect(response).to have_http_status(404)
+          expect(response.parsed_body).to eq({ 'error' => 'Not Found' })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
See here: https://github.com/davidrunger/david_runger/actions/runs/13222167275/job/36908608384#step:11:233

A request was made using JSON headers (via `Faraday.json_connection`) for a route that doesn't exist, and Rails responded with the 404 HTML page, rather than with JSON.

This change makes it so that we will now respond with JSON to such requests.

(That this doesn't happen already/automatically (i.e. that I need to add this `prioritize_json_format` method myself) sort of seems to me like a bug in Rails?)