### PR TITLE
Permit that there be no secret_key_base if SECRET_KEY_BASE_DUMMY=1

### DIFF
--- a/config/initializers/0w_secret_key_base.rb
+++ b/config/initializers/0w_secret_key_base.rb
@@ -6,6 +6,8 @@ secret_key_base =
 
 if secret_key_base.present?
   DavidRunger::Application.config.secret_key_base = secret_key_base
+  # :nocov:
 elsif ENV.fetch('SECRET_KEY_BASE_DUMMY', nil) != '1'
   fail('Could not find a secret_key_base in ENV or credentials.')
+  # :nocov:
 end

--- a/config/initializers/0w_secret_key_base.rb
+++ b/config/initializers/0w_secret_key_base.rb
@@ -1,6 +1,11 @@
-DavidRunger::Application.config.secret_key_base =
+secret_key_base =
   ENV.fetch(
     'SECRET_KEY_BASE',
     Rails.application.credentials.secret_key_base,
-  ).presence ||
+  ).presence
+
+if secret_key_base.present?
+  DavidRunger::Application.config.secret_key_base = secret_key_base
+elsif ENV.fetch('SECRET_KEY_BASE_DUMMY', nil) != '1'
   fail('Could not find a secret_key_base in ENV or credentials.')
+end


### PR DESCRIPTION
This should fix the deploy failures that we are currently seeing: https://github.com/davidrunger/david_runger/actions/runs/13470410549/job/37643263960#step:5:80

> Could not find a secret_key_base in ENV or credentials.