### PR TITLE
Turn off PaperTrail for specs (except where needed) [DEV-188]

### DIFF
--- a/app/controllers/api/items/bulk_updates_controller.rb
+++ b/app/controllers/api/items/bulk_updates_controller.rb
@@ -2,7 +2,7 @@ class Api::Items::BulkUpdatesController < Api::BaseController
   before_action :ensure_items_present, only: %i[create]
 
   def create
-    items.includes(:store).find_each { |item| authorize(item, :update?) }
+    items.includes(:store, :user).find_each { |item| authorize(item, :update?) }
     Items::BulkUpdate::Create.run!(items: items.to_a, attributes_change: attributes_change.to_h)
     head(:no_content)
   end

--- a/app/models/concerns/json_broadcastable.rb
+++ b/app/models/concerns/json_broadcastable.rb
@@ -2,7 +2,7 @@ module JsonBroadcastable
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def broadcasts_json_to(channel, channel_target_proc)
+    def broadcasts_json_to(channel, channel_target_proc, unless_for_destroyed: nil)
       after_create_commit(
         -> { broadcast_json_to(channel, channel_target_proc, :created) },
       )
@@ -13,6 +13,7 @@ module JsonBroadcastable
 
       after_destroy_commit(
         -> { broadcast_json_to(channel, channel_target_proc, :destroyed) },
+        unless: unless_for_destroyed || -> { false },
       )
     end
   end

--- a/app/models/concerns/json_broadcastable.rb
+++ b/app/models/concerns/json_broadcastable.rb
@@ -2,18 +2,22 @@ module JsonBroadcastable
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def broadcasts_json_to(channel, channel_target_proc, unless_for_destroyed: nil)
+    def broadcasts_json_to(channel, channel_target_proc, unless: nil)
+      unless_proc = binding.local_variable_get(:unless) || -> { false }
+
       after_create_commit(
         -> { broadcast_json_to(channel, channel_target_proc, :created) },
+        unless: unless_proc,
       )
 
       after_update_commit(
         -> { broadcast_json_to(channel, channel_target_proc, :updated) },
+        unless: unless_proc,
       )
 
       after_destroy_commit(
         -> { broadcast_json_to(channel, channel_target_proc, :destroyed) },
-        unless: unless_for_destroyed || -> { false },
+        unless: unless_proc,
       )
     end
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -31,6 +31,6 @@ class Item < ApplicationRecord
   broadcasts_json_to(
     GroceriesChannel,
     ->(item) { item.user&.marriage },
-    unless_for_destroyed: ->(item) { item.store.destroyed? },
+    unless: ->(item) { item.store.destroyed? },
   )
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -28,5 +28,9 @@ class Item < ApplicationRecord
   scope :needed, -> { where('items.needed > 0') }
   scope :unneeded, -> { where(needed: 0) }
 
