### PR TITLE
[run-release-tasks] Don't require 'web' service to be running

### DIFF
--- a/bin/server/run-release-tasks
+++ b/bin/server/run-release-tasks
@@ -3,7 +3,9 @@
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
 # Find currently deployed and running (but soon to be outgoing) Git sha.
-OUTGOING_GIT_SHA=$(docker compose exec web printenv GIT_REV)
+set +e
+OUTGOING_GIT_SHA=$(docker compose exec web printenv GIT_REV || false)
+set -e
 
 # Run release tasks.
 docker compose run --rm -e OUTGOING_GIT_SHA="$OUTGOING_GIT_SHA" web bin/server/release-tasks


### PR DESCRIPTION
`docker compose exec web`, which is part of the `bin/server/run-release-tasks` script that is being modified herein, will error if the `web` service isn't running (such as when booting up freshly on a brand new server, or maybe after there has been some sort of problem). It's not essential that we have an `OUTGOING_GIT_SHA` (and we explicitly handle the possibility of its absence where it is checked in `bin/server/release-tasks`), so, rather than erroring if `web` is not running, this change makes it so that we will simply set `OUTGOING_GIT_SHA` to nothing, in that case.

I noticed this issue while trying to boot up on a fresh Hetzner server via `GIT_REV=$(git log main --format=format:%H | head -1) bin/server/deploy.sh`.