### PR TITLE
Split feature specs into three separate tasks [DEV-126]

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -49,7 +49,10 @@ Rails.application.configure do
 
   # Set host to be used by links generated in mailer templates.
   # https://github.com/DavyJonesLocker/capybara-email#setting-your-test-host
-  config.action_mailer.default_url_options = { host: 'localhost', port: 3001 }
+  config.action_mailer.default_url_options = {
+    host: 'localhost',
+    port: Integer(ENV.fetch('CAPYBARA_SERVER_PORT', 3001)),
+  }
 
   # Raise exceptions on deprecation notices.
   config.active_support.deprecation = :raise

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -34,7 +34,7 @@ class Test::RequirementsResolver
         Test::Tasks::RunVitest => Test::Tasks::PnpmInstall,
         Test::Tasks::RunAnnotate => Test::Tasks::SetupDb,
         Test::Tasks::RunTypelizer => Test::Tasks::BuildFixtures,
-        Test::Tasks::ConvertSchemasToTs => nil,
+        Test::Tasks::ConvertSchemasToTs => Test::Tasks::SetupDb,
         Test::Tasks::RunBrakeman => nil,
         Test::Tasks::RunDatabaseConsistency => Test::Tasks::SetupDb,
         Test::Tasks::RunImmigrant => Test::Tasks::SetupDb,

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -19,6 +19,7 @@ class Test::RequirementsResolver
         Test::Tasks::SetupDb => nil,
         Test::Tasks::BuildFixtures => Test::Tasks::SetupDb,
         Test::Tasks::CreateDbCopies => Test::Tasks::BuildFixtures,
+        Test::Tasks::DivideFeatureSpecs => nil,
 
         # Checks
         Test::Tasks::CheckVersions => nil,
@@ -41,9 +42,22 @@ class Test::RequirementsResolver
         Test::Tasks::RunUnitTests => Test::Tasks::CreateDbCopies,
         Test::Tasks::RunApiControllerTests => Test::Tasks::CreateDbCopies,
         Test::Tasks::RunFileSizeChecks => Test::Tasks::CompileJavaScript,
