### PR TITLE
Set 'text-wrap-mode: unset' for 'pre' tags in text logs [LOG-32]

### DIFF
--- a/app/javascript/logs/components/EditableTextLogRow.vue
+++ b/app/javascript/logs/components/EditableTextLogRow.vue
@@ -115,4 +115,8 @@ async function updateLogEntry() {
     margin-left: 0;
   }
 }
+
+td :deep(pre) {
+  text-wrap-mode: unset;
+}
 </style>


### PR DESCRIPTION
Before:

![image](https://github.com/user-attachments/assets/77818e3a-5324-46be-ae16-0a169c63669d)

After:

![image](https://github.com/user-attachments/assets/cf4029b7-5059-46e2-a75f-03c7e0041516)