### PR TITLE
[specs] Make CompileJavaScript await ConvertSchemasToTs

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -15,7 +15,10 @@ class Test::RequirementsResolver
         # Installation / Setup
         Test::Tasks::PnpmInstall => nil,
         Test::Tasks::BuildRouteHelpers => Test::Tasks::PnpmInstall,
-        Test::Tasks::CompileJavaScript => Test::Tasks::BuildRouteHelpers,
+        Test::Tasks::CompileJavaScript => [
+          Test::Tasks::BuildRouteHelpers,
+          Test::Tasks::ConvertSchemasToTs,
+        ],
         Test::Tasks::SetupDb => nil,
         Test::Tasks::BuildFixtures => Test::Tasks::SetupDb,
         Test::Tasks::CreateDbCopies => Test::Tasks::BuildFixtures,

--- a/lib/test/tasks/convert_schemas_to_ts.rb
+++ b/lib/test/tasks/convert_schemas_to_ts.rb
@@ -2,9 +2,13 @@ class Test::Tasks::ConvertSchemasToTs < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    if !execute_system_command(<<~COMMAND)
-      bin/json-schemas-to-typescript && git diff --exit-code
-    COMMAND
+    puts("#{AmazingPrint::Colors.yellow('Writing JSON schemas as types')} ...")
+
+    JsonSchemasToTypescript.write_files
+
+    if execute_system_command('git diff --exit-code')
+      record_success_and_log_message('Wrote JSON schemas as types.')
+    else
       # Reset the git state, so it's clean for other test tasks.
       execute_system_command('git checkout .')
     end

--- a/lib/test/tasks/convert_schemas_to_ts.rb
+++ b/lib/test/tasks/convert_schemas_to_ts.rb
@@ -11,6 +11,10 @@ class Test::Tasks::ConvertSchemasToTs < Pallets::Task
     else
       # Reset the git state, so it's clean for other test tasks.
       execute_system_command('git checkout .')
+
+      record_failure_and_log_message(<<~LOG)
+        There was a git diff after converting JSON schemas to types.
+      LOG
     end
   end
 end


### PR DESCRIPTION
Because the schema task [does `rm -rf` on a directory][1], there's a risk that it will delete a file that Vite needs to compile the JavaScript. This seems to have happened [here][2].

To avoid this issue, this change makes the `CompileJavaScript` task wait for the completion of the `ConvertSchemasToTs`.

`ConvertSchemasToTs` was pretty slow (10+ seconds), so this change would have had a pretty negative performance impact on CI build times. However, I think that the vast majority of its slowness was unnecessary and a result of going through a Rails runner bin script, rather than just invoking the relevant Ruby code directly. This change begins to invoke the script directly, which I think will save a huge amount of time, hopefully making this change not very costly to CI run times.

[1]: https://github.com/davidrunger/david_runger/blob/7ead899fdeba0749aec65d7129c1fca0e3023954/tools/json_schemas_to_typescript.rb/#L39 [2]: https://github.com/davidrunger/david_runger/actions/runs/13283567361/job/37087085374#step:11:120