### PR TITLE
Increase Pallets concurrency from 5 to 6

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -79,7 +79,7 @@ jobs:
         run: bin/run-tests
         env:
           CI: true
-          PALLETS_CONCURRENCY: 5
+          PALLETS_CONCURRENCY: 6
           AWS_EC2_METADATA_DISABLED: true
           RAILS_ENV: test
           DISABLE_SPRING: 1

--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -1,7 +1,7 @@
 expected-num-github-checks: 4
 javascript-watch-command: bin/vite dev
 spec-commands: |
-  export RAILS_ENV=test PALLETS_CONCURRENCY=${PALLETS_CONCURRENCY:-5} DISABLE_SPRING=1
+  export RAILS_ENV=test PALLETS_CONCURRENCY=${PALLETS_CONCURRENCY:-6} DISABLE_SPRING=1
   export POSTGRES_USER=david_runger POSTGRES_HOST=localhost
   set -x
   redis-cli -n 10 FLUSHDB

--- a/lib/test/tasks/start_percy.rb
+++ b/lib/test/tasks/start_percy.rb
@@ -10,7 +10,7 @@ class Test::Tasks::StartPercy < Pallets::Task
       num_attempts = 20
 
       num_attempts.times do |index|
-        sleep(2)
+        sleep(4)
 
         if system('./node_modules/.bin/percy exec:ping')
           record_success_and_log_message("Percy is running after #{index + 1} check(s).")


### PR DESCRIPTION
There are some times when we are bound by the concurrency limit of 5 and would to better to be able to run 6 tasks simultaneously. This is particularly due to #6223, which causes the `StartPercy` task to take much longer. Since I think that task largely uses IO (waiting on network calls to the Percy server and/or sleeping), it's probably not using the CPU very much when it runs, so I think that (at least during that time) adding another concurrent task won't add much to the CPU burden.

This change increases the `sleep` in `StartPercy` iterations from 2 seconds to 4 seconds to try to make the CPU burden of `StartPercy` even lower. The only thing that really matters is that it completes before `CompileUserJavaScript` finishes, which I think that it still will do.