### PR TITLE
[css] Give all buttons 'cursor: pointer'

### DIFF
--- a/app/assets/stylesheets/tailwind_overrides.css
+++ b/app/assets/stylesheets/tailwind_overrides.css
@@ -11,6 +11,11 @@
     @apply text-blue-600 visited:text-purple-600;
   }
 
+  button:not(:disabled),
+  [role='button']:not(:disabled) {
+    cursor: pointer;
+  }
+
   body {
     h1 {
       @apply my-4 text-3xl font-bold;


### PR DESCRIPTION
https://tailwindcss.com/docs/upgrade-guide#buttons-use-the-default-cursor

Tailwind took this away in v4, I guess because that's what the specs or whatever call for / because that's the browser default behavior. But buttons are better with `cursor: pointer`. It's as simple as that (IMO).