### PR TITLE
Add CSS to make `pre` tags in text logs scroll (not wrap) [LOG-33]

### DIFF
--- a/app/javascript/logs/components/EditableTextLogRow.vue
+++ b/app/javascript/logs/components/EditableTextLogRow.vue
@@ -116,7 +116,14 @@ async function updateLogEntry() {
   }
 }
 
-td :deep(pre) {
-  text-wrap-mode: unset;
+:deep(pre) {
+  overflow-x: auto;
+}
+</style>
+
+<style>
+td:has(pre) {
+  width: 100%;
+  max-width: 0;
 }
 </style>

--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 div
-  .flex.justify-center
-    table.text-log-table.max-w-4xl
+  .flex.justify-center.w-full
+    table.text-log-table.w-full.max-w-4xl
       TransitionGroup(name='appear-vertically-list')
         EditableTextLogRow(
           v-for='(logEntry, index) in sortedLogEntries'


### PR DESCRIPTION
We deployed https://github.com/davidrunger/david_runger/pull/6087 to fix this bug https://davidrunger.atlassian.net/browse/LOG-32 .

However, I think that is not the final form that the bugfix should take. I think that will serve as just a quick-and dirty fix because I wanted to resolve the issue ASAP.

But I think that the real fix is that we shouldn't wrap `pre` tags that are too wide (which is what the above change does). Instead, we should make them horizontally scrollable within a limited width of their containing `td`. The original bug was essentially caused by the fact that the `td`'s width was not constrained or the `pre` tag width was not constrained within the containing `td` element.

This change makes it so that `pre` text will once again not wrap. Rather, now it will scroll within a `td` that will expand as far as reasonably possible to accommodate it, while still keeping the overall table width less than or equal to the max width.

## Before

A lengthy `pre` line wraps:

![image](https://github.com/user-attachments/assets/5ddcbda8-648f-49ff-8857-712d2b76f6af)

## After

The `pre` text does not wrap; it scrolls.

![image](https://github.com/user-attachments/assets/9e1de30e-53f4-41a0-bfee-342e60b2dd5a)