### PR TITLE
[eslint] Use vue/block-order rule to require template first [DEV-193]

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -119,6 +119,12 @@ export default defineConfigWithVueTs(
       'object-shorthand': ['error', 'always'],
       'operator-linebreak': 'off',
       'require-await': 'error',
+      'vue/block-order': [
+        'error',
+        {
+          order: ['template', 'script', 'style'],
+        },
+      ],
       'vue/multi-word-component-names': 'off',
     },
   },


### PR DESCRIPTION
https://eslint.vuejs.org/rules/block-order

The default is `{ "order": [ [ "script", "template" ], "style" ] }` which permits either the script or the template to come first. Although I know that some people like it, having the `script` come first feels "wrong"/unpleasant to me, though, so I want to disallow it.