### PR TITLE
Enable host verification for production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -103,13 +103,14 @@ Rails.application.configure do
   config.active_record.attributes_for_inspect = :all
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  # config.hosts = [
-  #   "example.com",     # Allow requests from example.com
-  #   /.*\.example\.com/ # Allow requests from subdomains like `www.example.com`
-  # ]
+  config.hosts = [
+    'davidrunger.com', # Allow requests from davidrunger.com.
+    /.*\.davidrunger\.com/, # Allow requests from subdomains like `www.davidrunger.com`.
+    'web:3000', # Allow access from other services in the Docker Compose network.
+  ]
   #
   # Skip DNS rebinding protection for the default health check endpoint.
-  # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  config.host_authorization = { exclude: ->(request) { request.path == '/up' } }
 
   # Email
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
I was not able to successfully deploy this when I tried this earlier. However, I think that has to do with the fact that I tried to deploy it in two steps (first uncommenting `config.hosts` and then in a later PR uncommenting `config.host_authorization`), and I think that this wasn't playing well with how we roll out new web instances to production. I think it will work if we make both changes simultaneously, which is what this change does.