### PR TITLE
Leverage eager loading when destroying user -> marriage [DEV-213]

### DIFF
--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -18,6 +18,7 @@ class MyAccountController < ApplicationController
         },
         stores: :items,
       ).find(current_user.id)
+
     authorize(@user)
 
     @user.destroy!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,8 +61,8 @@ class User < ApplicationRecord
   has_paper_trail_for_all_events
 
   before_destroy do |user|
-    if (marriage_id = user.marriage_membership&.marriage_id)
-      Marriage.find(marriage_id).destroy!
+    if (marriage = user.marriage)
+      marriage.destroy!
     end
   end
 


### PR DESCRIPTION
This avoids some N + 1 queries when a user deletes their account.

I believe that all of the remaining N + 1 queries are those (seemingly unnecessarily) caused by `paper_trail`, as mentioned [here][1].

[1]: https://davidrunger.atlassian.net/browse/DEV-213?focusedCommentId=10704