### PR TITLE
Add digits and '%' to Rack::Attack::PATH_FRAGMENT_SEPARATOR_REGEX

### DIFF
--- a/app/models/banned_path_fragment.rb
+++ b/app/models/banned_path_fragment.rb
@@ -15,7 +15,7 @@ class BannedPathFragment < ApplicationRecord
   validates(
     :value,
     presence: true,
-    format: { with: /\A[a-z0-9%]+\z/ },
+    format: { with: /\A[a-z]+\z/ },
     uniqueness: true,
   )
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,5 @@
 class Rack::Attack
-  PATH_FRAGMENT_SEPARATOR_REGEX = %r{/|\.|\?|-|_|=}
+  PATH_FRAGMENT_SEPARATOR_REGEX = %r{/|\.|\?|-|_|=|\d|%}
   PENTESTERS_PREFIX = 'pentesters-'
   PENTESTING_FINDTIME = 1.day.freeze
   WHITELISTED_PATH_PREFIXES = %w[

--- a/spec/features/rack_attack_spec.rb
+++ b/spec/features/rack_attack_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Rack::Attack', :rack_test_driver do
         visit(banned_path_2)
       end
 
-      let(:banned_path_1) { BannedPathFragment.first!.value }
+      let(:banned_path_1) { "something.#{BannedPathFragment.first!.value}7" }
       let(:banned_path_2) { BannedPathFragment.second!.value }
 
       it 'bans the user from visiting any page', :prerendering_disabled do

--- a/spec/models/banned_path_fragment_spec.rb
+++ b/spec/models/banned_path_fragment_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe BannedPathFragment do
 
   it { is_expected.to validate_presence_of(:value) }
   it { is_expected.to allow_value('phpmyadmin').for(:value) }
-  it { is_expected.to allow_value('%25alevins%25').for(:value) }
   it { is_expected.not_to allow_value('/phpmyadmin').for(:value) }
   it { is_expected.not_to allow_value('old-wp').for(:value) }
+  it { is_expected.not_to allow_value('php7').for(:value) }
 end


### PR DESCRIPTION
This will avoid Rollbar occurrences like [this][1] for `/ioxi002.PhP7` and [this][2] for `/baxa1.phP8`.

[1]: https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/699/occurrence/426982402396#detail [2]: https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/699/occurrence/426982405582#detail

Also, update the BannedPathFragment regex to reflect this (no longer allowing numbers and percent symbols in the BannedPathFragments).