### PR TITLE
Add endpoint to forward Grafana alert webhooks as emails [DEV-186]

### DIFF
--- a/app/controllers/api/webhook_email_forwards_controller.rb
+++ b/app/controllers/api/webhook_email_forwards_controller.rb
@@ -1,0 +1,15 @@
+class Api::WebhookEmailForwardsController < Api::BaseController
+  def create
+    authorize(:create?, policy_class: WebhookEmailForwardPolicy)
+
+    subject = params[:title]
+    html_body = params[:message]
+    GenericMailer.generic_html(
+      current_or_auth_token_user.email,
+      subject,
+      html_body,
+    ).deliver_later
+
+    head :created
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -123,7 +123,7 @@ class ApplicationController < ActionController::Base
 
   # override Rails's built-in #verify_authenticity_token method to allow for `auth_token` use
   def verify_authenticity_token
-    if auth_token_param.present?
+    if auth_token_secret.present?
       verify_valid_auth_token!
     else
       super

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -8,17 +8,27 @@ module TokenAuthenticatable
 
   memoize \
   def auth_token
-    return nil if auth_token_param.blank?
+    return nil if auth_token_secret.blank?
 
-    AuthToken.find_by(secret: auth_token_param)
+    AuthToken.find_by(secret: auth_token_secret)
   end
 
   memoize \
-  def auth_token_param
-    auth_token_param = params[:auth_token]
+  def auth_token_secret
+    auth_token_secret = params[:auth_token] || auth_token_in_authorization_header
     # For AuthTokensController requests, the top-level `auth_token` param might be a hash, which we
     # don't want here.
-    auth_token_param.is_a?(String) ? auth_token_param : nil
+    auth_token_secret.is_a?(String) ? auth_token_secret : nil
+  end
+
+  memoize \
+  def auth_token_in_authorization_header
+    authorization_header = request.headers['Authorization']
+
+    if authorization_header.present?
+      match = authorization_header.match(/\ABearer\s+(.+)\z/)
+      match&.captures&.first
+    end
   end
 
   memoize \

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -15,14 +15,14 @@ module TokenAuthenticatable
 
   memoize \
   def auth_token_secret
-    auth_token_secret = params[:auth_token] || auth_token_in_authorization_header
+    auth_token_secret = params[:auth_token] || auth_token_in_header
     # For AuthTokensController requests, the top-level `auth_token` param might be a hash, which we
     # don't want here.
     auth_token_secret.is_a?(String) ? auth_token_secret : nil
   end
 
   memoize \
-  def auth_token_in_authorization_header
+  def auth_token_in_header
     authorization_header = request.headers['Authorization']
 
     if authorization_header.present?

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -26,8 +26,8 @@ module TokenAuthenticatable
     authorization_header = request.headers['Authorization']
 
     if authorization_header.present?
-      match = authorization_header.match(/\ABearer\s+(.+)\z/)
-      match&.captures&.first
+      match = authorization_header.match(/\ABearer\s+(?<token>.+)\z/)
+      match&.named_captures&.[]('token')
     end
   end
 

--- a/app/mailers/generic_mailer.rb
+++ b/app/mailers/generic_mailer.rb
@@ -1,0 +1,5 @@
+class GenericMailer < ApplicationMailer
+  def generic_html(to, subject, html_body)
+    mail(to:, subject:, body: html_body, content_type: 'text/html')
+  end
+end

--- a/app/policies/webhook_email_forward_policy.rb
+++ b/app/policies/webhook_email_forward_policy.rb
@@ -1,0 +1,2 @@
+class WebhookEmailForwardPolicy < ApplicationPolicy
+end

