### PR TITLE
Speed up and otherwise improve feature specs [DEV-177]

### DIFF
--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -106,4 +106,13 @@ class QuizzesController < ApplicationController
     @quiz.participations.find_by(participant_id: current_user)
   end
   # rubocop:enable Style/MethodCallWithArgsParentheses
+
+  helper_method \
+  def async_partial_delay_for_rails_env(delay_milliseconds)
+    if Rails.env.test?
+      0
+    else
+      delay_milliseconds
+    end
+  end
 end

--- a/app/controllers/quizzes_controller.rb
+++ b/app/controllers/quizzes_controller.rb
@@ -112,7 +112,9 @@ class QuizzesController < ApplicationController
     if Rails.env.test?
       0
     else
+      # :nocov:
       delay_milliseconds
+      # :nocov:
     end
   end
 end

--- a/app/views/quiz_questions/_closed.html.haml
+++ b/app/views/quiz_questions/_closed.html.haml
@@ -7,10 +7,10 @@
 
 - if !@quiz.closed?
   %h3 Leaderboard
-  .mb-4{data: { async_partial_src: leaderboard_quiz_path(@quiz), delay: 750 }}
+  .mb-4{data: { async_partial_src: leaderboard_quiz_path(@quiz), delay: async_partial_delay_for_rails_env(750) }}
     .spinner--circle
 
   - if !@quiz.owned_by_current_user?
     %h3 Progress
-    %div{data: { async_partial_src: progress_quiz_path(@quiz), delay: 1000 }}
+    %div{data: { async_partial_src: progress_quiz_path(@quiz), delay: async_partial_delay_for_rails_env(1000) }}
       .spinner--circle

--- a/app/views/quiz_questions/_open.html.haml
+++ b/app/views/quiz_questions/_open.html.haml
@@ -11,14 +11,14 @@
 .pt-8
   %hr
   %h3 Respondents
-  .mb-4{data: { async_partial_src: respondents_quiz_path(@quiz), delay: 750 }}
+  .mb-4{data: { async_partial_src: respondents_quiz_path(@quiz), delay: async_partial_delay_for_rails_env(750) }}
     .spinner--circle
   %hr
   %h3 Leaderboard
-  .mb-4{data: { async_partial_src: leaderboard_quiz_path(@quiz), delay: 1000 }}
+  .mb-4{data: { async_partial_src: leaderboard_quiz_path(@quiz), delay: async_partial_delay_for_rails_env(1000) }}
     .spinner--circle
   - if !@quiz.owned_by_current_user?
     %hr
     %h3 Progress
-    %div{data: { async_partial_src: progress_quiz_path(@quiz), delay: 1250 }}
+    %div{data: { async_partial_src: progress_quiz_path(@quiz), delay: async_partial_delay_for_rails_env(1250) }}
       .spinner--circle

--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Logging in as an AdminUser via Google auth' do
     end
   end
 
-  context 'when there is no AdminUser in the databse with the email' do
+  context 'when there is no AdminUser in the database with the email' do
     let(:stubbed_admin_user_email) { "#{SecureRandom.uuid}@gmail.com" }
 
     before { expect(AdminUser.where(email: stubbed_admin_user_email)).not_to exist }

--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -50,8 +50,7 @@ RSpec.describe 'Check-Ins app' do
           Capybara.using_session('proposee') do
             wait_for do
               sign_in(proposee)
-              visit(logs_path)
-              page.has_text?(proposee.email)
+              sign_in_confirmed_via_my_account?(proposee)
             end.to eq(true)
 
             open_email(proposee.email)

--- a/spec/features/error_handling_spec.rb
+++ b/spec/features/error_handling_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
 
         it 'says that the page does not exist and returns a 404' do
           visit(nonexistent_path)
+
           expect(page).to have_text("The page you were looking for doesn't exist.")
           expect(page.status_code).to be(404)
           expect(Rails.logger).

--- a/spec/features/flipper_spec.rb
+++ b/spec/features/flipper_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'Flipper web UI', :rack_test_driver do
 
     it 'renders the flipper web UI homepage / dashboard' do
       visit_flipper_web_ui
+
       expect(page).to have_link('Add Feature')
       expect(page).to have_text("I'll flip your features.")
     end
@@ -16,6 +17,7 @@ RSpec.describe 'Flipper web UI', :rack_test_driver do
 
     it 'redirects to the root path', :prerendering_disabled do
       visit_flipper_web_ui
+
       expect(page).to have_current_path(new_admin_user_session_path)
     end
   end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe 'Home page', :prerendering_disabled do
     )
 
     page.scroll_to(:top)
-    sleep(0.2) # Wait a little bit for an Event to be created (though we don't want this).
 
     # Verify that we do _not_ add yet another scroll Event after scrolling back up.
     expect(Event.count).to eq(event_count_before + 1)

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -33,17 +33,17 @@ RSpec.describe 'proposing marriage to another user' do
             activate_feature!(:disable_fetch_ip_info_for_request_worker)
             num_emails_before = ActionMailer::Base.deliveries.size
             click_on('Submit')
