### PR TITLE
Source rspec-sidekiq from RubyGems again

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,8 +107,7 @@ group :test do
   gem 'rspec-instafail', require: false
   gem 'rspec-rails'
   gem 'rspec-retry'
-  # Install from RubyGems once released with https://github.com/wspurgin/rspec-sidekiq/pull/233 .
-  gem 'rspec-sidekiq', github: 'wspurgin/rspec-sidekiq'
+  gem 'rspec-sidekiq'
   gem 'rspec-wait'
   gem 'shoulda-matchers'
   gem 'simplecov'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,16 +37,6 @@ GIT
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
 
-GIT
-  remote: https://github.com/wspurgin/rspec-sidekiq.git
-  revision: eb8705bf30bceb5dea24489b183984bee320781d
-  specs:
-    rspec-sidekiq (5.0.0)
-      rspec-core (~> 3.0)
-      rspec-expectations (~> 3.0)
-      rspec-mocks (~> 3.0)
-      sidekiq (>= 5, < 9)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -597,6 +587,11 @@ GEM
       rspec-support (~> 3.13)
     rspec-retry (0.6.2)
       rspec-core (> 3.3)
+    rspec-sidekiq (5.1.0)
+      rspec-core (~> 3.0)
+      rspec-expectations (~> 3.0)
+      rspec-mocks (~> 3.0)
+      sidekiq (>= 5, < 9)
     rspec-support (3.13.2)
     rspec-wait (1.0.1)
       rspec (>= 3.4)
@@ -817,7 +812,7 @@ DEPENDENCIES
   rspec-instafail
   rspec-rails
   rspec-retry
-  rspec-sidekiq!
+  rspec-sidekiq
   rspec-wait
   rubocop!
   rubocop-capybara
@@ -1058,7 +1053,7 @@ CHECKSUMS
   rspec-mocks (3.13.2) sha256=2327335def0e1665325a9b617e3af9ae20272741d80ac550336309a7c59abdef
   rspec-rails (7.1.1) sha256=e15dccabed211e2fd92f21330c819adcbeb1591c1d66c580d8f2d8288557e331
   rspec-retry (0.6.2) sha256=6101ba23a38809811ae3484acde4ab481c54d846ac66d5037ccb40131a60d858
-  rspec-sidekiq (5.0.0)
+  rspec-sidekiq (5.1.0) sha256=ed671ce4a9948ea2395db464c8c846651ea006e124f7868ee5d497f693102867
   rspec-support (3.13.2) sha256=cea3a2463fd9b84b9dcc9685efd80ea701aa8f7b3decb3b3ce795ed67737dbec
   rspec-wait (1.0.1) sha256=50ce9cc7cd20b8bb67b95a4ed56b59a16d4af7e86ae91b28dbf20eeaa2481d1f
   rubocop (1.73.2)


### PR DESCRIPTION
`bundle update rspec-sidekiq`

The PR adding Sidekiq 8 compatibility is included in the 5.1.0 release, which is now available via RubyGems.