### PR TITLE
[ci] Try to reduce frequency of Ferrum::ProcessTimeoutError failures

### DIFF
--- a/spec/support/cuprite/custom_drivers.rb
+++ b/spec/support/cuprite/custom_drivers.rb
@@ -29,9 +29,31 @@ module Cuprite::CustomDrivers
       {
         headless: !SpecHelper.use_headful_chrome?,
         timeout:,
-        process_timeout: timeout,
+        process_timeout: 30,
         logger: Cuprite::BrowserLogger.new,
         window_size: [1200, 800],
+        browser_options: {
+          # Most of these are lifted from:
+          # https://github.com/AlexBeznoss/beagle/blob/ef29de15f74d4076ea41293e3b8703e568e42125/test/support/chromedriver.rb#L26
+          # Available flags (there are a ton) are listed here: https://peter.sh/experiments/chromium-command-line-switches/
+          'disable-background-timer-throttling' => nil,
+          'disable-breakpad' => nil,
+          'disable-client-side-phishing-detection' => nil,
+          'disable-default-apps' => nil,
+          'disable-extensions': nil,
+          'disable-features' => 'site-per-process,TranslateUI',
+          'disable-gpu': nil,
+          'disable-hang-monitor' => nil,
+          'disable-ipc-flooding-protection' => nil,
+          'disable-popup-blocking' => nil,
+          'disable-prompt-on-repost' => nil,
+          'disable-session-crashed-bubble' => nil,
+          'disable-sync' => nil,
+          'disable-translate' => nil,
+          'keep-alive-for-test' => nil,
+          'no-first-run' => nil,
+          'no-sandbox': nil,
+        },
       }
     end
   end


### PR DESCRIPTION
Some relatively recent builds with these errors:
1. https://github.com/davidrunger/david_runger/actions/runs/13753545303/job/38457512836
2. https://github.com/davidrunger/david_runger/actions/runs/13660930841/job/38191661306
3. https://github.com/davidrunger/david_runger/actions/runs/13490850823/job/37688744219

We try to rescue them [here][1], but it seems that sometimes the errors occur outside of the context where `rspec-retry` can rescue them.

[1]: https://github.com/davidrunger/david_runger/blob/72bf736d58a62094bbc00b6b62d7545bb76e0e26/spec/spec_helper.rb#L172-L175

In this change, I am trying a number of different things to try to reduce the frequency of `Ferrum::ProcessTimeoutError`s failing specs. It's going to be somewhat difficult to tell if this even makes a positive difference, because the rate of these errors is not super stable, nor is it super high. Additionally, even if it does seem to help, because of the fact that I'm trying multiple things at once, it will be difficult/impossible to know which things (or combination of things) produced the positive result. I am okay with all of this, I guess, because the main thing is that I'd just like to try to stop these errors from failing my test suite.

Specifically, this change does the following:
1. Run `GC.start` to free memory when `rspec-retry` catches a `Ferrum::ProcessTimeoutError`
2. In CI, prewarm applicable cuprite drivers in a `before(:suite)` block
3. Increase `process_timeout` from 10 seconds to 30 seconds
4. Add a bunch of Chrome browser options for the Cuprite drivers to try to make Chrome faster and less memory intensive

In addition to hoping that these changes might reduce `Ferrum::ProcessTimeoutError`s, I am also somewhat hopeful that they might make feature specs a little faster.

Most/all of the things that I'm trying were suggested by Claude 3.7 Sonnet. Private link: https://claude.ai/chat/ee4510b3-347e-467e-9cef-4519349751ee .

I got a lot of the flags for hopefully optimizing the Chrome browser from https://github.com/AlexBeznoss/beagle/blob/ef29de15f74d4076ea41293e3b8703e568e42125/test/support/chromedriver.rb#L26 .