### PR TITLE
Show duration of steps on hover in Gantt charts [CSR-7]

### DIFF
--- a/app/javascript/ci_step_results/renderGanttCharts.ts
+++ b/app/javascript/ci_step_results/renderGanttCharts.ts
@@ -38,7 +38,12 @@ export function renderGanttCharts(ciStepResultsSet: Array<CiStepResultsSet>) {
         },
         tooltip: [
           { field: 'name', type: 'nominal', title: 'Step' },
-          { field: 'seconds', type: 'quantitative', title: 'Seconds' },
+          {
+            field: 'seconds',
+            type: 'quantitative',
+            title: 'Seconds',
+            format: '.1f',
+          },
         ],
       },
     };

--- a/app/javascript/ci_step_results/renderGanttCharts.ts
+++ b/app/javascript/ci_step_results/renderGanttCharts.ts
@@ -36,7 +36,10 @@ export function renderGanttCharts(ciStepResultsSet: Array<CiStepResultsSet>) {
           type: 'nominal',
           legend: null,
         },
-        tooltip: [{ field: 'name', type: 'nominal', title: 'Step' }],
+        tooltip: [
+          { field: 'name', type: 'nominal', title: 'Step' },
+          { field: 'seconds', type: 'quantitative', title: 'Seconds' },
+        ],
       },
     };
 

--- a/app/javascript/types/bootstrap/CiStepResultsIndexBootstrap.ts
+++ b/app/javascript/types/bootstrap/CiStepResultsIndexBootstrap.ts
@@ -91,9 +91,12 @@ const schema = {
         "stopped_at": {
           "type": "string",
           "format": "date-time"
+        },
+        "seconds": {
+          "type": "number"
         }
       },
-      "required": ["name", "started_at", "stopped_at"],
+      "required": ["name", "seconds", "started_at", "stopped_at"],
       "title": "RunTime"
     }
   }

--- a/app/presenters/ci_step_results_presenter.rb
+++ b/app/presenters/ci_step_results_presenter.rb
@@ -48,7 +48,8 @@ class CiStepResultsPresenter
         JSON_BUILD_OBJECT(
           'name', ci_step_results.name,
           'started_at', ci_step_results.started_at,
-          'stopped_at', ci_step_results.stopped_at
+          'stopped_at', ci_step_results.stopped_at,
+          'seconds', ci_step_results.seconds
         ) ORDER BY ci_step_results.started_at
       ) AS run_times
     SQL

--- a/spec/support/schemas/bootstrap/ci_step_results/index.json
+++ b/spec/support/schemas/bootstrap/ci_step_results/index.json
@@ -87,9 +87,12 @@
         "stopped_at": {
           "type": "string",
           "format": "date-time"
+        },
+        "seconds": {
+          "type": "number"
         }
       },
-      "required": ["name", "started_at", "stopped_at"],
+      "required": ["name", "seconds", "started_at", "stopped_at"],
       "title": "RunTime"
     }
   }


### PR DESCRIPTION
(Note that we store seconds denormalized on the CiStepResults rather than calculating it from the started at and stopped at times so that the CpuTime step can have a greater number of seconds than its wall clock duration.)

Screenshot:

![image](https://github.com/user-attachments/assets/77354ab8-7487-4515-810b-0ab770ffd8e7)