### PR TITLE
[roll-out-web] Start an instance of web if none is running

### DIFF
--- a/bin/server/roll-out-web.sh
+++ b/bin/server/roll-out-web.sh
@@ -22,6 +22,11 @@ scale_web() {
   docker compose up --detach --no-deps --scale web="$scale" --no-recreate --remove-orphans web
 }
 
+# If web is not already running, then start it.
+if ! docker compose ps -q web | grep -q . ; then
+  docker compose up --detach --remove-orphans web
+fi
+
 old_container_id=$(docker ps --filter name=web --quiet | tail -1)
 
 # Bring a new container online, running new code.


### PR DESCRIPTION
I am not sure that I fully understand why this helps, but it does seem to help. Without this change, if I run `LOCAL_TEST=1 bin/server/deploy.sh` from a "cold start" (no Docker services running) on my local machine, then the server that gets spun up doesn't seem to use the new image of which that command triggers the creation. Rather, the spun up web server will use an older container, if one exists. (In contrast, the other Rails services, such as `worker`, do use the newly created image.)

I think that this might have to do with the `--no-recreate` option that we provide in the scaling command? I'm not sure.

Anyway, booting a `web` server using `docker compose up --detach
--remove-orphans web` if none is already running seems to fix this issue, i.e. the `web` server that is running after executing `LOCAL_TEST=1 bin/server/deploy.sh` from a "cold start" includes the latest changes. It also continues to work correctly (i.e. to include the latest changes) if run from a "warm start", i.e. if our Docker Compose services are already running, in which case we won't enter the conditional that this change adds.