### PR TITLE
Remove 'docker-compose.override.yml' from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,6 @@
 # JavaScript packages
 /node_modules
 
-# Docker
-docker-compose.override.yml
-
 # Generated JavaScript path helpers
 /app/javascript/rails_assets
 


### PR DESCRIPTION
This should probably have been removed in #5782 ("Pass logs through Vector and rotate them via Docker"), which removed the need to use a `docker-compose.override.yml` file. I guess that I left it, in case I want to override other aspects of the `docker-compose.yml` file in the future, but it's not looking like that is super likely, so let's remove this.