### PR TITLE
[logs/css] Remove 'display: inline-block' from 'p' tags

### DIFF
--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -100,12 +100,8 @@ table.text-log-table {
       text-align: left;
     }
 
-    p {
-      display: inline-block;
-
-      &:not(:first-of-type) {
-        margin-top: 16px;
-      }
+    p:not(:first-of-type) {
+      margin-top: 16px;
     }
   }
 


### PR DESCRIPTION
I have no idea why I had this (and I didn't look at the git history to see if there are any clues). It's hard to think of a good reason to have it, though. It can cause separate paragraphs to be rendered on the same line, rather than separately, which I don't think that I ever want. Therefore, I am removing it.

## Before

![image](https://github.com/user-attachments/assets/b0009d7a-a1e7-48cc-9633-f8c4588b749f)

## After

![image](https://github.com/user-attachments/assets/34147b7a-fa71-409b-807c-4c98b0950e41)