### PR TITLE
[RunRubocop] Use tap formatter

### DIFF
--- a/lib/test/tasks/run_rubocop.rb
+++ b/lib/test/tasks/run_rubocop.rb
@@ -3,7 +3,7 @@ class Test::Tasks::RunRubocop < Pallets::Task
 
   def run
     execute_system_command(<<~COMMAND)
-      bin/rubocop --color --format clang
+      bin/rubocop --color --format tap
     COMMAND
   end
 end


### PR DESCRIPTION
RuboCop has been really slow since re-enabling it:

![image](https://github.com/user-attachments/assets/09295f4d-afdb-491f-bfda-dd98e62b3fe1)

I'm hoping that this tap formatter (hopefully just temporarily) might give some insight into why that is.