### PR TITLE
Only include spec-related rulesets when linting 'spec/'

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,12 +1,8 @@
 inherit_gem:
   runger_style:
-    - rulesets/capybara.yml
     - rulesets/default.yml
-    - rulesets/factory_bot.yml
     - rulesets/performance.yml
     - rulesets/rails.yml
-    - rulesets/rspec_rails.yml
-    - rulesets/rspec.yml
 
 require:
   - ./tools/custom_cops/require_all_custom_cops.rb
@@ -15,6 +11,7 @@ AllCops:
   Exclude:
     - !ruby/regexp /db\/migrate\/(201|202[0-4])/
   StringLiteralsFrozenByDefault: true
+  SuggestExtensions: false
 
 CustomCops/DontRollBackDatamigration:
   Include:

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,0 +1,8 @@
+inherit_from: ../.rubocop.yml
+
+inherit_gem:
+  runger_style:
+    - rulesets/capybara.yml
+    - rulesets/factory_bot.yml
+    - rulesets/rspec_rails.yml
+    - rulesets/rspec.yml


### PR DESCRIPTION
I'm hoping that this might improve performance a little bit? Even if it doesn't, it still feels like a good idea, so that we don't have cops that are only relevant to specs also linting non-spec code.