### PR TITLE
Log stderr (just not stdout) when precompiling assets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,7 +70,7 @@ RUN DOCKER_BUILD=true \
   GIT_REV=${GIT_REV} \
   SECRET_KEY_BASE_DUMMY=1 \
   VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true \
-  bundle exec rails assets:precompile > /dev/null 2>&1
+  bundle exec rails assets:precompile > /dev/null
 
 # Precompile bootsnap code for faster boot times
 RUN bin/bootsnap precompile app/ lib/


### PR DESCRIPTION
The main thing is that we wanted to suppress the verbose output written to stdout. However, if an error occurs when precompiling assets (which is actually mostly downloading assets from S3), then it would be very helpful for that to be logged, which this change will at least make more likely.