### PR TITLE
Use Bake to build Docker Compose image(s) [DEV-182]

### DIFF
--- a/bin/build-docker
+++ b/bin/build-docker
@@ -16,12 +16,12 @@ build() {
   services=("$@")
 
   if [ "${#services[@]}" -eq 0 ]; then
-    docker compose --progress=plain build \
+    COMPOSE_BAKE=true docker compose --progress=plain build \
       --build-arg GIT_REV="$(git rev-parse origin/main)" \
       --build-arg RUBY_VERSION="$(cat .ruby-version)" \
       --build-arg RAILS_ENV="$rails_env"
   else
-    docker compose --progress=plain build "${services[@]}" \
+    COMPOSE_BAKE=true docker compose --progress=plain build "${services[@]}" \
       --build-arg GIT_REV="$(git rev-parse origin/main)" \
       --build-arg RUBY_VERSION="$(cat .ruby-version)" \
       --build-arg RAILS_ENV="$rails_env"


### PR DESCRIPTION
https://github.com/docker/compose/releases/tag/v2.33.0

As of Docker Compose v2.33.0 (released 2025-02-12), [Bake][1] can be used to build the Docker Compose images. Supposedly it's faster, and in my quick test, it does indeed seem that it might be faster, which is awesome. At least, it doesn't seem slower, and it doesn't seem to cause any problems.

[1]: https://docs.docker.com/build/bake/

In addition to hopefully being faster, this should also get rid of info messages like this:

> Compose now can delegate build to bake for better performances
> Just set COMPOSE_BAKE=true

-- https://github.com/davidrunger/david_runger/actions/runs/13471914702/job/37646535539#step:5:29