### PR TITLE
[CreateDbCopies] Specify fallbacks for Postgres env vars

### DIFF
--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -19,8 +19,8 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
       execute_system_command(<<~COMMAND)
         createdb
           -T david_runger_test #{db_name}
-          -U #{ENV.fetch('POSTGRES_USER', nil)}
-          -h #{ENV.fetch('POSTGRES_HOST', nil)}
+          -U #{ENV.fetch('POSTGRES_USER', 'david_runger')}
+          -h #{ENV.fetch('POSTGRES_HOST', 'localhost')}
           --no-password
       COMMAND
     end


### PR DESCRIPTION
This makes it so that `bin/run-test-steps BuildFixtures CreateDbCopies` succeeds locally.