### PR TITLE
[prerenderable] Skip prerendered content if there's a prerender param

### DIFF
--- a/app/controllers/concerns/prerenderable.rb
+++ b/app/controllers/concerns/prerenderable.rb
@@ -2,9 +2,10 @@ module Prerenderable
   extend ActiveSupport::Concern
 
   def serve_prerender_with_fallback(filename:, expected_content:, &fallback)
-    prerendered_html = prerendered_html(filename)
-
-    if prerendered_html
+    if params.key?('prerender')
+      Rails.logger.info('Skipping prerendered content because a prerender param is present.')
+      instance_eval(&fallback)
+    elsif (prerendered_html = prerendered_html(filename))
       if prerendered_html.include?(expected_content)
         # rubocop:disable Rails/OutputSafety
         render(

--- a/app/javascript/home/components/Projects.vue
+++ b/app/javascript/home/components/Projects.vue
@@ -66,11 +66,9 @@ HomeSection(section='projects' title='Projects')
 
         li.
 
-          The excellent
-
           #[a(href='https://vite-ruby.netlify.app/guide/rails.html') Vite Rails]
 
-          gem provides sub-second hot module replacement (HMR) in development,
+          provides sub-second hot module replacement (HMR) in development,
           and compiles the application's TypeScript and CSS for production.
 
         li.

--- a/spec/controllers/concerns/prerenderable_spec.rb
+++ b/spec/controllers/concerns/prerenderable_spec.rb
@@ -1,5 +1,8 @@
 RSpec.describe Prerenderable, :without_verifying_authorization do
-  before { stub_const('LIVE_RENDERED_PAGE_TEXT', 'Good morning, Vietnam!') }
+  before do
+    stub_const('EXPECTED_CONTENT', 'Great page text!')
+    stub_const('LIVE_RENDERED_PAGE_TEXT', 'Good morning, Vietnam!')
+  end
 
   controller(ApplicationController) do
     include Prerenderable
@@ -7,14 +10,16 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
     skip_before_action :authenticate_user!
 
     def index
-      serve_prerender_with_fallback(filename: 'home.html', expected_content: 'Great page text!') do
+      serve_prerender_with_fallback(filename: 'home.html', expected_content: EXPECTED_CONTENT) do
         render(plain: LIVE_RENDERED_PAGE_TEXT)
       end
     end
   end
 
   describe '#serve_prerender_with_fallback', :fake_aws_credentials do
-    subject(:get_index) { get(:index) }
+    subject(:get_index) { get(:index, params:) }
+
+    let(:params) { {} }
 
     context 'when ENV["GIT_REV"] is set' do
       around do |spec|
@@ -76,34 +81,88 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
         end
       end
 
-      context 'when S3 responds with an Aws::S3::Errors::NoSuchKey error' do
+      context 'when S3 will respond with an Aws::S3::Errors::NoSuchKey error' do
         before do
-          expect_any_instance_of(Aws::S3::Object). # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Aws::S3::Object). # rubocop:disable RSpec/AnyInstance
             to receive(:get).
             and_raise(Aws::S3::Errors::NoSuchKey.allocate)
         end
 
-        it 'serves the page via the fallback block' do
-          expect(Rails.logger).
-            to receive(:info).
-            with(%(Could not find a "home.html" prerender.)).
-            and_call_original
-          expect(Rails.logger).to receive(:info).at_least(:once).and_call_original # pass others
+        context 'when deploy fallback content including the expected content has been written to the cache', :cache do
+          before do
+            Rails.cache.write(
+              PrerenderUtils.cache_key(
+                git_rev: 'deploy-fallback',
+                filename: 'home.html',
+              ),
+              cached_deploy_fallback_html,
+            )
+          end
 
-          get_index
-          expect(response.body).to have_text(LIVE_RENDERED_PAGE_TEXT)
+          let(:cached_deploy_fallback_html) do
+            "<html>#{EXPECTED_CONTENT} Deploy fallback markup!</html>"
+          end
+
+          context 'when a "prerender" query param is present' do
+            let(:params) { super().merge({ prerender: true }) }
+
+            it 'serves the page via the fallback block' do
+              allow(Rails.logger).to receive(:info).and_call_original
+
+              get_index
+
+              expect(response.body).to eq(LIVE_RENDERED_PAGE_TEXT)
+              expect(Rails.logger).to have_received(:info).with(
+                'Skipping prerendered content because a prerender param is present.',
+              )
+            end
+          end
+
+          context 'when a "prerender" query param is not present' do
+            before do
+              expect(params.symbolize_keys).not_to have_key(:prerender)
+            end
+
+            it 'serves the cached, deploy-fallback content' do
+              get_index
+
+              expect(response.body).to eq(cached_deploy_fallback_html)
+            end
+          end
         end
 
-        it 'does not log an error to Rollbar' do
-          expect(Rollbar).not_to receive(:error)
-          get_index
-        end
+        context 'when a deploy fallback has not been written to the cache' do
+          before do
+            expect(Rails.cache.read(
+              PrerenderUtils.cache_key(
+                git_rev: 'deploy-fallback',
+                filename: 'home.html',
+              ),
+            )).to eq(nil)
+          end
 
-        it 'logs to Rails.logger' do
-          expect(Rails.logger).to receive(:warn).with(
-            /Could not fetch prerendered content/,
-          ).and_call_original
-          get_index
+          it 'serves the page via the fallback block' do
+            expect(Rails.logger).
+              to receive(:info).
+              with(%(Could not find a "home.html" prerender.)).
+              and_call_original
+            expect(Rails.logger).to receive(:info).at_least(:once).and_call_original # pass others
+
+            get_index
+            expect(response.body).to have_text(LIVE_RENDERED_PAGE_TEXT)
+          end
+
+          it 'does not log an error to Rollbar' do
+            expect(Rollbar).not_to receive(:error)
+            get_index
+          end
+
+          it 'logs to Rails.logger' do
+            expect(Rails.logger).to receive(:warn).with(
+              /Could not fetch prerendered content/,
+            ).and_call_original
+            get_index
+          end
         end
       end
 

--- a/spec/controllers/concerns/prerenderable_spec.rb
+++ b/spec/controllers/concerns/prerenderable_spec.rb
@@ -30,8 +30,8 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
 
       let(:commit_sha) { Digest::SHA1.hexdigest(rand(1_000_000).to_s) }
 
-      context 'when S3 responds with prerendered page content' do
-        let(:page_text) { 'Great page text!' }
+      context 'when S3 responds with prerendered page content including the expected text' do
+        let(:page_text) { "Some text. #{EXPECTED_CONTENT} More text!" }
 
         before do
           stub_request(


### PR DESCRIPTION
Otherwise, due to #6127, we will serve the previously prerendered content to the request to generate a new prerendered HTML page, so we keep the old content alive indefinitely.

This param is added as a query param when we make the prerendering request: https://github.com/davidrunger/david_runger/blob/24ac6c4d4dac5e5de61b5b08316347fabd198cab/bin/prerender/#L23

Also, tweak the Vite Rails description, so that I'll be able to see whether this works.