### PR TITLE
Install rspec-sidekiq from GitHub

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -106,7 +106,8 @@ group :test do
   gem 'rspec-instafail', require: false
   gem 'rspec-rails'
   gem 'rspec-retry'
-  gem 'rspec-sidekiq'
+  # Install from RubyGems once released with https://github.com/wspurgin/rspec-sidekiq/pull/233 .
+  gem 'rspec-sidekiq', github: 'wspurgin/rspec-sidekiq'
   gem 'rspec-wait'
   gem 'shoulda-matchers'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,16 @@ GIT
     typelizer (0.3.0)
       railties (>= 6.0.0)
 
+GIT
+  remote: https://github.com/wspurgin/rspec-sidekiq.git
+  revision: eb8705bf30bceb5dea24489b183984bee320781d
+  specs:
+    rspec-sidekiq (5.0.0)
+      rspec-core (~> 3.0)
+      rspec-expectations (~> 3.0)
+      rspec-mocks (~> 3.0)
+      sidekiq (>= 5, < 9)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -571,11 +581,6 @@ GEM
       rspec-support (~> 3.13)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
-    rspec-sidekiq (5.0.0)
-      rspec-core (~> 3.0)
-      rspec-expectations (~> 3.0)
-      rspec-mocks (~> 3.0)
-      sidekiq (>= 5, < 8)
     rspec-support (3.13.2)
     rspec-wait (1.0.1)
       rspec (>= 3.4)
@@ -807,7 +812,7 @@ DEPENDENCIES
   rspec-instafail
   rspec-rails
   rspec-retry
-  rspec-sidekiq
+  rspec-sidekiq!
   rspec-wait
   rubocop
   rubocop-capybara
@@ -1048,7 +1053,7 @@ CHECKSUMS
   rspec-mocks (3.13.2) sha256=2327335def0e1665325a9b617e3af9ae20272741d80ac550336309a7c59abdef
   rspec-rails (7.1.1) sha256=e15dccabed211e2fd92f21330c819adcbeb1591c1d66c580d8f2d8288557e331
   rspec-retry (0.6.2) sha256=6101ba23a38809811ae3484acde4ab481c54d846ac66d5037ccb40131a60d858
-  rspec-sidekiq (5.0.0) sha256=bd5d0958a9b6270ef4a3dd172cb2b064e572ccc97f93212b90fd1ad8d8884b23
+  rspec-sidekiq (5.0.0)
   rspec-support (3.13.2) sha256=cea3a2463fd9b84b9dcc9685efd80ea701aa8f7b3decb3b3ce795ed67737dbec
   rspec-wait (1.0.1) sha256=50ce9cc7cd20b8bb67b95a4ed56b59a16d4af7e86ae91b28dbf20eeaa2481d1f
   rubocop (1.73.2) sha256=35cd1b1365ba97234323fe771abcecd09c9b77098464cd726c76aa7d9bc12b5d


### PR DESCRIPTION
The GitHub version includes a PR that will allow upgrading to Sidekiq 8. I will trigger that update via Dependabot, so that the PR includes the Changelog and links and whatnot.