### PR TITLE
[groceries] Auto-linkify URLs in grocery items [GROC-25]

### DIFF
--- a/app/javascript/groceries/components/Item.vue
+++ b/app/javascript/groceries/components/Item.vue
@@ -26,7 +26,8 @@
       ref='itemNameInput'
     )
     span.item-name(v-else)
-      | {{item.name}}
+      span(v-html="linkify(item.name)")
+      |
       |
       a.js-link.text-neutral-400(@click='editItemName' class="hover:text-black")
         EditIcon(:size='ICON_SIZE')
@@ -48,6 +49,7 @@ import { EditIcon, MinusIcon, PlusIcon } from 'vue-tabler-icons';
 
 import { useGroceriesStore } from '@/groceries/store';
 import type { Item } from '@/groceries/types';
+import { linkify } from '@/lib/linkify';
 
 const ICON_SIZE = 17;
 

--- a/app/javascript/lib/linkify.ts
+++ b/app/javascript/lib/linkify.ts
@@ -1,0 +1,6 @@
+// eslint-disable-next-line max-len
+const httpUrlRegex = /(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*[a-zA-Z0-9/])(?:#[-a-zA-Z0-9()@:%_+.~#?&/=]*)?)/gi;
+
+export function linkify(text: string): string {
+  return text.replace(httpUrlRegex, '<a href="$1">$1</a>');
+}

--- a/app/javascript/lib/linkify.ts
+++ b/app/javascript/lib/linkify.ts
@@ -1,5 +1,5 @@
-// eslint-disable-next-line max-len
 const httpUrlRegex =
+  // eslint-disable-next-line max-len
   /(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*[a-zA-Z0-9/])(?:#[-a-zA-Z0-9()@:%_+.~#?&/=]*)?)/gi;
 
 export function linkify(text: string): string {

--- a/app/javascript/lib/linkify.ts
+++ b/app/javascript/lib/linkify.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line max-len
-const httpUrlRegex = /(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*[a-zA-Z0-9/])(?:#[-a-zA-Z0-9()@:%_+.~#?&/=]*)?)/gi;
+const httpUrlRegex =
+  /(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*[a-zA-Z0-9/])(?:#[-a-zA-Z0-9()@:%_+.~#?&/=]*)?)/gi;
 
 export function linkify(text: string): string {
   return text.replace(httpUrlRegex, '<a href="$1">$1</a>');

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe 'Groceries app' do
         # Verify that the item is listed only once.
         expect(page.text.scan(new_item_name).size).to eq(1)
         # Verify that the URL in the item name is automatically linkified.
-        expect(page).to have_link(url_in_item_name)
+        expect(page).to have_link(url_in_item_name, href: url_in_item_name)
 
         page.percy_snapshot('Groceries')
 

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -7,9 +7,10 @@ RSpec.describe 'Groceries app' do
     context 'when the user has a spouse' do
       before { expect(user.spouse).to be_present }
 
-      let(:new_item_name) { 'blueberries' }
+      let(:new_item_name) { "blueberries (#{url_in_item_name})" }
+      let(:url_in_item_name) { 'https://www.amazon.com/blueberries' }
 
-      it 'allows adding an item, deleting an item, undoing the deletion, and checking in a shopping trip' do
+      it 'allows adding an item (which it linkifies), deleting an item, undoing the deletion, and checking in a shopping trip' do
         visit groceries_path
 
         store = user.stores.reorder(:viewed_at).last!
@@ -35,7 +36,9 @@ RSpec.describe 'Groceries app' do
         end
 
         # Verify that the item is listed only once.
-        expect(page.body.scan(new_item_name).size).to eq(1)
+        expect(page.text.scan(new_item_name).size).to eq(1)
+        # Verify that the URL in the item name is automatically linkified.
+        expect(page).to have_link(url_in_item_name)
 
         page.percy_snapshot('Groceries')
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "jsx": "preserve",
     "lib": ["esnext", "dom"],
     "module": "esnext",
+    "moduleDetection": "force",
     "moduleResolution": "node",
     "noImplicitAny": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Sometimes I include URLs in my grocery items. It will be convenient for these URLs to be hyperlinked. This change implements that.

I tried to find a micro-library that would do this for me, but I couldn't find something with the characteristics that I want, so I am implementing it myself. Hopefully this regex will cover the relevant (edge) cases as I want it to.

Also, I am adding `"moduleDetection": "force"` to `tsconfig.json` to avoid the error ("Cannot redeclare block-scoped variable") that I was getting when editing a file (`app/javascript/typescript-scratchpad.ts`) that did not have any imports or exports and which had a constant name (`regex`) that was also in another file (`app/javascript/lib/linkify.ts`). Source: https://stackoverflow.com/a/77005521/4009384 .