### PR TITLE
[logs] Add 'maintainAspectRatio: false' to BarGraph options [LOG-35]

### DIFF
--- a/app/javascript/components/charts/BarGraph.vue
+++ b/app/javascript/components/charts/BarGraph.vue
@@ -76,6 +76,7 @@ const props = defineProps({
 
 const chartOptions = {
   responsive: true,
+  maintainAspectRatio: false,
   scales: {
     x: merge({}, commonAxisOptions, {
       offset: true,


### PR DESCRIPTION
This makes the graph render with the desired height of 300px. Without this, it renders much too tall. We [already have this setting for LineChart][1], which probably explains why line graphs (i.e. duration and number logs) weren't also having this issue; only bar charts (i.e. counter logs) were.

I am not sure if this is a new bug / how long things have been this way.

[1]: https://github.com/davidrunger/david_runger/blob/10b75e94567ce3f885b7da31ac2f358227839d7b/app/javascript/components/charts/LineChart.vue/#L59

## Before

![image](https://github.com/user-attachments/assets/0e4ea276-a3ea-41fa-8dc1-82ccf42412fc)

## After

![image](https://github.com/user-attachments/assets/da7c0b4c-f62e-4155-b952-6391c6110742)