### PR TITLE
Sidestep RuboCop 'Style/RequireOrder' warnings by using newlines

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,7 +1,7 @@
 require_relative 'boot'
 
 require 'rails'
-# rubocop:disable Style/RequireOrder
+
 require 'action_cable/engine'
 require 'action_controller/railtie'
 require 'action_mailbox/engine'
@@ -9,7 +9,6 @@ require 'action_mailer/railtie'
 require 'action_view/railtie'
 require 'active_job/railtie'
 require 'active_record/railtie'
-# rubocop:enable Style/RequireOrder
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,6 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
-# rubocop:disable Style/RequireOrder
 require 'bundler/setup' # Set up gems listed in the Gemfile.
+
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.
-# rubocop:enable Style/RequireOrder


### PR DESCRIPTION
This is a little cleaner/simpler. Although it certainly does not do so as clearly as disabling the RuboCop cop, I think that adding the extra newlines herein does still somewhat hints at the intent to do the first `require`s before the latter ones. On net, I think this way is better.