### PR TITLE
[RunRubocop] Add back linting of only git-tracked files

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,10 +12,7 @@ require:
   - ./tools/custom_cops/require_all_custom_cops.rb
 
 AllCops:
-  Exclude:
-  <% `git status --ignored --porcelain`.lines.grep(/^!! /).each do |path| %>
-    - <%= path.sub(/^!! /, '').sub(/\/$/, '/**/*').rstrip %>
-  <% end %>
+  Exclude: []
   StringLiteralsFrozenByDefault: true
 
 CustomCops/DontRollBackDatamigration:

--- a/lib/test/tasks/run_rubocop.rb
+++ b/lib/test/tasks/run_rubocop.rb
@@ -3,7 +3,7 @@ class Test::Tasks::RunRubocop < Pallets::Task
 
   def run
     execute_system_command(<<~COMMAND)
-      bin/rubocop --color --format tap
+      bin/rubocop $(git ls-files) --color --format clang --force-exclusion --cache=false
     COMMAND
   end
 end


### PR DESCRIPTION
Also, set `Exclude` to an empty array, since when it is `git status
--ignored --porcelain` paths I think that it might give a false sense of confidence that all gitignored paths will be excluded. But I have the suspicion (based on at least some evidence) that maybe if the RuboCop config is parsed before some excluded files/directories have been populated (e.g. `node_modules`), then maybe RuboCop will wastefully scan through those directories. By setting `Exclude` to an empty array, we don't risk misleadingly suggesting that all gitignored files will be ignored, when I think that the reality is that only gitignored files present at the time of RuboCop config parsing will be ignored.

I want to set the value to an empty array rather than just not setting it at all because I want to override the `Exclude` value that is inherited from `rubocop-rails`, which includes `bin/*`, since I want to lint Ruby files in the top level of `bin/`.

Use `--cache=false` for more realistic simulation of CI when running the command locally (since there will be no cache available in CI) and also to not waste a tiny bit of time checking the cache that will never be there in CI.

Also, switch from `tap` formatter back to `clang` because I am cautiously optimistic that this will fix the RunRubocop slowness that we have been seeing.