### PR TITLE
[ci] Run ESLint if the config file is changing [DEV-198]

### DIFF
--- a/lib/test/diff_helpers.rb
+++ b/lib/test/diff_helpers.rb
@@ -9,8 +9,14 @@ module DiffHelpers
 
   private
 
-  def file_changed?(filename)
-    files_changed.include?(filename)
+  def file_changed?(filename_pattern)
+    if filename_pattern.is_a?(String)
+      files_changed.include?(filename_pattern)
+    elsif filename_pattern.is_a?(Regexp)
+      file_changed.grep(filename_pattern).present?
+    else
+      fail "Unknown match pattern of class #{filename.class}."
+    end
   end
 
   memoize \
@@ -81,7 +87,7 @@ module DiffHelpers
 
   memoize \
   def files_with_js_changed?
-    Dir['app/javascript/**/*.{js,ts,vue}'].intersect?(files_changed)
+    Dir['app/javascript/**/*.{js,mjs,ts,vue}'].intersect?(files_changed)
   end
 
   memoize \

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -257,6 +257,7 @@ class Test::RequirementsResolver
     Test::Tasks::RunEslint => proc do
       !files_with_js_changed? &&
         !diff_mentions?('eslint') &&
+        !file_changed?(/eslint/i) &&
         !file_changed?('package.json') &&
         !file_changed?('pnpm-lock.yaml')
     end,


### PR DESCRIPTION
I think that either of the changes in this change (adding the `mjs` extension and adding `!file_changed?(/eslint/i)`) would have been sufficient to accomplish the goal of running ESLint if the config file (currently `eslint.config.mjs`) is changing.