### PR TITLE
[ci] Wait in WaitForPercyStart for API and unit tests, not JavaScript

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -28,10 +28,10 @@ class Test::RequirementsResolver
         Test::Tasks::CreateDbCopies => Test::Tasks::BuildFixtures,
         Test::Tasks::DivideFeatureSpecs => nil,
         Test::Tasks::StartPercy => Test::Tasks::PnpmInstall,
-        # WaitForPercyStart doesn't really need the JS assets, but for timing we'll wait 'til then.
+        # WaitForPercyStart doesn't really need these, but for timing we'll wait 'til they're done.
         Test::Tasks::WaitForPercyStart => [
-          Test::Tasks::CompileAdminJavaScript,
-          Test::Tasks::CompileUserJavaScript,
+          Test::Tasks::RunApiControllerTests,
+          Test::Tasks::RunUnitTests,
         ],
 
         # Checks


### PR DESCRIPTION
Visual illustration of motivation (showing a build prior to this change):

![image](https://github.com/user-attachments/assets/80ca595c-4b9c-4751-b692-7c6962545a4e)

This change will hopefully mean that `WaitForPercyStart` won't block feature test execution; it will have already been completed by the time that JavaScript assets have been compiled and feature tests are ready to run.

Here's the build for this PR:

![image](https://github.com/user-attachments/assets/79294845-d708-4cbf-8479-743bdac0838b)

As we can see, the feature tests were able to start running immediately after the JavaScript finished compiling.