### PR TITLE
[GitHub Action] Configure database to be fast for tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -85,6 +85,16 @@ jobs:
       - name: Ensure clean git status
         run: '! [[ -n $(git status --porcelain) ]] || (git status && false)'
 
+      - name: Configure database to be fast for tests
+        run: |
+          function set() {
+            docker exec ${{ job.services.postgres.id }} sh -c "echo $1=\'$2\' >> $PGDATADIR/postgresql.conf"
+          }
+          set fsync off
+          set full_page_writes off
+          set synchronous_commit off
+          docker kill --signal=SIGHUP ${{ job.services.postgres.id }}
+
       - name: Run tests & linters
         run: bin/run-tests
         env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Configure database for speed over reliability
         run: |
           export PGPASSWORD=postgres
-          psql -U postgres -c "ALTER SYSTEM SET fsync=off;"
-          psql -U postgres -c "ALTER SYSTEM SET full_page_writes=off;"
-          psql -U postgres -c "ALTER SYSTEM SET synchronous_commit=off;"
-          psql -U postgres -c "SELECT pg_reload_conf();"
+          psql -h 127.0.0.1 -c "ALTER SYSTEM SET fsync=off;"
+          psql -h 127.0.0.1 -c "ALTER SYSTEM SET full_page_writes=off;"
+          psql -h 127.0.0.1 -c "ALTER SYSTEM SET synchronous_commit=off;"
+          psql -h 127.0.0.1 -c "SELECT pg_reload_conf();"
 
       - uses: actions/checkout@v4
         with:
@@ -96,9 +96,9 @@ jobs:
       - name: Confirm that database is fast for tests
         run: |
           export PGPASSWORD=postgres
-          psql -U postgres -c "SHOW fsync;"
-          psql -U postgres -c "SHOW synchronous_commit;"
-          psql -U postgres -c "SHOW full_page_writes;"
+          psql -h 127.0.0.1 -c "SHOW fsync;"
+          psql -h 127.0.0.1 -c "SHOW synchronous_commit;"
+          psql -h 127.0.0.1 -c "SHOW full_page_writes;"
 
       - name: Run tests & linters
         run: bin/run-tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -48,8 +48,8 @@ jobs:
           psql -c "ALTER SYSTEM SET synchronous_commit=off;"
           psql -c "SELECT pg_reload_conf();"
         env:
-          POSTGRES_HOST: 127.0.0.1
-          POSTGRES_USER: postgres
+          PGHOST: 127.0.0.1
+          PGUSER: postgres
           PGPASSWORD: postgres
 
       - uses: actions/checkout@v4
@@ -102,8 +102,8 @@ jobs:
           psql -c "SHOW synchronous_commit;"
           psql -c "SHOW full_page_writes;"
         env:
-          POSTGRES_HOST: 127.0.0.1
-          POSTGRES_USER: postgres
+          PGHOST: 127.0.0.1
+          PGUSER: postgres
           PGPASSWORD: postgres
 
       - name: Run tests & linters

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,6 +41,20 @@ jobs:
         ports:
           - 6379:6379 # Maps port 6379 on service container to the host
     steps:
+      - name: Configure database to be fast for tests
+        run: |
+          function set() {
+            docker exec ${{ job.services.postgres.id }} sh -c "echo $1=\'$2\' >> $PGDATADIR/postgresql.conf"
+          }
+          export PGPASSWORD=postgres
+          psql -U postgres -h 127.0.0.1 -c "SHOW fsync;"
+          psql -U postgres -h 127.0.0.1 -c "SHOW synchronous_commit;"
+          psql -U postgres -h 127.0.0.1 -c "SHOW full_page_writes;"
+          set fsync off
+          set full_page_writes off
+          set synchronous_commit off
+          docker kill --signal=SIGHUP ${{ job.services.postgres.id }}
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10 # this might cause issues if there are more than 10 commits in a PR (?)
@@ -85,19 +99,9 @@ jobs:
       - name: Ensure clean git status
         run: '! [[ -n $(git status --porcelain) ]] || (git status && false)'
 
-      - name: Configure database to be fast for tests
+      - name: Confirm that database is fast for tests
         run: |
-          function set() {
-            docker exec ${{ job.services.postgres.id }} sh -c "echo $1=\'$2\' >> $PGDATADIR/postgresql.conf"
-          }
           export PGPASSWORD=postgres
-          psql -U postgres -h 127.0.0.1 -c "SHOW fsync;"
-          psql -U postgres -h 127.0.0.1 -c "SHOW synchronous_commit;"
-          psql -U postgres -h 127.0.0.1 -c "SHOW full_page_writes;"
-          set fsync off
-          set full_page_writes off
-          set synchronous_commit off
-          docker kill --signal=SIGHUP ${{ job.services.postgres.id }}
           psql -U postgres -h 127.0.0.1 -c "SHOW fsync;"
           psql -U postgres -h 127.0.0.1 -c "SHOW synchronous_commit;"
           psql -U postgres -h 127.0.0.1 -c "SHOW full_page_writes;"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -53,7 +53,7 @@ jobs:
           set fsync off
           set full_page_writes off
           set synchronous_commit off
