### PR TITLE
[ci-step-results] Make 'created_at' input a datepicker [CSR-12]

### DIFF
--- a/app/views/ci_step_results/index.html.haml
+++ b/app/views/ci_step_results/index.html.haml
@@ -16,7 +16,7 @@
 
   %div
     = f.label(:created_at_gt)
-    = f.search_field(:created_at_gt)
+    = f.date_field(:created_at_gt)
 
   %div
     = f.label(:name_eq)


### PR DESCRIPTION
Also, let's just make it a date (not a time), so that the user doesn't have to deal with the visual clutter and mental distraction of the time, which I doubt will frequently (if ever) really be needed.