### PR TITLE
[lograge] Stop suppressing HealthChecksController#index logs

### DIFF
--- a/config/initializers/lograge.rb
+++ b/config/initializers/lograge.rb
@@ -6,5 +6,4 @@ Rails.application.configure do
   config.lograge.enabled = true
   config.lograge.custom_options = ->(event) { Logs::LogBuilder.new(event).extra_logged_data }
   config.lograge.formatter = ->(data) { Logs::LogFormatter.new(data).call }
-  config.lograge.ignore_actions = ['HealthChecksController#index']
 end


### PR DESCRIPTION
When we initially added the HealthChecksController#index endpoint, the Docker Compose healthcheck was hitting it every 10 seconds, which would have been a lot of low value logs.

However, the health check is now done only every 5 minutes, which I think is not excessive to log.

Grafana seems to suggest that request to this endpoint stopped earlier this morning, and I don't know why that would be. I want to see whether or not that is corroborated by logs (or lack thereof), or whether this is possibly some sampling or other quirk of Grafana (though that seems unlikely?).

![image](https://github.com/user-attachments/assets/582b055a-0572-49df-a556-063fe7df1383)