-          docker kill --signal=SIGHUP ${{ job.services.postgres.id }}
+          psql -U postgres -h 127.0.0.1 -c "SELECT pg_reload_conf();"
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,7 +41,7 @@ jobs:
         ports:
           - 6379:6379 # Maps port 6379 on service container to the host
     steps:
-      - name: Configure database for speed over reliability
+      - name: Configure Postgres for speed over reliability
         run: |
           psql -c "ALTER SYSTEM SET fsync=off;"
           psql -c "ALTER SYSTEM SET full_page_writes=off;"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -41,7 +41,7 @@ jobs:
         ports:
           - 6379:6379 # Maps port 6379 on service container to the host
     steps:
-      - name: Configure database to be fast for tests
+      - name: Configure database for speed over reliability
         run: |
           export PGPASSWORD=postgres
           psql -U postgres -c "ALTER SYSTEM SET fsync=off;"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -44,10 +44,10 @@ jobs:
       - name: Configure database to be fast for tests
         run: |
           export PGPASSWORD=postgres
-          psql -U postgres -h 127.0.0.1 -c "ALTER SYSTEM SET fsync=off;"
-          psql -U postgres -h 127.0.0.1 -c "ALTER SYSTEM SET full_page_writes=off;"
-          psql -U postgres -h 127.0.0.1 -c "ALTER SYSTEM SET synchronous_commit=off;"
-          psql -U postgres -h 127.0.0.1 -c "SELECT pg_reload_conf();"
+          psql -U postgres -c "ALTER SYSTEM SET fsync=off;"
+          psql -U postgres -c "ALTER SYSTEM SET full_page_writes=off;"
+          psql -U postgres -c "ALTER SYSTEM SET synchronous_commit=off;"
+          psql -U postgres -c "SELECT pg_reload_conf();"
 
       - uses: actions/checkout@v4
         with:
@@ -96,9 +96,9 @@ jobs:
       - name: Confirm that database is fast for tests
         run: |
           export PGPASSWORD=postgres
-          psql -U postgres -h 127.0.0.1 -c "SHOW fsync;"
-          psql -U postgres -h 127.0.0.1 -c "SHOW synchronous_commit;"
-          psql -U postgres -h 127.0.0.1 -c "SHOW full_page_writes;"
+          psql -U postgres -c "SHOW fsync;"
+          psql -U postgres -c "SHOW synchronous_commit;"
+          psql -U postgres -c "SHOW full_page_writes;"
 
       - name: Run tests & linters
         run: bin/run-tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,16 +43,7 @@ jobs:
     steps:
       - name: Configure database to be fast for tests
         run: |
-          function set() {
-            docker exec ${{ job.services.postgres.id }} sh -c "echo $1=\'$2\' >> $PGDATADIR/postgresql.conf"
-          }
           export PGPASSWORD=postgres
-          psql -U postgres -h 127.0.0.1 -c "SHOW fsync;"
-          psql -U postgres -h 127.0.0.1 -c "SHOW synchronous_commit;"
-          psql -U postgres -h 127.0.0.1 -c "SHOW full_page_writes;"
-          set fsync off
-          set full_page_writes off
-          set synchronous_commit off
           psql -U postgres -h 127.0.0.1 -c "ALTER SYSTEM SET fsync=off;"
           psql -U postgres -h 127.0.0.1 -c "ALTER SYSTEM SET full_page_writes=off;"
           psql -U postgres -h 127.0.0.1 -c "ALTER SYSTEM SET synchronous_commit=off;"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -96,16 +96,6 @@ jobs:
       - name: Ensure clean git status
         run: '! [[ -n $(git status --porcelain) ]] || (git status && false)'
 
-      - name: Confirm that database is fast for tests
-        run: |
-          psql -c "SHOW fsync;"
-          psql -c "SHOW synchronous_commit;"
-          psql -c "SHOW full_page_writes;"
-        env:
-          PGHOST: 127.0.0.1
-          PGUSER: postgres
-          PGPASSWORD: postgres
-
       - name: Run tests & linters
         run: bin/run-tests
         env:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -53,6 +53,9 @@ jobs:
           set fsync off
           set full_page_writes off
           set synchronous_commit off
+          psql -U postgres -h 127.0.0.1 -c "ALTER SYSTEM SET fsync=off;"
+          psql -U postgres -h 127.0.0.1 -c "ALTER SYSTEM SET full_page_writes=off;"
+          psql -U postgres -h 127.0.0.1 -c "ALTER SYSTEM SET synchronous_commit=off;"
           psql -U postgres -h 127.0.0.1 -c "SELECT pg_reload_conf();"
 
       - uses: actions/checkout@v4

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -43,11 +43,14 @@ jobs:
     steps:
       - name: Configure database for speed over reliability
         run: |