-  broadcasts_json_to(GroceriesChannel, ->(item) { item.user&.marriage })
+  broadcasts_json_to(
+    GroceriesChannel,
+    ->(item) { item.user&.marriage },
+    unless_for_destroyed: ->(item) { item.store.destroyed? },
+  )
 end

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,4 +1,4 @@
-PaperTrail.config.enabled = true
+PaperTrail.config.enabled = !Rails.env.test?
 PaperTrail.config.has_paper_trail_defaults = {
   # Omit `create` events.
   on: %i[destroy touch update],

--- a/config/initializers/paper_trail.rb
+++ b/config/initializers/paper_trail.rb
@@ -1,4 +1,4 @@
-PaperTrail.config.enabled = !Rails.env.test?
+PaperTrail.config.enabled = true
 PaperTrail.config.has_paper_trail_defaults = {
   # Omit `create` events.
   on: %i[destroy touch update],

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Api::ItemsController do
       end
     end
 
-    context "when attempting to destroy one's own item", :paper_trail do
+    context "when attempting to destroy one's own item", :versioning do
       let(:user) { item.store.user }
 
       it 'destroys the item' do

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe Api::ItemsController do
       end
     end
 
-    context "when attempting to destroy one's own item" do
+    context "when attempting to destroy one's own item", :paper_trail do
       let(:user) { item.store.user }
 
       it 'destroys the item' do

--- a/spec/controllers/api/reifications_controller_spec.rb
+++ b/spec/controllers/api/reifications_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Api::ReificationsController do
+RSpec.describe Api::ReificationsController, :paper_trail do
   describe '#create' do
     subject(:post_create) { post(:create, params: { paper_trail_version_id: }) }
 

--- a/spec/controllers/api/reifications_controller_spec.rb
+++ b/spec/controllers/api/reifications_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe Api::ReificationsController, :paper_trail do
+RSpec.describe Api::ReificationsController, :versioning do
   describe '#create' do
     subject(:post_create) { post(:create, params: { paper_trail_version_id: }) }
 

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Groceries app' do
       let(:new_item_name) { "blueberries (#{url_in_item_name})" }
       let(:url_in_item_name) { 'https://www.amazon.com/blueberries' }
 
-      it 'allows adding an item (which it linkifies), deleting an item, undoing the deletion, and checking in a shopping trip' do
+      it 'allows adding an item (which it linkifies), deleting an item, undoing the deletion, and checking in a shopping trip', :paper_trail do
         visit groceries_path
 
         store = user.stores.reorder(:viewed_at).last!

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Groceries app' do
       let(:new_item_name) { "blueberries (#{url_in_item_name})" }
       let(:url_in_item_name) { 'https://www.amazon.com/blueberries' }
 
-      it 'allows adding an item (which it linkifies), deleting an item, undoing the deletion, and checking in a shopping trip', :paper_trail do
+      it 'allows adding an item (which it linkifies), deleting an item, undoing the deletion, and checking in a shopping trip', :versioning do
         visit groceries_path
 
         store = user.stores.reorder(:viewed_at).last!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -240,13 +240,6 @@ RSpec.configure do |config|
     Rails.cache = original_rails_cache
   end
 
-  config.around(:each, :paper_trail) do |spec|
-    # https://github.com/paper-trail-gem/paper_trail/blob/v16.0.0/README.md#7b-rspec
-    with_versioning do
-      spec.run
-    end
-  end
-
   config.around(:each, :frozen_time) do |spec|
     freeze_time
     spec.run

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,6 +54,7 @@ require 'capybara-screenshot/rspec' unless SpecHelper.use_headful_chrome?
 require 'mail'
 require 'percy/capybara'
 require 'super_diff/rspec-rails'
+require 'paper_trail/frameworks/rspec' # Disables PaperTrail in specs by default.
 require Rails.root.join('spec/support/fixture_builder.rb').to_s
 Dir['spec/support/**/*.rb'].each { |file| require Rails.root.join(file) }
 
@@ -240,7 +241,8 @@ RSpec.configure do |config|
   end
 
   config.around(:each, :paper_trail) do |spec|
-    PaperTrail.config.with(enabled: true) do
+    # https://github.com/paper-trail-gem/paper_trail/blob/v16.0.0/README.md#7b-rspec
+    with_versioning do
       spec.run
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -239,6 +239,12 @@ RSpec.configure do |config|
     Rails.cache = original_rails_cache
   end
 
+  config.around(:each, :paper_trail) do |spec|
+    PaperTrail.config.with(enabled: true) do
+      spec.run
+    end
+  end
+
   config.around(:each, :frozen_time) do |spec|
     freeze_time
     spec.run


### PR DESCRIPTION
`paper_trail` has docs about doing this: https://github.com/paper-trail-gem/paper_trail?tab=readme-ov-file#7b-rspec

This might make specs faster, especially since I recently added PaperTrail tracking for LogEntries (#6199).

I hate to diverge from what happens in production, but I think that this might be worth it. Let's merge and see.

There's something weird going on where disabling PaperTrail is causing `bullet` to ask for more eager loading / detect a need for eager loading in cases where it wasn't before. I'm not sure why that would be. Anyway, that issue is what motivated some of the changes in the second commit of this PR (https://github.com/davidrunger/david_runger/pull/6229/commits/d4bc3949141c9b1c6250084687262f658ba3effc), which I don't fully understand why those changes were needed. But those changes, while somewhat ugly/confusing, nevertheless seem otherwise relatively harmless and maybe good, so I don't feel too bad about making them.