### PR TITLE
[production.rb] Stop requiring master key

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
   # Ensures that a master key has been made available in ENV["RAILS_MASTER_KEY"], config/master.key, or an environment
   # key such as config/credentials/production.key. This key is used to decrypt credentials (and other encrypted files).
   # rubocop:enable Layout/LineLength
-  config.require_master_key = !IS_DOCKER_BUILD
+  config.require_master_key = false
 
   # Disable serving static files from `public/`, relying on NGINX/Apache to do so instead.
   config.public_file_server.enabled = false


### PR DESCRIPTION
We aren't using Rails credentials in production anymore (since #6262).

This no-longer-needed requirement is [causing deploys to fail][1], now that I have deleted the `RAILS_MASTER_KEY` env var.

[1]: https://github.com/davidrunger/david_runger/actions/runs/13503619081/job/37728561489#step:5:262

This change should fix the issue by setting `config.require_master_key = false`.