### PR TITLE
[vite.config.mjs] Build user JavaScript with maxParallelFileOps of 3

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -16,7 +16,7 @@ export default defineConfig({
           process.env.VITE_RUBY_PUBLIC_OUTPUT_DIR == 'vite-admin'
         ) ?
           1
-        : 4,
+        : 3,
     },
   },
   // https://github.com/vitejs/vite/issues/ 18164#issuecomment-2365310242


### PR DESCRIPTION
I think that 4 might be too high (resulting in an overall slowdown, due to switching costs) since I think that there is pretty much always at least one other fairly CPU-intensive process running at the same time that we are compiling user JavaScript. I hope that reducing the maxParallelFileOps to 3 (as thing change does) will lower those switching costs and actually make the user JavaScript compilation faster overall.