### PR TITLE
[blog] Add 'js' to allowlisted extensions [BLOG-17]

### DIFF
--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -9,6 +9,7 @@ class BlogController < ApplicationController
   all_actions = %i[assets index show]
   skip_before_action :authenticate_user!, only: all_actions
   before_action :skip_authorization, only: all_actions
+  protect_from_forgery except: :assets
 
   def assets
     send_blog_file(request.path)
@@ -57,7 +58,7 @@ class BlogController < ApplicationController
 
     if (
       absolute_path.start_with?(BLOG_DIRECTORY) &&
-        absolute_path.match?(/\.(css|html|jpg|png|xml)\z/)
+        absolute_path.match?(/\.(css|html|jpg|js|png|xml)\z/)
     )
       send_file(absolute_path, **kwargs)
     else


### PR DESCRIPTION
As of https://github.com/davidrunger/blog/pull/518 , we are now trying to serve JavaScript for the blog (to add "Copy Code" buttons to all `pre` tags). However, it's not working, because we weren't allowing requests for `.js` files. This change adds `js` to the list of allowlisted extensions and also disables forgery protection for the blog#assets action, which will allow that JavaScript code to load successfully.

Without disabling forgery protection, we get this error when requesting the JavaScript file:

> ActionController::InvalidCrossOriginRequest: Security warning: an embedded <script> tag on another site requested protected JavaScript. If you know what you're doing, go ahead and disable forgery protection on this action to permit cross-origin JavaScript embedding.