### PR TITLE
Add a graph of parallelism to CiStepResults index page [CSR-1]

### DIFF
--- a/app/controllers/ci_step_results_controller.rb
+++ b/app/controllers/ci_step_results_controller.rb
@@ -5,7 +5,7 @@ class CiStepResultsController < ApplicationController
     authorize(CiStepResult)
 
     @title = 'CI Timings'
-    @chart_data = CiStepResultsPresenter.new(current_user).data
+    @ci_step_results_presenter = CiStepResultsPresenter.new(current_user)
 
     render :index
   end

--- a/app/presenters/ci_step_results_presenter.rb
+++ b/app/presenters/ci_step_results_presenter.rb
@@ -7,7 +7,20 @@ class CiStepResultsPresenter
     @user = user
   end
 
-  def data
+  memoize \
+  def parallelism
+    wall_clock_times = run_times_by_step.detect { it[:name] == 'WallClockTime' }[:data]
+    cpu_times = run_times_by_step.detect { it[:name] == 'CpuTime' }[:data]
+
+    wall_clock_times.each.filter_map do |time, wall_clock_time|
+      if (cpu_time = cpu_times[time])
+        [time, cpu_time.fdiv(wall_clock_time)]
+      end
+    end.to_h
+  end
+
+  memoize \
+  def run_times_by_step
     results_grouped_by_name.map do |name, rows|
       {
         name:,

--- a/app/views/ci_step_results/index.html.haml
+++ b/app/views/ci_step_results/index.html.haml
@@ -3,4 +3,8 @@
 
 %h1= @title
 
-= line_chart(@chart_data, height: '640px', curve: false)
+%h2 Run times
+= line_chart(@ci_step_results_presenter.run_times_by_step, height: '640px', curve: false)
+
+%h2 Parallelism
+= line_chart(@ci_step_results_presenter.parallelism, curve: false, legend: false)

--- a/spec/controllers/ci_step_results_controller_spec.rb
+++ b/spec/controllers/ci_step_results_controller_spec.rb
@@ -4,13 +4,9 @@ RSpec.describe(CiStepResultsController) do
       before { sign_in(user) }
 
       context 'when the user has some ci_step_results' do
-        let(:user) do
-          User.
-            joins(:ci_step_results).
-            group(users: :id).
-            having('COUNT(ci_step_results.id) >= 2').
-            first!
-        end
+        before { expect(user.ci_step_results.size).to be >= 2 }
+
+        let(:user) { users(:user) }
 
         it 'responds with 200 and a chartkick line graph' do
           get(:index)

--- a/spec/factories/ci_step_results.rb
+++ b/spec/factories/ci_step_results.rb
@@ -40,6 +40,14 @@ FactoryBot.define do
     stopped_at { created_at_time - 5.seconds }
     updated_at { created_at_time }
 
+    trait(:wall_clock_time) do
+      name { 'WallClockTime' }
+    end
+
+    trait(:cpu_time) do
+      name { 'CpuTime' }
+    end
+
     trait(:feature_tests) do
       name { 'RunFeatureTests' }
     end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -130,9 +130,11 @@ FixtureBuilder.configure do |fbuilder|
     create(:event, user: nil, admin_user: nil)
 
     # CiStepResults
-    create(:ci_step_result, :feature_tests, user:)
-    create(:ci_step_result, :feature_tests, user:)
-    create(:ci_step_result, :unit_tests, user:)
-    create(:ci_step_result, :unit_tests, user:)
+    github_run_id = 888_777_666
+    github_run_attempt = 1
+    create(:ci_step_result, :wall_clock_time, user:, github_run_id:, github_run_attempt:)
+    create(:ci_step_result, :cpu_time, user:, github_run_id:, github_run_attempt:)
+    create(:ci_step_result, :feature_tests, user:, github_run_id:, github_run_attempt:)
+    create(:ci_step_result, :unit_tests, user:, github_run_id:, github_run_attempt:)
   end
 end


### PR DESCRIPTION
I think that this will be interesting / potentially useful information, especially since I am soon planning to increase the parallelism of our pallets runner from 2 to 4 (DEV-162).