### PR TITLE
[pallets] Increase GitHub Actions concurrency from 2 to 3 [DEV-162]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -79,7 +79,7 @@ jobs:
         run: bin/run-tests
         env:
           CI: true
-          PALLETS_CONCURRENCY: 4
+          PALLETS_CONCURRENCY: 3
           AWS_EC2_METADATA_DISABLED: true
           RAILS_ENV: test
           DISABLE_SPRING: 1

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -79,6 +79,7 @@ jobs:
         run: bin/run-tests
         env:
           CI: true
+          PALLETS_CONCURRENCY: 4
           AWS_EC2_METADATA_DISABLED: true
           RAILS_ENV: test
           DISABLE_SPRING: 1

--- a/lib/test/run_pallets_tests.rb
+++ b/lib/test/run_pallets_tests.rb
@@ -4,7 +4,10 @@ require_relative 'middleware/task_result_tracking_middleware.rb'
 require_relative 'runner.rb'
 
 Pallets.configure do |c|
-  c.concurrency = Integer(ENV.fetch('PALLETS_CONCURRENCY', 2))
+  concurrency = Integer(ENV.fetch('PALLETS_CONCURRENCY', 4))
+  puts("Pallets concurrency: #{concurrency}")
+
+  c.concurrency = concurrency
   c.max_failures = 0
   c.backend_args = { url: 'redis://127.0.0.1:6379/8' } # use redis db #8 (to avoid conflicts)
   c.middleware << Test::Middleware::ExitOnFailureMiddleware

--- a/lib/test/run_pallets_tests.rb
+++ b/lib/test/run_pallets_tests.rb
@@ -4,7 +4,7 @@ require_relative 'middleware/task_result_tracking_middleware.rb'
 require_relative 'runner.rb'
 
 Pallets.configure do |c|
-  concurrency = Integer(ENV.fetch('PALLETS_CONCURRENCY', 4))
+  concurrency = Integer(ENV.fetch('PALLETS_CONCURRENCY', 3))
   puts("Pallets concurrency: #{concurrency}")
 
   c.concurrency = concurrency


### PR DESCRIPTION
GitHub Actions machines now have [4 vCPUs][1], and I think CI will run fastest if we also set the pallets concurrency to 3. I initially tried 4, but it seems that might be too much.  https://github.com/davidrunger/david_runger/actions/runs/13224908173/job/36914542355?pr=6062 Parallelism increased, but CPU time also significantly increased, so that wall time (which is what we ultimately care about) is basically right in line with the baseline that we have established with concurrency of 2. Let's see if 3 is more of a sweet spot.

Moving from 4 to 3, we see that parallelism slightly decreased, but CPU time increased even more, such that wall clock time decreased:

![image](https://github.com/user-attachments/assets/c72e9a08-a916-41e1-87a7-7501f660135b)

To accomplish this, set a PALLETS_CONCURRENCY of 3 in the GitHub Actions `env`. I think that it's appropriate to set this specifically there, rather than relying on the default. However, I have also increased the default / fallback value.

Also, print the pallets concurrency. This should help with awareness of the concurrency level and will allow us to confirm that pallets is using the expected concurrency level in GitHub Actions.

[1]: https://github.blog/news-insights/product-news/github-hosted-runners-double-the-power-for-open-source/