### PR TITLE
[ci] Set PALLETS_CONCURRENCY to 1

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -79,7 +79,7 @@ jobs:
         run: bin/run-tests
         env:
           CI: true
-          PALLETS_CONCURRENCY: 6
+          PALLETS_CONCURRENCY: 1
           AWS_EC2_METADATA_DISABLED: true
           RAILS_ENV: test
           DISABLE_SPRING: 1


### PR DESCRIPTION
I want to see what the task runtimes are like without any concurrency.