### PR TITLE
[CreateDbCopies] Use disconnect! rather than remove_connection

### DIFF
--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -2,6 +2,8 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
   include Test::TaskHelpers
 
   def run
+    # The commands below will error if there are any active connections to the
+    # database, so disconnect.
     ActiveRecord::Base.connection_pool.connections.each(&:disconnect!)
 
     %w[unit api html].each do |db_suffix|

--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -2,13 +2,16 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    ActiveRecord::Base.remove_connection
+    ActiveRecord::Base.connection_pool.connections.each(&:disconnect!)
+
     %w[unit api html].each do |db_suffix|
       db_name = "david_runger_test_#{db_suffix}"
+
       # in CI, we know that the database doesn't exist, so don't waste any time dropping it
       unless ENV.key?('CI')
         execute_system_command("dropdb --if-exists #{db_name}")
       end
+
       execute_system_command(<<~COMMAND)
         createdb
           -T david_runger_test #{db_name}


### PR DESCRIPTION
`ActiveRecord::Base.remove_connection` usually takes just about exactly 10 seconds. Sometimes, however, it seems to take almost no time at all.

I think that it takes 10 seconds if [2 database connections][1] have been established by the Rails threads booted by Pallets. I think that maybe there is a 5 second timeout that apparently applies to each thread in series? I think it takes almost no time at all if the `CreateDbCopies` step executes before those connections can be established.

[1]: https://github.com/davidrunger/david_runger/blob/0437f114137b3066c414f868f537d1a9dd2645cd/.env.test/#L3

The reason that we were calling `ActiveRecord::Base.remove_connection` is because, if we don't, then the `dropdb` and/or `createdb` calls in `CreateDbCopies` can/will raise errors, complaining that there are active sessions connected to the database.

However, I think that calling `ActiveRecord::Base.connection_pool.connections.each(&:disconnect!)`, instead, also avoids these errors, while being much faster than `ActiveRecord::Base.remove_connection`, so this change switches to using `connections.each(&:disconnect!)`.

I think that this will make the `CreateDbCopies` CI step consistently much faster (by about 10 seconds in most cases), and I think it will positively affect our overall build times.