### PR TITLE
[deploy.sh] Boot NGINX if it is not already running

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -27,6 +27,11 @@ bin/build-docker production
 # Run release tasks.
 bin/server/run-release-tasks
 
+# If NGINX is not already running, then start it.
+if ! docker compose ps -q nginx | grep -q . ; then
+  docker compose up --detach --remove-orphans nginx
+fi
+
 # Copy fully built out public/ directory from web to nginx via app-public volume.
 docker run --rm \
   --mount source=david_runger_app-public,target=/app-public \

--- a/bin/server/roll-out-web.sh
+++ b/bin/server/roll-out-web.sh
@@ -73,14 +73,7 @@ while [ $attempt -le $max_attempts ] ; do
   fi
 done
 
-if docker compose ps -q nginx | grep -q .; then
-  # If NGINX is already running, reload to have it start routing requests to the
-  # new container instead of the old.
-  reload_nginx
-else
-  # If NGINX is not yet running, boot it up.
-  docker compose up --detach --remove-orphans nginx
-fi
+reload_nginx
 
 # Remove the old container.
 if [[ -n "$old_container_id" ]]; then


### PR DESCRIPTION
... and remove the check that NGINX is running from `roll-out-web.sh`, since that is essentially redundant with the check added to `deploy.sh` (assuming that `roll-out-web.sh` is only called from `deploy.sh`, which is true enough for our purposes).

**Motivation:** I think that we want/need to boot NGINX via Docker Compose prior to executing this code https://github.com/davidrunger/david_runger/blob/e92cf1641338cd8e3487b82a06904c53755f9571/bin/server/deploy.sh/#L30-L33 . Otherwise, I think that we risk this warning(/error?) when running `GIT_REV=$(git log main --format=format:%H | head -1) bin/server/deploy.sh` on a brand new server:

> WARN[0001] volume "david_runger_app-public" already exists but was not created by Docker Compose. Use `external: true` to use an existing volume