### PR TITLE
Increase height of CI step runtimes graph from 300px to 640px [CSR-4]

### DIFF
--- a/app/views/ci_step_results/index.html.haml
+++ b/app/views/ci_step_results/index.html.haml
@@ -3,4 +3,4 @@
 
 %h1= @title
 
-= line_chart(@chart_data, curve: false)
+= line_chart(@chart_data, height: '640px', curve: false)


### PR DESCRIPTION
**Motivation:** Currently, the graph feels fairly vertically smooshed to me. Making it taller will facilitate seeing differences along the y-axis (and hovering over distinct data points), which is currently fairly difficult, especially for all but the top ~3 or 4 slowest steps. The rest all get crammed together at the bottom of the graph.

## Before

![image](https://github.com/user-attachments/assets/164a0507-12c4-4379-ae00-03bec1815b0d)

## After

![image](https://github.com/user-attachments/assets/59205ab0-a936-4f9f-9b8d-b26d7057fa49)