### PR TITLE
[logs] Add 'dependent: :destroy' to LogEntry delegated_type

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,5 +18,14 @@ AllCops:
   <% end %>
   StringLiteralsFrozenByDefault: true
 
+CustomCops/DontRollBackDatamigration:
+  Include:
+    - db/datamigrate/**/*.rb
+CustomCops/DontIncludeSidekiqWorker:
+  Include:
+    - app/workers/**/*.rb
+Style/ClassAndModuleChildren:
+  Exclude:
+    - 'tools/custom_cops/**/*.rb'
 Style/FrozenStringLiteralComment:
   EnforcedStyle: never

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -22,7 +22,8 @@ class LogEntry < ApplicationRecord
   has_one :user, through: :log
   delegated_type :log_entry_datum,
     types: %w[NumberLogEntryDatum TextLogEntryDatum],
-    inverse_of: :log_entry
+    inverse_of: :log_entry,
+    dependent: :destroy
 
   validates :log_entry_datum, presence: true
   validates_associated :log_entry_datum

--- a/config/application.rb
+++ b/config/application.rb
@@ -45,7 +45,7 @@ class DavidRunger::Application < Rails::Application
   # Please, add to the `ignore` list any other `lib` subdirectories that do
   # not contain `.rb` files, or that should not be reloaded or eager loaded.
   # Common ones are `templates`, `generators`, or `middleware`, for example.
-  config.autoload_lib(ignore: %w[tasks test])
+  config.autoload_lib(ignore: %w[generators tasks test])
 
   # ActiveJob/Sidekiq
   config.active_job.queue_adapter = :sidekiq

--- a/db/datamigrate/20250220020837_destroy_orphaned_log_entry_data.rb
+++ b/db/datamigrate/20250220020837_destroy_orphaned_log_entry_data.rb
@@ -1,4 +1,4 @@
-class DestroyOrphanedLogEntryData < Datamigration
+class DestroyOrphanedLogEntryData < Datamigration::Base
   def run
     logging_start_and_finish do
       within_transaction do

--- a/db/datamigrate/20250220020837_destroy_orphaned_log_entry_data.rb
+++ b/db/datamigrate/20250220020837_destroy_orphaned_log_entry_data.rb
@@ -21,7 +21,7 @@ class DestroyOrphanedLogEntryData < Datamigration
 
       log('Done destroying orphaned number log entry data.')
     else
-      fail 'There were unexpectedly many orphaned text log entry data.'
+      fail 'There were unexpectedly many orphaned number log entry data.'
     end
   end
 

--- a/db/datamigrate/20250220020837_destroy_orphaned_log_entry_data.rb
+++ b/db/datamigrate/20250220020837_destroy_orphaned_log_entry_data.rb
@@ -1,0 +1,52 @@
+class DestroyOrphanedLogEntryData < Datamigration
+  def run
+    logging_start_and_finish do
+      within_transaction do
+        destroy_orphaned_number_log_entry_data
+        destroy_orphaned_text_log_entry_data
+      end
+    end
+  end
+
+  private
+
+  def destroy_orphaned_number_log_entry_data
+    # We expect 0.
+    if orphaned_number_log_entry_data.count <= 5
+      log(<<~LOG.squish)
+        About to destroy #{orphaned_number_log_entry_data.count} orphaned number log entry data.
+      LOG
+
+      orphaned_number_log_entry_data.find_each(&:destroy!)
+
+      log('Done destroying orphaned number log entry data.')
+    else
+      fail 'There were unexpectedly many orphaned text log entry data.'
+    end
+  end
+
+  def destroy_orphaned_text_log_entry_data
+    # We expect 16.
+    if orphaned_text_log_entry_data.count <= 20
+      log(<<~LOG.squish)
+        About to destroy #{orphaned_text_log_entry_data.count} orphaned text log entry data.
+      LOG
+
+      orphaned_text_log_entry_data.find_each(&:destroy!)
+
+      log('Done destroying orphaned text log entry data.')
+    else
+      fail 'There were unexpectedly many orphaned text log entry data.'
+    end
+  end
+
+  def orphaned_number_log_entry_data
+    NumberLogEntryDatum.left_outer_joins(:log_entry).where(log_entries: { id: nil })
+  end
+
+  def orphaned_text_log_entry_data
+    TextLogEntryDatum.left_outer_joins(:log_entry).where(log_entries: { id: nil })
+  end
+end
+
+DestroyOrphanedLogEntryData.new.run

