### PR TITLE
[ci] Enable interpolation in rspec command heredocs

### DIFF
--- a/lib/test/tasks/run_html_controller_tests.rb
+++ b/lib/test/tasks/run_html_controller_tests.rb
@@ -3,10 +3,10 @@ class Test::Tasks::RunHtmlControllerTests < Pallets::Task
 
   def run
     # run all tests in `spec/controllers/` _except_ those in `spec/controllers/api/`
-    execute_rspec_command(<<~'COMMAND')
+    execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_html
       bin/rspec
-      $(ls -d spec/controllers/*/ | grep -v 'spec/controllers/api/' | tr '\n' ' ')
+      $(ls -d spec/controllers/*/ | grep -v 'spec/controllers/api/')
       $(ls spec/controllers/*.rb)
       $(ls spec/helpers/*.rb)
       $(ls spec/requests/**/*.rb)

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -7,12 +7,11 @@ class Test::Tasks::RunUnitTests < Pallets::Task
     # RunApiControllerTests and RunHtmlControllerTests), `spec/tools/` (which
     # will be run by RunToolsTests), and `spec/features/` (which will be run by
     # RunFeatureTests).
-    execute_rspec_command(<<~'COMMAND')
+    execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_unit
       bin/rspec
       $(ls -d spec/*/ |
-        grep --extended-regex -v 'spec/(controllers|features|helpers|requests|tools)(/|$)' |
-        tr '\n' ' ')
+        grep --extended-regex -v 'spec/(controllers|features|helpers|requests|tools)(/|$)')
       #{rspec_output_options}
     COMMAND
   end


### PR DESCRIPTION
I noticed that the `#{rspec_output_options}` didn't seem to be getting interpolated into the commands being modified in this change, based on the fact that the test output didn't seem to have `--format failures
--format progress` formatting. That's because the heredoc markers had single quotes around them, meaning that there is no interpolation. This change removes the single quotes so that we have interpolation again.

The reason that we had the single-quoted heredoc markers, in the first place, was so that the `\n` characters wouldn't need to be double escaped. But we don't actually need those bits of the command, anyway, so this change simply removes them.