### PR TITLE
Wait to run HTML controller tests until after feature tests can start

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -73,10 +73,20 @@ class Test::RequirementsResolver
           Test::Tasks::CompileUserJavaScript,
           Test::Tasks::StartPercy,
         ],
+        Test::Tasks::FeatureTestsCanStart => [
+          Test::Tasks::CompileAdminJavaScript,
+          Test::Tasks::CompileUserJavaScript,
+          Test::Tasks::CreateDbCopies,
+          Test::Tasks::DivideFeatureSpecs,
+          Test::Tasks::RunApiControllerTests,
+          Test::Tasks::RunUnitTests,
+          Test::Tasks::StartPercy,
+        ],
         Test::Tasks::RunHtmlControllerTests => [
           Test::Tasks::CreateDbCopies,
           Test::Tasks::CompileAdminJavaScript,
           Test::Tasks::CompileUserJavaScript,
+          Test::Tasks::FeatureTestsCanStart,
         ],
 
         # Necessary processes.

--- a/lib/test/tasks/feature_tests_can_start.rb
+++ b/lib/test/tasks/feature_tests_can_start.rb
@@ -1,0 +1,11 @@
+class Test::Tasks::FeatureTestsCanStart < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    puts("#{AmazingPrint::Colors.yellow('Sleeping for 0.1 seconds')}...")
+
+    sleep(0.1)
+
+    record_success_and_log_message('Done sleeping for 0.1 seconds.')
+  end
+end


### PR DESCRIPTION
This way, the feature tests should start running first. We want this, because the feature tests currently always take longer than the HTML tests (even with the feature tests being divided into three groups).

With this change, we should start running the faster-executing task (HTML controller tests) after the slower-executing tasks (feature tests) have started, which should result in overall faster build times.

Here's the sort of situation that we are trying to avoid:

![image](https://github.com/user-attachments/assets/5fba137f-8f9c-4ef8-970f-405f42e8d9fa)

RunHtmlControllerTests (yellow) started sooner than RunFeatureTestsA, even though RunFeatureTestsA took longer (and probably pretty much always will take longer). The goal of this change is basically to swap the order of those steps, which should result in higher parallelism and faster builds.