--- a/bin/build-docker
+++ b/bin/build-docker
@@ -16,15 +16,17 @@ build() {
   services=("$@")
 
   if [ "${#services[@]}" -eq 0 ]; then
-    COMPOSE_BAKE=true docker compose --progress=plain build \
-      --build-arg GIT_REV="$(git rev-parse origin/main)" \
-      --build-arg RUBY_VERSION="$(cat .ruby-version)" \
-      --build-arg RAILS_ENV="$rails_env"
+    COMPOSE_BAKE=true \
+    GIT_REV="$(git rev-parse origin/main)" \
+    RAILS_ENV="$rails_env" \
+    RUBY_VERSION="$(cat .ruby-version)" \
+      docker compose --progress=plain build
   else
-    COMPOSE_BAKE=true docker compose --progress=plain build "${services[@]}" \
-      --build-arg GIT_REV="$(git rev-parse origin/main)" \
-      --build-arg RUBY_VERSION="$(cat .ruby-version)" \
-      --build-arg RAILS_ENV="$rails_env"
+    COMPOSE_BAKE=true \
+    GIT_REV="$(git rev-parse origin/main)" \
+    RAILS_ENV="$rails_env" \
+    RUBY_VERSION="$(cat .ruby-version)" \
+      docker compose --progress=plain build "${services[@]}"
   fi
 }
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -109,4 +109,7 @@ class DavidRunger::Application < Rails::Application
   # The log size limit causes tailing a log file to stop working when the limit
   # is reached, which is annoying, so disable the limit.
   config.log_file_size = nil
+
+  # Allow access from other services in the Docker Compose network.
+  config.hosts << 'web:3000'
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -109,7 +109,4 @@ class DavidRunger::Application < Rails::Application
   # The log size limit causes tailing a log file to stop working when the limit
   # is reached, which is annoying, so disable the limit.
   config.log_file_size = nil
-
-  # Allow access from other services in the Docker Compose network.
-  config.hosts << 'web:3000'
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -98,6 +98,9 @@ Rails.application.configure do
       :letter_opener
     end
 
+  # Allow access from other services in the Docker Compose network.
+  config.hosts << 'web:3000'
+
   local_hostname = ENV.fetch('LOCAL_HOSTNAME', nil)
   if local_hostname && !local_hostname.empty? # rubocop:disable Rails/Present
     config.hosts << local_hostname

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -98,9 +98,6 @@ Rails.application.configure do
       :letter_opener
     end
 
-  # Allow access from other services in the Docker Compose network.
-  config.hosts << 'web:3000'
-
   local_hostname = ENV.fetch('LOCAL_HOSTNAME', nil)
   if local_hostname && !local_hostname.empty? # rubocop:disable Rails/Present
     config.hosts << local_hostname

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,10 +103,11 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = :all
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    'davidrunger.com', # Allow requests from davidrunger.com.
+    /.*\.davidrunger\.com/, # Allow requests from subdomains like `www.davidrunger.com`.
+    'web:3000', # Allow access from other services in the Docker Compose network.
+  ]
   #
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
     resources :stores, only: %i[index create update destroy] do
       resources :items, only: %i[create]
     end
+    resources :webhook_email_forwards, only: %i[create]
     resources :workouts, only: %i[create update]
   end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,10 +7,19 @@ x-logging-config: &default-logging
 
 x-rails-config: &default-rails-config
   build:
+    args:
+      - GIT_REV=${GIT_REV}
+      - RUBY_VERSION=${RUBY_VERSION}
+      - RAILS_ENV=${RAILS_ENV}
     context: .
   depends_on:
     initialize_database:
       condition: service_completed_successfully
+  develop:
+    watch:
+      - action: sync
+        path: .
+        target: /app
   env_file:
     # NOTE: We need this to have DATABASE_URL in bin/docker-entrypoint.
     - .env.production.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ x-rails-config: &default-rails-config
   build:
     args:
       - GIT_REV=${GIT_REV}
-      - RUBY_VERSION=${RUBY_VERSION}
       - RAILS_ENV=${RAILS_ENV}
+      - RUBY_VERSION=${RUBY_VERSION}
     context: .
   depends_on:
     initialize_database:

