### PR TITLE
Provide a stable SECRET_KEY_BASE env var in development

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -2,5 +2,6 @@ BROWSER=firefox-devedition # this helps letter_opener/launchy to open emails in 
 JWT_SECRET=a-dummy-development-jwt-secret
 RAILS_ENV=development
 RAILS_MAX_THREADS=1 # run web server without concurrency for more clearly structured log output
+SECRET_KEY_BASE=dummy-development-secret-key-base
 VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true # this is set in the Dockerfile when compiling assets, so set it here, too
 WEB_CONCURRENCY=0 # run web server without concurrency for more clearly structured log output

--- a/config/initializers/0w_secret_key_base.rb
+++ b/config/initializers/0w_secret_key_base.rb
@@ -1,0 +1,6 @@
+DavidRunger::Application.config.secret_key_base =
+  ENV.fetch(
+    'SECRET_KEY_BASE',
+    Rails.application.credentials.secret_key_base,
+  ).presence ||
+  fail('Could not find a secret_key_base in ENV or credentials.')

--- a/config/initializers/secret_key_base.rb
+++ b/config/initializers/secret_key_base.rb
@@ -1,1 +1,0 @@
-DavidRunger::Application.config.secret_key_base = Rails.application.credentials.secret_key_base


### PR DESCRIPTION
This will make it so that Docker rebuilds after file changes (and also, I think, deleting `tmp/`) will no longer log users out in local development.

https://chat.deepseek.com/a/chat/s/f54c613b-ca4e-42be-b7dc-4b2053d03600

https://x.com/i/grok?conversation=1893160209570210301

We move the file earlier in the initializers (using lexicographical ordering) because we want it to run before `config/initializers/devise.rb`, which will reference the `Rails.application.secret_key_base` value that seems to get set by `DavidRunger::Application.config.secret_key_base = [...]`. (This doesn't seem to strictly be required in order to fix the issue of users being logged out in local development, but having the Devise secret key not match the Rails application key, even though it would appear from the code in `config/initializers/devise.rb` that they should/will match, seems like a potential source of confusion/bugs that I would rather avoid.)