### PR TITLE
[ci-step-results] Make 'branch' input a typeahead (datalist) [CSR-13]

### DIFF
--- a/app/controllers/ci_step_results_controller.rb
+++ b/app/controllers/ci_step_results_controller.rb
@@ -1,4 +1,6 @@
 class CiStepResultsController < ApplicationController
+  prepend Memoization
+
   self.container_classes = %w[p-8]
 
   content_security_policy(only: :index) do |policy|
@@ -14,7 +16,12 @@ class CiStepResultsController < ApplicationController
       current_user.
         ci_step_results.
         ransack(search_params_with_defaults)
-    @ci_step_results_presenter = CiStepResultsPresenter.new(@ransack_query.result)
+    @ci_step_results_presenter =
+      CiStepResultsPresenter.new(
+        ci_step_results: @ransack_query.result,
+        user: current_user,
+        search_params: search_params_with_defaults,
+      )
 
     bootstrap(
       recent_gantt_chart_metadatas:
@@ -26,6 +33,7 @@ class CiStepResultsController < ApplicationController
 
   private
 
+  memoize \
   def search_params_with_defaults
     default_index_filters.merge(search_params[:q] || {})
   end

--- a/app/presenters/ci_step_results_presenter.rb
+++ b/app/presenters/ci_step_results_presenter.rb
@@ -3,8 +3,26 @@ class CiStepResultsPresenter
 
   FIELDS_TO_PLUCK = %i[name github_run_id github_run_attempt created_at seconds].freeze
 
-  def initialize(ci_step_results)
+  def initialize(ci_step_results:, user:, search_params:)
     @ci_step_results = ci_step_results
+    @user = user
+    @search_params = search_params
+  end
+
+  memoize \
+  def branch_names
+    @user.
+      ci_step_results.
+      where(created_at: @search_params.fetch('created_at_gt')..).
+      distinct.
+      pluck(:branch).
+      sort_by do |branch_name|
+        if branch_name == 'main'
+          ''
+        else
+          branch_name.downcase
+        end
+      end
   end
 
   # rubocop:disable Metrics/PerceivedComplexity

--- a/app/views/ci_step_results/index.html.haml
+++ b/app/views/ci_step_results/index.html.haml
@@ -6,8 +6,10 @@
 
 = search_form_for(@ransack_query) do |f|
   %div
+    %datalist{id: 'branches'}
+      = options_for_select(@ci_step_results_presenter.branch_names)
     = f.label(:branch_eq)
-    = f.search_field(:branch_eq)
+    = f.text_field(:branch_eq, list: 'branches')
 
   %div
     = f.label(:passed_eq)

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -130,11 +130,29 @@ FixtureBuilder.configure do |fbuilder|
     create(:event, user: nil, admin_user: nil)
 
     # CiStepResults
-    github_run_id = 888_777_666
+    github_run_id = rand(1_000_000_000)
     github_run_attempt = 1
     create(:ci_step_result, :wall_clock_time, user:, github_run_id:, github_run_attempt:)
     create(:ci_step_result, :cpu_time, user:, github_run_id:, github_run_attempt:)
     create(:ci_step_result, :feature_tests, user:, github_run_id:, github_run_attempt:)
     create(:ci_step_result, :unit_tests, user:, github_run_id:, github_run_attempt:)
+    other_github_run_id = github_run_id + rand(1_000_000_000)
+    github_run_attempt = 1
+    create(
+      :ci_step_result,
+      :wall_clock_time,
+      user:,
+      github_run_id: other_github_run_id,
+      github_run_attempt:,
+      branch: 'bugfix',
+    )
+    create(
+      :ci_step_result,
+      :cpu_time,
+      user:,
+      github_run_id: other_github_run_id,
+      github_run_attempt:,
+      branch: 'bugfix',
+    )
   end
 end

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -31,8 +31,10 @@ export default defineConfig({
   plugins: [
     FullReload([
       'app/assets/stylesheets/**/*',
+      'app/controllers/**/*',
       'app/decorators/**/*',
       'app/helpers/**/*',
+      'app/presenters/**/*',
       'app/views/**/*',
     ]),
     RubyPlugin(),


### PR DESCRIPTION
I wasn't sure where to put the `branch_names` method. I stuck it into the presenter, but this required adding two new initialization params and also (relatedly) isn't really aligned with the single purpose of "presenting CI step results". But that's okay for now.

This change uses an HTML `datalist` element to create basically a typeahead experience using a native HTML text input.

Also, since it was helpful to me in working on this feature, this change also adds `controllers` and `presenters` to the list of files upon modification of which Vite will reload the page.

![image](https://github.com/user-attachments/assets/32163bb0-3c57-46bf-b5b5-3cc1c5022dcc)