### PR TITLE
Extract a #window_data_script_tag view helper method

### DIFF
--- a/app/helpers/window_data_helper.rb
+++ b/app/helpers/window_data_helper.rb
@@ -1,0 +1,10 @@
+module WindowDataHelper
+  def window_data_script_tag
+    # rubocop:disable Rails/OutputSafety
+    javascript_tag(<<~JS.rstrip, nonce: true)
+      window.davidrunger = {env: '#{Rails.env}'};
+      window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript(schema_validated_data(bootstrap).to_json))}");
+    JS
+    # rubocop:enable Rails/OutputSafety
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -32,9 +32,7 @@
     %meta{name: 'theme-color', content: '#ffffff'}
 
     = csrf_meta_tags
-    = javascript_tag(nonce: true) do
-      window.davidrunger = {env: '#{Rails.env}'};
-      window.davidrunger.bootstrap = JSON.parse("#{raw(escape_javascript(schema_validated_data(bootstrap).to_json))}");
+    = window_data_script_tag
 
     - if Rails.env.development? && !ENV['PRODUCTION_ASSET_CONFIG'].present?
       = vite_client_tag


### PR DESCRIPTION
This will make it easier to also inject this window data (including bootstrap data and the environment string) into blog posts' HTML.