### PR TITLE
Fix 'http_logger' config for version 1.0.0 breaking changes

### DIFF
--- a/config/initializers/http_logger.rb
+++ b/config/initializers/http_logger.rb
@@ -1,5 +1,7 @@
 if Rails.env.development? && !IS_DOCKER
   # :nocov:
-  HttpLogger.log_headers = true
+  HttpLogger.configure do |config|
+    config.log_headers = true
+  end
   # :nocov:
 end


### PR DESCRIPTION
This is a follow-up to #6258. That wasn't caught by specs because this is a development-only dependency.