### PR TITLE
Prioritize Atom/XML over other mime types for feed [BLOG-15]

### DIFF
--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -19,7 +19,7 @@ class BlogController < ApplicationController
   end
 
   def show
-    # Prioritize Atom/XML over other mime types.
+    # For feed requests, prioritize Atom/XML over other mime types.
     if xml_request_for_feed?
       request.format = :xml
     end

--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -19,6 +19,11 @@ class BlogController < ApplicationController
   end
 
   def show
+    # Prioritize Atom/XML over other mime types.
+    if xml_request_for_feed?
+      request.format = :xml
+    end
+
     request_format_symbol = request.format.symbol
 
     if request_format_symbol.in?(VALID_SHOW_ACTION_REQUEST_TYPES)
@@ -82,5 +87,10 @@ class BlogController < ApplicationController
 
   def render_blog_404
     send_file(Rails.root.join('blog/404.html'), status: 404, disposition: :inline)
+  end
+
+  def xml_request_for_feed?
+    request.path == '/blog/feed.xml' &&
+      Set.new(request.accepts).intersect?(Set.new([Mime[:atom], Mime[:xml]]))
   end
 end

--- a/spec/controllers/blog_controller_spec.rb
+++ b/spec/controllers/blog_controller_spec.rb
@@ -1,4 +1,6 @@
 RSpec.describe(BlogController) do
+  include BlogSpecHelpers
+
   context 'when there is a 404 HTML file in the blog directory' do
     around do |example|
       with_blog_file('404.html', not_found_page_content) do
@@ -161,15 +163,5 @@ RSpec.describe(BlogController) do
         end
       end
     end
-  end
-
-  def with_blog_file(path, content)
-    file_path = Rails.root.join('blog', path)
-    FileUtils.mkdir_p(file_path.dirname)
-    File.write(file_path, content)
-
-    yield
-
-    FileUtils.rm(file_path)
   end
 end

--- a/spec/requests/blog_spec.rb
+++ b/spec/requests/blog_spec.rb
@@ -1,0 +1,58 @@
+RSpec.describe 'Blog requests' do
+  include BlogSpecHelpers
+
+  describe 'GET /blog/some-article' do
+    subject(:get_blog_feed) { get('/blog/some-article', headers:) }
+
+    let(:headers) { {} }
+
+    context 'when an HTML file exists that matches the requested path' do
+      around do |spec|
+        with_blog_file('some-article.html', '<html><head></head><body></body></html>') do
+          spec.run
+        end
+      end
+
+      context 'when there is an Accept header for HTML, and Atom formats' do
+        let(:headers) { { 'Accept' => 'text/html, application/atom+xml' } }
+
+        it 'responds successfully with an HTML content type', :aggregate_failures do
+          get_blog_feed
+
+          expect(response).to have_http_status(200)
+          expect(response.content_type).to eq('text/html')
+        end
+      end
+    end
+  end
+
+  describe 'GET /blog/feed.xml?test=true' do
+    subject(:get_blog_feed) { get('/blog/feed.xml?test=true', headers:) }
+
+    let(:headers) { {} }
+
+    context 'when an XML file exists for the Atom feed' do
+      around do |spec|
+        with_blog_file('feed.xml', '<?xml version="1.0" encoding="utf-8"?>') do
+          spec.run
+        end
+      end
+
+      context 'when there is an Accept header for Atom, RSS, JSON, and any formats' do
+        let(:headers) do
+          {
+            'Accept' =>
+              'application/atom+xml, application/rss+xml, application/json, */*;q=0.1',
+          }
+        end
+
+        it 'responds successfully with an XML content type', :aggregate_failures do
+          get_blog_feed
+
+          expect(response).to have_http_status(200)
+          expect(response.content_type).to eq('application/xml')
+        end
+      end
+    end
+  end
+end

--- a/spec/support/blog_spec_helpers.rb
+++ b/spec/support/blog_spec_helpers.rb
@@ -1,0 +1,11 @@
+module BlogSpecHelpers
+  def with_blog_file(path, content)
+    file_path = Rails.root.join('blog', path)
+    FileUtils.mkdir_p(file_path.dirname)
+    File.write(file_path, content)
+
+    yield
+
+    FileUtils.rm(file_path)
+  end
+end


### PR DESCRIPTION
https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/712/
rb#712

This fixes avoids sending handled BlogController::InvalidShowRequestFormat errors to Rollbar.

Inoreader was sending some requests with an `Accept` header of `application/atom+xml, application/rss+xml, application/json, application/rdf+xml;q=0.9, application/xml;q=0.8, text/xml;q=0.8, text/html;q=0.7, unknown/unknown;q=0.1, application/unknown;q=0.1, */*;q=0.1`. This includes both `application/atom+xml` and `application/json`. Rails was classifying this as a `:json` request, which we don't know how to handle. This change will now classify such a request as `:xml`, instead (which we do know how to handle).