### PR TITLE
[rack-attack] Don't ban IPs going to an auth failure path

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -4,6 +4,7 @@ class Rack::Attack
   PENTESTING_FINDTIME = 1.day.freeze
   WHITELISTED_PATH_PREFIXES = %w[
     /assets/blazer/
+    /auth/failure?
     /auth/google_oauth2?
     /blazer/
     /flipper/

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -2,13 +2,40 @@ RSpec.describe('Rack::Attack') do
   describe '::blocked_path?' do
     subject(:blocked_path?) { Rack::Attack.blocked_path?(request) }
 
-    let(:request) { instance_double(Rack::Attack::Request, fullpath: request_path) }
+    let(:request) do
+      instance_double(
+        Rack::Attack::Request,
+        env: {},
+        fullpath: request_path,
+        path: request_path.split('?').first,
+      )
+    end
 
     context "when the request path includes \u0000" do
       let(:request_path) { "/junk?spam=other\u0000stuff" }
 
       it 'returns true' do
         expect(blocked_path?).to eq(true)
+      end
+    end
+
+    context 'when the request includes a banned path fragment' do
+      let(:banned_path_fragment_value) { BannedPathFragment.first!.value }
+
+      context 'when the path does not begin with a whitelisted prefix' do
+        let(:request_path) { "/auth/not_allowed?#{banned_path_fragment_value}" }
+
+        it 'returns true' do
+          expect(blocked_path?).to eq(true)
+        end
+      end
+
+      context 'when the path begins with "/auth/failure?" (a whitelisted prefix)' do
+        let(:request_path) { "/auth/failure?#{banned_path_fragment_value}" }
+
+        it 'returns false' do
+          expect(blocked_path?).to eq(false)
+        end
       end
     end
 


### PR DESCRIPTION
I noticed that a real user was banned due to going to `/auth/failure?message=access_denied&origin=https%3A%2F%2Fdavidrunger.com%2Flogin&strategy=google_oauth2 (at 2025-03-14 16:15:28 -0500)` twice.

![image](https://github.com/user-attachments/assets/ec9b8e29-e9d8-4449-bd3a-145e224423cd)

^ I'm going to delete this IpBlock, but I thought I'd make a note of it in this screenshot.