### PR TITLE
Fix method name typo in DiffHelpers#file_changed?

### DIFF
--- a/lib/test/diff_helpers.rb
+++ b/lib/test/diff_helpers.rb
@@ -13,7 +13,7 @@ module DiffHelpers
     if filename_pattern.is_a?(String)
       files_changed.include?(filename_pattern)
     elsif filename_pattern.is_a?(Regexp)
-      file_changed.grep(filename_pattern).present?
+      files_changed.grep(filename_pattern).present?
     else
       fail "Unknown match pattern of class #{filename.class}."
     end


### PR DESCRIPTION
`file_changed` => `files_changed`

This fixes a bug in #6308 .