### PR TITLE
Dedupe dependencies in pnpm-lock.yaml

### DIFF
--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -10,7 +10,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'check_ins*.css' => (10..15),
     'check_ins*.js' => (191..201),
     'check_ins_index*.js' => (5..15),
-    'ci_step_gantt_charts*.js' => (804..814),
+    'ci_step_gantt_charts*.js' => (830..840),
     'comments*.css' => (0..10),
     'comments*.js' => (246..256),
     'copy_to_clipboard*.css' => (0..10),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7462,7 +7462,7 @@ snapshots:
       d3-color: 3.1.0
       d3-geo: 3.1.1
       vega-dataflow: 5.7.7
-      vega-expression: 5.1.2
+      vega-expression: 5.2.0
       vega-scale: 7.4.2
       vega-scenegraph: 4.13.1
       vega-selections: 5.6.0
@@ -7621,7 +7621,7 @@ snapshots:
     dependencies:
       '@types/geojson': 7946.0.4
       vega-event-selector: 3.0.1
-      vega-expression: 5.1.2
+      vega-expression: 5.2.0
       vega-util: 1.17.3
 
   vega-util@1.17.3: {}


### PR DESCRIPTION
`pnpm dedupe`

For some reason (presumably some sort of bug in `vega-expression`?), I think that this causes some(/all?) of the `vega-expression` code to be included twice, which significantly increases the size of the `ci_step_gantt_charts*.js` package. Whatever. Hopefully they will fix it at some point (if, indeed, it's really a bug; I think it probably is). But, since this bundle is not really used by users other than me, I'm not going to worry about it.