### PR TITLE
Open json-to-schema converter in browser on validation fail [DEV-172]

### DIFF
--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -24,10 +24,7 @@ class JsonSchemaValidator
 
       raise(
         NonconformingData,
-        <<~ERROR_MESSAGE,
-          Violation of #{relative_schema_path} : #{schema_validation_errors}.
-          The JSON has been copied to your clipboard.
-        ERROR_MESSAGE
+        "Violation of #{relative_schema_path} : #{schema_validation_errors}.",
       )
     else
       @data

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -21,10 +21,14 @@ class JsonSchemaValidator
         schema_validation_errors.present?
     )
       copy_data_to_clipboard
+      system('open https://jsonformatter.org/json-to-jsonschema', exception: true)
 
       raise(
         NonconformingData,
-        "Violation of #{relative_schema_path} : #{schema_validation_errors}",
+        <<~ERROR_MESSAGE,
+          Violation of #{relative_schema_path} : #{schema_validation_errors}.
+          The JSON has been copied to your clipboard.
+        ERROR_MESSAGE
       )
     else
       @data

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -20,8 +20,7 @@ class JsonSchemaValidator
         !(universal_bootstrap_data? && !schema_file_exists?) &&
         schema_validation_errors.present?
     )
-      copy_data_to_clipboard
-      system('open https://jsonformatter.org/json-to-jsonschema', exception: true)
+      copy_data_to_clipboard_and_open_schema_converter
 
       raise(
         NonconformingData,
@@ -55,7 +54,7 @@ class JsonSchemaValidator
     if Rails.env.development?
       # :nocov:
       create_and_open_schema_file_in_editor
-      copy_data_to_clipboard
+      copy_data_to_clipboard_and_open_schema_converter
       # :nocov:
     end
 
@@ -106,7 +105,7 @@ class JsonSchemaValidator
     # :nocov:
   end
 
-  def copy_data_to_clipboard
+  def copy_data_to_clipboard_and_open_schema_converter
     if Rails.env.development?
       # :nocov:
       string_to_copy =
@@ -121,6 +120,8 @@ class JsonSchemaValidator
 
         puts('Copied JSON to clipboard.'.yellow)
       end
+
+      system('open https://jsonformatter.org/json-to-jsonschema', exception: true)
       # :nocov:
     end
   end

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -20,7 +20,7 @@ class JsonSchemaValidator
         !(universal_bootstrap_data? && !schema_file_exists?) &&
         schema_validation_errors.present?
     )
-      copy_data_to_clipboard_and_open_schema_converter
+      copy_data_to_clipboard_and_open_schema_converter_if_development
 
       raise(
         NonconformingData,
@@ -54,7 +54,7 @@ class JsonSchemaValidator
     if Rails.env.development?
       # :nocov:
       create_and_open_schema_file_in_editor
-      copy_data_to_clipboard_and_open_schema_converter
+      copy_data_to_clipboard_and_open_schema_converter_if_development
       # :nocov:
     end
 
@@ -105,7 +105,7 @@ class JsonSchemaValidator
     # :nocov:
   end
 
-  def copy_data_to_clipboard_and_open_schema_converter
+  def copy_data_to_clipboard_and_open_schema_converter_if_development
     if Rails.env.development?
       # :nocov:
       string_to_copy =


### PR DESCRIPTION
It's annoying to have to look up the converter website ( https://jsonformatter.org/json-to-jsonschema ) every time that this happens. Why not just open the page automatically? We already copy the data to the clipboard automatically. This change starts opening that website automatically.