### PR TITLE
[prettierignore] Remove '/.rubocop.yml'

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-/.rubocop.yml
 /app/javascript/rails_assets/
 /app/javascript/types/bootstrap/
 /app/javascript/types/responses/


### PR DESCRIPTION
We were ignoring it before because Prettier couldn't parse it because we had ERB in it, but we removed the ERB in #6334 . So, this change makes it so that Prettier can now format `.rubocop.yml`, by removing `/.rubocop.yml` from the `.prettierignore` file.