### PR TITLE
[StoreRequestBlockInRedis] Allow IPs as short as 3 characters

### DIFF
--- a/app/actions/ip_blocks/store_request_block_in_redis.rb
+++ b/app/actions/ip_blocks/store_request_block_in_redis.rb
@@ -1,5 +1,5 @@
 class IpBlocks::StoreRequestBlockInRedis < ApplicationAction
-  requires :ip, String, format: { with: /\A[.:0-9a-f]{7,39}\z/ }
+  requires :ip, String, format: { with: /\A[.:0-9a-f]{3,39}\z/ }
   requires :path, String, format: { with: %r{\A/} }
 
   def execute

--- a/spec/actions/ip_blocks/store_request_block_in_redis_spec.rb
+++ b/spec/actions/ip_blocks/store_request_block_in_redis_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe IpBlocks::StoreRequestBlockInRedis do
           RungerActions::TypeMismatch,
           <<~ERROR.squish)
             One or more required params are of the wrong type: `ip` is expected to be shaped like
-            String validating {format: {with: /\\A[.:0-9a-f]{7,39}\\z/}}, but was `"this is not an
+            String validating {format: {with: /\\A[.:0-9a-f]{3,39}\\z/}}, but was `"this is not an
             IP"` ; `path` is expected to be shaped like String validating
             {format: {with: /\\A\\//}}, but was `"this is not a path"`.
           ERROR
@@ -43,6 +43,14 @@ RSpec.describe IpBlocks::StoreRequestBlockInRedis do
 
     it 'does not raise an error' do
       expect { store_request_block_action }.not_to raise_error
+    end
+
+    context 'when it is a local IP address' do
+      let(:store_request_block_params) { super().merge(ip: '::1') }
+
+      it 'does not raise an error' do
+        expect { store_request_block_action }.not_to raise_error
+      end
     end
   end
 end


### PR DESCRIPTION
In particular, this will now support `::1` (i.e. a local IPv6 address). Before, `http http://localhost:3000/hacking.php` would raise an error from [here][1]:

> RungerActions::TypeMismatch : One or more required params are of the wrong type: `ip` is expected to be shaped like String validating {format: {with: /\A[.:0-9a-f]{7,39}\z/}}, but was `"::1"`.

Now, no such error will be raised.

[1]: https://github.com/davidrunger/david_runger/blob/5a200ece/config/initializers/rack_attack.rb/#L80