### PR TITLE
[spec/features/logs] Add 200 ms sleep before downloading CSV [LOG-38]

### DIFF
--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -198,6 +198,8 @@ RSpec.describe 'Logs app' do
         it 'allows the user to download a CSV with the log data' do
           visit(log_path(slug: log.slug))
 
+          # Give some time for the download link to be fully set up.
+          sleep(0.2)
           click_on('Download CSV')
 
           csv = CSV.read(downloaded_file_path('*.csv'), headers: true)


### PR DESCRIPTION
Hopefully this will fix some flakiness that we have seen in this spec (both in CI and locally).

On my machine, this was flaking about 3% of the time before this change. With this change, I ran the spec 200 times and didn't get a failure.

The feature spec server logs added in #6003 were really helpful, because they showed that no request to download the logs is reaching the server when the spec fails, which focused the possible causes of the flakiness and the possible fixes to try.