### PR TITLE
Don't try to save Blazer requests as Requests

### DIFF
--- a/app/poros/save_request/skip_checker.rb
+++ b/app/poros/save_request/skip_checker.rb
@@ -9,6 +9,7 @@ class SaveRequest::SkipChecker
     case [@controller, @action, @params.symbolize_keys]
     in (
       ['health_checks', _, _] |
+      [%r{\Ablazer/}, _, _] |
       ['anonymous', _, _] |
       ['blog', 'assets', _] |
       ['api/events', 'create', _] |

--- a/spec/poros/save_request/skip_checker_spec.rb
+++ b/spec/poros/save_request/skip_checker_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe SaveRequest::SkipChecker do
       end
     end
 
+    context 'when the controller starts with "blazer/"' do
+      let(:params) { { 'controller' => 'blazer/queries', 'action' => 'home' } }
+
+      it 'returns true' do
+        expect(skip?).to eq(true)
+      end
+    end
+
     context 'when uptime_robot is among the params keys' do
       let(:params) { { 'controller' => 'home', 'action' => 'index', 'uptime_robot' => '1' } }
 


### PR DESCRIPTION
fix https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/725
fix rb#725

Fixes this error: Request::CreateRequestError: Initial stashed JSON for request logging was blank.

This error is happening because we only have final stashed JSON for Blazer requests (I guess because blazer [skips][1] our `store_initial_request_data_in_redis` `before_action` that stores the initial request JSON).

[1]: https://github.com/ankane/blazer/blob/v3.2.0/app/controllers/blazer/base_controller.rb#L3-L7

By not trying to save Blazer requests as Request records, we'll avoid these errors (and stop saving the "final" JSON request data to Redis).