### PR TITLE
Delete init.sql file

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -1,1 +1,0 @@
-CREATE USER david_runger SUPERUSER;


### PR DESCRIPTION
I think that I added this because of this:

> If we put a file called init.sql at the project root, Docker will find it and execute it.

-- https://www.codewithjason.com/dockerize-rails-apps-database/

However, I don't think that is true? All LLMs that I spoke to are pretty confident that the mere presence of an `init.sql` file won't cause its contents to be executed. And, as far as I can tell, they are correct. I cannot find any documentation stating that this would happen. I get no hits searching for `init.sql` in `gemd`.

The `init.sql` file that we had was intended to create a SUPERUSER named `david_runger`. However, I think that what actually happens is that a SUPERUSER will be created for the `POSTGRES_USER`, which we specify here: https://github.com/davidrunger/david_runger/blob/ef8c12d567b06b939cd366f4bdd0bad66685497a/docker-compose.yml/#L203 . I think _that_ is what we really need, not the `init.sql` file, which I think does nothing.

I had a vague memory that something was broken for me but adding/using `init.sql` fixed it, but I think that either my memory is mistaken and/or I didn't understand exactly what was happening.