### PR TITLE
Confirm before deleting log entries [LOG-34]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,7 @@
 class ApplicationController < ActionController::Base
   include Bootstrappable
   include BrowserSupportCheckable
-  include ContainerClassable
+  include Classable
   include Pundit::Authorization
   include RequestRecordable
   include SchemaValidatable

--- a/app/controllers/concerns/classable.rb
+++ b/app/controllers/concerns/classable.rb
@@ -1,8 +1,9 @@
-module ContainerClassable
+module Classable
   extend ActiveSupport::Concern
 
   included do
     helper_method :container_classes
+    helper_method :html_classes
   end
 
   class_methods do
@@ -13,9 +14,21 @@ module ContainerClassable
     def container_classes
       @container_classes || []
     end
+
+    def html_classes=(classes)
+      @html_classes = classes
+    end
+
+    def html_classes
+      @html_classes || []
+    end
   end
 
   def container_classes
     self.class.container_classes
+  end
+
+  def html_classes
+    self.class.html_classes
   end
 end

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -1,4 +1,6 @@
 class LogsController < ApplicationController
+  self.html_classes = %w[dark]
+
   skip_before_action(
     :authenticate_user!,
     if: -> { action_name == 'index' && shared_log&.publicly_viewable? },

--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -22,6 +22,8 @@ import { useModalStore } from '@/shared/modal/store';
 import LogSelectorModal from './components/LogSelectorModal.vue';
 import type { Bootstrap } from './types';
 
+import 'element-plus/theme-chalk/dark/css-vars.css'
+
 const bootstrap = untypedBootstrap as Bootstrap;
 const logsStore = useLogsStore();
 const modalStore = useModalStore();

--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -22,7 +22,7 @@ import { useModalStore } from '@/shared/modal/store';
 import LogSelectorModal from './components/LogSelectorModal.vue';
 import type { Bootstrap } from './types';
 
-import 'element-plus/theme-chalk/dark/css-vars.css'
+import 'element-plus/theme-chalk/dark/css-vars.css';
 
 const bootstrap = untypedBootstrap as Bootstrap;
 const logsStore = useLogsStore();

--- a/app/javascript/logs/components/EditableTextLogRow.vue
+++ b/app/javascript/logs/components/EditableTextLogRow.vue
@@ -20,16 +20,20 @@ tr
         link
         type='primary'
       ) Edit
-      el-button(
-        @click='destroyLogEntry'
-        link
-        type='danger'
-      ) Delete
+      el-popconfirm(
+        title="Delete this log entry?"
+        @confirm="destroyLogEntry"
+      )
+        template(#reference)
+          el-button(
+            link
+            type='danger'
+          ) Delete
 </template>
 
 <script setup lang="ts">
 import createDOMPurify from 'dompurify';
-import { ElInput } from 'element-plus';
+import { ElInput, ElPopconfirm } from 'element-plus';
 import { marked } from 'marked';
 import strftime from 'strftime';
 import { computed, ref, watch, type PropType } from 'vue';

--- a/app/javascript/logs/components/Log.vue
+++ b/app/javascript/logs/components/Log.vue
@@ -17,7 +17,12 @@ div
       :log='log'
     )
     .mt-2(v-if='showDeleteLastEntryButton')
-      el-button(@click='destroyLastEntry') Delete last entry
+      el-popconfirm(
+          title="Delete the last log entry?"
+          @confirm="destroyLastEntry"
+        )
+          template(#reference)
+            el-button Delete last entry
     .mt-2
       a.download-link(
         :href='download_log_path(log.slug)'
@@ -50,6 +55,7 @@ div
 
 <script setup lang="ts">
 import { useTitle } from '@vueuse/core';
+import { ElPopconfirm } from 'element-plus';
 import Cookies from 'js-cookie';
 import { storeToRefs } from 'pinia';
 import { computed, h } from 'vue';
@@ -102,13 +108,7 @@ const showDeleteLastEntryButton = computed((): boolean => {
 });
 
 function destroyLastEntry() {
-  const confirmation = window.confirm(
-    `Are you sure that you want to delete the last entry from the ${log.name} log?`,
-  );
-
-  if (confirmation === true) {
-    logsStore.deleteLastLogEntry({ log });
-  }
+  logsStore.deleteLastLogEntry({ log });
 }
 
 function destroyLog() {

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,5 +1,5 @@
 !!! 5
-%html{lang: 'en'}
+%html{lang: 'en', class: html_classes}
   %head
     %meta{charset: 'UTF-8'}
     %meta{name: 'viewport', content: 'width=device-width, initial-scale=1, minimum-scale=1'}

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -19,7 +19,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'groceries*.js' => (441..451),
     'home*.css' => (0..10),
     'home*.js' => (229..239),
-    'logs*.css' => (95..105),
+    'logs*.css' => (102..112),
     'logs*.js' => (809..819),
     'quizzes*.js' => (123..133),
     'styles*.css' => (26..36),


### PR DESCRIPTION
I think that the UX of doing this with the ElPopconfirm is nice because the user's mouse doesn't have to move very far to click "Yes" to confirm.

![image](https://github.com/user-attachments/assets/d3092def-5bc0-48c6-b0bc-5af7611e1298)