### PR TITLE
Don't modify globally shared filesystem in CSV download spec [LOG-36]

### DIFF
--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -194,18 +194,12 @@ RSpec.describe 'Logs app' do
           end
         end
 
-        it 'allows the user to download a CSV with the log data' do
+        it 'allows the user to download a CSV with the log data', :with_tmp_download_dir do
           visit(log_path(slug: log.slug))
-
-          csv_glob = Capybara.save_path.join('*.csv')
-          Rails.root.glob(csv_glob).each { FileUtils.rm(it) }
 
           click_on('Download CSV')
 
-          wait_for { Rails.root.glob(csv_glob) }.to be_present
-
-          downloaded_csv_path = Rails.root.glob(csv_glob).last
-          csv = CSV.read(downloaded_csv_path, headers: true)
+          csv = CSV.read(downloaded_file_path('*.csv'), headers: true)
 
           expect(csv.headers).to eq(['Time', log.data_label])
 

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -194,7 +194,7 @@ RSpec.describe 'Logs app' do
           end
         end
 
-        it 'allows the user to download a CSV with the log data', :with_tmp_download_dir do
+        it 'allows the user to download a CSV with the log data' do
           visit(log_path(slug: log.slug))
 
           click_on('Download CSV')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,6 +148,7 @@ RSpec.configure do |config|
   config.include(SidekiqSpecHelpers)
   config.include(Devise::Test::ControllerHelpers, type: :controller)
   config.include(Devise::Test::IntegrationHelpers, type: :feature)