--- a/lib/datamigration.rb
+++ b/lib/datamigration.rb
@@ -1,0 +1,42 @@
+class Datamigration
+  prepend Memoization
+
+  private
+
+  def logging_start_and_finish
+    log('Starting...')
+
+    yield
+
+    log('Finished.')
+  end
+
+  def within_transaction(rollback: false)
+    ApplicationRecord.transaction do
+      yield
+
+      if rollback
+        log('Rolling back...')
+
+        raise(ActiveRecord::Rollback)
+      end
+    end
+  end
+
+  def log(message)
+    logger.info(message)
+  end
+
+  memoize \
+  def logger
+    ActiveSupport::Logger.new($stdout).tap do |logger|
+      logger.formatter =
+        proc do |_severity, time, _program_name, message|
+          "#{time.utc.iso8601(3)} #{message}\n"
+        end
+    end.then do |logger|
+      ActiveSupport::TaggedLogging.new(logger)
+    end.
+      tagged(self.class.name)
+  end
+end

--- a/lib/datamigration/base.rb
+++ b/lib/datamigration/base.rb
@@ -29,12 +29,7 @@ class Datamigration::Base
 
   memoize \
   def logger
-    ActiveSupport::Logger.new($stdout).tap do |logger|
-      logger.formatter =
-        proc do |_severity, time, _program_name, message|
-          "#{time.utc.iso8601(3)} #{message}\n"
-        end
-    end.then do |logger|
+    Rails.logger.then do |logger|
       ActiveSupport::TaggedLogging.new(logger)
     end.
       tagged(self.class.name)

--- a/lib/datamigration/base.rb
+++ b/lib/datamigration/base.rb
@@ -1,4 +1,4 @@
-class Datamigration
+class Datamigration::Base
   prepend Memoization
 
   private

--- a/lib/generators/datamigration/datamigration_generator.rb
+++ b/lib/generators/datamigration/datamigration_generator.rb
@@ -1,0 +1,24 @@
+class DatamigrationGenerator < Rails::Generators::NamedBase
+  source_root File.expand_path('templates', __dir__)
+
+  def create_datamigration_file
+    if behavior == :invoke
+      timestamp = Time.now.utc.strftime('%Y%m%d%H%M%S')
+      migration_filename = "#{timestamp}_#{file_name.underscore}.rb"
+      template('datamigration_template.tt', "db/datamigrate/#{migration_filename}")
+    else
+      # In revoke mode, find and remove the most recent matching file.
+      datamigration_absolute_path =
+        Rails.root.
+          glob("db/datamigrate/*_#{file_name.underscore}.rb").
+          last
+
+      if datamigration_absolute_path
+        datamigration_relative_path = datamigration_absolute_path.relative_path_from(Rails.root)
+
+        say_status('remove', datamigration_relative_path, :red)
+        File.delete(datamigration_relative_path)
+      end
+    end
+  end
+end

--- a/lib/generators/datamigration/templates/datamigration_template.tt
+++ b/lib/generators/datamigration/templates/datamigration_template.tt
@@ -1,0 +1,11 @@
+class <%= class_name %> < Datamigration
+  def run
+    logging_start_and_finish do
+      within_transaction(rollback: true) do
+        # ...
+      end
+    end
+  end
+end
+
+<%= class_name %>.new.run

--- a/lib/generators/datamigration/templates/datamigration_template.tt
+++ b/lib/generators/datamigration/templates/datamigration_template.tt
@@ -1,4 +1,4 @@
-class <%= class_name %> < Datamigration
+class <%= class_name %> < Datamigration::Base
   def run
     logging_start_and_finish do
       within_transaction(rollback: true) do

