### PR TITLE
Allow filtering CiStepResults by branch, passed, & created_at [CSR-3]

### DIFF
--- a/app/presenters/ci_step_results_presenter.rb
+++ b/app/presenters/ci_step_results_presenter.rb
@@ -11,18 +11,14 @@ class CiStepResultsPresenter
   # rubocop:disable Metrics/PerceivedComplexity
   memoize \
   def parallelism
-    if run_times_by_step.present?
-      wall_clock_times = run_times_by_step.detect { it[:name] == 'WallClockTime' }&.[](:data)
-      cpu_times = run_times_by_step.detect { it[:name] == 'CpuTime' }&.[](:data)
+    wall_clock_times = run_times_by_step.detect { it[:name] == 'WallClockTime' }&.[](:data)
+    cpu_times = run_times_by_step.detect { it[:name] == 'CpuTime' }&.[](:data)
 
-      (wall_clock_times || []).each.filter_map do |time, wall_clock_time|
-        if cpu_times && (cpu_time = cpu_times[time])
-          [time, cpu_time.fdiv(wall_clock_time)]
-        end
-      end.to_h
-    else
-      {}
-    end
+    (wall_clock_times || []).each.filter_map do |time, wall_clock_time|
+      if cpu_times && (cpu_time = cpu_times[time])
+        [time, cpu_time.fdiv(wall_clock_time)]
+      end
+    end.to_h
   end
   # rubocop:enable Metrics/PerceivedComplexity
   # rubocop:enable Metrics/CyclomaticComplexity

--- a/app/presenters/ci_step_results_presenter.rb
+++ b/app/presenters/ci_step_results_presenter.rb
@@ -3,20 +3,24 @@ class CiStepResultsPresenter
 
   FIELDS_TO_PLUCK = %i[name github_run_id github_run_attempt created_at seconds].freeze
 
-  def initialize(user)
-    @user = user
+  def initialize(ci_step_results)
+    @ci_step_results = ci_step_results
   end
 
   memoize \
   def parallelism
-    wall_clock_times = run_times_by_step.detect { it[:name] == 'WallClockTime' }[:data]
-    cpu_times = run_times_by_step.detect { it[:name] == 'CpuTime' }[:data]
+    if run_times_by_step.present?
+      wall_clock_times = run_times_by_step.detect { it[:name] == 'WallClockTime' }[:data]
+      cpu_times = run_times_by_step.detect { it[:name] == 'CpuTime' }[:data]
 
-    wall_clock_times.each.filter_map do |time, wall_clock_time|
-      if (cpu_time = cpu_times[time])
-        [time, cpu_time.fdiv(wall_clock_time)]
-      end
-    end.to_h
+      wall_clock_times.each.filter_map do |time, wall_clock_time|
+        if (cpu_time = cpu_times[time])
+          [time, cpu_time.fdiv(wall_clock_time)]
+        end
+      end.to_h
+    else
+      {}
+    end
   end
 
   memoize \
@@ -38,7 +42,7 @@ class CiStepResultsPresenter
   # rubocop:disable Metrics/MethodLength
   memoize \
   def recent_gantt_chart_metadatas
