### PR TITLE
[tailwind_overrides] Remove global 'p' line-height

### DIFF
--- a/app/assets/stylesheets/tailwind_overrides.css
+++ b/app/assets/stylesheets/tailwind_overrides.css
@@ -41,10 +41,6 @@
       display: inline;
     }
 
-    p {
-      line-height: 1.3rem;
-    }
-
     p:not(:first-of-type) {
       margin-top: 1em;
     }


### PR DESCRIPTION
It was messing up the alignment of numbers in `ol`s in log entries. The misalignment is not outrageous, but it's definitely there. Removing the global `p` `line-height` fixes the issue.

## Before

![image](https://github.com/user-attachments/assets/7d023846-1973-4341-a641-10d60d7ea550)

## After

![image](https://github.com/user-attachments/assets/42d172e7-49af-4da7-bfee-cf2a7a5754fd)