### PR TITLE
[CreateDbCopies] Add debug query to see problematic PG connections

### DIFF
--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -1,7 +1,7 @@
 class Test::Tasks::CreateDbCopies < Pallets::Task
   include Test::TaskHelpers
 
-  # rubocop:disable Metrics/PerceivedComplexity
+  # rubocop:disable Metrics
   def run
     # The commands below will error if there are any active connections to the
     # database, so disconnect.
@@ -47,5 +47,5 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
       COMMAND
     end
   end
-  # rubocop:enable Metrics/PerceivedComplexity
+  # rubocop:enable Metrics
 end

--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -31,6 +31,13 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
         execute_system_command("dropdb --if-exists #{db_name}")
       end
 
+      execute_system_command(<<~COMMAND.squish)
+        psql -U postgres -h 127.0.0.1 -d david_runger_test -c "
+        SELECT pid, usename, application_name, client_addr, state, query
+        FROM pg_stat_activity
+        WHERE datname = 'david_runger_test' AND pid != pg_backend_pid();"
+      COMMAND
+
       execute_system_command(<<~COMMAND)
         createdb
           -T david_runger_test #{db_name}


### PR DESCRIPTION
I want more insight into these intermittent errors:

```
createdb: error: database creation failed: ERROR:  source database "david_runger_test" is being accessed by other users
DETAIL:  There are 2 other sessions using the database.
'createdb -T david_runger_test david_runger_test_unit -U postgres -h 127.0.0.1 --no-password' with ENV vars {} failed (exited with 1, took 5.224).
```

https://github.com/davidrunger/david_runger/actions/runs/13615687843/job/38058422747?pr=6305#step:12:163