+
+            expect(page).to have_flash_message('Invitation sent.')
+
             wait_for { ActionMailer::Base.deliveries.size }.to eq(num_emails_before + 1)
           end
-
-          expect(page).to have_flash_message('Invitation sent.')
 
           # log in proposee and accept the proposal
           Capybara.using_session('proposee') do
             wait_for do
               sign_in(proposee)
-              visit(logs_path)
-              page.has_text?(proposee.email)
+              sign_in_confirmed_via_my_account?(proposee)
             end.to eq(true)
 
             open_email(proposee.email)
@@ -59,7 +59,7 @@ RSpec.describe 'proposing marriage to another user' do
       end
     end
 
-    context 'when the user is in a marriage with a partner' do
+    context 'when the user is in a marriage with a partner', :rack_test_driver do
       before { expect(user.marriage.partners.compact.size).to eq(2) }
 
       let(:spouse) { user.spouse }

--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Quizzes app' do
         wait.for do
           sign_in(participant)
           visit(quiz_path)
-          Capybara.using_wait_time(0.1) do # Undo `wait_time: 10` set for the spec overall.
+          Capybara.using_wait_time(0.1) do # Override `wait_time: 10` set for the spec overall.
             page.has_css?('input#display_name')
           end
         end.to eq(true)

--- a/spec/features/quizzes_spec.rb
+++ b/spec/features/quizzes_spec.rb
@@ -33,17 +33,16 @@ RSpec.describe 'Quizzes app' do
       # quiz show page expectations without participant
       expect(page).not_to have_text(participant_name)
 
-      # NOTE: Sleeping for 1 second here makes the login below about 10 seconds
-      # faster, and it might also help these specs not to flake on my machine.
-      sleep(1)
-
-      # a participant joins
+      # A participant joins.
       using_session('Quiz participant session') do
-        wait(20.seconds).for do
+        wait.for do
           sign_in(participant)
           visit(quiz_path)
-          page.has_css?('input#display_name')
+          Capybara.using_wait_time(0.1) do # Undo `wait_time: 10` set for the spec overall.
+            page.has_css?('input#display_name')
+          end
         end.to eq(true)
+
         fill_in('display_name', with: participant_name)
         click_on('Join the quiz!')
       end
@@ -123,10 +122,13 @@ RSpec.describe 'Quizzes app' do
 
       quiz_to_destroy = existing_quiz
 
-      accept_confirm { click_on('Delete') }
+      expect {
+        accept_confirm { click_on('Delete') }
 
-      expect(page).to have_flash_message("Destroyed quiz '#{quiz_to_destroy.name}'.")
-      expect(Quiz.find_by(id: quiz_to_destroy.id)).to eq(nil)
+        expect(page).to have_flash_message("Destroyed quiz '#{quiz_to_destroy.name}'.")
+      }.to change {
+        Quiz.find_by(id: quiz_to_destroy.id)
+      }.from(Quiz).to(nil)
     end
   end
 end

--- a/spec/features/rack_attack_spec.rb
+++ b/spec/features/rack_attack_spec.rb
@@ -1,16 +1,11 @@
 RSpec.describe 'Rack::Attack', :rack_test_driver do
   context 'when Rails caching is enabled/functional & Rack::Attack uses the Rails cache', :cache do
     around do |spec|
-      original_rack_attack_store = Rack::Attack.cache.store
       expect(Rails.cache).to be_a(ActiveSupport::Cache::MemoryStore)
 
-      Rails.cache.clear
-      Rack::Attack.cache.store = Rails.cache
-
-      spec.run
-    ensure
-      Rack::Attack.cache.store = original_rack_attack_store
-      Rails.cache.clear
+      Rack::Attack.cache.with(store: Rails.cache) do
+        spec.run
+      end
     end
 
     context 'when -- two times in one day -- a user requests paths with banned segments' do
@@ -26,7 +21,7 @@ RSpec.describe 'Rack::Attack', :rack_test_driver do
         expect {
           request_two_banned_paths
         }.to change {
-          visit(root_path)
+          visit(up_path)
           page.status_code
         }.from(200).to(403)
       end

--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -18,12 +18,11 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
         expect(page).to have_current_path(root_path)
         expect(page).to have_text('David Runger Full stack web developer')
 
-        visit(logs_path)
-        expect(page).to have_text(user.email)
+        expect(sign_in_confirmed_via_my_account?(user)).to eq(true)
       end
     end
 
-    context 'when there is no user in the databse with the email' do
+    context 'when there is no user in the database with the email' do
       let(:stubbed_user_email) { "#{SecureRandom.uuid}@gmail.com" }
 
       before { expect(User.where(email: stubbed_user_email)).not_to exist }
@@ -35,8 +34,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
         expect { click_on(class: 'google-login') }.to change { User.count }.by(1)
         user = User.find_by!(email: stubbed_user_email)
 
-        visit(logs_path)
-        expect(page).to have_text(user.email)
+        expect(sign_in_confirmed_via_my_account?(user)).to eq(true)
       end
     end
   end