--- a/spec/lib/datamigration/base_spec.rb
+++ b/spec/lib/datamigration/base_spec.rb
@@ -1,0 +1,112 @@
+RSpec.describe(Datamigration::Base) do
+  let(:datamigration) { described_class.new }
+  let(:logdev) { datamigration.send(:logger).broadcasts.first.instance_variable_get(:@logdev) }
+
+  before do
+    allow(logdev).to receive(:write).and_call_original
+  end
+
+  context 'when Rails.logger.level is :info' do
+    around do |spec|
+      Rails.logger.with(level: :info) do
+        spec.run
+      end
+    end
+
+    describe '#logging_start_and_finish' do
+      it 'logs start and finish messages around the given block' do
+        result = nil
+
+        datamigration.send(:logging_start_and_finish) do
+          result = 'block executed'
+        end
+
+        expect(logdev).to have_received(:write).ordered.with(
+          "[Datamigration::Base] Starting...\n",
+        )
+        expect(logdev).to have_received(:write).ordered.with(
+          "[Datamigration::Base] Finished.\n",
+        )
+        expect(result).to eq('block executed')
+      end
+
+      it 'logs starting message and propagates any exceptions that occur' do
+        expect do
+          datamigration.send(:logging_start_and_finish) do
+            raise('test error')
+          end
+        end.to raise_error('test error')
+
+        expect(logdev).to have_received(:write).exactly(:once)
+        expect(logdev).to have_received(:write).with(
+          "[Datamigration::Base] Starting...\n",
+        )
+      end
+    end
+
+    # rubocop:disable RSpec/InstanceVariable
+    describe '#within_transaction' do
+      subject(:within_transaction) do
+        @executed = false
+
+        datamigration.send(:within_transaction, rollback:) do
+          User.create!(email:)
+          @executed = true
+        end
+      end
+
+      let(:email) { 'datamigrationbasespec@example.com' }
+
+      before { allow(ApplicationRecord).to receive(:transaction).and_call_original }
+
+      context 'when :rollback is false' do
+        let(:rollback) { false }
+
+        it 'does not roll back the transaction' do
+          within_transaction
+
+          expect(User.where(email:)).to exist
+          expect(@executed).to be(true)
+          expect(ApplicationRecord).to have_received(:transaction)
+        end
+      end
+
+      context 'when :rollback is true' do
+        let(:rollback) { true }
+
+        it 'executes the block and rolls back the transaction' do
+          within_transaction
+
+          expect(User.where(email:)).not_to exist
+          expect(@executed).to be(true)
+          expect(ApplicationRecord).to have_received(:transaction)
+          expect(logdev).to have_received(:write).exactly(:once)
+          expect(logdev).to have_received(:write).with(
+            "[Datamigration::Base] Rolling back...\n",
+          )
+        end
+      end
+    end
+    # rubocop:enable RSpec/InstanceVariable
+
+    describe '#log' do
+      it 'logs messages with class name tag' do
+        datamigration.send(:log, 'test message')
+
+        expect(logdev).to have_received(:write).exactly(:once)
+        expect(logdev).to have_received(:write).with(
+          "[Datamigration::Base] test message\n",
+        )
+      end
+    end
+
+    describe '#logger' do
+      it 'memoizes the logger instance' do
+        first_logger = datamigration.send(:logger)
+        second_logger = datamigration.send(:logger)
+
+        expect(first_logger.object_id).to eq(second_logger.object_id)
+      end
+    end
+  end
+end

--- a/spec/models/log_entry_spec.rb
+++ b/spec/models/log_entry_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe(LogEntry) do
+  subject(:log_entry) { LogEntry.first! }
+
+  it { is_expected.to belong_to(:log) }
+  it { is_expected.to have_one(:user).through(:log) }
+
+  it { is_expected.to validate_presence_of(:log_entry_datum) }
+
+  describe '#data' do
+    subject(:data) { log_entry.data }
+
+    it 'returns the data value from the log_entry_datum' do
+      log_entry_datum = log_entry.log_entry_datum
+
+      expect(data).to eq(log_entry_datum.data)
+    end
+  end
+
+  context 'when destroyed' do
+    subject(:destroy!) { log_entry.destroy! }
+
+    it 'also destroys the associated log_entry_datum' do
+      log_entry_datum = log_entry.log_entry_datum
+
+      expect {
+        destroy!
+      }.to change {
+        log_entry.log_entry_datum_type.constantize.exists?(log_entry_datum.id)
+      }.from(true).to(false)
+    end
+  end
+end

--- a/spec/tools/custom_cops/dont_include_sidekiq_worker_spec.rb
+++ b/spec/tools/custom_cops/dont_include_sidekiq_worker_spec.rb
@@ -2,19 +2,15 @@ require 'rubocop'
 require 'rubocop/rspec/support'
 require Rails.root.join('tools/custom_cops/dont_include_sidekiq_worker.rb')
 
-RSpec.describe CustomCops::DontIncludeSidekiqWorker do
+RSpec.describe CustomCops::DontIncludeSidekiqWorker, :config do
   include RuboCop::RSpec::ExpectOffense
-
-  subject(:cop) { described_class.new }
-
-  let(:msg) { 'Use `prepend ApplicationWorker` rather than `include Sidekiq::Worker`' }
 
   context 'when using `include Sidekiq::Worker`' do
     it 'registers an offense and can autocorrect it' do
       expect_offense(<<~RUBY)
         class MyWorker
           include Sidekiq::Worker
-          ^^^^^^^^^^^^^^^^^^^^^^^ CustomCops/DontIncludeSidekiqWorker: Use `prepend ApplicationWorker` rather than `include Sidekiq::Worker` or `include Sidekiq::Job`
+          ^^^^^^^^^^^^^^^^^^^^^^^ Use `prepend ApplicationWorker` rather than `include Sidekiq::Worker` or `include Sidekiq::Job`
         end
       RUBY
 
@@ -31,7 +27,7 @@ RSpec.describe CustomCops::DontIncludeSidekiqWorker do
       expect_offense(<<~RUBY)
         class MyWorker
           include Sidekiq::Job
