### PR TITLE
[emoji-picker] Remove dots from 'li's

### DIFF
--- a/app/assets/stylesheets/tailwind_overrides.css
+++ b/app/assets/stylesheets/tailwind_overrides.css
@@ -52,10 +52,6 @@
       }
     }
 
-    ul {
-      list-style: unset;
-    }
-
     ol {
       list-style-type: decimal;
       list-style-position: outside;


### PR DESCRIPTION
The dots were unintentionally (and buggily) introduced in #6089 ([here][1]).

[1]: https://github.com/davidrunger/david_runger/pull/6089/files#diff-06ee6254c66bde187cba5b5d4ee5dcabd8dc6c0210867bf6f2080275e5d6b207R59-R61

## Before

![image](https://github.com/user-attachments/assets/b3a1cee3-08ef-42e3-97d0-7f911fe2a901)

## After

![image](https://github.com/user-attachments/assets/7b1329da-17e5-4499-9fb2-a811765a4780)