### PR TITLE
[logs] Add PaperTrail tracking for LogEntries [LOG-37]

### DIFF
--- a/app/models/concerns/log_entry_datum.rb
+++ b/app/models/concerns/log_entry_datum.rb
@@ -6,5 +6,7 @@ module LogEntryDatum
 
     validates :data, presence: true
     validates :log_entry, presence: true
+
+    has_paper_trail
   end
 end

--- a/app/models/log_entry.rb
+++ b/app/models/log_entry.rb
@@ -30,5 +30,7 @@ class LogEntry < ApplicationRecord
 
   delegate :data, to: :log_entry_datum
 
+  has_paper_trail
+
   broadcasts_json_to(LogEntriesChannel, ->(log_entry) { log_entry.log })
 end


### PR DESCRIPTION
Also, track `TextLogEntryDatum` and `NumberLogEntryDatum` (via the `LogEntryDatum` concern), which perhaps are arguably actually the more relevant models to track, as they contain the actual log entry data.

I didn't feel like adding the `paper_trail-association_tracking` gem (which would also require and additional table), so instead I am just tracking all three models via plain `paper_trail`. It's potentially sort of YAGNI to be adding any of this, in the first place, so I don't really feel like adding another gem and table to accomplish this. I think we still get the biggest intended goal (i.e. having some record of changes and ability to restore) with this simpler approach, although admittedly the data might not be quite as reliable and/or easy to browse and work with as it might be with that gem.

**Motivation:** I was recently editing a user's log entry, and I would like to have been able to revert to the original if I made some sort of mistake, or be able to confirm (by referencing the original version and my changes since then) that I hadn't made a mistake.

I can also imagine this being useful, in general, in case a user edits a log entry accidentally or otherwise wants to be able to recover some historical data and possibly revert to a previous state.