### PR TITLE
[.rubocop.yml] Add db migrations from previous years to 'Exclude'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,8 @@ require:
   - ./tools/custom_cops/require_all_custom_cops.rb
 
 AllCops:
-  Exclude: []
+  Exclude:
+    - !ruby/regexp /db\/migrate\/(201|202[0-4])/
   StringLiteralsFrozenByDefault: true
 
 CustomCops/DontRollBackDatamigration:


### PR DESCRIPTION
Motivation: faster rubocop runs (particularly in CI).

We'll have to update this regex in future years to exclude additional years. That seems like an acceptable maintenance burden.