### PR TITLE
Save Google 'sub' immediately for newly created users [DEV-194]

### DIFF
--- a/app/actions/users/create.rb
+++ b/app/actions/users/create.rb
@@ -1,10 +1,11 @@
 class Users::Create < ApplicationAction
   requires :email, String
+  requires :google_sub, String
 
   returns :user, User
 
   def execute
-    result.user = User.create!(email:)
+    result.user = User.create!(email:, google_sub:)
     AdminMailer.user_created(result.user.id).deliver_later
   end
 end

--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
 
       before { expect(User.where(email: stubbed_user_email)).not_to exist }
 
-      it 'allows a user to sign up (and log in) with Google' do
+      it "allows a user to sign up (and log in) with Google and saves the user's Google 'sub' value" do
         visit(new_user_session_path)
         expect(page).to have_css('button.google-login')
 
@@ -92,6 +92,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
         user = User.find_by!(email: stubbed_user_email)
 
         expect(sign_in_confirmed_via_my_account?(user)).to eq(true)
+        expect(user.google_sub).to eq(mocked_google_response_sub)
       end
     end
   end


### PR DESCRIPTION
The Google `sub` value should be saved immediately for new users when they sign up, but it's currently not being saved for them. This change fixes that (by saving the Google `sub` value immediately when a new user signs up).