### PR TITLE
Split feature tests into 3 groups (not 2)

### DIFF
--- a/app/poros/redis_options.rb
+++ b/app/poros/redis_options.rb
@@ -28,7 +28,7 @@ class RedisOptions
       when '_unit', nil then 4
       when '_api' then 5
       when '_html' then 6
-      when '_feature_c' then 7
+      when '_feature' then 7
       else raise('Unexpected DB_SUFFIX!')
       end
     else

--- a/app/poros/redis_options.rb
+++ b/app/poros/redis_options.rb
@@ -28,7 +28,7 @@ class RedisOptions
       when '_unit', nil then 4
       when '_api' then 5
       when '_html' then 6
-      when '_feature' then 7
+      when '_feature_c' then 7
       else raise('Unexpected DB_SUFFIX!')
       end
     else

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -73,6 +73,14 @@ class Test::RequirementsResolver
           Test::Tasks::RunApiControllerTests,
           Test::Tasks::WaitForPercyStart,
         ],
+        Test::Tasks::RunFeatureTestsC => [
+          Test::Tasks::DivideFeatureSpecs,
+          Test::Tasks::CreateDbCopies,
+          Test::Tasks::CompileAdminJavaScript,
+          Test::Tasks::CompileUserJavaScript,
+          Test::Tasks::StartPercy,
+          Test::Tasks::WaitForPercyStart,
+        ],
         Test::Tasks::RunHtmlControllerTests => [
           Test::Tasks::CreateDbCopies,
           Test::Tasks::CompileAdminJavaScript,
@@ -104,6 +112,7 @@ class Test::RequirementsResolver
           Test::Tasks::RunEslint,
           Test::Tasks::RunFeatureTestsA,
           Test::Tasks::RunFeatureTestsB,
+          Test::Tasks::RunFeatureTestsC,
           Test::Tasks::RunFileSizeChecks,
           Test::Tasks::RunHtmlControllerTests,
           Test::Tasks::RunImmigrant,

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -231,13 +231,18 @@ class Test::RequirementsResolver
         !files_added_in?('spec/serializers')
     end,
     Test::Tasks::RunBrakeman => proc do
-      true
+      (!(haml_files_changed? || ruby_files_changed?) || running_locally?) &&
+        !diff_mentions?('brakeman')
     end,
     Test::Tasks::RunDatabaseConsistency => proc do
       !db_schema_changed? && !diff_mentions?('database_consistency')
     end,
     Test::Tasks::CheckTypescript => proc do
-      true
+      !files_with_js_changed? &&
+        !diff_mentions?('tsc|typescript') &&
+        !file_changed?('package.json') &&
+        !file_changed?('pnpm-lock.yaml') &&
+        !file_changed?('tsconfig.json')
     end,
     Test::Tasks::RunEslint => proc do
       !files_with_js_changed? &&
@@ -252,7 +257,10 @@ class Test::RequirementsResolver
         !diff_mentions?('prettier')
     end,
     Test::Tasks::RunRubocop => proc do
-      true
+      !ruby_files_changed? &&
+        !rubocop_files_changed? &&
+        !diff_mentions?('rubocop') &&
+        !diff_mentions?('runger_style')
     end,
     Test::Tasks::RunStylelint => proc { !files_with_css_changed? && !diff_mentions?('stylelint') },
     Test::Tasks::SetupDb => proc { running_locally? },

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -238,11 +238,7 @@ class Test::RequirementsResolver
       !db_schema_changed? && !diff_mentions?('database_consistency')
     end,
     Test::Tasks::CheckTypescript => proc do
-      !files_with_js_changed? &&
-        !diff_mentions?('\b(tsc|typescript)\b') &&
-        !file_changed?('package.json') &&
-        !file_changed?('pnpm-lock.yaml') &&
-        !file_changed?('tsconfig.json')
+      true
     end,
     Test::Tasks::RunEslint => proc do
       !files_with_js_changed? &&

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -91,6 +91,7 @@ class Test::RequirementsResolver
         Test::Tasks::StopPercy => [
           Test::Tasks::RunFeatureTestsA,
           Test::Tasks::RunFeatureTestsB,
+          Test::Tasks::RunFeatureTestsC,
         ],
         Test::Tasks::UploadViteAssets => [
           Test::Tasks::CompileAdminJavaScript,

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -231,8 +231,7 @@ class Test::RequirementsResolver
         !files_added_in?('spec/serializers')
     end,
     Test::Tasks::RunBrakeman => proc do
-      (!(haml_files_changed? || ruby_files_changed?) || running_locally?) &&
-        !diff_mentions?('brakeman')
+      true
     end,
     Test::Tasks::RunDatabaseConsistency => proc do
       !db_schema_changed? && !diff_mentions?('database_consistency')
@@ -253,10 +252,7 @@ class Test::RequirementsResolver
         !diff_mentions?('prettier')
     end,
     Test::Tasks::RunRubocop => proc do
-      !ruby_files_changed? &&
-        !rubocop_files_changed? &&
-        !diff_mentions?('rubocop') &&
-        !diff_mentions?('runger_style')
+      true
     end,
     Test::Tasks::RunStylelint => proc { !files_with_css_changed? && !diff_mentions?('stylelint') },
     Test::Tasks::SetupDb => proc { running_locally? },

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -239,7 +239,7 @@ class Test::RequirementsResolver
     end,
     Test::Tasks::CheckTypescript => proc do
       !files_with_js_changed? &&
-        !diff_mentions?('tsc|typescript') &&
+        !diff_mentions?('\b(tsc|typescript)\b') &&
         !file_changed?('package.json') &&
         !file_changed?('pnpm-lock.yaml') &&
         !file_changed?('tsconfig.json')

--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -6,7 +6,7 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
     # database, so disconnect.
     ActiveRecord::Base.connection_pool.connections.each(&:disconnect!)
 
-    %w[unit api html feature_c].each do |db_suffix|
+    %w[unit api html feature].each do |db_suffix|
       db_name = "david_runger_test_#{db_suffix}"
 
       # in CI, we know that the database doesn't exist, so don't waste any time dropping it

--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -6,7 +6,7 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
     # database, so disconnect.
     ActiveRecord::Base.connection_pool.connections.each(&:disconnect!)
 
-    %w[unit api html].each do |db_suffix|
+    %w[unit api html feature_c].each do |db_suffix|
       db_name = "david_runger_test_#{db_suffix}"
 
       # in CI, we know that the database doesn't exist, so don't waste any time dropping it

--- a/lib/test/tasks/divide_feature_specs.rb
+++ b/lib/test/tasks/divide_feature_specs.rb
@@ -1,7 +1,7 @@
 class Test::Tasks::DivideFeatureSpecs < Pallets::Task
   include Test::TaskHelpers
 
-  NUM_FEATURE_SPEC_GROUPS = 2
+  NUM_FEATURE_SPEC_GROUPS = 3
 
   def run
     puts("#{AmazingPrint::Colors.yellow('Dividing feature specs')}...")
@@ -11,7 +11,7 @@ class Test::Tasks::DivideFeatureSpecs < Pallets::Task
       group_by.with_index { |_file, index| index % NUM_FEATURE_SPEC_GROUPS }.
       values.
       each_with_index do |array, index|
-        letter = ('a'..'b').to_a.fetch(index)
+        letter = ('a'..'c').to_a.fetch(index)
         File.write("tmp/feature_specs_#{letter}.txt", array.join(' '))
       end
 

--- a/lib/test/tasks/run_feature_tests_c.rb
+++ b/lib/test/tasks/run_feature_tests_c.rb
@@ -3,7 +3,7 @@ class Test::Tasks::RunFeatureTestsC < Pallets::Task
 
   def run
     execute_rspec_command(<<~COMMAND)
-      DB_SUFFIX=_feature_c CAPYBARA_SERVER_PORT=3003
+      DB_SUFFIX=_feature CAPYBARA_SERVER_PORT=3003
       bin/rspec $(cat tmp/feature_specs_c.txt)
       --format RSpec::Instafail --format progress --force-color
     COMMAND

--- a/lib/test/tasks/run_feature_tests_c.rb
+++ b/lib/test/tasks/run_feature_tests_c.rb
@@ -1,0 +1,11 @@
+class Test::Tasks::RunFeatureTestsC < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    execute_rspec_command(<<~COMMAND)
+      DB_SUFFIX=_feature_c CAPYBARA_SERVER_PORT=3003
+      bin/rspec $(cat tmp/feature_specs_c.txt)
+      --format RSpec::Instafail --format progress --force-color
+    COMMAND
+  end
+end

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -4,7 +4,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
   def run
     # Run all tests in `spec/` _except_ those in `spec/controllers/` and `spec/features/`.
     # Tests in `spec/controllers/` will be run by RunApiControllerTests and RunHtmlControllerTests.
-    # Tests in `spec/features/` will be run by RunFeatureTests[A,B].
+    # Tests in `spec/features/` will be run by RunFeatureTests task(s).
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_unit
       bin/rspec


### PR DESCRIPTION
I think that this will better make use of the 4 vCPUs that are on GitHub Actions's machines. I tried this before (#6063), and it didn't seem to work, but I didn't have some things in place then that I have now (like more robust and efficient Percy setup for parallel runs, and also the Gantt charts, which are super helpful to understand what's going on), so I think it might work well this time around, i.e. I think it might decrease overall run time.