### PR TITLE
[home#index monitor] Tighten median expectation to 5..50 ms

### DIFF
--- a/app/workers/data_monitors/home_index_requests.rb
+++ b/app/workers/data_monitors/home_index_requests.rb
@@ -7,7 +7,7 @@ class DataMonitors::HomeIndexRequests < DataMonitors::Base
 
     verify_data_expectation(
       check_name: :median_response_time_in_past_day,
-      expectation: (10..100),
+      expectation: (5..50),
     )
   end
 


### PR DESCRIPTION
I received an email today saying that our responses are too fast!

> The DataMonitors::HomeIndexRequests#median_response_time_in_past_day check failed to match its expected value.
> Actual value: 9.0
> Expected value: 10..100
> Checked at: 2025-02-22 07:07:12 -0600 

This is because our new Hetzner server is speedy!

This change updates the expectation to be more in line with our fast new server, lowering the expected median response time from a range of `10..100` to `5..50`.