### PR TITLE
[ci-step-results] Add ability to filter by name/type [CSR-10]

### DIFF
--- a/app/controllers/ci_step_results_controller.rb
+++ b/app/controllers/ci_step_results_controller.rb
@@ -30,14 +30,14 @@ class CiStepResultsController < ApplicationController
   private
 
   def search_params
-    params.permit(q: %i[branch_eq passed_eq created_at_gt])
+    params.permit(q: %i[branch_eq created_at_gt name_eq passed_eq])
   end
 
   def default_index_filters
     {
       'branch_eq' => 'main',
-      'passed_eq' => true,
       'created_at_gt' => 2.months.ago,
+      'passed_eq' => true,
     }
   end
 end

--- a/app/views/ci_step_results/index.html.haml
+++ b/app/views/ci_step_results/index.html.haml
@@ -10,6 +10,10 @@
     = f.search_field(:branch_eq)
 
   %div
+    = f.label(:name_eq)
+    = f.search_field(:name_eq)
+
+  %div
     = f.label(:passed_eq)
     = f.search_field(:passed_eq)
 


### PR DESCRIPTION
The run times line graph doesn't give us the ability to show only a single type of CI step (except by toggling off every one of the many other CI step types), which is something that I sometimes want to do (e.g. to see if RuboCop has slowed down). This makes it possible by filtering the data on the server side.

(Note: some steps (such as `RubRubocop`) don't run on `main`, which is a filter applied by default, so one must remember to clear the `main` branch filter in order to see results for such a CI step that doesn't run on `main`.)

![image](https://github.com/user-attachments/assets/58b5d9cc-8e95-429b-b677-b14592ead556)