### PR TITLE
[Exit] Uppercase CI_STEP_RESULTS_HOST in printed message

### DIFF
--- a/lib/test/tasks/exit.rb
+++ b/lib/test/tasks/exit.rb
@@ -38,7 +38,7 @@ class Test::Tasks::Exit < Pallets::Task
         pp(error)
       end
     else
-      puts('ci_step_results_host is not present; not sending results.')
+      puts('CI_STEP_RESULTS_HOST is not present; not sending results.')
     end
   end
 


### PR DESCRIPTION
This just makes it more clear what's going on.