### PR TITLE
Increase sleep in CreateDbCopies after disconnect from 0.1 to 0.5 s

### DIFF
--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -6,7 +6,7 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
     # database, so disconnect.
     ActiveRecord::Base.connection_pool.connections.each(&:disconnect!)
     # Give a little time for the disconnections to complete (?).
-    sleep(0.1)
+    sleep(0.5)
 
     %w[unit api html feature_a feature_c].each do |db_suffix|
       db_name = "david_runger_test_#{db_suffix}"


### PR DESCRIPTION
I'm hoping that this will fix errors like this:

```
createdb: error: database creation failed: ERROR:  source database "david_runger_test" is being accessed by other users
DETAIL:  There are 2 other sessions using the database.
'createdb -T david_runger_test david_runger_test_unit -U postgres -h 127.0.0.1 --no-password' with ENV vars {} failed (exited with 1, took 5.207).
```

-- https://github.com/davidrunger/david_runger/actions/runs/13605035674/job/38035517491?pr=6297#step:12:159