### PR TITLE
[ci] Run API controller tests after StartPercy completes

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -53,7 +53,12 @@ class Test::RequirementsResolver
           Test::Tasks::CreateDbCopies,
           Test::Tasks::RunApiControllerTests,
         ],
-        Test::Tasks::RunApiControllerTests => Test::Tasks::CreateDbCopies,
+        # RunApiControllerTests doesn't really depend on StartPercy,
+        # but it's better for the timing of steps if it waits for it.
+        Test::Tasks::RunApiControllerTests => [
+          Test::Tasks::CreateDbCopies,
+          Test::Tasks::StartPercy,
+        ],
         Test::Tasks::RunFileSizeChecks => Test::Tasks::CompileUserJavaScript,
         Test::Tasks::RunFeatureTestsA => [
           Test::Tasks::DivideFeatureSpecs,


### PR DESCRIPTION
This change builds on #6246 to further try to reduce concurrency while JavaScript assets are being compiled. My hope is that this will make JavaScript compilation faster, allowing feature tests to start sooner, and that this might be worth the price paid in terms of higher concurrency during feature specs and a later start for unit tests and API controller tests. It's not clear whether the implications of this will be an overall win for test suite run time, but I think it might be, and I think it might be worth giving this a shot.

My inspiration for this change is largely #6245, which showed that, when PALLETS_CONCURRENCY is 1, we can have these run times:

```
CompileAdminJavaScript : exited with 0 (took 12.866 seconds)
 CompileUserJavaScript : exited with 0 (took 16.567 seconds)
```

That's only 29.4 seconds total, which is faster than even just the `CompileUserJavaScript` steps takes alone when running with PALLETS_CONCURRENCY of 6. So, the clear implication seems to be that lower concurrency during JavaScript builds can shorten the build time significantly. This change aims to accomplish that (lower concurrency during JavaScript builds).