### PR TITLE
Create a backup DB in 'bin/qr' and restore from it with 'bin/dbrest'

### DIFF
--- a/bin/dbrest
+++ b/bin/dbrest
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+bin/terminate-db-connections
+dropdb --if-exists david_runger_development
+createdb -T david_runger_development_backup david_runger_development --no-password

--- a/bin/qr
+++ b/bin/qr
@@ -31,3 +31,9 @@ echo "Done."
 echo "Setting ar_internal_metadata environment to development."
 RAILS_ENV=development bin/rails db:environment:set
 echo "Done."
+
+echo "Creating a backup copy of the database. (Use bin/dbrest to restore from the backup.)"
+dropdb --if-exists david_runger_development_backup
+bin/terminate-db-connections
+createdb -T david_runger_development david_runger_development_backup --no-password
+echo "Done."

--- a/bin/terminate-db-connections
+++ b/bin/terminate-db-connections
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+# Kill existing database connections. It seems they will re-establish themselves automatically (?).
+psql -c "\
+SELECT pg_terminate_backend(pg_stat_activity.pid)
+FROM pg_stat_activity
+WHERE datname='david_runger_development'
+AND pid <> pg_backend_pid();
+"


### PR DESCRIPTION
This can be super helpful when repeatedly testing something that nontrivially modifies the database, such as a datamigration, or even just a user flow in the web UX that modifies some data.

I think that both the create-backup-DB functionality in `bin/qr` and the restore-from-backup-DB functionality in `bin/dbrest` require that nothing be connected to the relevant database(s) when those operations are performed, so this change adds a small `bin/terminate-db-connections` script that is shared by both `bin/qr` and `bin/dbrest` for this purpose. Previously, when I have done such a thing (at CommonLit), I think that it was necessary to monkeypatch the Postgres ActiveRecord adapter to try to re-establish a connection, if the connection found itself to be disconnected (due to having been disconnected for the sack of restoring from the backup DB, for example), but it seems that now Rails does this for us? At least, in my testing, no such monkeypatch seems to be necessary, in the version of Rails that I am currently on (8.0.1). This just works, as is.