### PR TITLE
Save user's Google 'sub' value in DB and check it on login [DEV-122]

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -7,7 +7,21 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
     email = access_token.info['email']
 
     user = User.find_by(email:)
-    if !user
+
+    if user
+      # https://cyberinsider.com/unfixed-google-oauth-flaw-exposes-millions-to-account-takeovers/
+      sub = access_token.dig('extra', 'id_info', 'sub').presence!
+
+      if user.google_sub
+        if sub != user.google_sub
+          flash[:alert] = 'You are attempting a domain identity takeover attack. Blocked!'
+          redirect_to(new_user_session_path)
+          return
+        end
+      else
+        user.update!(google_sub: sub)
+      end
+    else
       user = Users::Create.run!(email:).user
     end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,7 @@
 #
 #  created_at :datetime         not null
 #  email      :string           not null
+#  google_sub :string
 #  id         :bigint           not null, primary key
 #  updated_at :datetime         not null
 #

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -4,6 +4,7 @@
 #
 #  created_at :datetime         not null
 #  email      :string           not null
+#  google_sub :string
 #  id         :bigint           not null, primary key
 #  updated_at :datetime         not null
 #

--- a/db/migrate/20250218004533_add_google_sub_to_users.rb
+++ b/db/migrate/20250218004533_add_google_sub_to_users.rb
@@ -1,0 +1,5 @@
+class AddGoogleSubToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :google_sub, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_02_08_092554) do
+ActiveRecord::Schema[8.0].define(version: 2025_02_18_004533) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -363,6 +363,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_02_08_092554) do
     t.string "email", null: false
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
+    t.string "google_sub"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -4,6 +4,7 @@
 #
 #  created_at :datetime         not null
 #  email      :string           not null
+#  google_sub :string
 #  id         :bigint           not null, primary key
 #  updated_at :datetime         not null
 #

--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe 'Logging in as an AdminUser via Google auth' do
-  before { MockOmniAuth.google_oauth2(email: stubbed_admin_user_email) }
+  before { MockOmniAuth.google_oauth2(email: stubbed_admin_user_email, sub: rand(100_000_000_000)) }
 
   context 'when an AdminUser with the email exists in the database' do
     let(:stubbed_admin_user_email) { admin_user.email }

--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -2,10 +2,10 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
   context 'when OmniAuth test mode is enabled and OmniAuth is mocked' do
     before do
       expect(OmniAuth.config.test_mode).to eq(true)
-      MockOmniAuth.google_oauth2(email: stubbed_user_email, sub:)
+      MockOmniAuth.google_oauth2(email: stubbed_user_email, sub: mocked_google_response_sub)
     end
 
-    let(:sub) { "1#{rand(100_000_000_000_000_000)}" }
+    let(:mocked_google_response_sub) { "1#{rand(100_000_000_000_000_000)}" }
 
     context 'when the user already exists in the database' do
       let(:stubbed_user_email) { user.email }
@@ -29,7 +29,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
 
       context 'when the user has a google_sub in the database' do
         context 'when the sub returned from Google matches the google_sub in our database' do
-          before { user.update!(google_sub: sub) }
+          before { user.update!(google_sub: mocked_google_response_sub) }
 
           it 'allows the user to log in with Google' do
             visit(new_user_session_path)
@@ -45,7 +45,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
         end
 
         context 'when the sub returned from Google does not match the google_sub in our database' do
-          before { user.update!(google_sub: (Integer(sub) + 1).to_s) }
+          before { user.update!(google_sub: (Integer(mocked_google_response_sub) + 1).to_s) }
 
           it 'redirects with an error message, does not sign in the user, and sends a report to Rollbar' do
             allow(Rails.error).to receive(:report).and_call_original
@@ -65,7 +65,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
                 Users::OmniauthCallbacksController::SubMismatch,
                 context: {
                   user_sub_in_db: user.google_sub,
-                  sub_in_google_response: sub,
+                  sub_in_google_response: mocked_google_response_sub,
                 },
               )
 

--- a/spec/support/mock_omni_auth.rb
+++ b/spec/support/mock_omni_auth.rb
@@ -1,5 +1,5 @@
 module MockOmniAuth
-  def self.google_oauth2(email:)
+  def self.google_oauth2(email:, sub:)
     OmniAuth.config.add_mock(
       :google_oauth2,
       provider: 'google_oauth2',
@@ -11,6 +11,11 @@ module MockOmniAuth
         token: 'abcdefg12345',
         expires_at: 1.hour.from_now,
         expires: true,
+      },
+      extra: {
+        id_info: {
+          sub:,
+        },
       },
     )
   end


### PR DESCRIPTION
This should help to protect users against domain takeover identity attacks as described here: https://cyberinsider.com/unfixed-google-oauth-flaw-exposes-millions-to-account-takeovers/ .

NOTE: That article claims the `sub` to be unreliable in 0.04% of cases. I am going to just hope that those cases won't include any of our users.