### PR TITLE
[ci] Remove double backslash escapes by using single quoted heredocs

### DIFF
--- a/lib/test/tasks/run_html_controller_tests.rb
+++ b/lib/test/tasks/run_html_controller_tests.rb
@@ -3,10 +3,10 @@ class Test::Tasks::RunHtmlControllerTests < Pallets::Task
 
   def run
     # run all tests in `spec/controllers/` _except_ those in `spec/controllers/api/`
-    execute_rspec_command(<<~COMMAND)
+    execute_rspec_command(<<~'COMMAND')
       DB_SUFFIX=_html
       bin/rspec
-      $(ls -d spec/controllers/*/ | grep -v 'spec/controllers/api/' | tr '\\n' ' ')
+      $(ls -d spec/controllers/*/ | grep -v 'spec/controllers/api/' | tr '\n' ' ')
       $(ls spec/controllers/*.rb)
       $(ls spec/helpers/*.rb)
       --format RSpec::Instafail --format progress --force-color

--- a/lib/test/tasks/run_typelizer.rb
+++ b/lib/test/tasks/run_typelizer.rb
@@ -3,7 +3,9 @@ class Test::Tasks::RunTypelizer < Pallets::Task
 
   def run
     execute_rake_task('typelizer:generate')
-    execute_system_command("! grep --quiet -RP '\\bunknown\\b' app/javascript/types/serializers/")
+    execute_system_command(<<~'COMMAND')
+      ! grep --quiet -RP '\bunknown\b' app/javascript/types/serializers/
+    COMMAND
 
     if !execute_system_command('git diff --exit-code')
       # Reset the git state, so it's clean for other test tasks.

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -5,12 +5,12 @@ class Test::Tasks::RunUnitTests < Pallets::Task
     # Run all tests in `spec/` _except_ those in `spec/controllers/` and `spec/features/`.
     # Tests in `spec/controllers/` will be run by RunApiControllerTests and RunHtmlControllerTests.
     # Tests in `spec/features/` will be run by RunFeatureTests task(s).
-    execute_rspec_command(<<~COMMAND)
+    execute_rspec_command(<<~'COMMAND')
       DB_SUFFIX=_unit
       bin/rspec
       $(ls -d spec/*/ |
         grep --extended-regex -v 'spec/(controllers|features|helpers)(/|$)' |
-        tr '\\n' ' ')
+        tr '\n' ' ')
       --format RSpec::Instafail --format progress --force-color
     COMMAND
   end


### PR DESCRIPTION
This makes it easier to copy the commands into a terminal when I want/need to replicate one of the CI steps on my local machine.