### PR TITLE
Don't use Rollbar in development

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -20,7 +20,7 @@ Rollbar.configure do |config|
   # Without configuration, Rollbar is enabled in all environments.
   # To disable in specific environments, set config.enabled=false.
   if Rails.env.in?(%w[development test])
-    config.enabled = access_token.present?
+    config.enabled = access_token.present? && (!IS_DOCKER || ENV.key?('ENABLE_ROLLBAR'))
   end
 
   # NOTE: Instead of having Rollbar send uncaught errors on its own, we will


### PR DESCRIPTION
... unless and access token is present in the ENV and either the app is not being run in Docker or it is being run in Docker and an `ENABLE_ROLLBAR` env var is present.

This is a followup to #6262, which caused me to inadvertently send errors in development to Rollbar when running the app in Docker.