### PR TITLE
Remove RunUnitTests => RunApiControllerTests dependency [DEV-200]

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -60,12 +60,7 @@ class Test::RequirementsResolver
         Test::Tasks::RunDatabaseConsistency => Test::Tasks::SetupDb,
         Test::Tasks::RunImmigrant => Test::Tasks::SetupDb,
         Test::Tasks::RunRubocop => nil,
-        # RunUnitTests doesn't really depend on RunApiControllerTests,
-        # but it's better for the timing of steps if it waits for it.
-        Test::Tasks::RunUnitTests => [
-          Test::Tasks::CreateDbCopies,
-          Test::Tasks::RunApiControllerTests,
-        ],
+        Test::Tasks::RunUnitTests => Test::Tasks::CreateDbCopies,
         Test::Tasks::RunApiControllerTests => Test::Tasks::CreateDbCopies,
         Test::Tasks::RunFileSizeChecks => Test::Tasks::CompileUserJavaScript,
         Test::Tasks::RunFeatureTestsA => [


### PR DESCRIPTION
I think that this made more sense back when JS compilation took longer, and so RunApiControllerTests and then RunUnitTests could complete in series in not much more time than it took to compile the JavaScript.

However, now that JavaScript is compiling much faster, when RunUnitTests depends on RunApiControllerTests, RunUnitTests ends up running mostly after the compilation of JavaScript, in parallel with the 3 feature tests runners and HTML tests. I think that this backloads too much concurrency and we will probably get faster builds by starting RunUnitTests earlier, which this change accomplishes by removing the artificial dependency on RunApiControllerTests.

Goal: spread out concurrency more evenly by pulling some concurrent load forward by starting RunUnitTests earlier:

![image](https://github.com/user-attachments/assets/980eda95-9057-4924-801b-0642aefd826f)