### PR TITLE
[deploy.sh] Behave differently if LOCAL_TEST=1 [DEV-180]

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -2,27 +2,41 @@
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 
+if [ ! -v LOCAL_TEST ] && [ "$(git config user.email)" != '' ] ; then
+  echo 'You probably want to run this with LOCAL_TEST=1 ?'
+  exit 1
+fi
+
 if [[ -n $(git status --porcelain) ]] ; then
   echo 'The working directory is not clean. Aborting.'
   exit 1
 fi
 
-git fetch
-git checkout "$GIT_REV"
+# Check out the GIT_REV target commit (unless testing locally).
+if [ ! -v LOCAL_TEST ] ; then
+  git fetch
+  git checkout "$GIT_REV"
 
-current_commit=$(git rev-parse HEAD)
+  current_commit=$(git rev-parse HEAD)
 
-# Confirm that we were able to check out the intended commit.
-if [ "$current_commit" != "$GIT_REV" ] ; then
-  echo "Failed to check out $GIT_REV; at $current_commit instead."
-  exit 1
+  # Confirm that we were able to check out the intended commit.
+  if [ "$current_commit" != "$GIT_REV" ] ; then
+    echo "Failed to check out $GIT_REV; at $current_commit instead."
+    exit 1
+  fi
 fi
 
-# Run the install script.
-bin/server/install.sh
+# Run the install script (unless testing locally).
+if [ ! -v LOCAL_TEST ] ; then
+  bin/server/install.sh
+fi
 
-# Rebuild the app.
-bin/build-docker production
+# Rebuild the app (for development if testing locally, otherwise for production).
+if [ -v LOCAL_TEST ] ; then
+  bin/build-docker development
+else
+  bin/build-docker production
+fi
 
 # Run release tasks.
 bin/server/run-release-tasks
@@ -43,9 +57,11 @@ bin/server/roll-out-web.sh
 # Launch fresh versions of all other services.
 docker compose up --detach --remove-orphans
 
-# Check out and update main branch.
-git checkout main
-git reset --hard origin/main
+# Check out and update main branch (unless testing locally).
+if [ ! -v LOCAL_TEST ] ; then
+  git checkout main
+  git reset --hard origin/main
+fi
 
 # Verify that all expected services are running.
 bin/server/verify-expected-services.sh


### PR DESCRIPTION
Currently, to test what a deployment will do, I either issue a big command in my terminal like:

```
{ docker stop $(docker ps -q) || true } && bin/build-docker development && docker compose run --rm web bin/server/release-tasks && bin/server/boot-services.sh && bin/server/verify-expected-services.sh
```

or else copy `bin/server/deploy.sh` to `personal/bash.sh` and tweak it.

This change tweaks `bin/server/deploy.sh` so that it will do what we want (i.e. skip certain steps and build with `Rails.env == 'development'`) if run with `LOCAL_TEST=1`. This way, I don't need to run a big command in my terminal or tweak a copied version of `deploy.sh` every time that I want to test what a deployment will do.

We add a check at the beginning such that the script will exit with an error if LOCAL_TEST is _not_ set but if `git config user.email` is present (i.e. if we are probably on a developer's local machine). This should decrease the likelihood of running the production deployment locally.