### PR TITLE
Add MarriageMembership model (not foreign keys on marriage) [DEV-208]

### DIFF
--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -7,6 +7,10 @@ class MyAccountController < ApplicationController
         :auth_tokens,
         :need_satisfaction_ratings,
         logs: [:log_shares, { log_entries: :log_entry_datum }],
+        marriage: {
+          check_ins: %i[check_in_submissions need_satisfaction_ratings],
+          emotional_needs: :need_satisfaction_ratings,
+        },
         quiz_participations: %i[quiz_question_answer_selections],
         quizzes: {
           participations: :quiz_question_answer_selections,

--- a/app/models/marriage.rb
+++ b/app/models/marriage.rb
@@ -18,6 +18,7 @@ class Marriage < ApplicationRecord
   belongs_to :partner_2, class_name: 'User', optional: true
   has_many :check_ins, dependent: :destroy
   has_many :emotional_needs, dependent: :destroy
+  has_many :memberships, dependent: :destroy, class_name: 'MarriageMembership'
 
   has_paper_trail
 

--- a/app/models/marriage_membership.rb
+++ b/app/models/marriage_membership.rb
@@ -1,0 +1,21 @@
+# == Schema Information
+#
+# Table name: marriage_memberships
+#
+#  created_at  :datetime         not null
+#  id          :bigint           not null, primary key
+#  marriage_id :bigint           not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint           not null
+#
+# Indexes
+#
+#  index_marriage_memberships_on_marriage_id  (marriage_id)
+#  index_marriage_memberships_on_user_id      (user_id) UNIQUE
+#
+class MarriageMembership < ApplicationRecord
+  belongs_to :marriage
+  belongs_to :user
+
+  validates :user_id, uniqueness: true
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,6 +40,8 @@ class User < ApplicationRecord
   has_many :ci_step_results, dependent: :destroy
   has_many :comments, dependent: :nullify
 
+  has_one :marriage_membership, dependent: :destroy
+
   JsonPreference::Types.constants.each do |constant_name|
     scope_name = JsonPreference::Types.const_get(constant_name).to_sym
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,7 @@ class User < ApplicationRecord
   has_many :comments, dependent: :nullify
 
   has_one :marriage_membership, dependent: :destroy
+  has_one :marriage, through: :marriage_membership
 
   JsonPreference::Types.constants.each do |constant_name|
     scope_name = JsonPreference::Types.const_get(constant_name).to_sym

--- a/db/datamigrate/20250312024453_migrate_marriages_to_marriage_memberships.rb
+++ b/db/datamigrate/20250312024453_migrate_marriages_to_marriage_memberships.rb
@@ -1,0 +1,28 @@
+class MigrateMarriagesToMarriageMemberships < Datamigration::Base
+  def run
+    within_transaction do
+      Marriage.find_each do |marriage|
+        if (partner_1 = marriage.partner_1)
+          log("Adding #{partner_1.email} to #{marriage.class_id_string}.")
+          marriage.memberships.create!(
+            user: partner_1,
+            created_at: marriage.created_at,
+          )
+        end
+
+        if (partner_2 = marriage.partner_2)
+          log("Adding #{partner_2.email} to #{marriage.class_id_string}.")
+          marriage.memberships.create!(
+            user: partner_2,
+            # Partner 2 might not actually have joined at the marriage's
+            # updated_at timestamp, but it's our best available guess, and it
+            # is probably usually accurate.
+            created_at: marriage.updated_at,
+          )
+        end
+      end
+    end
+  end
+end
+
+Datamigration::Runner.new(MigrateMarriagesToMarriageMemberships).run

--- a/db/migrate/20250312024221_create_marriage_memberships.rb
+++ b/db/migrate/20250312024221_create_marriage_memberships.rb
@@ -1,0 +1,12 @@
+class CreateMarriageMemberships < ActiveRecord::Migration[8.0]
+  def change
+    create_table :marriage_memberships do |t|
+      t.references :marriage, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true, index: false
+
+      t.timestamps
+    end
+
+    add_index :marriage_memberships, :user_id, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_06_184730) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_12_024221) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -310,6 +310,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_06_184730) do
     t.index ["user_id", "slug"], name: "index_logs_on_user_id_and_slug", unique: true
   end
 
+  create_table "marriage_memberships", force: :cascade do |t|
+    t.bigint "marriage_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["marriage_id"], name: "index_marriage_memberships_on_marriage_id"
+    t.index ["user_id"], name: "index_marriage_memberships_on_user_id", unique: true
+  end
+
   create_table "marriages", force: :cascade do |t|
     t.bigint "partner_1_id", null: false
     t.bigint "partner_2_id"
@@ -494,6 +503,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_06_184730) do
   add_foreign_key "log_entries", "logs"
   add_foreign_key "log_shares", "logs"
   add_foreign_key "logs", "users"
+  add_foreign_key "marriage_memberships", "marriages"
+  add_foreign_key "marriage_memberships", "users"
   add_foreign_key "marriages", "users", column: "partner_1_id"
   add_foreign_key "marriages", "users", column: "partner_2_id"
   add_foreign_key "need_satisfaction_ratings", "check_ins"


### PR DESCRIPTION
Motivation: this allows us to define User#marriage as a proper Rails association (which we can eager load), rather than defining it as an instance method on User (which we cannot eager load). This will allow us to get rid (in a future PR) of hacks such as [this][1].

[1]: https://github.com/davidrunger/david_runger/blob/f99333e0b247f83dd4f23a6739f47e122b890662/app/models/user.rb#L57-L69

I think that this data model is also a little bit more elegant, robust, and versatile. It feels right. As one example, it allows us to more confidently/accurately track when the second partner joined the marriage (which currently we could only guess to maybe/probably be Marriage#updated_at). It's also more flexible; for example, this new model can accommodate polygamous marriages, which our previous model could not.

To do this as safely as possible, I will do it in two PRs. The first will be this PR, which includes a datamigration to copy marriages to the new join table model. Then, in a subsequent PR, we will drop the `partner_1_id` and `partner_2_id` columns from the `marriages` table and remove any code related to those dropped foreign key columns.