### PR TITLE
Decrease sleep to wait for DB disconnections from 500 ms to 100 ms

### DIFF
--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -6,7 +6,7 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
     # database, so disconnect.
     ActiveRecord::Base.connection_pool.connections.each(&:disconnect!)
     # Give a little time for the disconnections to complete (?).
-    sleep(0.5)
+    sleep(0.1)
 
     %w[unit api html feature_a feature_c].each do |db_suffix|
       db_name = "david_runger_test_#{db_suffix}"


### PR DESCRIPTION
I have a suspicion that this will still be long enough? Since multiple steps await the completion of this one before they can begin, I think it's worth trying to keep this sleep a little shorter, if we can.