### PR TITLE
Specify actions for [skip_]before_actions in ModelGraphController

### DIFF
--- a/app/controllers/model_graph_controller.rb
+++ b/app/controllers/model_graph_controller.rb
@@ -1,6 +1,6 @@
 class ModelGraphController < ApplicationController
-  skip_before_action :authenticate_user!
-  before_action :skip_authorization
+  skip_before_action :authenticate_user!, only: %i[index]
+  before_action :skip_authorization, only: %i[index]
   before_action :skip_bootstrap_schema_validation, only: %i[index]
 
   def index


### PR DESCRIPTION
I think that this is a best practice and try to follow it. If we add another action to this controller, then we might not want these skip_before_action(s)/before_action(s) to apply to those routes by default. Since our default before_actions are generally designed for security, any alterations to them generally makes things less secure, and so I want to need to opt-in to such alterations.