### PR TITLE
Use previous prerendered page up to 5 minutes after deploy [DEV-114]

### DIFF
--- a/app/controllers/concerns/prerenderable.rb
+++ b/app/controllers/concerns/prerenderable.rb
@@ -39,7 +39,7 @@ module Prerenderable
       expires_in: 1.day,
       skip_nil: true,
     ) do
-      PrerenderUtils.transformed_s3_content(git_rev, filename)
+      PrerenderUtils.transformed_s3_content(git_rev:, filename:)
     end ||
       Rails.cache.read(
         PrerenderUtils.cache_key(git_rev: 'deploy-fallback', filename:),

--- a/app/controllers/concerns/prerenderable.rb
+++ b/app/controllers/concerns/prerenderable.rb
@@ -3,6 +3,7 @@ module Prerenderable
 
   def serve_prerender_with_fallback(filename:, expected_content:, &fallback)
     prerendered_html = prerendered_html(filename)
+
     if prerendered_html
       if prerendered_html.include?(expected_content)
         # rubocop:disable Rails/OutputSafety
@@ -34,44 +35,19 @@ module Prerenderable
     git_rev = ENV.fetch('GIT_REV')
 
     Rails.cache.fetch(
-      "prerendered-pages:#{git_rev}:#{filename}",
+      PrerenderUtils.cache_key(git_rev:, filename:),
       expires_in: 1.day,
       skip_nil: true,
     ) do
-      Aws::S3::Resource.new(region: 'us-east-1').
-        bucket('david-runger-uploads').
-        object("prerenders/#{git_rev}/#{filename}").
-        get.body.read.
-        then { html_with_absolutized_asset_paths(_1) }
-    rescue Aws::S3::Errors::NoSuchKey => error
-      log_warning(error)
-      nil
-    rescue => error
-      case Rails.env
-      when 'production' then Rails.error.report(error, severity: :error, context: { filename: })
-      when 'test' then raise(error)
-      else log_warning(error)
-      end
-
-      nil
-    end
-  end
-
-  def html_with_absolutized_asset_paths(html)
-    if Rails.env.development?
-      # convert relative asset paths to absolute paths pointing to davidrunger.com
-      html.gsub!(%r{(href|src)="/vite/assets/}, %(\\1="#{DavidRunger::CANONICAL_URL}vite/assets/))
-    end
-
-    html
+      PrerenderUtils.transformed_s3_content(git_rev, filename)
+    end ||
+      Rails.cache.read(
+        PrerenderUtils.cache_key(git_rev: 'deploy-fallback', filename:),
+      )
   end
 
   def html_with_nonced_scripts(html)
     html.gsub!(/<script +nonce="" *>/, %(<script nonce="#{content_security_policy_nonce}">))
     html
-  end
-
-  def log_warning(error)
-    Rails.logger.warn("Could not fetch prerendered content: #{error.inspect}")
   end
 end

--- a/app/poros/prerender_utils.rb
+++ b/app/poros/prerender_utils.rb
@@ -1,0 +1,42 @@
+module PrerenderUtils
+  class << self
+    def cache_key(git_rev:, filename:)
+      "prerendered-pages:#{git_rev}:#{filename}"
+    end
+
+    def transformed_s3_content(git_rev, filename)
+      Aws::S3::Resource.new(region: 'us-east-1').
+        bucket('david-runger-uploads').
+        object("prerenders/#{git_rev}/#{filename}").
+        get.body.read.
+        then { html_with_absolutized_asset_paths(_1) }
+    rescue Aws::S3::Errors::NoSuchKey => error
+      log_warning(error)
+
+      nil
+    rescue => error
+      case Rails.env
+      when 'production' then Rails.error.report(error, severity: :error, context: { filename: })
+      when 'test' then raise(error)
+      else log_warning(error)
+      end
+
+      nil
+    end
+
+    private
+
+    def html_with_absolutized_asset_paths(html)
+      if Rails.env.development?
+        # convert relative asset paths to absolute paths pointing to davidrunger.com
+        html.gsub!(%r{(href|src)="/vite/assets/}, %(\\1="#{DavidRunger::CANONICAL_URL}vite/assets/))
+      end
+
+      html
+    end
+
+    def log_warning(error)
+      Rails.logger.warn("Could not fetch prerendered content: #{error.inspect}")
+    end
+  end
+end

--- a/app/poros/prerender_utils.rb
+++ b/app/poros/prerender_utils.rb
@@ -4,7 +4,7 @@ module PrerenderUtils
       "prerendered-pages:#{git_rev}:#{filename}"
     end
 
-    def transformed_s3_content(git_rev, filename)
+    def transformed_s3_content(git_rev:, filename:)
       Aws::S3::Resource.new(region: 'us-east-1').
         bucket('david-runger-uploads').
         object("prerenders/#{git_rev}/#{filename}").

--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -25,7 +25,7 @@ bin/server/install.sh
 bin/build-docker production
 
 # Run release tasks.
-docker compose run --rm web bin/server/release-tasks
+bin/server/run-release-tasks
 
 # Copy fully built out public/ directory from web to nginx via app-public volume.
 docker run --rm \

--- a/bin/server/release-tasks
+++ b/bin/server/release-tasks
@@ -77,3 +77,28 @@ if Rails.env.production?
     )
   end
 end
+
+runner.run_task('Caching temporary fallback for prerendered home page') do
+  outgoing_git_sha = ENV.fetch('OUTGOING_GIT_SHA', nil)
+
+  if outgoing_git_sha.present?
+    filename = 'home.html'
+
+    outgoing_cached_value =
+      Rails.cache.read(
+        PrerenderUtils.cache_key(git_rev: outgoing_git_sha, filename:),
+      ) || PrerenderUtils.transformed_s3_content(outgoing_git_sha, filename)
+
+    if outgoing_cached_value.present?
+      Rails.cache.write(
+        PrerenderUtils.cache_key(git_rev: 'deploy-fallback', filename:),
+        outgoing_cached_value,
+        expires_in: 5.minutes,
+      )
+    else
+      print('could not find an outgoing cached value... ')
+    end
+  else
+    print('could not find an outgoing git sha... ')
+  end
+end

--- a/bin/server/release-tasks
+++ b/bin/server/release-tasks
@@ -87,7 +87,7 @@ runner.run_task('Caching temporary fallback for prerendered home page') do
     outgoing_cached_value =
       Rails.cache.read(
         PrerenderUtils.cache_key(git_rev: outgoing_git_sha, filename:),
-      ) || PrerenderUtils.transformed_s3_content(outgoing_git_sha, filename)
+      ) || PrerenderUtils.transformed_s3_content(git_rev: outgoing_git_sha, filename:)
 
     if outgoing_cached_value.present?
       Rails.cache.write(

--- a/bin/server/run-release-tasks
+++ b/bin/server/run-release-tasks
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+# Find currently deployed and running (but soon to be outgoing) Git sha.
+OUTGOING_GIT_SHA=$(docker compose exec web printenv GIT_REV)
+
+# Run release tasks.
+docker compose run --rm -e OUTGOING_GIT_SHA="$OUTGOING_GIT_SHA" web bin/server/release-tasks


### PR DESCRIPTION
The amount of time that we want to cover is the amount of time from when the relevant release task (added in this change) executes until a new prerender is generated and uploaded to S3. It seems that this often takes about 5 minutes, so we'll start with writing the cache value to last for that long.