### PR TITLE
Remove note from second number log entry datum

### DIFF
--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -26,14 +26,8 @@ FixtureBuilder.configure do |fbuilder|
 
     # number logs
     number_log = name(:number_log, create(:log, user:, data_type: 'number')).first
-    number_log.build_log_entry_with_datum(
-      data: 102,
-      note: 'I am glad it is an even number',
-    ).save!
-    number_log.build_log_entry_with_datum(
-      data: 98,
-      note: 'Going down. Still even.',
-    ).save!
+    number_log.build_log_entry_with_datum(data: 102, note: 'I am glad it is an even number').save!
+    number_log.build_log_entry_with_datum(data: 98, note: nil).save!
 
     create(
       :log,


### PR DESCRIPTION
Many log entries will not have a note, and so I think it's good that our fixture data reflect this possibility. For example, this could plausibly surface in specs a `NoMethodError` bug (when called on `nil`) so that we don't ship such a bug to production.