### PR TITLE
[ApplicationWorker] Increase min retry wait from 1s to 10s [DEV-209]

### DIFF
--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -6,6 +6,7 @@ module ApplicationWorker
   include SpacedLaunching
 
   MAX_RETRY_WAIT_TIME = 30 # seconds
+  MIN_RETRY_WAIT_TIME = 10 # seconds
 
   module ClassMethods
     def unique_while_executing!
@@ -66,7 +67,7 @@ module ApplicationWorker
   end
 
   def reschedule(args)
-    reschedule_wait = rand((1..MAX_RETRY_WAIT_TIME))
+    reschedule_wait = rand((MIN_RETRY_WAIT_TIME..MAX_RETRY_WAIT_TIME))
     Rails.logger.info(<<~LOG.squish)
       Rescheduling #{self.class.name} worker with args #{args}
       in #{reschedule_wait} seconds because uniqueness lock


### PR DESCRIPTION
I believe that this has a decent chance to fix the spec flakiness reported in https://davidrunger.atlassian.net/browse/DEV-209 . I was previously pretty confident that it would, but now that I just saw the spec in question flake for the second time in one day, which I think would be extremely unlikely, if my hypothesis as to the cause of the spec flakiness were correct, I am having significant doubts. But, let's try this. It's probably a sort of good change, anyway. I feel a little bit bad, because a significant fraction of my motivation in making this change to application code is to make the spec more reliable, but I justify it to myself by telling myself that it probably is better, even ignoring the anti-spec-flakiness motivation, to wait at least 10 seconds before retrying to execute a job that initially fails to execute due to a uniqueness violation.