### PR TITLE
Add bin script to run datamigrations on the server

### DIFF
--- a/bin/server/run-datamigration
+++ b/bin/server/run-datamigration
@@ -15,4 +15,4 @@ datamigration_path=$1
 # Use `tee` to write both to the terminal and also to the stdout (file
 # descriptor 1) of process 1 (i.e. the rails web server process), because only
 # that output is picked up by Docker/Vector.
-docker compose exec web sh -c "bin/rails runner \"$datamigration_path\" | tee /proc/1/fd/1"
+docker compose exec web bash -c 'bin/rails runner "$datamigration_path" > >(tee /proc/1/fd/1) 2> >(tee /proc/1/fd/2 >&2)'

--- a/bin/server/run-datamigration
+++ b/bin/server/run-datamigration
@@ -15,4 +15,4 @@ datamigration_path=$1
 # Use `tee` to write both to the terminal and also to the stdout (file
 # descriptor 1) of process 1 (i.e. the rails web server process), because only
 # that output is picked up by Docker/Vector.
-docker compose exec web bash -c 'bin/rails runner "$datamigration_path" > >(tee /proc/1/fd/1) 2> >(tee /proc/1/fd/2 >&2)'
+docker compose exec web bash -c "bin/rails runner '$datamigration_path' > >(tee /proc/1/fd/1) 2> >(tee /proc/1/fd/2 >&2)"

--- a/bin/server/run-datamigration
+++ b/bin/server/run-datamigration
@@ -15,4 +15,4 @@ datamigration_path=$1
 # Use `tee` to write both to the terminal and also to the stdout (file
 # descriptor 1) of process 1 (i.e. the rails web server process), because only
 # that output is picked up by Docker/Vector.
-docker compose exec web bash -c "bin/rails runner '$datamigration_path' > >(tee /proc/1/fd/1) 2> >(tee /proc/1/fd/2 >&2)"
+docker compose exec web sh -c "bin/rails runner \"$datamigration_path\" 2>&1 | tee /proc/1/fd/1"

--- a/bin/server/run-datamigration
+++ b/bin/server/run-datamigration
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Run a datamigration via Docker Compose, logging both to the terminal and to Docker/Vector.
+#
+# Usage:
+#   bin/server/run-datamigration DATAMIGRATION_PATH
+#
+# Example:
+#   bin/server/run-datamigration db/datamigrate/20250220020837_destroy_orphaned_data.rb
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+datamigration_path=$1
+
+# Use `tee` to write both to the terminal and also to the stdout (file
+# descriptor 1) of process 1 (i.e. the rails web server process), because only
+# that output is picked up by Docker/Vector.
+docker compose exec web sh -c "bin/rails runner \"$datamigration_path\" | tee /proc/1/fd/1"

--- a/lib/datamigration/base.rb
+++ b/lib/datamigration/base.rb
@@ -29,9 +29,23 @@ class Datamigration::Base
 
   memoize \
   def logger
-    Rails.logger.then do |logger|
+    logger_base.then do |logger|
       ActiveSupport::TaggedLogging.new(logger)
     end.
       tagged(self.class.name)
+  end
+
+  memoize \
+  def logger_base
+    if Rails.env.development?
+      # In development, Rails.logger doesn't log to stdout, but we want to do so here.
+      ActiveSupport::Logger.new($stdout).tap do |logger|
+        logger.formatter = ActiveSupport::Logger::SimpleFormatter.new
+      end
+    else
+      # In test, we don't want to write to stdout, and Rails.logger doesn't.
+      # In production, we do want to write to stdout, and Rails.logger does.
+      Rails.logger
+    end
   end
 end


### PR DESCRIPTION
When naively running a datamigration via `docker compose exec` (e.g. `docker compose exec web bin/rails runner db/datamigrate/20250220020837_destroy_orphaned_log_entry_data.rb`), the output won't go to our logs (Docker -> Vector -> Loki -> Grafana) by default; it only prints to the terminal.

However, we can use `tee` to both print to stdout and to write to the stdout (file descriptor 1) of process 1, which will cause the logs to be captured by the Docker -> Vector -> Loki -> Grafana pipeline. This change adds a script which does that.

Also, modify `Datamigration::Base` so that it chooses a different `logger_base` depending on the environment. See code comments on that code change for a little more detail. Without this change, there is not output to stdout when running migrations in development (whether via this new `bin/` script or via `rails runner` directly); instead I think that the output is written to `log/development.log` (in the container, I guess).