### PR TITLE
Wait for Percy to be running before starting feature specs

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -28,6 +28,11 @@ class Test::RequirementsResolver
         Test::Tasks::CreateDbCopies => Test::Tasks::BuildFixtures,
         Test::Tasks::DivideFeatureSpecs => nil,
         Test::Tasks::StartPercy => Test::Tasks::PnpmInstall,
+        # WaitForPercyStart doesn't really need the JS assets, but for timing we'll wait 'til then.
+        Test::Tasks::WaitForPercyStart => [
+          Test::Tasks::CompileAdminJavaScript,
+          Test::Tasks::CompileUserJavaScript,
+        ],
 
         # Checks
         Test::Tasks::CheckVersions => nil,
@@ -57,6 +62,7 @@ class Test::RequirementsResolver
           Test::Tasks::CompileUserJavaScript,
           Test::Tasks::StartPercy,
           Test::Tasks::RunUnitTests,
+          Test::Tasks::WaitForPercyStart,
         ],
         Test::Tasks::RunFeatureTestsB => [
           Test::Tasks::DivideFeatureSpecs,
@@ -65,6 +71,7 @@ class Test::RequirementsResolver
           Test::Tasks::CompileUserJavaScript,
           Test::Tasks::StartPercy,
           Test::Tasks::RunApiControllerTests,
+          Test::Tasks::WaitForPercyStart,
         ],
         Test::Tasks::RunHtmlControllerTests => [
           Test::Tasks::CreateDbCopies,

--- a/lib/test/tasks/wait_for_percy_start.rb
+++ b/lib/test/tasks/wait_for_percy_start.rb
@@ -7,15 +7,17 @@ class Test::Tasks::WaitForPercyStart < Pallets::Task
       # take particularly long if there is a new Chromium version to download.)
       num_attempts = 20
 
-      num_attempts.times do
+      num_attempts.times do |index|
         if system('./node_modules/.bin/percy exec:ping')
-          record_success_and_log_message('Percy is running.')
+          record_success_and_log_message("Percy is running after #{index + 1} checks.")
 
-          return
+          break
+        elsif index == num_attempts - 1
+          record_failure_and_log_message(<<~LOG)
+            Percy is still not running after #{index + 1} attempts.
+          LOG
         end
       end
-
-      record_failure_and_log_message("Percy is still not running after #{num_attempts} attempts.")
     else
       record_success_and_log_message('Percy token was not present; skipping percy exec:ping.')
     end

--- a/lib/test/tasks/wait_for_percy_start.rb
+++ b/lib/test/tasks/wait_for_percy_start.rb
@@ -1,0 +1,23 @@
+class Test::Tasks::WaitForPercyStart < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    if ENV['PERCY_TOKEN'].present?
+      # Make up to 20 attempts to verify that Percy is running. (It tends to
+      # take particularly long if there is a new Chromium version to download.)
+      num_attempts = 20
+
+      num_attempts.times do
+        if system('./node_modules/.bin/percy exec:ping')
+          record_success_and_log_message('Percy is running.')
+
+          return
+        end
+      end
+
+      record_failure_and_log_message("Percy is still not running after #{num_attempts} attempts.")
+    else
+      record_success_and_log_message('Percy token was not present; skipping percy exec:ping.')
+    end
+  end
+end

--- a/lib/test/tasks/wait_for_percy_start.rb
+++ b/lib/test/tasks/wait_for_percy_start.rb
@@ -9,12 +9,12 @@ class Test::Tasks::WaitForPercyStart < Pallets::Task
 
       num_attempts.times do |index|
         if system('./node_modules/.bin/percy exec:ping')
-          record_success_and_log_message("Percy is running after #{index + 1} checks.")
+          record_success_and_log_message("Percy is running after #{index + 1} check(s).")
 
           break
         elsif index == num_attempts - 1
           record_failure_and_log_message(<<~LOG)
-            Percy is still not running after #{index + 1} attempts.
+            Percy is still not running after #{index + 1} attempt(s).
           LOG
         end
       end


### PR DESCRIPTION
We saw a Percy failure ([one][1], [two][2]) where Percy didn't receive any snapshots. I think that this is because the Percy server wasn't yet running when the Percy-snapshot-taking feature specs ran. I think that this is because there was a new version of Chromium to download. In general, I think that Percy will take a particularly long to start up if there is a new Chromium version to download.

[1]: https://percy.io/David-Runger/web/david_runger/builds/38736162/failed
[2]: https://github.com/davidrunger/david_runger/actions/runs/13333515282/job/37243233305?pr=6142#step:11:166

To avoid this issue, this change adds a `WaitForPercyStart` test step that uses `percy exec:ping` to make sure that Percy is running before starting feature specs.