-          export PGPASSWORD=postgres
-          psql -h 127.0.0.1 -c "ALTER SYSTEM SET fsync=off;"
-          psql -h 127.0.0.1 -c "ALTER SYSTEM SET full_page_writes=off;"
-          psql -h 127.0.0.1 -c "ALTER SYSTEM SET synchronous_commit=off;"
-          psql -h 127.0.0.1 -c "SELECT pg_reload_conf();"
+          psql -c "ALTER SYSTEM SET fsync=off;"
+          psql -c "ALTER SYSTEM SET full_page_writes=off;"
+          psql -c "ALTER SYSTEM SET synchronous_commit=off;"
+          psql -c "SELECT pg_reload_conf();"
+        env:
+          POSTGRES_HOST: 127.0.0.1
+          POSTGRES_USER: postgres
+          PGPASSWORD: postgres
 
       - uses: actions/checkout@v4
         with:
@@ -95,10 +98,13 @@ jobs:
 
       - name: Confirm that database is fast for tests
         run: |
-          export PGPASSWORD=postgres
-          psql -h 127.0.0.1 -c "SHOW fsync;"
-          psql -h 127.0.0.1 -c "SHOW synchronous_commit;"
-          psql -h 127.0.0.1 -c "SHOW full_page_writes;"
+          psql -c "SHOW fsync;"
+          psql -c "SHOW synchronous_commit;"
+          psql -c "SHOW full_page_writes;"
+        env:
+          POSTGRES_HOST: 127.0.0.1
+          POSTGRES_USER: postgres
+          PGPASSWORD: postgres
 
       - name: Run tests & linters
         run: bin/run-tests

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -90,6 +90,7 @@ jobs:
           function set() {
             docker exec ${{ job.services.postgres.id }} sh -c "echo $1=\'$2\' >> $PGDATADIR/postgresql.conf"
           }
+          export PGPASSWORD=postgres
           psql -U postgres -h 127.0.0.1 -c "SHOW fsync;"
           psql -U postgres -h 127.0.0.1 -c "SHOW synchronous_commit;"
           psql -U postgres -h 127.0.0.1 -c "SHOW full_page_writes;"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -90,10 +90,16 @@ jobs:
           function set() {
             docker exec ${{ job.services.postgres.id }} sh -c "echo $1=\'$2\' >> $PGDATADIR/postgresql.conf"
           }
+          psql -U postgres -h 127.0.0.1 -c "SHOW fsync;"
+          psql -U postgres -h 127.0.0.1 -c "SHOW synchronous_commit;"
+          psql -U postgres -h 127.0.0.1 -c "SHOW full_page_writes;"
           set fsync off
           set full_page_writes off
           set synchronous_commit off
           docker kill --signal=SIGHUP ${{ job.services.postgres.id }}
+          psql -U postgres -h 127.0.0.1 -c "SHOW fsync;"
+          psql -U postgres -h 127.0.0.1 -c "SHOW synchronous_commit;"
+          psql -U postgres -h 127.0.0.1 -c "SHOW full_page_writes;"
 
       - name: Run tests & linters
         run: bin/run-tests


### PR DESCRIPTION
It's hard to be sure whether this is having much of an effect, but it seems fairly unlikely to hurt anything, and it will probably help at least somewhat (and maybe significantly), so let's try it.

Private convo: https://x.com/i/grok?conversation=1898060880509637048

---

Based on common PostgreSQL performance tuning practices and the context of test environments, it’s likely that GitLab adjusts certain PostgreSQL settings in test mode to make their tests run faster. In test environments, where data durability is less critical than speed, settings that reduce disk I/O are often modified to optimize performance. Here are the PostgreSQL settings that GitLab most likely changes:

- `fsync=off`: This setting disables the forced synchronization of data to disk, which speeds up write operations by reducing the number of times PostgreSQL waits for the operating system to confirm that data has been written. While this sacrifices data integrity in the event of a crash, that’s typically acceptable in a test environment where data is disposable.
- `synchronous_commit=off`: When set to `off`, this allows transactions to be considered committed without waiting for the Write-Ahead Log (WAL) to be written to disk. This reduces the overhead of disk operations, further accelerating test execution.
- `full_page_writes=off`: Disabling this setting minimizes the amount of data written to the WAL by preventing full page images from being logged during writes. This can improve performance by lowering the logging overhead, though it increases the risk of data corruption in a crash—again, a trade-off that’s tolerable in testing.

These adjustments are particularly effective in test mode, such as in GitLab’s CI/CD pipelines, where databases are often recreated for each test run, making data durability a non-issue. To implement these changes, GitLab would need to configure them at the server level, either by modifying the `postgresql.conf` file or by passing command-line options when starting the PostgreSQL server, as these parameters cannot be altered after the database is initialized.

In summary, GitLab likely sets `fsync=off`, `synchronous_commit=off`, and `full_page_writes=off` in their PostgreSQL configuration for test mode to reduce disk I/O and make their tests run faster.