### PR TITLE
[ci] Stop trying to capture stdout from rake tasks [DEV-169]

### DIFF
--- a/lib/test/task_helpers.rb
+++ b/lib/test/task_helpers.rb
@@ -82,38 +82,23 @@ module Test::TaskHelpers
     end
   end
 
-  # rubocop:disable Metrics/CyclomaticComplexity
-  # rubocop:disable Metrics/MethodLength
-  # rubocop:disable Metrics/PerceivedComplexity
-  def execute_rake_task(task_name, *args, log_stdout_only_on_failure: false)
+  def execute_rake_task(task_name, *args)
     puts(<<~LOG.squish)
       Running rake task '#{AmazingPrint::Colors.yellow(task_name)}'
       with args #{AmazingPrint::Colors.yellow(args.inspect)} ...
     LOG
 
     time = nil
-    captured_stdout = nil
     exception = nil
 
     begin
       time =
         Benchmark.measure do
-          exception, captured_stdout =
-            capturing_stdout_and_all_exceptions do
-              Rake::Task[task_name].invoke(*args)
-            end
+          Rake::Task[task_name].invoke(*args)
         end.real
-
-      if exception
-        raise(exception)
-      end
     rescue => error
       exception = error
     ensure
-      if captured_stdout.present? && (!log_stdout_only_on_failure || exception.present?)
-        puts(captured_stdout)
-      end
-
       if exception.present?
         update_job_result_exit_code(1)
 
@@ -128,26 +113,6 @@ module Test::TaskHelpers
         record_success_and_log_message("'#{task_name}' succeeded (took #{time.round(3)}).")
       end
     end
-  end
-  # rubocop:enable Metrics/CyclomaticComplexity
-  # rubocop:enable Metrics/MethodLength
-  # rubocop:enable Metrics/PerceivedComplexity
-
-  def capturing_stdout_and_all_exceptions
-    original_stdout = $stdout
-    captured = StringIO.new
-    $stdout = captured
-    exception = nil
-
-    begin
-      yield
-    rescue Exception => error # rubocop:disable Lint/RescueException
-      exception = error
-    end
-
-    [exception, captured.string]
-  ensure
-    $stdout = original_stdout
   end
 
   def record_success_and_log_message(message)

--- a/lib/test/tasks/run_typelizer.rb
+++ b/lib/test/tasks/run_typelizer.rb
@@ -2,7 +2,7 @@ class Test::Tasks::RunTypelizer < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    execute_rake_task('typelizer:generate', log_stdout_only_on_failure: true)
+    execute_rake_task('typelizer:generate')
     execute_system_command("! grep --quiet -RP '\\bunknown\\b' app/javascript/types/serializers/")
 
     if !execute_system_command('git diff --exit-code')

--- a/lib/test/tasks/upload_vite_assets.rb
+++ b/lib/test/tasks/upload_vite_assets.rb
@@ -3,10 +3,7 @@ class Test::Tasks::UploadViteAssets < Pallets::Task
 
   def run
     if ENV.fetch('CI', nil) == 'true' && ENV.fetch('GITHUB_REF_NAME') == 'main'
-      execute_rake_task(
-        'assets:upload_vite_assets',
-        log_stdout_only_on_failure: true,
-      )
+      execute_rake_task('assets:upload_vite_assets')
     else
       record_success_and_log_message(<<~LOG)
         Not running in CI on main; skipping assets:upload_vite_assets.


### PR DESCRIPTION
What we were doing (assigning to the global $stdout variable) isn't thread-safe, and I think it might not be (reasonably?) possible to do in a thread-safe manner. ChatGPT can't think of anything, at least (private convo: https://chatgpt.com/c/67afb9a6-1ebc-8007-b253-28d1d6517335 ).

Hopefully this will make logging when running specs via Pallets reliable. It has been a fairly significant annoyance that, for the past week or two (I think?, at least, insofar as I have noticed, though it's possible that I just didn't notice before, since I wasn't looking at CI logs so much), I haven't been able to reliably see output from the CI builds. It's particularly annoying when there is a failure, and I cannot even see what the failure is or see a stack trace.