### PR TITLE
[ci] Extract 'tools/' tests to standalone task

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -260,7 +260,7 @@ class Test::RequirementsResolver
     Test::Tasks::RunDatabaseConsistency => proc do
       !db_schema_changed? && !diff_mentions?('database_consistency')
     end,
-    Test::Tasks::RunToolsTests => do
+    Test::Tasks::RunToolsTests => proc do
       !file_changed?(%r{^tools/}i) &&
         !file_changed?(%r{^spec/tools/}i) &&
         !diff_mentions?('rubocop')

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -61,6 +61,7 @@ class Test::RequirementsResolver
         Test::Tasks::RunImmigrant => Test::Tasks::SetupDb,
         Test::Tasks::RunRubocop => nil,
         Test::Tasks::RunUnitTests => Test::Tasks::CreateDbCopies,
+        Test::Tasks::RunToolsTests => Test::Tasks::RunUnitTests,
         Test::Tasks::RunApiControllerTests => Test::Tasks::CreateDbCopies,
         Test::Tasks::RunFileSizeChecks => Test::Tasks::CompileUserJavaScript,
         Test::Tasks::RunFeatureTestsA => [
@@ -133,6 +134,7 @@ class Test::RequirementsResolver
           Test::Tasks::RunPrettier,
           Test::Tasks::RunRubocop,
           Test::Tasks::RunStylelint,
+          Test::Tasks::RunToolsTests,
           Test::Tasks::RunTsd,
           Test::Tasks::RunTypelizer,
           Test::Tasks::RunUnitTests,
@@ -237,9 +239,9 @@ class Test::RequirementsResolver
 
   CHECK_CAN_BE_SKIPPED_CONDITIONS = {
     Test::Tasks::ConvertSchemasToTs => proc do
-      !file_changed?(%r{app/javascript/types/bootstrap/}i) &&
-        !file_changed?(%r{app/javascript/types/responses/}i) &&
-        !file_changed?(%r{spec/support/schemas/}i) &&
+      !file_changed?(%r{^app/javascript/types/bootstrap/}i) &&
+        !file_changed?(%r{^app/javascript/types/responses/}i) &&
+        !file_changed?(%r{^spec/support/schemas/}i) &&
         !file_changed?('tools/json_schemas_to_typescript.rb') &&
         !diff_mentions?('quicktype')
     end,
@@ -257,6 +259,11 @@ class Test::RequirementsResolver
     end,
     Test::Tasks::RunDatabaseConsistency => proc do
       !db_schema_changed? && !diff_mentions?('database_consistency')
+    end,
+    Test::Tasks::RunToolsTests => do
+      !file_changed?(%r{^tools/}i) &&
+        !file_changed?(%r{^spec/tools/}i) &&
+        !diff_mentions?('rubocop')
     end,
     Test::Tasks::RunTsd => proc do
       !file_changed?('app/javascript/types/index.ts') &&

--- a/lib/test/tasks/run_tools_tests.rb
+++ b/lib/test/tasks/run_tools_tests.rb
@@ -2,7 +2,7 @@ class Test::Tasks::RunToolsTests < Pallets::Task
   include Test::TaskHelpers
 
   def run
-    execute_rspec_command(<<~'COMMAND')
+    execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_unit
       SPEC_GROUP=tools
       bin/rspec

--- a/lib/test/tasks/run_tools_tests.rb
+++ b/lib/test/tasks/run_tools_tests.rb
@@ -1,0 +1,13 @@
+class Test::Tasks::RunToolsTests < Pallets::Task
+  include Test::TaskHelpers
+
+  def run
+    execute_rspec_command(<<~'COMMAND')
+      DB_SUFFIX=_unit
+      SPEC_GROUP=tools
+      bin/rspec
+      spec/tools/
+      --format RSpec::Instafail --format progress --force-color
+    COMMAND
+  end
+end

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -4,13 +4,14 @@ class Test::Tasks::RunUnitTests < Pallets::Task
   def run
     # Run all tests in `spec/` _except_ those in
     # `spec/{controllers,helpers,requests}/` (which will we run by
-    # RunApiControllerTests and RunHtmlControllerTests) and `spec/features/`
-    # (which will be run by RunFeatureTests).
+    # RunApiControllerTests and RunHtmlControllerTests), `spec/tools/` (which
+    # will be run by RunToolsTests), and `spec/features/` (which will be run by
+    # RunFeatureTests).
     execute_rspec_command(<<~'COMMAND')
       DB_SUFFIX=_unit
       bin/rspec
       $(ls -d spec/*/ |
-        grep --extended-regex -v 'spec/(controllers|features|helpers|requests)(/|$)' |
+        grep --extended-regex -v 'spec/(controllers|features|helpers|requests|tools)(/|$)' |
         tr '\n' ' ')
       --format RSpec::Instafail --format progress --force-color
     COMMAND

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,10 +17,10 @@ SimpleCov.start do
   capybara_server_port = ENV.fetch('CAPYBARA_SERVER_PORT', nil)
   # rubocop:disable Rails/Present -- At this point, we have not yet loaded Rails.
   if !db_suffix.nil? && !db_suffix.empty?
-    command_name(<<~COMMAND_NAME.squish)
-      Tests on DB #{db_suffix} w/ Capybara port #{capybara_server_port.inspect}
-      (spec group: #{spec_group.inspect})
-    COMMAND_NAME
+    command_name(
+      "Tests on DB #{db_suffix} w/ Capybara port #{capybara_server_port.inspect} " \
+      "(spec group: #{spec_group.inspect})",
+    )
   end
   # rubocop:enable Rails/Present
   add_filter(%r{^/spec/})

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,10 +13,14 @@ require 'simplecov'
 SimpleCov.coverage_dir('tmp/simple_cov') # must match codecov-action directory option
 SimpleCov.start do
   db_suffix = ENV.fetch('DB_SUFFIX', nil)
+  spec_group = ENV.fetch('SPEC_GROUP', nil)
   capybara_server_port = ENV.fetch('CAPYBARA_SERVER_PORT', nil)
   # rubocop:disable Rails/Present -- At this point, we have not yet loaded Rails.
   if !db_suffix.nil? && !db_suffix.empty?
-    command_name("Tests on DB #{db_suffix} w/ Capybara port #{capybara_server_port.inspect}")
+    command_name(<<~COMMAND_NAME.squish)
+      Tests on DB #{db_suffix} w/ Capybara port #{capybara_server_port.inspect}
+      (spec group: #{spec_group.inspect})
+    COMMAND_NAME
   end
   # rubocop:enable Rails/Present
   add_filter(%r{^/spec/})


### PR DESCRIPTION
Requiring the rubocop rspec stuff seems to immensely slow down the whole test suite. Let's isolate that and only run those tests when needed.