### PR TITLE
[BrowserLogger] Remove Rainbow refinement

### DIFF
--- a/spec/support/cuprite/browser_logger.rb
+++ b/spec/support/cuprite/browser_logger.rb
@@ -1,7 +1,3 @@
-require 'rainbow/refinement'
-
-using Rainbow
-
 class Cuprite::BrowserLogger
   JSON_EXTRACTION_REGEX = /\A\s*[▶◀]\s+\d+\.\d+ ({.*})\n?\z/
   LOG_MESSAGES_TO_IGNORE = [
@@ -60,7 +56,7 @@ class Cuprite::BrowserLogger
             "#{path ? "app/javascript/#{path}" : url}"
         end
 
-      $stdout.puts("JavaScript error: #{exception_message}".red)
+      $stdout.puts(Rainbow("JavaScript error: #{exception_message}").red)
       $stdout.puts(formatted_stack_trace)
 
       self.class.javascript_errors << exception_message


### PR DESCRIPTION
According to Vernier, this takes a non-trivial amount of time (4.7% of the total time to run API controller specs)? This is particularly wasteful, since API controller specs don't even use the BrowserLogger, anyway.

![image](https://github.com/user-attachments/assets/99e3f1cb-72b4-4515-922b-b093d5ae6676)