### PR TITLE
Don't require production DATABASE_URL

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -89,4 +89,4 @@ test:
 production:
   <<: *default
   database: david_runger_production
-  url: <%= ENV.fetch('DATABASE_URL', Rails.env.production? ? fail('Missing DATABASE_URL!') : nil) %>
+  url: <%= ENV.fetch('DATABASE_URL', nil) %>


### PR DESCRIPTION
It's failing deploys: https://github.com/davidrunger/david_runger/actions/runs/13877276521/job/38831169118#step:5:95

There is no DATABASE_URL when we run this: https://github.com/davidrunger/david_runger/blob/7a6386f453453ad2a5a47aa30910a12c83cc2cd9/Dockerfile#L69-L73