### PR TITLE
Remove app-wide registrations of Modal component [DEV-197]

### DIFF
--- a/app/javascript/entrypoints/groceries_app.ts
+++ b/app/javascript/entrypoints/groceries_app.ts
@@ -1,7 +1,6 @@
 import { createPinia } from 'pinia';
 import Toast from 'vue-toastification';
 
-import Modal from '@/components/Modal.vue';
 import Groceries from '@/groceries/Groceries.vue';
 import { renderApp } from '@/shared/customized_vue';
 
@@ -9,7 +8,5 @@ const app = renderApp(Groceries);
 
 const pinia = createPinia();
 app.use(pinia);
-
-app.component('Modal', Modal);
 
 app.use(Toast);

--- a/app/javascript/entrypoints/logs_app.ts
+++ b/app/javascript/entrypoints/logs_app.ts
@@ -1,7 +1,6 @@
 import { createPinia } from 'pinia';
 import { markRaw } from 'vue';
 
-import Modal from '@/components/Modal.vue';
 import LogApp from '@/logs/Logs.vue';
 import router from '@/logs/router';
 import { renderApp } from '@/shared/customized_vue';
@@ -13,7 +12,5 @@ pinia.use(({ store }) => {
   store.router = markRaw(router);
 });
 app.use(pinia);
-
-app.component('Modal', Modal);
 
 app.use(router);

--- a/app/javascript/entrypoints/workout_app.ts
+++ b/app/javascript/entrypoints/workout_app.ts
@@ -1,10 +1,8 @@
 import { createPinia } from 'pinia';
 
-import Modal from '@/components/Modal.vue';
 import { renderApp } from '@/shared/customized_vue';
 import WorkoutApp from '@/workout/Workout.vue';
 
 const app = renderApp(WorkoutApp);
 const pinia = createPinia();
 app.use(pinia);
-app.component('Modal', Modal);

--- a/app/javascript/groceries/components/CheckInModal.vue
+++ b/app/javascript/groceries/components/CheckInModal.vue
@@ -53,6 +53,7 @@ import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import { TYPE } from 'vue-toastification';
 
+import Modal from '@/components/Modal.vue';
 import { useGroceriesStore } from '@/groceries/store';
 import { vueToast } from '@/lib/vue_toasts';
 import { useModalStore } from '@/shared/modal/store';

--- a/app/javascript/groceries/components/ManageCheckInStoresModal.vue
+++ b/app/javascript/groceries/components/ManageCheckInStoresModal.vue
@@ -21,6 +21,7 @@ Modal(
 <script setup lang="ts">
 import { ElButton } from 'element-plus';
 
+import Modal from '@/components/Modal.vue';
 import { useGroceriesStore } from '@/groceries/store';
 import { useModalStore } from '@/shared/modal/store';
 

--- a/app/javascript/logs/components/EditLogRemindersModal.vue
+++ b/app/javascript/logs/components/EditLogRemindersModal.vue
@@ -46,6 +46,7 @@ Modal(
 import { ElButton } from 'element-plus';
 import { computed, ref, type PropType } from 'vue';
 
+import Modal from '@/components/Modal.vue';
 import { toast } from '@/lib/toasts';
 import { useLogsStore } from '@/logs/store';
 import type { Log } from '@/logs/types';

--- a/app/javascript/logs/components/EditLogSharingSettingsModal.vue
+++ b/app/javascript/logs/components/EditLogSharingSettingsModal.vue
@@ -56,6 +56,7 @@ import {
 } from 'element-plus';
 import { computed, nextTick, ref } from 'vue';
 
+import Modal from '@/components/Modal.vue';
 import { bootstrap } from '@/lib/bootstrap';
 import { useLogsStore } from '@/logs/store';
 import type { Bootstrap } from '@/logs/types';

--- a/app/javascript/logs/components/LogSelectorModal.vue
+++ b/app/javascript/logs/components/LogSelectorModal.vue
@@ -27,6 +27,7 @@ import { storeToRefs } from 'pinia';
 import { computed, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
+import Modal from '@/components/Modal.vue';
 import { useFuzzyTypeahead } from '@/lib/composables/useFuzzyTypeahead';
 import { useSubscription } from '@/lib/composables/useSubscription';
 import { useLogsStore } from '@/logs/store';

--- a/app/javascript/workout/components/ConfirmWorkoutModal.vue
+++ b/app/javascript/workout/components/ConfirmWorkoutModal.vue
@@ -34,6 +34,7 @@ Modal(
 import { ElButton, ElCheckbox } from 'element-plus';
 import { ref } from 'vue';
 
+import Modal from '@/components/Modal.vue';
 import { toast } from '@/lib/toasts';
 import { useModalStore } from '@/shared/modal/store';
 import { useWorkoutsStore } from '@/workout/store';

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -120,6 +120,7 @@ export default defineConfigWithVueTs(
       'operator-linebreak': 'off',
       'require-await': 'error',
       'vue/multi-word-component-names': 'off',
+      'vue/no-undef-components': 'error',
     },
   },
 );

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -120,7 +120,6 @@ export default defineConfigWithVueTs(
       'operator-linebreak': 'off',
       'require-await': 'error',
       'vue/multi-word-component-names': 'off',
-      'vue/no-undef-components': 'error',
     },
   },
 );


### PR DESCRIPTION
**Motivation:** I think that this will give us better syntax highlighting and also probably better TypeScript support.

I would like to be able to enable the `vue/no-undef-components` rule to detect this issue programmatically, but it doesn't work with pug templates. There is this https://github.com/rashfael/eslint-plugin-vue-pug , which probably could make it work with pug templates, but I don't love the idea of adding a quasi-random package like that, and also that package isn't yet natively compatible with eslint's new "flat config" https://github.com/rashfael/eslint-plugin-vue-pug/issues/ 29#issuecomment-2459341391 (and there is no reply from the maintainer to a question asking about it). So, I will just rely on myself, rather than tooling.