### PR TITLE
[ci] Use 'vite' JS lib (not 'vite_ruby' gem) to compile JavaScript

### DIFF
--- a/lib/test/tasks/compile_admin_java_script.rb
+++ b/lib/test/tasks/compile_admin_java_script.rb
@@ -5,7 +5,7 @@ class Test::Tasks::CompileAdminJavaScript < Pallets::Task
     execute_system_command('rm -rf public/vite-admin/')
 
     execute_system_command(
-      'bin/vite build --force > /dev/null',
+      './node_modules/.bin/vite build > /dev/null',
       {
         'NODE_ENV' => 'production',
         'VITE_RUBY_ENTRYPOINTS_DIR' => 'admin_entrypoints',

--- a/lib/test/tasks/compile_admin_java_script.rb
+++ b/lib/test/tasks/compile_admin_java_script.rb
@@ -5,7 +5,7 @@ class Test::Tasks::CompileAdminJavaScript < Pallets::Task
     execute_system_command('rm -rf public/vite-admin/')
 
     execute_system_command(
-      './node_modules/.bin/vite build > /dev/null',
+      './node_modules/.bin/vite build 2> /dev/null',
       {
         'NODE_ENV' => 'production',
         'VITE_RUBY_ENTRYPOINTS_DIR' => 'admin_entrypoints',

--- a/lib/test/tasks/compile_admin_java_script.rb
+++ b/lib/test/tasks/compile_admin_java_script.rb
@@ -7,6 +7,7 @@ class Test::Tasks::CompileAdminJavaScript < Pallets::Task
     execute_system_command(
       './node_modules/.bin/vite build 2> /dev/null',
       {
+        'CI' => 'true', # This makes Vite not output info about all file sizes.
         'NODE_ENV' => 'production',
         'VITE_RUBY_ENTRYPOINTS_DIR' => 'admin_entrypoints',
         'VITE_RUBY_PUBLIC_OUTPUT_DIR' => 'vite-admin',

--- a/lib/test/tasks/compile_user_java_script.rb
+++ b/lib/test/tasks/compile_user_java_script.rb
@@ -7,6 +7,7 @@ class Test::Tasks::CompileUserJavaScript < Pallets::Task
     execute_system_command(
       './node_modules/.bin/vite build',
       {
+        'CI' => 'true', # This makes Vite not output info about all file sizes.
         'NODE_ENV' => 'production',
       },
     )

--- a/lib/test/tasks/compile_user_java_script.rb
+++ b/lib/test/tasks/compile_user_java_script.rb
@@ -5,7 +5,7 @@ class Test::Tasks::CompileUserJavaScript < Pallets::Task
     execute_system_command('rm -rf public/vite/')
 
     execute_system_command(
-      'bin/vite build --force',
+      './node_modules/.bin/vite build',
       {
         'NODE_ENV' => 'production',
       },

--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -1,7 +1,6 @@
 class Test::Tasks::CreateDbCopies < Pallets::Task
   include Test::TaskHelpers
 
-  # rubocop:disable Metrics
   def run
     # The commands below will error if there are any active connections to the
     # database, so disconnect.
@@ -28,5 +27,4 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
       COMMAND
     end
   end
-  # rubocop:enable Metrics
 end


### PR DESCRIPTION
Motivation: I think that this might be faster and avoid issues in `CreateDbCopies` caused by `vite_ruby` connecting to the database.

https://github.com/davidrunger/david_runger/actions/runs/13658563557/job/38183952758?pr=6317#step:13:149

```
 pid | usename  | application_name | client_addr | state |                  query                   
-----+----------+------------------+-------------+-------+------------------------------------------
 121 | postgres | bin/vite         | 172.18.0.1  | idle  | SELECT "ip_blocks"."ip" FROM "ip_blocks"
 122 | postgres | bin/vite         | 172.18.0.1  | idle  | SELECT "ip_blocks"."ip" FROM "ip_blocks"
(2 rows)
```