### PR TITLE
[logs/css] Add blockquote styling

### DIFF
--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -93,6 +93,21 @@ ul {
   }
 }
 
+blockquote {
+  position: relative;
+  padding-left: 20px;
+}
+
+blockquote::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 1.3em;
+  bottom: 1.3em;
+  width: 4px;
+  background: #bbb;
+}
+
 .el-button + .el-button {
   margin-left: 5px;
 }


### PR DESCRIPTION
I had to use a pseudo before element. Otherwise, the vertical line extended too far above and below the text (inextricably linked with the somewhat generous line height that we are using).

## Before

![image](https://github.com/user-attachments/assets/2afe1ae6-7948-4661-b9cc-6ddb8e778c37)

## After

![image](https://github.com/user-attachments/assets/2c96e91d-c1bb-4c43-9f7c-01cdf4af00ed)