### PR TITLE
Make RunTypelizer depend on CreateDbCopies

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -41,7 +41,7 @@ class Test::RequirementsResolver
         Test::Tasks::RunEslint => Test::Tasks::PnpmInstall,
         Test::Tasks::RunVitest => Test::Tasks::PnpmInstall,
         Test::Tasks::RunAnnotate => Test::Tasks::SetupDb,
-        Test::Tasks::RunTypelizer => Test::Tasks::BuildFixtures,
+        Test::Tasks::RunTypelizer => Test::Tasks::CreateDbCopies,
         Test::Tasks::ConvertSchemasToTs => Test::Tasks::SetupDb,
         Test::Tasks::RunBrakeman => nil,
         Test::Tasks::RunDatabaseConsistency => Test::Tasks::SetupDb,


### PR DESCRIPTION
I am hoping that this will avoid errors like this:

```
createdb: error: database creation failed: ERROR:  source database "david_runger_test" is being accessed by other users
DETAIL:  There are 2 other sessions using the database.
'createdb -T david_runger_test david_runger_test_feature_a -U postgres -h 127.0.0.1 --no-password' with ENV vars {} failed (exited with 1, took 5.087).
```

-- https://github.com/davidrunger/david_runger/actions/runs/13604936208/job/38035323653?pr=6296#step:12:202