### PR TITLE
[ci] Increase Pallets concurrency from 4 to 5

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -79,7 +79,7 @@ jobs:
         run: bin/run-tests
         env:
           CI: true
-          PALLETS_CONCURRENCY: 4
+          PALLETS_CONCURRENCY: 5
           AWS_EC2_METADATA_DISABLED: true
           RAILS_ENV: test
           DISABLE_SPRING: 1

--- a/lib/test/run_pallets_tests.rb
+++ b/lib/test/run_pallets_tests.rb
@@ -4,7 +4,7 @@ require_relative 'middleware/task_result_tracking_middleware.rb'
 require_relative 'runner.rb'
 
 Pallets.configure do |c|
-  concurrency = Integer(ENV.fetch('PALLETS_CONCURRENCY', 4))
+  concurrency = Integer(ENV.fetch('PALLETS_CONCURRENCY'))
   puts("Pallets concurrency: #{concurrency}")
 
   c.concurrency = concurrency


### PR DESCRIPTION
Also, remove fallback when fetching the `PALLETS_CONCURRENCY` env var. Anyone running pallets will now have to always provide that env var. Motivation: I was getting a little sick of changing it in two places, and I think arguably it's more clear to not have the fallback, so that someone reading this code knows that the pallets concurrency is being set by the env var being passed in rather than potentially coming from the fallback value.

This change might seem a little crazy, because the GitHub Actions machines have only 4 vCPUs, so we are now going beyond that. However, looking at test runs like this one...

![image](https://github.com/user-attachments/assets/f40b9d7d-3d29-426f-9c12-5f690c43bac8)

... we can see that the concurrency of 4 is a limiting factor in some runs, and having a concurrency of 5 would have enabled `RunUnitTests` to start sooner.

Below is the Gantt chart for this PR's run. We can see that we do use the parallelism of 5 for part of the time.

![image](https://github.com/user-attachments/assets/72662152-267d-4e6d-bef8-0c2452eb752d)

It's a little hard to know the impact that this will have on average run times, because that PR run time was slowed down by the unlucky uneven distribution of feature specs and by running prettier. The `CompileUserJavaScript` step took somewhat unusually long (40.3 seconds), probably because of the increased CPU contention. It's possible that this change could be a net negative, but I suspect it will be a net positive. I am going to merge this, so we can see how it plays out.