### PR TITLE
Remove deprecated 'max-len' and 'quotes' eslint rules [DEV-192]

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -82,13 +82,6 @@ export default defineConfigWithVueTs(
         },
       ],
       'import/prefer-default-export': 'off',
-      'max-len': [
-        'warn',
-        {
-          code: 100,
-          ignoreUrls: true,
-        },
-      ],
       'newline-per-chained-call': 'off',
       'no-alert': 'off',
       'no-console': 'warn',
@@ -125,13 +118,6 @@ export default defineConfigWithVueTs(
       'no-unused-vars': 'off',
       'object-shorthand': ['error', 'always'],
       'operator-linebreak': 'off',
-      quotes: [
-        'warn',
-        'single',
-        {
-          avoidEscape: true,
-        },
-      ],
       'require-await': 'error',
       'vue/multi-word-component-names': 'off',
     },


### PR DESCRIPTION
We also have the deprecated `vue/component-tags-order` rule via `eslint-plugin-vue`, I believe. That will be resolved in v10 of `eslint-plugin-vue`, which is not yet released.