### PR TITLE
[paper_trail] Stop logging 'create' events, by default

### DIFF
--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -18,7 +18,7 @@ class AdminUser < ApplicationRecord
 
   devise
 
-  has_paper_trail
+  has_paper_trail_for_all_events
 
   def display_name
     email.split('@').first

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -11,6 +11,11 @@ class ApplicationRecord < ActiveRecord::Base
     def serializer_class
       "#{name}Serializer".constantize
     end
+
+    def has_paper_trail_for_all_events # rubocop:disable Naming/PredicateName
+      # Log all events, including `create` (which we omit by default).
+      has_paper_trail(on: %i[create destroy touch update])
+    end
   end
 
   def as_json

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -21,5 +21,5 @@ class AuthToken < ApplicationRecord
   belongs_to :user
   has_many :requests, dependent: :nullify
 
-  has_paper_trail
+  has_paper_trail_for_all_events
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -50,7 +50,7 @@ class User < ApplicationRecord
 
   devise
 
-  has_paper_trail
+  has_paper_trail_for_all_events
 
   before_destroy do |user|
     if user.reload.marriage

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,1 +1,5 @@
 PaperTrail.config.enabled = true
+PaperTrail.config.has_paper_trail_defaults = {
+  # Omit `create` events.
+  on: %i[destroy touch update],
+}


### PR DESCRIPTION
I think that creation events are pretty low-value. The record will have a `created_at` timestamp, and the record's current state plus it's `update` and `destroy` PaperTrail version history should be enough to reconstruct the record's state at creation, if needed (which I don't think it ever has been, so far).

For security auditing purposes, for authentication-related records (AdminUsers, AuthTokens, Users), we will continue to log the `create` events.