### PR TITLE
Remove spaces from postgres configs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,9 +193,9 @@ services:
       - -c
       - pg_stat_statements.track=all
       - -c
-      - pg_stat_statements.max = 10000
+      - pg_stat_statements.max=10000
       - -c
-      - track_activity_query_size = 2048
+      - track_activity_query_size=2048
     cpu_shares: 2048
     depends_on:
       vector:


### PR DESCRIPTION
The site is currently down because Postgres is failing to boot because of this.

```
docker compose logs postgres --since 3m
postgres-1  | 
postgres-1  | PostgreSQL Database directory appears to contain a database; Skipping initialization
postgres-1  | 
postgres-1  | 2025-03-15 22:51:13.723 GMT [1] FATAL:  invalid configuration parameter name "pg_stat_statements.max "
postgres-1  | 2025-03-15 22:51:13.723 GMT [1] DETAIL:  Custom parameter names must be two or more simple identifiers separated by dots.
```