### PR TITLE
[ci] Stop creating dedicated feature specs database

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -56,6 +56,7 @@ class Test::RequirementsResolver
           Test::Tasks::CompileAdminJavaScript,
           Test::Tasks::CompileUserJavaScript,
           Test::Tasks::StartPercy,
+          Test::Tasks::RunUnitTests,
         ],
         Test::Tasks::RunFeatureTestsB => [
           Test::Tasks::DivideFeatureSpecs,

--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -3,7 +3,7 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
 
   def run
     ActiveRecord::Base.remove_connection
-    %w[unit api html feature].each do |db_suffix|
+    %w[unit api html].each do |db_suffix|
       db_name = "david_runger_test_#{db_suffix}"
       # in CI, we know that the database doesn't exist, so don't waste any time dropping it
       unless ENV.key?('CI')

--- a/lib/test/tasks/run_feature_tests_a.rb
+++ b/lib/test/tasks/run_feature_tests_a.rb
@@ -3,7 +3,7 @@ class Test::Tasks::RunFeatureTestsA < Pallets::Task
 
   def run
     execute_rspec_command(<<~COMMAND)
-      DB_SUFFIX=_feature CAPYBARA_SERVER_PORT=3001
+      DB_SUFFIX=_unit CAPYBARA_SERVER_PORT=3001
       bin/rspec $(cat tmp/feature_specs_a.txt)
       --format RSpec::Instafail --format progress --force-color
     COMMAND


### PR DESCRIPTION
With this change, instead of using a dedicated DB, `RunFeatureTestsA` will now use the `_unit` DB (similar to how `RunFeatureTestsB` uses the `_api` DB).

The `CreateDbCopies` step takes a nontrivial amount of time (~10+ seconds). I think that reducing the number of DBs created by 25%, which this change does (by no longer creating a dedicated DB for feature specs), will probably also decrease the time that `CreateDbCopies` takes by ~25%. That will allow us to start running the unit tests and API controller tests more quickly. Since it seems that the unit tests usually finish running before our JavaScript has finished compiling (although there are exceptions to this), we aren't able to start feature specs in parallel with the unit tests, anyway.

If unit tests ever start taking longer and/or if compiling JavaScript starts taking less time, then it might be worth undoing this change. But, for now, I think it's the optimal flow.

It's weird: sometimes CreateDbCopies takes ~10 seconds, but sometimes it takes only ~1 second, and there aren't really any in-between times like 5 seconds. I'm not sure what causes this. If we can somehow start to get more ~1 second runs of CreateDbCopies, then that might also make this change not make sense. But, for now, let's try it.