### PR TITLE
Remove outdated DigitalOcean mentions

### DIFF
--- a/app/javascript/home/components/Projects.vue
+++ b/app/javascript/home/components/Projects.vue
@@ -53,10 +53,7 @@ HomeSection(
           A #[a(href="https://rubyonrails.org/") Rails 8] backend serves various
           #[a(href="https://vuejs.org/") Vue 3] front-end apps.
 
-        li.
-          The app's deployment is managed with
-          #[a(href="https://docs.docker.com/compose/") Docker Compose] on a
-          #[a(href="https://www.digitalocean.com/") DigitalOcean] host.
+        li The app's deployment is managed with #[a(href="https://docs.docker.com/compose/") Docker Compose].
 
         li.
           The app's 6,000+ lines of testable Ruby code are
@@ -265,16 +262,7 @@ HomeSection(
           #[a(href="https://github.com/sidekiq-scheduler/sidekiq-scheduler/") sidekiq-scheduler],
           but I wanted something that wasn't so dependent on Sidekiq internals.
 
-        p.
-          Thus, partially as an excuse to try out the
-          #[a(href="https://crystal-lang.org/") Crystal]
-
-          programming language, I wrote a simple job runner in Crystal called
-          #[code skedjewel],
-
-          which I use to execute scheduled Sidekiq jobs for DavidRunger.com. I love the small
-          memory consumption of the compiled skedjewel Crystal binary, since memory is a precious
-          resource on my small DigitalOcean droplet.
+        p Thus, partially as an excuse to try out the #[a(href="https://crystal-lang.org/") Crystal] programming language, I wrote a simple job runner in Crystal called #[code skedjewel], which I use to execute scheduled Sidekiq jobs for DavidRunger.com. I love the small memory consumption of the compiled skedjewel Crystal binary, since memory is a precious resource on my relatively small hobby server.
 
   Project
     template(v-slot:title)


### PR DESCRIPTION
I'm now using Hetzner, but I don't really think it bears mentioning at all which hosting company I am using, so I'm deleting the references to my hosting company, rather than replacing them with Hetzner.

Also, I think I'm going to stop hard wrapping content in Pug templates. Just having everything on a single line makes a number of things significantly easier and more pleasant. The only thing that really would be somewhat of a notable downside is that `delta` doesn't handle long lines very well by default in the side-by-side view; at a certain point, it just truncates the line. However, https://github.com/davidrunger/dotfiles/pull/611 largely solves this issue, so even that's not really a problem.