--- a/spec/features/vue_playground_spec.rb
+++ b/spec/features/vue_playground_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Vue Playground' do
   context 'when logged in as a mere User' do
     before { sign_in(users(:user)) }
 
-    it 'redirects to the root path', :prerendering_disabled do
+    it 'redirects to the root path', :prerendering_disabled, :rack_test_driver do
       visit_vue_playground_path
 
       expect(page).to have_current_path(new_admin_user_session_path)
@@ -24,7 +24,7 @@ RSpec.describe 'Vue Playground' do
   context 'when not logged in' do
     before { Devise.sign_out_all_scopes }
 
-    it 'redirects to the root path', :prerendering_disabled do
+    it 'redirects to the root path', :prerendering_disabled, :rack_test_driver do
       visit_vue_playground_path
 
       expect(page).to have_current_path(new_admin_user_session_path)

--- a/spec/features/workout_spec.rb
+++ b/spec/features/workout_spec.rb
@@ -4,28 +4,6 @@ RSpec.describe 'Workout app' do
   context 'when user is signed in' do
     before { sign_in(user) }
 
-    it 'renders expected content' do
-      visit workout_path
-
-      # form for new workout
-      expect(page).to have_text('New Workout')
-      expect(page).to have_css('form')
-      expect(page).to have_button('Initialize Workout!')
-
-      # own workouts
-      expect(page).to have_text('Previous workouts')
-      expect(page).to have_text(
-        user.workouts.first!.rep_totals.to_json.
-          gsub(%r{\{|\}|"}, '').
-          gsub(',', ', ').
-          gsub(/:(?! )/, ': '),
-      )
-
-      # public workouts of others
-      expect(page).to have_text("Others' workouts\nNone", normalize_ws: false)
-      expect(page).not_to have_text('Loading')
-    end
-
     context 'when the user has a default workout saved in their preferences' do
       before do
         user.default_workout ||= build(:json_preference, :default_workout, user:)
@@ -46,11 +24,13 @@ RSpec.describe 'Workout app' do
       let(:exercise_2_name) { 'chinups' }
       let(:exercise_2_reps) { 5 }
 
-      it 'renders the new-workout form preloaded with their default workout' do
+      it 'renders the new-workout form preloaded with their default workout and shows past workouts of the user and public workouts of others' do
         visit workout_path
 
+        # Form for a new workout:
         expect(page).to have_text('New Workout')
         expect(page).to have_css('form')
+        expect(page).to have_button('Initialize Workout!')
 
         expect(page).to have_field('minutes', with: minutes)
         expect(page).to have_field('numberOfSets', with: sets)
@@ -60,6 +40,19 @@ RSpec.describe 'Workout app' do
         expect(page).to have_field('exercise-1-reps', with: exercise_2_reps)
 
         expect(page).to have_button('Initialize Workout!')
+
+        # Own past workouts:
+        expect(page).to have_text('Previous workouts')
+        expect(page).to have_text(
+          user.workouts.first!.rep_totals.to_json.
+            gsub(%r{\{|\}|"}, '').
+            gsub(',', ', ').
+            gsub(/:(?! )/, ': '),
+        )
+
+        # Public workouts of others:
+        expect(page).to have_text("Others' workouts\nNone", normalize_ws: false)
+        expect(page).not_to have_text('Loading')
       end
 
       context 'when the user initializes a workout and makes time and exercise count adjustments' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,6 +148,7 @@ RSpec.configure do |config|
   config.include(SidekiqSpecHelpers)
   config.include(Devise::Test::ControllerHelpers, type: :controller)
   config.include(Devise::Test::IntegrationHelpers, type: :feature)
+  config.include(Features::SignInHelpers, type: :feature)
   config.include(Monkeypatches::MakeAllRequestsAsJson, request_format: :json)
   config.include(ActionCable::TestHelper, :action_cable_test_adapter)
   config.include(ActionMailbox::TestHelper, type: :mailbox)

--- a/spec/support/features/sign_in_helpers.rb
+++ b/spec/support/features/sign_in_helpers.rb
@@ -1,0 +1,9 @@
+module Features::SignInHelpers
+  def sign_in_confirmed_via_my_account?(user)
+    visit(my_account_path)
+
+    Capybara.using_wait_time(0.1) do
+      page.has_text?(user.email)
+    end
+  end
+end


### PR DESCRIPTION
I think that the biggest performance improvement here comes from the new `sign_in_confirmed_via_my_account?` method.

`async_partial_delay_for_rails_env` also helps.

Changing some specs to `:rack_test_driver` helps.

Even changing `root_path` to `up_path` in `spec/features/rack_attack_spec.rb` helps.

Consolidating two specs in the workouts file helps a bit.

Some of these changes make our tests somewhat worse. For example, `async_partial_delay_for_rails_env` creates a divergence between the test environment and the real environment. Removing some `sleep`s that we had to try to catch problems that could theoretically emerge of a certain amount of time increases our risk of missing some bugs. But, on balance, I am estimating that these tradeoffs are overall worthwhile, in order to have faster feature specs.

Other changes are just cosmetic/formatting or otherwise minor changes.