### PR TITLE
[ci] Run unit tests only after API controller tests have completed

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -47,7 +47,12 @@ class Test::RequirementsResolver
         Test::Tasks::RunDatabaseConsistency => Test::Tasks::SetupDb,
         Test::Tasks::RunImmigrant => Test::Tasks::SetupDb,
         Test::Tasks::RunRubocop => nil,
-        Test::Tasks::RunUnitTests => Test::Tasks::CreateDbCopies,
+        # RunUnitTests doesn't really depend on RunApiControllerTests,
+        # but it's better for the timing of steps if it waits for it.
+        Test::Tasks::RunUnitTests => [
+          Test::Tasks::CreateDbCopies,
+          Test::Tasks::RunApiControllerTests,
+        ],
         Test::Tasks::RunApiControllerTests => Test::Tasks::CreateDbCopies,
         Test::Tasks::RunFileSizeChecks => Test::Tasks::CompileUserJavaScript,
         Test::Tasks::RunFeatureTestsA => [


### PR DESCRIPTION
My thinking is that this will hopefully reduce the parallel CPU demands during JavaScript compilation, allowing feature tests to start sooner. It's not clear whether the implications of this will be an overall win for test suite run time, but I think it might be, and I think it might be worth giving this a shot.