### PR TITLE
[DivideFeatureSpecs] Create tmp/ directory

### DIFF
--- a/lib/test/tasks/divide_feature_specs.rb
+++ b/lib/test/tasks/divide_feature_specs.rb
@@ -6,6 +6,8 @@ class Test::Tasks::DivideFeatureSpecs < Pallets::Task
   def run
     puts("#{AmazingPrint::Colors.yellow('Dividing feature specs')}...")
 
+    FileUtils.mkdir_p('tmp')
+
     Dir.glob('spec/features/**/*_spec.rb').
       shuffle.
       group_by.with_index { |_file, index| index % NUM_FEATURE_SPEC_GROUPS }.


### PR DESCRIPTION
If this runs quickly enough, I think it's possible that nothing else will have yet created a `tmp/` directory, in which case this task will error, unless it creates the `tmp/` directory itself, which this change causes it to do.