### PR TITLE
[api/logs#destroy] Fix N+1 query

### DIFF
--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -9,7 +9,7 @@ ActiveAdmin.register(User) do
       if params[:action] == 'destroy'
         collection =
           collection.includes(
-            logs: %i[log_entries log_shares],
+            logs: [:log_shares, { log_entries: :log_entry_datum }],
             stores: %i[items],
           )
       end

--- a/app/controllers/api/logs_controller.rb
+++ b/app/controllers/api/logs_controller.rb
@@ -46,7 +46,17 @@ class Api::LogsController < Api::BaseController
   end
 
   def set_log
-    @log = current_user.logs.find_by(id: params[:id])
-    head(:not_found) if @log.nil?
+    @log = current_user.logs.includes(eager_loads).find_by(id: params[:id])
+
+    if @log.nil?
+      head(:not_found)
+    end
+  end
+
+  def eager_loads
+    case params[:action]
+    in 'destroy' then { log_entries: :log_entry_datum }
+    else {}
+    end
   end
 end

--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -2,22 +2,7 @@ class MyAccountController < ApplicationController
   self.container_classes = %w[p-8]
 
   def destroy
-    @user =
-      User.includes(
-        :auth_tokens,
-        :need_satisfaction_ratings,
-        logs: [:log_shares, { log_entries: :log_entry_datum }],
-        marriage: {
-          check_ins: %i[check_in_submissions need_satisfaction_ratings],
-          emotional_needs: :need_satisfaction_ratings,
-        },
-        quiz_participations: %i[quiz_question_answer_selections],
-        quizzes: {
-          participations: :quiz_question_answer_selections,
-          questions: { answers: :selections },
-        },
-        stores: :items,
-      ).find(current_user.id)
+    @user = User.with_eager_loading_for_destroy.find(current_user.id)
 
     authorize(@user)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,8 +66,28 @@ class User < ApplicationRecord
     end
   end
 
-  def self.ransackable_attributes(_auth_object = nil)
-    %w[created_at email id updated_at]
+  class << self
+    def ransackable_attributes(_auth_object = nil)
+      %w[created_at email id updated_at]
+    end
+
+    def with_eager_loading_for_destroy
+      includes(
+        :auth_tokens,
+        :need_satisfaction_ratings,
+        logs: [:log_shares, { log_entries: :log_entry_datum }],
+        marriage: {
+          check_ins: %i[check_in_submissions need_satisfaction_ratings],
+          emotional_needs: :need_satisfaction_ratings,
+        },
+        quiz_participations: %i[quiz_question_answer_selections],
+        quizzes: {
+          participations: :quiz_question_answer_selections,
+          questions: { answers: :selections },
+        },
+        stores: :items,
+      )
+    end
   end
 
   memoize \

--- a/spec/controllers/api/logs_controller_spec.rb
+++ b/spec/controllers/api/logs_controller_spec.rb
@@ -122,13 +122,14 @@ RSpec.describe Api::LogsController do
     context "when attempting to destroy one's own log" do
       let(:user) { log.user }
 
-      it 'destroys the log' do
-        expect { delete_destroy }.to change { Log.find_by(id: log.id) }.from(Log).to(nil)
-      end
+      context 'when the log has more than one entry' do
+        before { expect(log.log_entries.size).to be > 1 }
 
-      it 'returns a 204 status code' do
-        delete_destroy
-        expect(response).to have_http_status(204)
+        it 'destroys the log and returns a 204 status code without raising an N+1 query error' do
+          expect { delete_destroy }.to change { Log.find_by(id: log.id) }.from(Log).to(nil)
+
+          expect(response).to have_http_status(204)
+        end
       end
     end
   end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Log do
 
         context 'when all log entries were created long enough ago that a reminder is needed' do
           before do
-            log.log_entries.find_each do |log_entry|
+            log.log_entries.includes(:log_entry_datum).find_each do |log_entry|
               log_entry.update!(created_at: reminder_time_interval.ago - 2.hours)
             end
           end
@@ -84,7 +84,7 @@ RSpec.describe Log do
       end
 
       context 'when the log has no log entries' do
-        before { log.log_entries.find_each(&:destroy!) }
+        before { log.log_entries.includes(:log_entry_datum).find_each(&:destroy!) }
 
         context 'when the log was created long enough ago that a reminder is needed' do
           before { log.update!(created_at: reminder_time_interval.ago - 2.hours) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -56,16 +56,7 @@ RSpec.describe User do
   describe '#destroy' do
     subject(:destroy) { user.destroy }
 
-    let(:user) do
-      User.
-        includes(
-          :quizzes,
-          logs: %i[log_shares log_entries],
-          quiz_participations: :quiz_question_answer_selections,
-          stores: :items,
-        ).
-        find(users(:user).id)
-    end
+    let(:user) { User.with_eager_loading_for_destroy.find(users(:user).id) }
     let!(:user_id) { user.id }
 
     context 'when the user has a marriage' do

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -30,6 +30,10 @@ FixtureBuilder.configure do |fbuilder|
       data: 102,
       note: 'I am glad it is an even number',
     ).save!
+    number_log.build_log_entry_with_datum(
+      data: 98,
+      note: 'Going down. Still even.',
+    ).save!
 
     create(
       :log,

--- a/spec/workers/send_log_reminder_emails_spec.rb
+++ b/spec/workers/send_log_reminder_emails_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe SendLogReminderEmails do
           reminder_last_sent_at: nil,
           reminder_time_in_seconds: Integer(1.hour),
         )
-        log.log_entries.find_each { _1.update!(created_at: 2.hours.ago) }
+        log.log_entries.includes(:log_entry_datum).find_each { _1.update!(created_at: 2.hours.ago) }
       end
 
       it 'updates the reminder_last_sent_at timestamp (making the log no longer need reminding)' do


### PR DESCRIPTION
Prosopite flagged the N+1 query when I deleted a log locally to test a change for https://davidrunger.atlassian.net/browse/DEV-217 .

I wonder if `bullet` would also have caught this? It would seem that it didn't, but we didn't have test coverage for it before, and it's possible that maybe I just never deleted a log in development since adding `bullet`. That seems slightly unlikely, though. I'm guessing that `bullet` had a chance to catch this, but failed. If so, then, nice job, Prosopite, catching what Bullet missed.