### PR TITLE
[spec/features/logs] Add a 50 ms sleep for ElPopconfirm click binding

### DIFF
--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -91,6 +91,7 @@ RSpec.describe 'Logs app' do
             number_log.log_entries.reorder(:created_at).last!
 
           expect {
+            sleep(0.05) # Give 50 ms for ElPopconfirm click handler to bind.
             click_on(delete_last_entry_text)
             within('.el-popconfirm') do
               click_on('Yes')


### PR DESCRIPTION
Without this, the spec is decently flaky on my local machine (though I don't think I have yet seen it flake in CI).