### PR TITLE
[ci] Don't have RunApiControllerTests wait for StartPercy [DEV-200]

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -66,12 +66,7 @@ class Test::RequirementsResolver
           Test::Tasks::CreateDbCopies,
           Test::Tasks::RunApiControllerTests,
         ],
-        # RunApiControllerTests doesn't really depend on StartPercy,
-        # but it's better for the timing of steps if it waits for it.
-        Test::Tasks::RunApiControllerTests => [
-          Test::Tasks::CreateDbCopies,
-          Test::Tasks::StartPercy,
-        ],
+        Test::Tasks::RunApiControllerTests => Test::Tasks::CreateDbCopies,
         Test::Tasks::RunFileSizeChecks => Test::Tasks::CompileUserJavaScript,
         Test::Tasks::RunFeatureTestsA => [
           Test::Tasks::DivideFeatureSpecs,


### PR DESCRIPTION
Compiling JavaScript is much faster now because of #6318 .

Some of the dependency relationships in `RequirementsResolver` were predicated on the assumption that compiling JavaScript would take a certain length of time, and I think that some of those assumptions no longer hold.

One such assumption is that, even if RunApiControllerTests starts after StartPercy, then it will still complete before JS compilation is finished. This is no longer true, and it results in unnecessary downstream delays in the execution of CI steps, with ultimately RunUnitTests sometimes being the last CI step to finish.

Accordingly, this change removes the dependency of RunApiControllerTests on StartPercy, which will allow RunApiControllerTests to start running earlier, which will hopefully produce an overall faster and more efficient build timeline.

To illustrate the issue which this PR aims to fix... A flow like that below, where RunUnitTests (pink) is the last step to complete, seems inefficient and suboptimal:

![image](https://github.com/user-attachments/assets/7724dadb-b5be-47ed-b6eb-d06cdecba064)