-          ^^^^^^^^^^^^^^^^^^^^ CustomCops/DontIncludeSidekiqWorker: Use `prepend ApplicationWorker` rather than `include Sidekiq::Worker` or `include Sidekiq::Job`
+          ^^^^^^^^^^^^^^^^^^^^ Use `prepend ApplicationWorker` rather than `include Sidekiq::Worker` or `include Sidekiq::Job`
         end
       RUBY
 

--- a/spec/tools/custom_cops/dont_roll_back_datamigration_spec.rb
+++ b/spec/tools/custom_cops/dont_roll_back_datamigration_spec.rb
@@ -1,0 +1,58 @@
+require 'rubocop'
+require 'rubocop/rspec/support'
+require Rails.root.join('tools/custom_cops/dont_roll_back_datamigration.rb')
+
+RSpec.describe CustomCops::DontRollBackDatamigration, :config do
+  include RuboCop::RSpec::ExpectOffense
+
+  context 'when calling within_transaction with a rollback keyword argument' do
+    it 'registers an offense' do
+      expect_offense(<<~RUBY)
+        within_transaction(rollback: true) do
+                           ^^^^^^^^^^^^^^ Only use the `:rollback` keyword argument for testing. Remove before pushing.
+          perform_task
+        end
+      RUBY
+    end
+  end
+
+  context 'when calling within_transaction with a positional argument' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        within_transaction(:rollback) do
+          perform_task
+        end
+      RUBY
+    end
+  end
+
+  context 'when calling within_transaction without any argument' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        within_transaction do
+          perform_task
+        end
+      RUBY
+    end
+  end
+
+  context 'when calling a different method with a rollback keyword argument' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        some_other_method(rollback: true) do
+          perform_task
+        end
+      RUBY
+    end
+  end
+
+  context 'when calling within_transaction with other keyword arguments' do
+    it 'does not register an offense' do
+      expect_no_offenses(<<~RUBY)
+        within_transaction(foo: true, bar: false) do
+          perform_task
+        end
+      RUBY
+    end
+  end
+end

--- a/tools/custom_cops/dont_include_sidekiq_worker.rb
+++ b/tools/custom_cops/dont_include_sidekiq_worker.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Style/ClassAndModuleChildren
 module CustomCops
   class DontIncludeSidekiqWorker < RuboCop::Cop::Base
     extend RuboCop::Cop::AutoCorrector
@@ -20,4 +19,3 @@ module CustomCops
     end
   end
 end
-# rubocop:enable Style/ClassAndModuleChildren

--- a/tools/custom_cops/dont_roll_back_datamigration.rb
+++ b/tools/custom_cops/dont_roll_back_datamigration.rb
@@ -8,14 +8,15 @@ module CustomCops
 
       # Check each argument; if it's a hash, inspect its pairs.
       node.arguments.each do |arg|
-        next unless arg.hash_type?
+        if arg.hash_type?
+          arg.pairs.each do |pair|
+            key, _value = *pair
 
-        arg.pairs.each do |pair|
-          key, _value = *pair
-          # If the key is a symbol and equals :rollback, register an offense.
-          next unless key.sym_type? && key.value == :rollback
-
-          add_offense(pair, message: MSG)
+            # If the key is a symbol and equals :rollback, register an offense.
+            if key.sym_type? && key.value == :rollback
+              add_offense(pair, message: MSG)
+            end
+          end
         end
       end
     end

--- a/tools/custom_cops/dont_roll_back_datamigration.rb
+++ b/tools/custom_cops/dont_roll_back_datamigration.rb
@@ -1,0 +1,23 @@
+module CustomCops
+  class DontRollBackDatamigration < RuboCop::Cop::Base
+    MSG = 'Only use the `:rollback` keyword argument for testing. Remove before pushing.'
+
+    def on_send(node)
+      # Only examine calls to within_transaction.
+      return unless node.method_name == :within_transaction
+
+      # Check each argument; if it's a hash, inspect its pairs.
+      node.arguments.each do |arg|
+        next unless arg.hash_type?
+
+        arg.pairs.each do |pair|
+          key, _value = *pair
+          # If the key is a symbol and equals :rollback, register an offense.
+          next unless key.sym_type? && key.value == :rollback
+
+          add_offense(pair, message: MSG)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Also, add a datamigration to destroy log entry datum records that were orphaned before adding this `dependent: :destroy` just now.

Also, add a generator to create timestamped datamigrations that will use a `Datamigration` library class (which includes a tagged logger and an easy mechanism to test and roll back the datamigration within a transaction for testing locally and repeatedly).

Also, while fiddling with custom cops config, apply `CustomCops/DontIncludeSidekiqWorker` only to `app/workers/**/*.rb` and exclude `tools/custom_cops/**/*.rb` from `Style/ClassAndModuleChildren`.