### PR TITLE
[check-ins] Import ElPopover in component (not entrypoint)

### DIFF
--- a/app/javascript/check_ins/components/Ratings.vue
+++ b/app/javascript/check_ins/components/Ratings.vue
@@ -7,10 +7,16 @@
     el-popover(
       placement='top-end'
       trigger='click'
-      :content='needSatisfactionRating.emotional_need.description'
     )
       template(#reference)
         span.circled-text.monospace.js-link i
+      div(v-if='needSatisfactionRating.emotional_need.description')
+        | {{ needSatisfactionRating.emotional_need.description }}
+      div(v-else)
+        | No description. You can add one
+        |
+        a(:href='edit_emotional_need_path(needSatisfactionRating.emotional_need.id)') here
+        | .
     a.ml-2(:href='graphLink(needSatisfactionRating)') graph
   div
     EmojiButton(
@@ -31,7 +37,10 @@ import type { PropType } from 'vue';
 
 import { useCheckInsStore } from '@/check_ins/store';
 import type { NeedSatisfactionRating, Rating } from '@/check_ins/types';
-import { history_emotional_need_path } from '@/rails_assets/routes';
+import {
+  edit_emotional_need_path,
+  history_emotional_need_path,
+} from '@/rails_assets/routes';
 
 import EmojiButton from './EmojiButton.vue';
 

--- a/app/javascript/check_ins/components/Ratings.vue
+++ b/app/javascript/check_ins/components/Ratings.vue
@@ -24,6 +24,7 @@ button.btn-primary.mt-2.h3(v-if='editable && !submitted' @click='submitCheckIn')
 </template>
 
 <script setup lang="ts">
+import { ElPopover } from 'element-plus';
 import { range } from 'lodash-es';
 import { storeToRefs } from 'pinia';
 import type { PropType } from 'vue';

--- a/app/javascript/entrypoints/check_ins.ts
+++ b/app/javascript/entrypoints/check_ins.ts
@@ -1,4 +1,3 @@
-import { ElPopover } from 'element-plus';
 import { createPinia } from 'pinia';
 
 import CheckIns from '@/check_ins/App.vue';
@@ -7,4 +6,3 @@ import { renderApp } from '@/shared/customized_vue';
 const app = renderApp(CheckIns, '#check_ins_app');
 const pinia = createPinia();
 app.use(pinia);
-app.use(ElPopover);


### PR DESCRIPTION
The motivation for this change is partially for consistency with #6135 ; I would have made this change in that PR, if I'd have noticed this issue, then.

In general, my goal is to have each component that uses a component library's component(s) import that component library's component(s) in my component(s) that use it/them. I think that this makes it a little more clear "where things are coming from" and might also make it easier to replace. It also provides better TypeScript support. (Indeed, this change surfaced a TypeScript violation, which was somewhat of the motivation for the feature improvement herein of linking to the emotional need edit page for an emotional need without a description.)