### PR TITLE
[gitignore] Remove database dump files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,10 +22,6 @@
 /lib/test/.tests.yml
 /spec/fixtures/*.yml
 
-# Database dumps
-*.dump*
-export
-
 # Assets
 # NOTE: public/assets/ is generated when running assets:precompile
 /public/assets/


### PR DESCRIPTION
For one thing, `bin/qr` only creates files in `tmp/`, which is itself gitignored, so ignoring these file names is somewhat redundant. Indeed, having redundant protection against accidentally committing a database dump file to git was a big part of the reason that I added these. However, instead of having this layer of redundancy, I am instead going to lean on a new linter that I plan to create soon that will fail if any non-image, non-text files are committed to the repo (https://davidrunger.atlassian.net/browse/DOT-93).