### PR TITLE
[ci-step-results] Show branch name in Gantt chart titles [CSR-8]

### DIFF
--- a/app/javascript/types/bootstrap/CiStepResultsIndexBootstrap.ts
+++ b/app/javascript/types/bootstrap/CiStepResultsIndexBootstrap.ts
@@ -48,6 +48,9 @@ const schema = {
         "pretty_start_time": {
           "type": "string"
         },
+        "branch": {
+          "type": "string"
+        },
         "pretty_github_run_info": {
           "type": "string"
         },
@@ -68,6 +71,7 @@ const schema = {
         }
       },
       "required": [
+        "branch",
         "dom_id",
         "github_run_attempt",
         "github_run_id",

--- a/app/presenters/ci_step_results_presenter.rb
+++ b/app/presenters/ci_step_results_presenter.rb
@@ -41,6 +41,7 @@ class CiStepResultsPresenter
     CiStepResult.
       select(
         'MIN(ci_step_results.started_at) AS min_started_at',
+        'ci_step_results.branch',
         'ci_step_results.github_run_id',
         'ci_step_results.github_run_attempt',
         <<-SQL.squish,
@@ -54,13 +55,14 @@ class CiStepResultsPresenter
       ) AS run_times
     SQL
       ).
-      group(:github_run_id, :github_run_attempt).
+      group(:branch, :github_run_id, :github_run_attempt).
       order('min_started_at DESC').
       limit(10).
       map do |ci_step_result|
         {
           pretty_start_time:
             ci_step_result.min_started_at.in_time_zone.strftime('%b %d, %-l:%M %p'),
+          branch: ci_step_result.branch,
           pretty_github_run_info:
             "Run #{ci_step_result.github_run_id}, Attempt #{ci_step_result.github_run_attempt}",
           github_run_id:

--- a/app/views/ci_step_results/index.html.haml
+++ b/app/views/ci_step_results/index.html.haml
@@ -15,7 +15,9 @@
   - github_run_id = gantt_chart_metadata.fetch(:github_run_id)
   - github_run_attempt = gantt_chart_metadata.fetch(:github_run_attempt)
   %div
-    %h3
-      = gantt_chart_metadata.fetch(:pretty_start_time)
-      (#{link_to(gantt_chart_metadata.fetch(:pretty_github_run_info), "https://github.com/davidrunger/david_runger/actions/runs/#{github_run_id}/attempts/#{github_run_attempt}")})
+    - pretty_time = gantt_chart_metadata.fetch(:pretty_start_time)
+    - github_link = link_to(gantt_chart_metadata.fetch(:pretty_github_run_info),
+        "https://github.com/davidrunger/david_runger/actions/runs/#{github_run_id}/attempts/#{github_run_attempt}")
+    - branch = gantt_chart_metadata.fetch(:branch)
+    %h3= "#{pretty_time} (#{github_link} on #{content_tag(:code, branch)})"
     .w-full{id: gantt_chart_metadata.fetch(:dom_id)}

--- a/spec/support/schemas/bootstrap/ci_step_results/index.json
+++ b/spec/support/schemas/bootstrap/ci_step_results/index.json
@@ -44,6 +44,9 @@
         "pretty_start_time": {
           "type": "string"
         },
+        "branch": {
+          "type": "string"
+        },
         "pretty_github_run_info": {
           "type": "string"
         },
@@ -64,6 +67,7 @@
         }
       },
       "required": [
+        "branch",
         "dom_id",
         "github_run_attempt",
         "github_run_id",


### PR DESCRIPTION
Since `main` vs PR branch runs have different characteristics, it would be helpful to be able to quickly and confidently distinguish simply by looking at the title of each Gantt chart whether the branch was `main` or something else.

![image](https://github.com/user-attachments/assets/6428c8f1-c69c-4950-9719-e57f9be6e4c5)