### PR TITLE
Delete no-longer-needed Rails/CreateTableWithTimestamps disablements

### DIFF
--- a/db/migrate/20200606140044_create_active_storage_tables.active_storage.rb
+++ b/db/migrate/20200606140044_create_active_storage_tables.active_storage.rb
@@ -30,7 +30,6 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
 
-    # rubocop:disable Rails/CreateTableWithTimestamps
     create_table :active_storage_variant_records do |t|
       t.belongs_to :blob, null: false, index: false
       t.string :variation_digest, null: false
@@ -42,7 +41,6 @@ class CreateActiveStorageTables < ActiveRecord::Migration[5.2]
       )
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
-    # rubocop:enable Rails/CreateTableWithTimestamps
   end
   # rubocop:enable Metrics/MethodLength
 end

--- a/db/migrate/20220614035332_create_active_storage_variant_records.active_storage.rb
+++ b/db/migrate/20220614035332_create_active_storage_variant_records.active_storage.rb
@@ -4,7 +4,6 @@ class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
     return unless table_exists?(:active_storage_blobs)
 
     # Use Active Record's configured type for primary key
-    # rubocop:disable Rails/CreateTableWithTimestamps
     create_table :active_storage_variant_records, id: primary_key_type, if_not_exists: true do |t|
       t.belongs_to :blob, null: false, index: false, type: blobs_primary_key_type
       t.string :variation_digest, null: false
@@ -16,7 +15,6 @@ class CreateActiveStorageVariantRecords < ActiveRecord::Migration[6.0]
       )
       t.foreign_key :active_storage_blobs, column: :blob_id
     end
-    # rubocop:enable Rails/CreateTableWithTimestamps
   end
 
   private


### PR DESCRIPTION
`delete-lines '^\s*# rubocop:(disable|enable) Rails/CreateTableWithTimestamps$' $(git ls-files | rg "db\/migrate\/(201|202[0-4])")`

We [don't lint these files anymore][1], so we don't need these disablements anymore.

[1]: https://github.com/davidrunger/david_runger/blob/965b5f2a06507e482f2694ab69d52174c39c312d/.rubocop.yml#L16

**Motivation:** I have been checking cop disablements to see if there are cops that should be disabled/modified in `runger_style`, and having these still be flagged makes the cop in question show up in the list more times than it's really relevant.

```
$ rg "rubocop:disable" | sed -E 's/.*rubocop:disable[[:space:]]+//' | tr ',' '\n' | sed 's/^[[:space:]]*//' | sort | uniq -c | sort -nr | rg -v '^\s+1 '
      9 RSpec/AnyInstance
      7 Layout/LineLength
      4 Rails/CreateTableWithTimestamps
      [...]
```

Deleting these no-longer-needed disablements will reduce the number of such disablements so they won't be as much of a distraction when looking, now or in the future, at commonly disabled cops.