-        Test::Tasks::RunFeatureTests => [
+        Test::Tasks::RunFeatureTestsA => [
+          Test::Tasks::DivideFeatureSpecs,
           Test::Tasks::CreateDbCopies,
           Test::Tasks::CompileJavaScript,
+        ],
+        Test::Tasks::RunFeatureTestsB => [
+          Test::Tasks::DivideFeatureSpecs,
+          Test::Tasks::CreateDbCopies,
+          Test::Tasks::CompileJavaScript,
+          Test::Tasks::RunApiControllerTests,
+        ],
+        Test::Tasks::RunFeatureTestsC => [
+          Test::Tasks::DivideFeatureSpecs,
+          Test::Tasks::CreateDbCopies,
+          Test::Tasks::CompileJavaScript,
+          Test::Tasks::RunUnitTests,
         ],
         Test::Tasks::RunHtmlControllerTests => [
           Test::Tasks::CreateDbCopies,
@@ -60,7 +74,9 @@ class Test::RequirementsResolver
           Test::Tasks::RunBrakeman,
           Test::Tasks::RunDatabaseConsistency,
           Test::Tasks::RunEslint,
-          Test::Tasks::RunFeatureTests,
+          Test::Tasks::RunFeatureTestsA,
+          Test::Tasks::RunFeatureTestsB,
+          Test::Tasks::RunFeatureTestsC,
           Test::Tasks::RunFileSizeChecks,
           Test::Tasks::RunHtmlControllerTests,
           Test::Tasks::RunImmigrant,

--- a/lib/test/tasks/divide_feature_specs.rb
+++ b/lib/test/tasks/divide_feature_specs.rb
@@ -1,0 +1,18 @@
+class Test::Tasks::DivideFeatureSpecs < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    puts("#{AmazingPrint::Colors.yellow('Dividing feature specs')}...")
+
+    Dir.glob('spec/features/**/*_spec.rb').
+      shuffle.
+      group_by.with_index { |_file, index| index % 3 }.
+      values.
+      each_with_index do |array, index|
+        letter = ('a'..'c').to_a[index]
+        File.write("tmp/feature_specs_#{letter}.txt", array.join(' '))
+      end
+
+    record_success_and_log_message('Divided feature specs randomly into three groups.')
+  end
+end

--- a/lib/test/tasks/run_feature_tests_a.rb
+++ b/lib/test/tasks/run_feature_tests_a.rb
@@ -1,0 +1,12 @@
+class Test::Tasks::RunFeatureTestsA < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    execute_rspec_command(<<~COMMAND)
+      DB_SUFFIX=_feature CAPYBARA_SERVER_PORT=3001
+      #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
+      bin/rspec $(cat tmp/feature_specs_a.txt)
+      --format RSpec::Instafail --format progress --force-color
+    COMMAND
+  end
+end

--- a/lib/test/tasks/run_feature_tests_a.rb
+++ b/lib/test/tasks/run_feature_tests_a.rb
@@ -4,7 +4,7 @@ class Test::Tasks::RunFeatureTestsA < Pallets::Task
   def run
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_feature CAPYBARA_SERVER_PORT=3001
-      #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
+      #{'./node_modules/.bin/percy exec --port 5338 -- ' if ENV['PERCY_TOKEN'].present?}
       bin/rspec $(cat tmp/feature_specs_a.txt)
       --format RSpec::Instafail --format progress --force-color
     COMMAND

--- a/lib/test/tasks/run_feature_tests_b.rb
+++ b/lib/test/tasks/run_feature_tests_b.rb
@@ -1,12 +1,11 @@
-class Test::Tasks::RunFeatureTests < Pallets::Task
+class Test::Tasks::RunFeatureTestsB < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    # run all tests in `spec/features/` (wrapped by percy, if PERCY_TOKEN is present)
     execute_rspec_command(<<~COMMAND)
-      DB_SUFFIX=_feature
+      DB_SUFFIX=_api CAPYBARA_SERVER_PORT=3002
       #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
-      bin/rspec spec/features/
+      bin/rspec $(cat tmp/feature_specs_b.txt)
       --format RSpec::Instafail --format progress --force-color
     COMMAND
   end

--- a/lib/test/tasks/run_feature_tests_b.rb
+++ b/lib/test/tasks/run_feature_tests_b.rb
@@ -4,7 +4,7 @@ class Test::Tasks::RunFeatureTestsB < Pallets::Task
   def run
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_api CAPYBARA_SERVER_PORT=3002
-      #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
+      #{'./node_modules/.bin/percy exec --port 5339 -- ' if ENV['PERCY_TOKEN'].present?}
       bin/rspec $(cat tmp/feature_specs_b.txt)
       --format RSpec::Instafail --format progress --force-color
     COMMAND

--- a/lib/test/tasks/run_feature_tests_c.rb
+++ b/lib/test/tasks/run_feature_tests_c.rb
@@ -1,0 +1,12 @@
+class Test::Tasks::RunFeatureTestsC < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    execute_rspec_command(<<~COMMAND)
+      DB_SUFFIX=_unit CAPYBARA_SERVER_PORT=3003
+      #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
+      bin/rspec $(cat tmp/feature_specs_c.txt)
+      --format RSpec::Instafail --format progress --force-color
+    COMMAND
+  end
+end

--- a/lib/test/tasks/run_feature_tests_c.rb
+++ b/lib/test/tasks/run_feature_tests_c.rb
@@ -4,7 +4,7 @@ class Test::Tasks::RunFeatureTestsC < Pallets::Task
   def run
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_unit CAPYBARA_SERVER_PORT=3003
-      #{'./node_modules/.bin/percy exec -- ' if ENV['PERCY_TOKEN'].present?}
+      #{'./node_modules/.bin/percy exec --port 5340 -- ' if ENV['PERCY_TOKEN'].present?}
       bin/rspec $(cat tmp/feature_specs_c.txt)
       --format RSpec::Instafail --format progress --force-color
     COMMAND

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -4,7 +4,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
   def run
     # Run all tests in `spec/` _except_ those in `spec/controllers/` and `spec/features/`.
     # Tests in `spec/controllers/` will be run by RunApiControllerTests and RunHtmlControllerTests.
-    # Tests in `spec/features/` will be run by RunFeatureTests.
+    # Tests in `spec/features/` will be run by RunFeatureTests[A,B,C].
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_unit
       bin/rspec

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -119,7 +119,7 @@ RSpec.describe 'Home page', :prerendering_disabled do
                 'admin_user_id' => nil,
                 'user_id' => nil,
                 'auth_token_id' => nil,
-                'url' => 'http://localhost:3001/',
+                'url' => "http://localhost:#{Capybara.server_port}/",
                 'handler' => 'home#index',
                 'referer' => nil,
                 'params' => {},

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,9 +90,10 @@ Capybara.javascript_driver = Cuprite::CustomDrivers::DOMAIN_RESTRICTED_CUPRITE
 Capybara.asset_host = 'http://localhost:3000'
 Capybara.server = :puma, { Silent: true }
 Capybara.default_normalize_ws = true
-# this matches setting in config/environments/test.rb
-Capybara.server_port = 3001
-Capybara.app_host = 'http://localhost:3001'
+# This port matches a config in config/environments/test.rb.
+capybara_port = Integer(ENV.fetch('CAPYBARA_SERVER_PORT', 3001))
+Capybara.server_port = capybara_port
+Capybara.app_host = "http://localhost:#{capybara_port}"
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
This is quite rough/ugly, but I'm interested to see if it can significantly improve test run time. I think that it might, in which case I think that I might go forward with this, despite the significant ugliness and to some extent risk of brittleness.

I guess that splitting into three feature spec groups makes sense because currently we are running specs with a pallets concurrency of 3, so no more than that many feature specs can run simultaneously, anyhow.