--- a/spec/controllers/api/webhook_email_forwards_controller_spec.rb
+++ b/spec/controllers/api/webhook_email_forwards_controller_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe Api::WebhookEmailForwardsController do
+  describe '#create' do
+    subject(:post_create) do
+      post(:create, params:)
+    end
+
+    let(:params) { {} }
+
+    context 'when the request includes a valid AuthToken secret' do
+      before { request.headers['Authorization'] = "Bearer #{auth_token.secret}" }
+
+      let(:auth_token) { AuthToken.first! }
+
+      context 'when the request params include a "title" and "message"' do
+        let(:params) do
+          super().merge({
+            'title' => alert_title,
+            'message' => alert_body,
+          })
+        end
+        let(:alert_title) { 'CPU usage is high!' }
+        let(:alert_body) { '<html><head></head><body><p>CPU problem!</p></body></html>' }
+
+        it 'sends an HTML email to the AuthToken user with the title as the subject and the message as the body' do
+          with_inline_sidekiq do
+            post_create
+          end
+
+          # expect email to have been sent
+          expect(ActionMailer::Base.deliveries.size).to eq(1)
+          mail = ActionMailer::Base.deliveries.first
+          expect(mail.content_type).to eq('text/html; charset=UTF-8')
+          expect(mail.subject).to eq(alert_title)
+          expect(mail.body.to_s).to eq(alert_body)
+        end
+      end
+    end
+  end
+end

--- a/spec/controllers/api/webhook_email_forwards_controller_spec.rb
+++ b/spec/controllers/api/webhook_email_forwards_controller_spec.rb
@@ -26,10 +26,11 @@ RSpec.describe Api::WebhookEmailForwardsController do
             post_create
           end
 
-          # expect email to have been sent
+          # Check that email was sent with expected properties.
           expect(ActionMailer::Base.deliveries.size).to eq(1)
           mail = ActionMailer::Base.deliveries.first
           expect(mail.content_type).to eq('text/html; charset=UTF-8')
+          expect(mail.to).to eq([auth_token.user.email])
           expect(mail.subject).to eq(alert_title)
           expect(mail.body.to_s).to eq(alert_body)
         end


### PR DESCRIPTION
I want to make it so that Grafana can send a webhook to my app when a monitoring alert is triggered, and my app will convert that webhook content into an email and send it to me. (There's something unideal about using the system that is being monitored as part of the alert-sending process, but I'll take that risk.)

I'm doing this instead of just having Grafana send the email because it seems that configuring Grafana to send emails itself is a decently big pain and/or somewhat of a security risk (e.g. having to put a GMail password for my personal account onto the server).

To develop and test the Grafana -> `web` webhook, I wanted to be able to iterate quickly on changes to the Rails web app while running the Rails web app within the Docker Compose context (where it could be pinged by Grafana's alert test requests). I didn't want to have to rebuild the Docker image each time that I made a change to the Rails app source code, though; that would have been very slow and annoying!

Fortunately, Docker Compose has something that seems to be designed for this use case, [Compose Watch][1].

[1]: https://docs.docker.com/compose/how-tos/file-watch/

We can use Docker Compose Watch via a command like this...

```
COMPOSE_BAKE=true GIT_REV=$(git rev-parse origin/main) RUBY_VERSION=$(cat .ruby-version) RAILS_ENV=development docker compose watch cadvisor clock grafana loki nginx node_exporter postgres prometheus rails_metrics redis-app redis-cache vector web worker
```

... which will boot the specified services (which is all that run in production, except for `certbot`, which there's not really a point in running locally) and which will sync file changes to the running Docker images that were built with a `develop.watch` configuration in `docker-compose.yml`, which is currently the services that use the `default-rails-config`.

We cannot use `--build-arg` with Docker Compose Watch, though, so this change switches from using `--build-arg` for the `docker compose build` commands in `bin/build-docker` to instead pass environment variables which (per the changes herein to `docker-compose.yml`) will be pulled in via `build.args`.

Also, so that Rails won't reject the requests made within the Docker Compose network to `http://web:3000` (in either development or production), this change also adds `web:3000` as a permitted host in `config/application.rb`.

This change also expands the `TokenAuthenticatable` concern to look for a possible auth token not only in `params`, as we were doing before, but also in an `Authorization: Bearer <the secret here>` header, since this is one of Grafana's two options for sending an authentication secret (the other being basic auth).

Other than that, this change basically just adds a simple route, controller action, policy, and mailer to forward the webhook request content as an email.