### PR TITLE
[request_recordable_spec.rb] Use 'JSON.parse()' explicitly (not JSON)

### DIFF
--- a/spec/controllers/concerns/request_recordable_spec.rb
+++ b/spec/controllers/concerns/request_recordable_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe RequestRecordable, :without_verifying_authorization do
       perform_request
 
       $redis_pool.with do |conn|
-        JSON(conn.call('get', controller.send(:initial_request_data_redis_key)))
+        JSON.parse(conn.call('get', controller.send(:initial_request_data_redis_key)))
       end
     end
 


### PR DESCRIPTION
I think that this will give us an earlier and better error message, in the event that the string coming from Redis cannot be parsed as a JSON string. I think that I have seen something like this happen before. Also, I think it just makes the code more explicit, clear, and easily readable.