### PR TITLE
Don't require PGHERO_DATABASE_URL

### DIFF
--- a/config/pghero.yml
+++ b/config/pghero.yml
@@ -1,7 +1,7 @@
 databases:
   primary:
     # Database URL
-    url: <%= ENV.fetch('PGHERO_DATABASE_URL', Rails.env.test? ? nil : fail('Missing PGHERO_DATABASE_URL')) %>
+    url: <%= ENV.fetch('PGHERO_DATABASE_URL', 'missing-PGHERO_DATABASE_URL') %>
 
     # System stats
     # aws_db_instance_identifier: my-instance

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,8 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema[8.0].define(version: 2025_03_15_194328) do
+  create_schema "pghero"
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"


### PR DESCRIPTION
I believe that requiring it was the cause of this deploy failure: https://github.com/davidrunger/david_runger/actions/runs/13877192439/job/38830995512#step:5:167

Also, add `create_schema "pghero"` to `db/schema.rb`. This happened after `dbm` was run on my machine after having run `ruby script/create_pghero_user.rb`. I guess it's a good thing to commit.