### PR TITLE
[RunRubocop] Stop explicitly listing files

### DIFF
--- a/lib/test/tasks/run_rubocop.rb
+++ b/lib/test/tasks/run_rubocop.rb
@@ -3,7 +3,7 @@ class Test::Tasks::RunRubocop < Pallets::Task
 
   def run
     execute_system_command(<<~COMMAND)
-      bin/rubocop $(git ls-tree -r HEAD --name-only) --color --force-exclusion --format clang
+      bin/rubocop --color --force-exclusion --format clang
     COMMAND
   end
 end


### PR DESCRIPTION
It shouldn't be needed, now that we have this code: https://github.com/davidrunger/david_runger/blob/dc93a82f3edb1a02b01a15b0becadb8be49f9ae9/.rubocop.yml/#L16-L18

I think that removing the file list might make RuboCop run more quickly?