### PR TITLE
[ci] Create a dedicated database for RunFeatureTestsA

### DIFF
--- a/.env.test
+++ b/.env.test
@@ -1,3 +1,4 @@
 GOOGLE_OAUTH_CLIENT_ID=fake-google-oauth-client-id
 GOOGLE_OAUTH_CLIENT_SECRET=fake-google-oauth-client-secret
 RAILS_MAX_THREADS=2
+SECRET_KEY_BASE=dummy-test-secret-key-base

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -85,7 +85,6 @@ jobs:
           DISABLE_SPRING: 1
           PERCY_SKIP_UPDATE_CHECK: 1
           VITE_RUBY_AUTO_BUILD: false
-          SECRET_KEY_BASE: 0af8c0e49e9259f2d777cfcd121d8540cee914c34b0abf08dd825bdee47c402daf9f2b9b74a9fff6f88ed95257ae39504e0d59c66400413b0cf7d29079c6358b # gitleaks:allow This is just for the test environment; not a real secret.
           # The hostname used to communicate with the PostgreSQL service container
           POSTGRES_HOST: 127.0.0.1
           POSTGRES_USER: postgres

--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -4,5 +4,5 @@ spec-commands: |
   export RAILS_ENV=test PALLETS_CONCURRENCY=${PALLETS_CONCURRENCY:-5} DISABLE_SPRING=1
   export POSTGRES_USER=david_runger POSTGRES_HOST=localhost
   set -x
-  redis-cli -n 8 FLUSHDB
+  redis-cli -n 10 FLUSHDB
   bin/run-tests

--- a/app/poros/redis_options.rb
+++ b/app/poros/redis_options.rb
@@ -28,7 +28,8 @@ class RedisOptions
       when '_unit', nil then 4
       when '_api' then 5
       when '_html' then 6
-      when '_feature' then 7
+      when '_feature_a' then 7
+      when '_feature_c' then 9
       else raise('Unexpected DB_SUFFIX!')
       end
     else

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -56,7 +56,6 @@ class Test::RequirementsResolver
           Test::Tasks::CompileAdminJavaScript,
           Test::Tasks::CompileUserJavaScript,
           Test::Tasks::StartPercy,
-          Test::Tasks::RunUnitTests,
         ],
         Test::Tasks::RunFeatureTestsB => [
           Test::Tasks::DivideFeatureSpecs,
@@ -79,7 +78,6 @@ class Test::RequirementsResolver
           Test::Tasks::CreateDbCopies,
           Test::Tasks::DivideFeatureSpecs,
           Test::Tasks::RunApiControllerTests,
-          Test::Tasks::RunUnitTests,
           Test::Tasks::StartPercy,
         ],
         Test::Tasks::RunHtmlControllerTests => [

--- a/lib/test/run_pallets_tests.rb
+++ b/lib/test/run_pallets_tests.rb
@@ -9,7 +9,7 @@ Pallets.configure do |c|
 
   c.concurrency = concurrency
   c.max_failures = 0
-  c.backend_args = { url: 'redis://127.0.0.1:6379/8' } # use redis db #8 (to avoid conflicts)
+  c.backend_args = { url: 'redis://127.0.0.1:6379/10' } # use redis db #10 (to avoid conflicts)
   c.middleware << Test::Middleware::ExitOnFailureMiddleware
   c.middleware << Test::Middleware::TaskResultTrackingMiddleware
 end

--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -5,6 +5,8 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
     # The commands below will error if there are any active connections to the
     # database, so disconnect.
     ActiveRecord::Base.connection_pool.connections.each(&:disconnect!)
+    # Give a little time for the disconnections to complete (?).
+    sleep(0.5)
 
     %w[unit api html feature_a feature_c].each do |db_suffix|
       db_name = "david_runger_test_#{db_suffix}"

--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -6,7 +6,7 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
     # database, so disconnect.
     ActiveRecord::Base.connection_pool.connections.each(&:disconnect!)
 
-    %w[unit api html feature].each do |db_suffix|
+    %w[unit api html feature_a feature_c].each do |db_suffix|
       db_name = "david_runger_test_#{db_suffix}"
 
       # in CI, we know that the database doesn't exist, so don't waste any time dropping it

--- a/lib/test/tasks/run_feature_tests_a.rb
+++ b/lib/test/tasks/run_feature_tests_a.rb
@@ -3,7 +3,7 @@ class Test::Tasks::RunFeatureTestsA < Pallets::Task
 
   def run
     execute_rspec_command(<<~COMMAND)
-      DB_SUFFIX=_unit CAPYBARA_SERVER_PORT=3001
+      DB_SUFFIX=_feature_a CAPYBARA_SERVER_PORT=3001
       bin/rspec $(cat tmp/feature_specs_a.txt)
       --format RSpec::Instafail --format progress --force-color
     COMMAND

--- a/lib/test/tasks/run_feature_tests_c.rb
+++ b/lib/test/tasks/run_feature_tests_c.rb
@@ -3,7 +3,7 @@ class Test::Tasks::RunFeatureTestsC < Pallets::Task
 
   def run
     execute_rspec_command(<<~COMMAND)
-      DB_SUFFIX=_feature CAPYBARA_SERVER_PORT=3003
+      DB_SUFFIX=_feature_c CAPYBARA_SERVER_PORT=3003
       bin/rspec $(cat tmp/feature_specs_c.txt)
       --format RSpec::Instafail --format progress --force-color
     COMMAND

--- a/spec/poros/redis_options_spec.rb
+++ b/spec/poros/redis_options_spec.rb
@@ -79,11 +79,19 @@ RSpec.describe RedisOptions do
         end
       end
 
-      context 'when DB_SUFFIX is _feature' do
-        around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature') { spec.run } }
+      context 'when DB_SUFFIX is _feature_a' do
+        around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_a') { spec.run } }
 
         it 'returns 7' do
           expect(default_db_number).to eq(7)
+        end
+      end
+
+      context 'when DB_SUFFIX is _feature_c' do
+        around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_c') { spec.run } }
+
+        it 'returns 9' do
+          expect(default_db_number).to eq(9)
         end
       end
 


### PR DESCRIPTION
This way, RunFeatureTestsA won't have to wait for RunUnitTests to complete before RunFeatureTestsA can start running. Having to wait used not to be a problem, because RunUnitTests always finished before CompileUserJavaScript, anyway, but that's not the case anymore.

The goal is to avoid runs like the one below, where RunFeatureTests A waits for RunUnitTests even though CompileUserJavaScript had already completed:

![image](https://github.com/user-attachments/assets/f7410562-ad55-4dd1-932e-66ac3568394f)

That run was particularly unlucky because RunFeatureTestsA happened to be the slowest of the three feature test runners, and it started last, due to waiting for the unit tests. With this change, there will no longer be any waiting for unit tests.