### PR TITLE
[logs] Increase td line-height from 1.13rem to 1.3 rem

### DIFF
--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -91,7 +91,7 @@ table.text-log-table {
     padding: 18px 10px;
     word-break: initial;
     white-space: pre-wrap;
-    line-height: 1.13rem;
+    line-height: 1.3rem;
     text-align: center;
     vertical-align: middle;
     min-width: 140px;


### PR DESCRIPTION
I think that the log entries look better / are easier to read with more vertical spacing.

This fixes a visual regression that was introduced in #6090 (though that did fix a different visual issue).

## Before

![image](https://github.com/user-attachments/assets/e6ebd119-9758-4df9-8cd7-3ae2f3c104b9)

## After

![image](https://github.com/user-attachments/assets/5901544a-6087-4513-b173-6bfbed26501e)