+  config.include(Features::DownloadHelpers, type: :feature)
   config.include(Features::SignInHelpers, type: :feature)
   config.include(Monkeypatches::MakeAllRequestsAsJson, request_format: :json)
   config.include(ActionCable::TestHelper, :action_cable_test_adapter)

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -31,7 +31,7 @@ module Features::DownloadHelpers
         puts(%(relative_glob_pattern: #{relative_glob_pattern}))
         puts(%(absolute_glob_pattern: #{absolute_glob_pattern}))
         puts(%(system("ls -ld #{@capybara_downloads_tmp_dir}"): #{system("ls -ld #{@capybara_downloads_tmp_dir}")}))
-        puts(%(`ls #{absolute_glob_pattern}`: #{`ls #{absolute_glob_pattern}`}))
+        puts(%(`ls #{@capybara_downloads_tmp_dir}`: #{`ls #{@capybara_downloads_tmp_dir}`}))
 
         raise(<<~ERROR)
           Could not find a file matching '#{relative_glob_pattern}' after

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -1,6 +1,6 @@
 RSpec.configure do |config|
   config.around(:each, :with_tmp_download_dir) do |spec|
-    Dir.mktmpdir do |tmp_dir|
+    Dir.mktmpdir(nil, Rails.root.join('tmp')) do |tmp_dir|
       @capybara_downloads_tmp_dir = tmp_dir
 
       Capybara.with(save_path: tmp_dir) do

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -1,6 +1,7 @@
 RSpec.configure do |config|
   config.before(:all, type: :feature) do
     tmp_dir = Dir.mktmpdir
+    puts(%(tmp_dir: #{tmp_dir}))
     @capybara_downloads_tmp_dir = tmp_dir
     Capybara.save_path = tmp_dir
   end
@@ -10,6 +11,7 @@ module Features::DownloadHelpers
   private
 
   def downloaded_file_path(relative_glob_pattern, max_attempts: 100, sleep_seconds: 0.05)
+    puts(%(page.driver.browser.options.instance_variable_get(:@options)[:save_path]: #{page.driver.browser.options.instance_variable_get(:@options)[:save_path]}))
     absolute_glob_pattern = File.join(@capybara_downloads_tmp_dir, relative_glob_pattern)
 
     max_attempts.times do |index|

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.before(:suite, type: :feature) do
+  config.before(:suite) do
     tmp_dir = Dir.mktmpdir
     @capybara_downloads_tmp_dir = tmp_dir
     Capybara.save_path = tmp_dir

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -1,5 +1,5 @@
 RSpec.configure do |config|
-  config.before(:all, type: :feature) do
+  config.before(:suite, type: :feature) do
     tmp_dir = Dir.mktmpdir
     puts(%(tmp_dir: #{tmp_dir}))
     @capybara_downloads_tmp_dir = tmp_dir

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -1,7 +1,6 @@
 RSpec.configure do |config|
   config.before(:suite, type: :feature) do
     tmp_dir = Dir.mktmpdir
-    puts(%(tmp_dir: #{tmp_dir}))
     @capybara_downloads_tmp_dir = tmp_dir
     Capybara.save_path = tmp_dir
   end
@@ -11,7 +10,6 @@ module Features::DownloadHelpers
   private
 
   def downloaded_file_path(relative_glob_pattern, max_attempts: 100, sleep_seconds: 0.05)
-    puts(%(page.driver.browser.options.instance_variable_get(:@options)[:save_path]: #{page.driver.browser.options.instance_variable_get(:@options)[:save_path]}))
     absolute_glob_pattern = File.join(@capybara_downloads_tmp_dir, relative_glob_pattern)
 
     max_attempts.times do |index|

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -1,0 +1,36 @@
+RSpec.configure do |config|
+  config.around(:each, :with_tmp_download_dir) do |spec|
+    Dir.mktmpdir do |tmp_dir|
+      @capybara_downloads_tmp_dir = tmp_dir
+
+      Capybara.with(save_path: tmp_dir) do
+        spec.run
+      end
+    end
+  end
+end
+
+module Features::DownloadHelpers
+  def downloaded_file_path(relative_glob_pattern, max_attempts: 100, sleep_seconds: 0.05)
+    if @capybara_downloads_tmp_dir.nil?
+      raise('Apply the :with_tmp_download_dir RSpec metadata to the spec.')
+    end
+
+    absolute_glob_pattern = File.join(@capybara_downloads_tmp_dir, relative_glob_pattern)
+
+    max_attempts.times do |index|
+      matching_paths = Dir.glob(absolute_glob_pattern)
+
+      if (matching_path = matching_paths.first)
+        break matching_path
+      elsif index == max_attempts - 1
+        raise(<<~ERROR)
+          Could not find a file matching '#{relative_glob_pattern}' after
+          #{max_attempts} attempt(s) with a sleep of #{sleep_seconds} seconds.
+        ERROR
+      else
+        sleep(sleep_seconds)
+      end
+    end
+  end
+end

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -30,7 +30,7 @@ module Features::DownloadHelpers
         puts(%(@capybara_downloads_tmp_dir: #{@capybara_downloads_tmp_dir}))
         puts(%(relative_glob_pattern: #{relative_glob_pattern}))
         puts(%(absolute_glob_pattern: #{absolute_glob_pattern}))
-        puts(%(system('ls -ld /tmp'): #{system('ls -ld /tmp')}))
+        puts(%(system("ls -ld #{@capybara_downloads_tmp_dir}"): #{system("ls -ld #{@capybara_downloads_tmp_dir}")}))
         puts(%(`ls #{absolute_glob_pattern}`: #{`ls #{absolute_glob_pattern}`}))
 
         raise(<<~ERROR)

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
 end
 
 module Features::DownloadHelpers
-  def downloaded_file_path(relative_glob_pattern, max_attempts: 100, sleep_seconds: 0.05)
+  def downloaded_file_path(relative_glob_pattern, max_attempts: 100, sleep_seconds: 0.1)
     if @capybara_downloads_tmp_dir.nil?
       raise('Apply the :with_tmp_download_dir RSpec metadata to the spec.')
     end
@@ -22,8 +22,16 @@ module Features::DownloadHelpers
       matching_paths = Dir.glob(absolute_glob_pattern)
 
       if (matching_path = matching_paths.first)
+        puts("Success on attempt #{index + 1}.")
+
         break matching_path
       elsif index == max_attempts - 1
+        puts(%(Capybara.save_path: #{Capybara.save_path}))
+        puts(%(@capybara_downloads_tmp_dir: #{@capybara_downloads_tmp_dir}))
+        puts(%(relative_glob_pattern: #{relative_glob_pattern}))
+        puts(%(absolute_glob_pattern: #{absolute_glob_pattern}))
+        puts(%(`ls #{absolute_glob_pattern}`: #{`ls #{absolute_glob_pattern}`}))
+
         raise(<<~ERROR)
           Could not find a file matching '#{relative_glob_pattern}' after
           #{max_attempts} attempt(s) with a sleep of #{sleep_seconds} seconds.

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -10,10 +10,6 @@ module Features::DownloadHelpers
   private
 
   def downloaded_file_path(relative_glob_pattern, max_attempts: 100, sleep_seconds: 0.05)
-    if @capybara_downloads_tmp_dir.nil?
-      raise('Apply the :with_tmp_download_dir RSpec metadata to the spec.')
-    end
-
     absolute_glob_pattern = File.join(@capybara_downloads_tmp_dir, relative_glob_pattern)
 
     max_attempts.times do |index|

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -30,6 +30,7 @@ module Features::DownloadHelpers
         puts(%(@capybara_downloads_tmp_dir: #{@capybara_downloads_tmp_dir}))
         puts(%(relative_glob_pattern: #{relative_glob_pattern}))
         puts(%(absolute_glob_pattern: #{absolute_glob_pattern}))
+        puts(%(system('ls -ld /tmp'): #{system('ls -ld /tmp')}))
         puts(%(`ls #{absolute_glob_pattern}`: #{`ls #{absolute_glob_pattern}`}))
 
         raise(<<~ERROR)

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -1,7 +1,6 @@
 RSpec.configure do |config|
   config.before(:suite) do
     tmp_dir = Dir.mktmpdir
-    @capybara_downloads_tmp_dir = tmp_dir
     Capybara.save_path = tmp_dir
   end
 end
@@ -10,7 +9,7 @@ module Features::DownloadHelpers
   private
 
   def downloaded_file_path(relative_glob_pattern, max_attempts: 100, sleep_seconds: 0.05)
-    absolute_glob_pattern = File.join(@capybara_downloads_tmp_dir, relative_glob_pattern)
+    absolute_glob_pattern = File.join(Capybara.save_path, relative_glob_pattern)
 
     max_attempts.times do |index|
       matching_paths = Dir.glob(absolute_glob_pattern)

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -18,7 +18,7 @@ module Features::DownloadHelpers
       if (matching_path = matching_paths.first)
         break matching_path
       elsif index == max_attempts - 1
-        raise(<<~ERROR)
+        raise(<<~ERROR.squish)
           Could not find a file matching '#{relative_glob_pattern}' after
           #{max_attempts} attempt(s) with a sleep of #{sleep_seconds} seconds.
         ERROR


### PR DESCRIPTION
In the spec being modified herein, the filesystem at `Capybara.save_path` was acting essentially as shared global state among all specs. I think that there was at least a theoretical risk that the spec could conflict with another spec that also modified the state of files in `Capybara.save_path` .

To fix, before running feature specs, we will set `Capybara.save_path` to a unique, randomly generated, temporary directory, in order to essentially carve out a space in the file system that is local only to this suite of feature specs. This change also provides a `downloaded_file_path` helper method to then access files downloaded to that directory.

Note that this solution doesn't 100% solve the issue of global state modification; we've just moved the problem from modifying a global directory in the filesystem to instead modifying the global `Capybara.save_path`. Still, this is an improvement, because the file system is shared by all processes on the same machine, whereas `Capybara.save_path` is only shared by simultaneously executing Ruby threads in the same process. So, the scope of global modification is at least made smaller, and since I don't think that we run RSpec tests in parallel threads within the same process, that shouldn't be a risk to us.