### PR TITLE
[prune-docker-and-rebuild] Provide required RAILS_ENV env var

### DIFF
--- a/bin/build-docker
+++ b/bin/build-docker
@@ -2,11 +2,13 @@
 
 # This script builds a Docker image of our Rails app with the specified Rails env.
 #
+# Required: RAILS_ENV env var.
+#
 # Example: build for development
-#   bin/build-docker development
+#   RAILS_ENV=development bin/build-docker
 #
 # Example: build for production
-#   bin/build-docker production
+#   RAILS_ENV=production bin/build-docker
 
 set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
 

--- a/bin/server/prune-docker-and-rebuild.sh
+++ b/bin/server/prune-docker-and-rebuild.sh
@@ -9,4 +9,4 @@ cd /root/david_runger
 docker system prune --all --force
 
 # Rebuild Docker image(s).
-bin/build-docker production
+RAILS_ENV=production bin/build-docker


### PR DESCRIPTION
Also, update documentation and examples in `bin/build-docker`.

Without this, `bin/server/prune-docker-and-rebuild.sh` fails:

```
#11 [base 6/7] RUN test -n ""
#11 ERROR: process "/bin/sh -c test -n \"$RAILS_ENV\"" did not complete successfully: exit code: 1
------
 > [base 6/7] RUN test -n "":
------
failed to solve: process "/bin/sh -c test -n \"$RAILS_ENV\"" did not complete successfully: exit code: 1
exit status 1
```