### PR TITLE
Remove 'config/credentials/production.key' from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,7 +5,6 @@
 .ruby-lsp
 app/javascript/rails_assets
 bin/skedjewel
-config/credentials/production.key
 docs
 log
 node_modules


### PR DESCRIPTION
This change doesn't substantively do anything, because we don't have a `config/credentials/production.key` file anywhere, anyway. That's sort of why I want to make this change (removing `config/credentials/production.key` from `.dockerignore`), because it suggests that we might have such files somewhere.

I think it's there currently mostly because I copied from `.gitignore`, which also references such a file. I'm considering removing it from there, as well, although I think maybe having it there might make a little more sense, and so removing it might not be worthwhile/good.