### PR TITLE
Don't require SECRET_KEY_BASE if SECRET_KEY_BASE_DUMMY=1

### DIFF
--- a/config/initializers/0w_secret_key_base.rb
+++ b/config/initializers/0w_secret_key_base.rb
@@ -1,9 +1,9 @@
-secret_key_base = ENV.fetch('SECRET_KEY_BASE')
+secret_key_base = ENV.fetch('SECRET_KEY_BASE', nil)
 
 if secret_key_base.present?
   DavidRunger::Application.config.secret_key_base = secret_key_base
   # :nocov:
 elsif ENV.fetch('SECRET_KEY_BASE_DUMMY', nil) != '1'
-  fail('Could not find a secret_key_base in ENV or credentials.')
+  fail('Could not find SECRET_KEY_BASE in ENV.')
   # :nocov:
 end


### PR DESCRIPTION
This should fix deploys, which are currently failing. https://github.com/davidrunger/david_runger/actions/runs/13503267388/job/37726931183#step:5:96

> KeyError: key not found: "SECRET_KEY_BASE" (KeyError)