### PR TITLE
Don't require HASHID_SALT env var

### DIFF
--- a/config/initializers/hashid.rb
+++ b/config/initializers/hashid.rb
@@ -1,5 +1,5 @@
 Hashid::Rails.configure do |config|
-  config.salt = ENV.fetch('HASHID_SALT')
+  config.salt = ENV.fetch('HASHID_SALT', nil)
   # we'll only use lowercase letters (default setting is to use capitals, as well)
   config.alphabet = (('a'..'z').to_a + ('0'..'9').to_a).join('').freeze
   config.override_find = false


### PR DESCRIPTION
We weren't requiring this before, but I tried to sneak in making it required in this change: https://github.com/davidrunger/david_runger/pull/6262/files#diff-6a05bb27f9fa61ed052269b29331fc7a4a86b81ffc5a44487abe25271ae691e7R2

However, it's failing deploys: https://github.com/davidrunger/david_runger/actions/runs/13503449287/job/37727538007#step:5:81

We want this to always be present in production (except when compiling assets), but unfortunately it won't be entirely trivial to enforce that with a simple `ENV.fetch('HASHID_SALT')` because it's not present when building the Docker image.

This change gives a fallback value of `nil` if `HASHID_SALT` is not present (e.g. when compiling assets).