### PR TITLE
Replace rspec-instafail formatter with built-in failures formatter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -104,7 +104,6 @@ group :test do
   gem 'pallets', github: 'davidrunger/pallets'
   gem 'percy-capybara'
   gem 'rails-controller-testing'
-  gem 'rspec-instafail', require: false
   gem 'rspec-rails'
   gem 'rspec-retry'
   gem 'rspec-sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -572,8 +572,6 @@ GEM
     rspec-expectations (3.13.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
-    rspec-instafail (1.0.0)
-      rspec
     rspec-mocks (3.13.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
@@ -809,7 +807,6 @@ DEPENDENCIES
   request_store
   request_store-sidekiq
   rollbar
-  rspec-instafail
   rspec-rails
   rspec-retry
   rspec-sidekiq
@@ -1049,7 +1046,6 @@ CHECKSUMS
   rspec (3.13.0) sha256=d490914ac1d5a5a64a0e1400c1d54ddd2a501324d703b8cfe83f458337bab993
   rspec-core (3.13.3) sha256=25136507f4f9cf2e8977a2851e64e438b4331646054e345998714108745cdfe4
   rspec-expectations (3.13.3) sha256=0e6b5af59b900147698ea0ff80456c4f2e69cac4394fbd392fbd1ca561f66c58
-  rspec-instafail (1.0.0) sha256=591f8fa73a081ef902daa6ed31bf6ca29aa754d0f5d755a659b0c786473eb05f
   rspec-mocks (3.13.2) sha256=2327335def0e1665325a9b617e3af9ae20272741d80ac550336309a7c59abdef
   rspec-rails (7.1.1) sha256=e15dccabed211e2fd92f21330c819adcbeb1591c1d66c580d8f2d8288557e331
   rspec-retry (0.6.2) sha256=6101ba23a38809811ae3484acde4ab481c54d846ac66d5037ccb40131a60d858

--- a/lib/test/task_helpers.rb
+++ b/lib/test/task_helpers.rb
@@ -172,4 +172,8 @@ module Test::TaskHelpers
       Test::Middleware::TaskResultTrackingMiddleware.job_results
     end
   end
+
+  def rspec_output_options
+    '--format failures --format progress --force-color'
+  end
 end

--- a/lib/test/tasks/run_api_controller_tests.rb
+++ b/lib/test/tasks/run_api_controller_tests.rb
@@ -6,7 +6,7 @@ class Test::Tasks::RunApiControllerTests < Pallets::Task
       DB_SUFFIX=_api
       bin/rspec
       spec/controllers/api/
-      --format failures --format progress --force-color
+      #{rspec_output_options}
     COMMAND
   end
 end

--- a/lib/test/tasks/run_api_controller_tests.rb
+++ b/lib/test/tasks/run_api_controller_tests.rb
@@ -6,7 +6,7 @@ class Test::Tasks::RunApiControllerTests < Pallets::Task
       DB_SUFFIX=_api
       bin/rspec
       spec/controllers/api/
-      --format progress --force-color
+      --format failures --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_api_controller_tests.rb
+++ b/lib/test/tasks/run_api_controller_tests.rb
@@ -6,7 +6,7 @@ class Test::Tasks::RunApiControllerTests < Pallets::Task
       DB_SUFFIX=_api
       bin/rspec
       spec/controllers/api/
-      --format RSpec::Instafail --format progress --force-color
+      --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_feature_tests_a.rb
+++ b/lib/test/tasks/run_feature_tests_a.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunFeatureTestsA < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_feature_a CAPYBARA_SERVER_PORT=3001
       bin/rspec $(cat tmp/feature_specs_a.txt)
-      --format RSpec::Instafail --format progress --force-color
+      --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_feature_tests_a.rb
+++ b/lib/test/tasks/run_feature_tests_a.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunFeatureTestsA < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_feature_a CAPYBARA_SERVER_PORT=3001
       bin/rspec $(cat tmp/feature_specs_a.txt)
-      --format failures --format progress --force-color
+      #{rspec_output_options}
     COMMAND
   end
 end

--- a/lib/test/tasks/run_feature_tests_a.rb
+++ b/lib/test/tasks/run_feature_tests_a.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunFeatureTestsA < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_feature_a CAPYBARA_SERVER_PORT=3001
       bin/rspec $(cat tmp/feature_specs_a.txt)
-      --format progress --force-color
+      --format failures --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_feature_tests_b.rb
+++ b/lib/test/tasks/run_feature_tests_b.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunFeatureTestsB < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_api CAPYBARA_SERVER_PORT=3002
       bin/rspec $(cat tmp/feature_specs_b.txt)
-      --format RSpec::Instafail --format progress --force-color
+      --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_feature_tests_b.rb
+++ b/lib/test/tasks/run_feature_tests_b.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunFeatureTestsB < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_api CAPYBARA_SERVER_PORT=3002
       bin/rspec $(cat tmp/feature_specs_b.txt)
-      --format failures --format progress --force-color
+      #{rspec_output_options}
     COMMAND
   end
 end

--- a/lib/test/tasks/run_feature_tests_b.rb
+++ b/lib/test/tasks/run_feature_tests_b.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunFeatureTestsB < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_api CAPYBARA_SERVER_PORT=3002
       bin/rspec $(cat tmp/feature_specs_b.txt)
-      --format progress --force-color
+      --format failures --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_feature_tests_c.rb
+++ b/lib/test/tasks/run_feature_tests_c.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunFeatureTestsC < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_feature_c CAPYBARA_SERVER_PORT=3003
       bin/rspec $(cat tmp/feature_specs_c.txt)
-      --format RSpec::Instafail --format progress --force-color
+      --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_feature_tests_c.rb
+++ b/lib/test/tasks/run_feature_tests_c.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunFeatureTestsC < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_feature_c CAPYBARA_SERVER_PORT=3003
       bin/rspec $(cat tmp/feature_specs_c.txt)
-      --format progress --force-color
+      --format failures --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_feature_tests_c.rb
+++ b/lib/test/tasks/run_feature_tests_c.rb
@@ -5,7 +5,7 @@ class Test::Tasks::RunFeatureTestsC < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_feature_c CAPYBARA_SERVER_PORT=3003
       bin/rspec $(cat tmp/feature_specs_c.txt)
-      --format failures --format progress --force-color
+      #{rspec_output_options}
     COMMAND
   end
 end

--- a/lib/test/tasks/run_html_controller_tests.rb
+++ b/lib/test/tasks/run_html_controller_tests.rb
@@ -11,7 +11,7 @@ class Test::Tasks::RunHtmlControllerTests < Pallets::Task
       $(ls spec/helpers/*.rb)
       $(ls spec/requests/**/*.rb)
       $(ls spec/requests/*.rb)
-      --format progress --force-color
+      --format failures --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_html_controller_tests.rb
+++ b/lib/test/tasks/run_html_controller_tests.rb
@@ -11,7 +11,7 @@ class Test::Tasks::RunHtmlControllerTests < Pallets::Task
       $(ls spec/helpers/*.rb)
       $(ls spec/requests/**/*.rb)
       $(ls spec/requests/*.rb)
-      --format RSpec::Instafail --format progress --force-color
+      --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_html_controller_tests.rb
+++ b/lib/test/tasks/run_html_controller_tests.rb
@@ -11,7 +11,7 @@ class Test::Tasks::RunHtmlControllerTests < Pallets::Task
       $(ls spec/helpers/*.rb)
       $(ls spec/requests/**/*.rb)
       $(ls spec/requests/*.rb)
-      --format failures --format progress --force-color
+      #{rspec_output_options}
     COMMAND
   end
 end

--- a/lib/test/tasks/run_tools_tests.rb
+++ b/lib/test/tasks/run_tools_tests.rb
@@ -7,7 +7,7 @@ class Test::Tasks::RunToolsTests < Pallets::Task
       SPEC_GROUP=tools
       bin/rspec
       spec/tools/
-      --format progress --force-color
+      --format failures --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_tools_tests.rb
+++ b/lib/test/tasks/run_tools_tests.rb
@@ -7,7 +7,7 @@ class Test::Tasks::RunToolsTests < Pallets::Task
       SPEC_GROUP=tools
       bin/rspec
       spec/tools/
-      --format RSpec::Instafail --format progress --force-color
+      --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_tools_tests.rb
+++ b/lib/test/tasks/run_tools_tests.rb
@@ -7,7 +7,7 @@ class Test::Tasks::RunToolsTests < Pallets::Task
       SPEC_GROUP=tools
       bin/rspec
       spec/tools/
-      --format failures --format progress --force-color
+      #{rspec_output_options}
     COMMAND
   end
 end

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -13,7 +13,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
       $(ls -d spec/*/ |
         grep --extended-regex -v 'spec/(controllers|features|helpers|requests|tools)(/|$)' |
         tr '\n' ' ')
-      --format RSpec::Instafail --format progress --force-color
+      --format progress --force-color
     COMMAND
   end
 end

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -13,7 +13,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
       $(ls -d spec/*/ |
         grep --extended-regex -v 'spec/(controllers|features|helpers|requests|tools)(/|$)' |
         tr '\n' ' ')
-      --format failures --format progress --force-color
+      #{rspec_output_options}
     COMMAND
   end
 end

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -13,7 +13,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
       $(ls -d spec/*/ |
         grep --extended-regex -v 'spec/(controllers|features|helpers|requests|tools)(/|$)' |
         tr '\n' ' ')
-      --format progress --force-color
+      --format failures --format progress --force-color
     COMMAND
   end
 end

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'Groceries app' do
 
           # Make sure that the new store is added to the list.
           within('aside') do
-            expect(page).to have_text(unique_new_store_name)
+            expect(page).to have_text('this will fail')
           end
         end
       end

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe 'Groceries app' do
 
           # Make sure that the new store is added to the list.
           within('aside') do
-            expect(page).to have_text('this will fail')
+            expect(page).to have_text(unique_new_store_name)
           end
         end
       end


### PR DESCRIPTION
Don't we nowadays [buffer all of the stdout](https://github.com/davidrunger/david_runger/blob/1d380df8d824d8e8f137c1f4e26274a2c9611a42/lib/test/task_helpers.rb#L23-L30) until each rspec test suite completes, anyway, thereby defeating the whole purpose of this formatter? The result is just that each failure gets printed twice, which is not very helpful.

This change replaces the rspec-instafail formatter with the built-in failure formatter. This way, when there is a failure, concise info about the failure is printed (file, line, description), but no more. The advantage of printing a little info is that it makes it clear which spec the failure screenshot(s) are for.

![image](https://github.com/user-attachments/assets/88b431fc-e692-40c5-8c77-78dbdea3c9d9)