### PR TITLE
[routes] Mount engines using :at keyword

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -104,9 +104,9 @@ Rails.application.routes.draw do
 
   authenticate :admin_user do
     get 'vue-playground', to: 'vue_playground#index'
-    mount Blazer::Engine => '/blazer'
-    mount Flipper::UI.app(Flipper) => '/flipper'
-    mount Sidekiq::Web => '/sidekiq'
+    mount Blazer::Engine, at: 'blazer'
+    mount Flipper::UI.app(Flipper), at: 'flipper'
+    mount Sidekiq::Web, at: 'sidekiq'
   end
 
   get 'up', to: 'health_checks#index'


### PR DESCRIPTION
I tried adding a route for local testing purposes like `get('/blazer-db-url', to: ->(_env) { plain_text_response(ENV.fetch('BLAZER_DATABASE_URL')) })`. This route could not be accessed when mounting the Blazer engine via `mount Blazer::Engine => '/blazer'`; instead, it seems that the Blazer engine was matching the path but then catching it as a 404, since the Blazer engine doesn't provide such a route.

In contrast, with the change made in this PR, where we instead mount the Blazer engine (and similarly the Flipper and Sidekiq engines) using the `:at` keyword (`mount Blazer::Engine, at: 'blazer'`), such a route can be accessed. This seems much better to me, and so this change does that.