### PR TITLE
Monkeypatch 'rspec-wait' to call 'Prosopite.pause'

### DIFF
--- a/config/initializers/monkeypatches/rspec_wait_handler.rb
+++ b/config/initializers/monkeypatches/rspec_wait_handler.rb
@@ -11,19 +11,21 @@ if defined?(RSpec::Wait::Handler) && defined?(Prosopite)
       Prosopite.pause do
         matcher = RSpec.configuration.clone_wait_matcher ? initial_matcher.clone : initial_matcher
 
+        grandfather_method = method(:handle_matcher).super_method.super_method
+
         answer =
           if (
             matcher.respond_to?(:supports_block_expectations?) &&
             matcher.supports_block_expectations?
           )
-            method(:handle_matcher).super_method.super_method.call(
+            grandfather_method.call(
               target,
               matcher,
               message,
               &block
             )
           else
-            method(:handle_matcher).super_method.super_method.call(
+            grandfather_method.call(
               target.call,
               matcher,
               message,

--- a/config/initializers/monkeypatches/rspec_wait_handler.rb
+++ b/config/initializers/monkeypatches/rspec_wait_handler.rb
@@ -1,5 +1,7 @@
 if defined?(RSpec::Wait::Handler) && defined?(Prosopite)
   module RSpecWaitHandlerPatches
+    # We are monkeypatching this method:
+    # https://github.com/laserlemon/rspec-wait/blob/v1.0.1/lib/rspec/wait/handler.rb#L11-L31
     # rubocop:disable Metrics
     def handle_matcher(target, initial_matcher, message, &block)
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)

--- a/config/initializers/monkeypatches/rspec_wait_handler.rb
+++ b/config/initializers/monkeypatches/rspec_wait_handler.rb
@@ -18,12 +18,14 @@ if defined?(RSpec::Wait::Handler) && defined?(Prosopite)
             matcher.respond_to?(:supports_block_expectations?) &&
             matcher.supports_block_expectations?
           )
+            # :nocov:
             grandfather_method.call(
               target,
               matcher,
               message,
               &block
             )
+            # :nocov:
           else
             grandfather_method.call(
               target.call,

--- a/config/initializers/monkeypatches/rspec_wait_handler.rb
+++ b/config/initializers/monkeypatches/rspec_wait_handler.rb
@@ -1,0 +1,47 @@
+if defined?(RSpec::Wait::Handler) && defined?(Prosopite)
+  module RSpecWaitHandlerPatches
+    # rubocop:disable Metrics
+    def handle_matcher(target, initial_matcher, message, &block)
+      start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+      answer = nil
+
+      Prosopite.pause do
+        matcher = RSpec.configuration.clone_wait_matcher ? initial_matcher.clone : initial_matcher
+
+        answer =
+          if (
+            matcher.respond_to?(:supports_block_expectations?) &&
+            matcher.supports_block_expectations?
+          )
+            method(:handle_matcher).super_method.super_method.call(
+              target,
+              matcher,
+              message,
+              &block
+            )
+          else
+            method(:handle_matcher).super_method.super_method.call(
+              target.call,
+              matcher,
+              message,
+              &block
+            )
+          end
+      rescue RSpec::Expectations::ExpectationNotMetError
+        raise if RSpec.world.wants_to_quit
+
+        elapsed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - start_time
+        raise if elapsed_time > RSpec.configuration.wait_timeout
+
+        sleep(RSpec.configuration.wait_delay)
+        retry
+      end
+
+      answer
+    end
+  end
+  # rubocop:enable Metrics
+
+  RSpec::Wait::Handler.prepend(RSpecWaitHandlerPatches)
+end

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -30,9 +30,7 @@ RSpec.describe 'Home page', :prerendering_disabled do
 
     page.scroll_to(:bottom)
 
-    Prosopite.pause do
-      wait_for { Event.count }.to eq(event_count_before + 1)
-    end
+    wait_for { Event.count }.to eq(event_count_before + 1)
 
     new_event = Event.reorder(:created_at).last!
 


### PR DESCRIPTION
This makes it so that the repeated calls (if the expectation is not initially satisfied) in a `wait_for` block don't get flagged as an N + 1 query by Prosopite.