### PR TITLE
Remove Rails credentials key files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,11 +39,6 @@ export
 # NOTE: blog/ is populated via the GitHub Actions deployment of davidrunger/blog.
 /blog/
 
-# Credentials
-/config/credentials/development.key
-/config/credentials/test.key
-/config/credentials/production.key
-
 # Skedjewel
 /bin/skedjewel
 


### PR DESCRIPTION
I don't use these key files, so there's not really any need to have them listed in the .gitignore, and having them there might be somewhat confusing/misdirecting. Therefore, this change removes them from the `.gitignore`.

The downside of this change is that, if I ever do start using Rails credentials key files (again?), this change will increase the risk that I will accidentally commit the keys. However, I think it's pretty unlikely that I will use Rails credentials key files again, and also I think and hope that, even if I do, I will be mindful enough not to accidentally commit the key files at that time.