### PR TITLE
[ci] Increase Pallets concurrency from 3 to 4 [DEV-175]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -79,7 +79,7 @@ jobs:
         run: bin/run-tests
         env:
           CI: true
-          PALLETS_CONCURRENCY: 3
+          PALLETS_CONCURRENCY: 4
           AWS_EC2_METADATA_DISABLED: true
           RAILS_ENV: test
           DISABLE_SPRING: 1

--- a/lib/test/run_pallets_tests.rb
+++ b/lib/test/run_pallets_tests.rb
@@ -4,7 +4,7 @@ require_relative 'middleware/task_result_tracking_middleware.rb'
 require_relative 'runner.rb'
 
 Pallets.configure do |c|
-  concurrency = Integer(ENV.fetch('PALLETS_CONCURRENCY', 3))
+  concurrency = Integer(ENV.fetch('PALLETS_CONCURRENCY', 4))
   puts("Pallets concurrency: #{concurrency}")
 
   c.concurrency = concurrency


### PR DESCRIPTION
This change increases the Pallets concurrency in CI from 3 to 4.

I think that this makes a certain amount of sense, because we have 4 vCPU cores.

This change is also is somewhat of a response to recent changes that broke up some steps into smaller sub-tasks, namely #6107 (feature specs) and especially #6118 (Vite builds). That's good, because it allows for more parallelization, but I think it can also cause some problems, because now more of our concurrency "slots" can be occupied by those now parallelized tasks, which can delay the execution of other tasks (e.g. DB setup) that are now waiting for a slot, whereas previously those other tasks (e.g. DB setup) might have been able to start executing sooner, because available concurrency slots were not being so occupied by parallelized tasks.