-    CiStepResult.
+    @ci_step_results.
       select(
         'MIN(ci_step_results.started_at) AS min_started_at',
         'ci_step_results.branch',
@@ -90,9 +94,7 @@ class CiStepResultsPresenter
 
   memoize \
   def ci_step_results_row_data
-    @user.
-      ci_step_results.
-      pluck(*FIELDS_TO_PLUCK)
+    @ci_step_results.pluck(*FIELDS_TO_PLUCK)
   end
 
   def results_grouped_by_name

--- a/app/presenters/ci_step_results_presenter.rb
+++ b/app/presenters/ci_step_results_presenter.rb
@@ -7,13 +7,15 @@ class CiStepResultsPresenter
     @ci_step_results = ci_step_results
   end
 
+  # rubocop:disable Metrics/CyclomaticComplexity
+  # rubocop:disable Metrics/PerceivedComplexity
   memoize \
   def parallelism
     if run_times_by_step.present?
-      wall_clock_times = run_times_by_step.detect { it[:name] == 'WallClockTime' }[:data]
-      cpu_times = run_times_by_step.detect { it[:name] == 'CpuTime' }[:data]
+      wall_clock_times = run_times_by_step.detect { it[:name] == 'WallClockTime' }&.[](:data)
+      cpu_times = run_times_by_step.detect { it[:name] == 'CpuTime' }&.[](:data)
 
-      wall_clock_times.each.filter_map do |time, wall_clock_time|
+      (wall_clock_times || []).each.filter_map do |time, wall_clock_time|
         if (cpu_time = cpu_times[time])
           [time, cpu_time.fdiv(wall_clock_time)]
         end
@@ -22,6 +24,8 @@ class CiStepResultsPresenter
       {}
     end
   end
+  # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics/CyclomaticComplexity
 
   memoize \
   def run_times_by_step

--- a/app/presenters/ci_step_results_presenter.rb
+++ b/app/presenters/ci_step_results_presenter.rb
@@ -16,7 +16,7 @@ class CiStepResultsPresenter
       cpu_times = run_times_by_step.detect { it[:name] == 'CpuTime' }&.[](:data)
 
       (wall_clock_times || []).each.filter_map do |time, wall_clock_time|
-        if (cpu_time = cpu_times[time])
+        if cpu_times && (cpu_time = cpu_times[time])
           [time, cpu_time.fdiv(wall_clock_time)]
         end
       end.to_h

--- a/app/views/ci_step_results/index.html.haml
+++ b/app/views/ci_step_results/index.html.haml
@@ -5,16 +5,20 @@
 %h1= @title
 
 = search_form_for(@ransack_query) do |f|
-  = f.label(:branch_eq)
-  = f.search_field(:branch_eq)
+  %div
+    = f.label(:branch_eq)
+    = f.search_field(:branch_eq)
 
-  = f.label(:passed_eq)
-  = f.search_field(:passed_eq)
+  %div
+    = f.label(:passed_eq)
+    = f.search_field(:passed_eq)
 
-  = f.label(:created_at_gt)
-  = f.search_field(:created_at_gt)
+  %div
+    = f.label(:created_at_gt)
+    = f.search_field(:created_at_gt)
 
-  = f.submit(class: 'btn-primary btn-small')
+  %div
+    = f.submit(class: 'btn-primary btn-small')
 
 %h2 Run times
 = line_chart(@ci_step_results_presenter.run_times_by_step, height: '640px', curve: false)

--- a/app/views/ci_step_results/index.html.haml
+++ b/app/views/ci_step_results/index.html.haml
@@ -4,6 +4,18 @@
 
 %h1= @title
 
+= search_form_for(@ransack_query) do |f|
+  = f.label(:branch_eq)
+  = f.search_field(:branch_eq)
+
+  = f.label(:passed_eq)
+  = f.search_field(:passed_eq)
+
+  = f.label(:created_at_gt)
+  = f.search_field(:created_at_gt)
+
+  = f.submit(class: 'btn-primary btn-small')
+
 %h2 Run times
 = line_chart(@ci_step_results_presenter.run_times_by_step, height: '640px', curve: false)
 

--- a/spec/factories/ci_step_results.rb
+++ b/spec/factories/ci_step_results.rb
@@ -33,7 +33,7 @@ FactoryBot.define do
     github_run_attempt { rand(1..2) }
     sequence(:github_run_id) { |n| github_run_id_seed + n }
     name { 'RunFeatureTests' }
-    passed { [true, false].sample }
+    passed { true }
     seconds { rand(80..90) + rand }
     sha { SecureRandom.hex(20) }
     started_at { created_at_time - 90.seconds }


### PR DESCRIPTION
Ransack docs: https://activerecord-hackery.github.io/ransack/getting-started/simple-mode/

This will be useful because different CI runs execute different tasks and in different orders, etc. By allowing filtering, it should be somewhat possible to view a subset of results that are more closely related to each other. One especially useful filter will be `branch`, particularly looking at the `main` branch (which always runs the same CI steps), so this change filters by the `main` branch by default. This change also adds the ability to filter by `passed` status (default: true) and by `created_at` time (default: past 2 months).

This filtering applies both to the "Run times" and "Parallelism" line charts as well as the Gantt charts.

This initial implementation is quite quick-and-dirty, with all three of the filtering inputs currently just being text fields. Ideally `branch` would probably be some sort of typeahead, `passed` would probably be a select dropdown, and `created_at` would be a date-and-time-picker. However, in order to get something merged and to keep the change as small as possible, for now, I think that this is good enough. I have added a ticket to the backlog to improve the UX of these form inputs: https://davidrunger.atlassian.net/browse/CSR-9 .