### PR TITLE
Reenable RuboCop [DEV-191]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Set GIT_REV environment variable
         uses: ./.github/actions/git_rev
 
+      - name: Ensure clean git status
+        run: '! [[ -n $(git status --porcelain) ]] || (git status && false)'
+
       - name: Run tests & linters
         run: bin/run-tests
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,11 @@
 .env
 .env.*.local
 
-# Gems
+# Bundler config
 /.bundle/
+
+# Gems
+/vendor/bundle/
 
 # Logs
 /log/

--- a/lib/test/tasks/run_rubocop.rb
+++ b/lib/test/tasks/run_rubocop.rb
@@ -2,9 +2,8 @@ class Test::Tasks::RunRubocop < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    # bin/rubocop --color --format clang
     execute_system_command(<<~COMMAND)
-      echo 'Temporarily disabled due to bugs (?) in RuboCop.'
+      bin/rubocop --color --format clang
     COMMAND
   end
 end


### PR DESCRIPTION
This change fixes a problem that I think was introduced here: https://github.com/davidrunger/david_runger/pull/6241/files#diff-c93842a347a7cfd07504eaee4efb2e8e0df57ebacfe34e0ec7b86225040107c7L6

In that change, we removed `git ls-tree -r HEAD --name-only` from the `bin/rubocop` command. As I mentioned in that PR description, I thought that is fine because we now have this: https://github.com/davidrunger/david_runger/blob/fc549cc68846583346a39deb8a322079c5ec5c14/.rubocop.yml/#L16-L18

I think that logic is sound ... as long as we are gitignoring all of the relevant files. However, we weren't! In CI, gems are installed to `vendor/bundle/`, which, until this change, we weren't gitignoring. This change adds `vendor/bundle/` to our gitignored files, and also it adds a check to our CI steps to ensure that the git status is clean before running tests. This would have detected this issue and will hopefully avoid similar problems in the future.

Unfortunately, running RuboCop on branches again is going to slow down those builds, but c'est la vie, I guess. I guess that ensuring that our code stays clean has a price.