### PR TITLE
[production.rb] Skip host validation for '/up'

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -110,7 +110,7 @@ Rails.application.configure do
   ]
   #
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == '/up' } }
 
   # Email
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
I think that this will fix our deploy failure https://github.com/davidrunger/david_runger/actions/runs/13483444237/job/37671590476#step:5:395 caused by https://github.com/davidrunger/david_runger/pull/6235/files#diff-da60b4e96eff2b132991226d308949e23f4ef3aad45ad59edd09cbc32cc6251eR106-R110 .