### PR TITLE
Update NPM packages other than Tailwind

### DIFF
--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -23,7 +23,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'home*.js' => (247..257),
     'logs*.css' => (101..111),
     'logs*.js' => (813..823),
-    'model_graph*.js' => (601..611),
+    'model_graph*.js' => (623..633),
     'model_graph*.css' => (2..12),
     'quizzes*.js' => (123..133),
     'styles*.css' => (14..24),

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "@activeadmin/activeadmin": "^3.3.0",
-    "@davidrunger/vue-model-explorer": "^0.0.5",
+    "@davidrunger/vue-model-explorer": "^0.2.0",
     "@hotwired/turbo": "^8.0.13",
     "@hotwired/turbo-rails": "^8.0.13",
     "@rails/actioncable": "^8.0.200",
@@ -26,7 +26,7 @@
     "chartkick": "^5.0.1",
     "dompurify": "^3.2.4",
     "easytimer.js": "^4.6.0",
-    "element-plus": "^2.9.6",
+    "element-plus": "^2.9.7",
     "emojilib": "^4.0.1",
     "eslint": "^9.22.0",
     "eslint-import-resolver-custom-alias": "^1.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^3.3.0
         version: 3.3.0
       '@davidrunger/vue-model-explorer':
-        specifier: ^0.0.5
-        version: 0.0.5(vue@3.5.13(typescript@5.8.2))
+        specifier: ^0.2.0
+        version: 0.2.0(vue@3.5.13(typescript@5.8.2))
       '@hotwired/turbo':
         specifier: ^8.0.13
         version: 8.0.13
@@ -60,8 +60,8 @@ importers:
         specifier: ^4.6.0
         version: 4.6.0
       element-plus:
-        specifier: ^2.9.6
-        version: 2.9.6(vue@3.5.13(typescript@5.8.2))
+        specifier: ^2.9.7
+        version: 2.9.7(vue@3.5.13(typescript@5.8.2))
       emojilib:
         specifier: ^4.0.1
         version: 4.0.1
@@ -368,8 +368,8 @@ packages:
     resolution: {integrity: sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==}
     engines: {node: '>=10'}
 
-  '@davidrunger/vue-model-explorer@0.0.5':
-    resolution: {integrity: sha512-sZ5VP88o9QMc7I3xDDQ+ejyUPlnwFFynKzom8XLfbzV4+4/9y+lH8GSqPGGNWxDuNfTOdYr52qCFH55Nuam97A==}
+  '@davidrunger/vue-model-explorer@0.2.0':
+    resolution: {integrity: sha512-hZ85dvsEktVnTh0mZRhyENfwK7f1I8UcVEzGIDduBlT9Coj79b7QGFE2SwL+EY2204zZjrLq0K602T6dNuxmkg==}
     peerDependencies:
       vue: ^3.5.13
 
@@ -2024,8 +2024,8 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
-  element-plus@2.9.6:
-    resolution: {integrity: sha512-D9zU28Ce0s/9O/Vp3ewemikxzFVA6gdZyMwmWijHijo+t5/9H3sHRTIm1WlfeNpFW2Yq0y8nHXD0fU5YxU6qlQ==}
+  element-plus@2.9.7:
+    resolution: {integrity: sha512-6vjZh5SXBncLhUwJGTVKS5oDljfgGMh6J4zVTeAZK3YdMUN76FgpvHkwwFXocpJpMbii6rDYU3sgie64FyPerQ==}
     peerDependencies:
       vue: ^3.2.0
 
@@ -4581,10 +4581,12 @@ snapshots:
 
   '@ctrl/tinycolor@3.6.1': {}
 
-  '@davidrunger/vue-model-explorer@0.0.5(vue@3.5.13(typescript@5.8.2))':
+  '@davidrunger/vue-model-explorer@0.2.0(vue@3.5.13(typescript@5.8.2))':
     dependencies:
+      '@vueuse/core': 13.0.0(vue@3.5.13(typescript@5.8.2))
       cytoscape: 3.31.1
       cytoscape-dagre: 2.5.0(cytoscape@3.31.1)
+      fuse.js: 7.1.0
       lodash-es: 4.17.21
       vue: 3.5.13(typescript@5.8.2)
 
@@ -6260,7 +6262,7 @@ snapshots:
       minimatch: 9.0.1
       semver: 7.7.1
 
-  element-plus@2.9.6(vue@3.5.13(typescript@5.8.2)):
+  element-plus@2.9.7(vue@3.5.13(typescript@5.8.2)):
     dependencies:
       '@ctrl/tinycolor': 3.6.1
       '@element-plus/icons-vue': 2.3.1(vue@3.5.13(typescript@5.8.2))


### PR DESCRIPTION
`pnpx npm-check-updates --interactive`

(Tailwind has a bug: https://github.com/tailwindlabs/tailwindcss/issues/ 17313 , so we are holding it back for now.)

I'm surprised that `model_graph*.js` only increased ~22 KiB, after bringing in `fuse.js` and `@vueuse/core`. It's a pleasant surprise, though. Bundlephobia says that `@vueuse/core@13.0.0` is 149.2 kB minified ( https://bundlephobia.com/package/@vueuse/core@13.0.0 )! So, I guess that we are able to tree shake most of that? That's very good to know/see.