### PR TITLE
Have UploadViteAssets "depend on" (wait for) RunHtmlControllerTests

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -79,6 +79,9 @@ class Test::RequirementsResolver
         Test::Tasks::UploadViteAssets => [
           Test::Tasks::CompileAdminJavaScript,
           Test::Tasks::CompileUserJavaScript,
+          # UploadViteAssets doesn't really depend on RunHtmlControllerTests,
+          # but it's better for the timing of steps if it waits until after it.
+          Test::Tasks::RunHtmlControllerTests,
         ],
 
         # Exit depends on all tasks completing that are actual checks (as opposed to setup steps)


### PR DESCRIPTION
UploadViteAssets doesn't really depend on RunHtmlControllerTests, but it's better for the timing of steps if it waits until after it.

This is basically a micro-optimization, and I'm not sure it's going to actually help. But, looking at a recent build on `main`, it looks like we might benefit ever so slightly from running `UploadViteAssets` after `RunHtmlControllerTests`. This will distribute the parallelism more evenly (hopefully reducing CPU contention and increasing overall runtime speed), rather than having 4 tasks running in parallel when the feature specs start.

![image](https://github.com/user-attachments/assets/93904b7a-88ef-4394-804d-421085b7c5fa)

It's very possible that this might not make much difference, though, since `UploadViteAssets` is probably largely an IO / network using step, rather than a CPU using step. But whatever. I am going to try merging this, in the hope that it will help a little.