### PR TITLE
[specs] Register success when skipping StartPercy and StopPercy tasks

### DIFF
--- a/lib/test/tasks/exit.rb
+++ b/lib/test/tasks/exit.rb
@@ -173,7 +173,7 @@ class Test::Tasks::Exit < Pallets::Task
 
   def sorted_job_results
     job_results.sort_by do |_task_name, result_hash|
-      [result_hash[:exit_code], result_hash[:run_time]]
+      [result_hash.fetch(:exit_code), result_hash.fetch(:run_time)]
     end
   end
 

--- a/lib/test/tasks/start_percy.rb
+++ b/lib/test/tasks/start_percy.rb
@@ -5,7 +5,7 @@ class Test::Tasks::StartPercy < Pallets::Task
     if ENV['PERCY_TOKEN'].present?
       execute_detached_system_command('./node_modules/.bin/percy exec:start')
     else
-      puts('Percy token was not present; skipping start.')
+      record_success_and_log_message('Percy token was not present; skipping percy exec:start.')
     end
   end
 end

--- a/lib/test/tasks/stop_percy.rb
+++ b/lib/test/tasks/stop_percy.rb
@@ -5,7 +5,7 @@ class Test::Tasks::StopPercy < Pallets::Task
     if ENV['PERCY_TOKEN'].present?
       execute_system_command('./node_modules/.bin/percy exec:stop')
     else
-      puts('Percy token was not present; skipping stop.')
+      record_success_and_log_message('Percy token was not present; skipping percy exec:stop.')
     end
   end
 end


### PR DESCRIPTION
Without this, the `Exit` task fails locally, because it tries to compare `exit_code`s of `nil`. Also, to better surface errors like that, we switch from `[]` hash access to `fetch`.