### PR TITLE
[vite] Set maxParallelFileOps for builds in CI

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -11,10 +11,11 @@ export default defineConfig({
   build: {
     rollupOptions: {
       maxParallelFileOps:
-        process.env.CI ?
-          process.env.VITE_RUBY_PUBLIC_OUTPUT_DIR == 'vite-admin' ?
-            1
-          : 2
+        (
+          process.env.CI &&
+          process.env.VITE_RUBY_PUBLIC_OUTPUT_DIR == 'vite-admin'
+        ) ?
+          1
         : 4,
     },
   },

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -8,6 +8,16 @@ import FullReload from 'vite-plugin-full-reload';
 import RubyPlugin from 'vite-plugin-ruby';
 
 export default defineConfig({
+  build: {
+    rollupOptions: {
+      maxParallelFileOps:
+        process.env.CI ?
+          process.env.VITE_RUBY_PUBLIC_OUTPUT_DIR == 'vite-admin' ?
+            1
+          : 2
+        : 4,
+    },
+  },
   // https://github.com/vitejs/vite/issues/ 18164#issuecomment-2365310242
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
I'm hoping that specifying these limits might reduce CPU contention and make builds faster overall.

In CI, maxParallelFileOps will be 1 for the admin build, to hopefully deprioritize it and cause less CPU contention (since it still seems to finish reliably before the user JS build). For all other cases, we'll set maxParallelFileOps to 4.

It's sort of hard to test whether this is having any effect, and I'm not 100% sure that it is. The admin JS builds don't seem much slower than before. But I'll guess I'll merge it, in case it helps.