### PR TITLE
Replace most 'setTimeout' calls with Vue's 'nextTick' [DEV-217]

### DIFF
--- a/app/javascript/comments/Comments.vue
+++ b/app/javascript/comments/Comments.vue
@@ -22,7 +22,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue';
+import { nextTick, onMounted } from 'vue';
 
 import Comment from '@/comments/components/Comment.vue';
 import CommentForm from '@/comments/components/CommentForm.vue';
@@ -38,7 +38,7 @@ onMounted(async () => {
   if (hash === '#comments') {
     const element = document.getElementById(hash.substring(1));
     if (element) {
-      setTimeout(() => {
+      nextTick(() => {
         element.scrollIntoView();
       });
     }

--- a/app/javascript/groceries/components/Item.vue
+++ b/app/javascript/groceries/components/Item.vue
@@ -42,7 +42,7 @@
 
 <script setup lang="ts">
 import { debounce } from 'lodash-es';
-import { ref, type PropType } from 'vue';
+import { nextTick, ref, type PropType } from 'vue';
 import { EditIcon, MinusIcon, PlusIcon, XIcon } from 'vue-tabler-icons';
 
 import { useGroceriesStore } from '@/groceries/store';
@@ -77,8 +77,8 @@ function decrement(item: Item) {
 
 function editItemName() {
   editingName.value = true;
-  // wait a tick for input to render, then focus it
-  setTimeout(() => {
+  // Wait a tick for input to render, then focus it.
+  nextTick(() => {
     if (itemNameInput.value) {
       (itemNameInput.value as HTMLInputElement).focus();
     }

--- a/app/javascript/groceries/components/StoreHeader.vue
+++ b/app/javascript/groceries/components/StoreHeader.vue
@@ -28,7 +28,7 @@ h2.store-name.my-4
 <script setup lang="ts">
 import { ElButton } from 'element-plus';
 import { storeToRefs } from 'pinia';
-import { ref, type PropType } from 'vue';
+import { nextTick, ref, type PropType } from 'vue';
 import { EditIcon } from 'vue-tabler-icons';
 
 import { useGroceriesStore } from '@/groceries/store';
@@ -50,21 +50,18 @@ const storeNameInput = ref(null);
 
 function editStoreName() {
   editingName.value = true;
-  // wait a tick for input to render, then focus it
-  setTimeout(focusStoreNameInput);
+  // Wait a tick for input to render, then focus it.
+  nextTick(focusStoreNameInput);
 }
 
-function focusStoreNameInput(callsAlready = 0) {
+function focusStoreNameInput() {
   if (!editingName.value) return;
 
-  if (storeNameInput.value) {
-    (storeNameInput.value as HTMLInputElement).focus();
-  } else if (callsAlready < 20) {
-    // the storeNameInput hasn't had time to render yet; retry later
-    setTimeout(() => {
-      focusStoreNameInput(callsAlready + 1);
-    }, 50);
-  }
+  nextTick(() => {
+    if (storeNameInput.value) {
+      (storeNameInput.value as HTMLInputElement).focus();
+    }
+  });
 }
 
 function stopEditingAndUpdateStoreName() {

--- a/app/javascript/groceries/components/StoreNotes.vue
+++ b/app/javascript/groceries/components/StoreNotes.vue
@@ -25,7 +25,7 @@
 
 <script setup lang="ts">
 import { ElInput } from 'element-plus';
-import { ref, type PropType } from 'vue';
+import { nextTick, ref, type PropType } from 'vue';
 import { EditIcon } from 'vue-tabler-icons';
 
 import { useGroceriesStore } from '@/groceries/store';
@@ -45,21 +45,18 @@ const storeNotesInput = ref(null);
 
 function editStoreNotes() {
   editingNotes.value = true;
-  // wait a tick for input to render, then focus it
-  setTimeout(focusStoreNotesInput);
+  // Wait a tick for input to render, then focus it.
+  nextTick(focusStoreNotesInput);
 }
 
-function focusStoreNotesInput(callsAlready = 0) {
+function focusStoreNotesInput() {
   if (!editingNotes.value) return;
 
-  if (storeNotesInput.value) {
-    (storeNotesInput.value as HTMLInputElement).focus();
-  } else if (callsAlready < 20) {
-    // the storeNotesInput hasn't had time to render yet; retry later
-    setTimeout(() => {
-      focusStoreNotesInput(callsAlready + 1);
-    }, 50);
-  }
+  nextTick(() => {
+    if (storeNotesInput.value) {
+      (storeNotesInput.value as HTMLInputElement).focus();
+    }
+  });
 }
 
 function stopEditingAndUpdateStoreNotes() {

--- a/app/javascript/logs/components/EditableTextLogRow.vue
+++ b/app/javascript/logs/components/EditableTextLogRow.vue
@@ -45,7 +45,7 @@ import createDOMPurify from 'dompurify';
 import { ElButton, ElInput, ElPopconfirm } from 'element-plus';
 import { marked } from 'marked';
 import strftime from 'strftime';
-import { computed, ref, watch, type PropType } from 'vue';
+import { computed, nextTick, ref, watch, type PropType } from 'vue';
 
 import { useLogsStore } from '@/logs/store';
 import type { Log, TextLogEntry } from '@/logs/types';
@@ -80,13 +80,13 @@ const html = computed((): string => {
 });
 
 watch(editing, () => {
-  setTimeout(() => {
+  nextTick(() => {
     if (editing.value && textInput.value) {
       (
         (textInput.value as typeof ElInput).$el.children[0] as HTMLInputElement
       ).focus();
     }
-  }, 0);
+  });
 });
 
 function cancelEditing() {

--- a/app/javascript/logs/components/LogSelectorModal.vue
+++ b/app/javascript/logs/components/LogSelectorModal.vue
@@ -24,7 +24,7 @@ Modal(
 <script setup lang="ts">
 import { refDebounced } from '@vueuse/core';
 import { storeToRefs } from 'pinia';
-import { computed, ref, watch } from 'vue';
+import { computed, nextTick, ref, watch } from 'vue';
 import { useRouter } from 'vue-router';
 
 import Modal from '@/components/Modal.vue';
@@ -63,7 +63,7 @@ const showingLogSelectorModal = computed(() => {
 
 watch(showingLogSelectorModal, () => {
   // Wait a tick for input to render, then focus it. Autofocus only works once, so we need this.
-  setTimeout(() => {
+  nextTick(() => {
     if (logSearchInput.value) {
       (logSearchInput.value as HTMLInputElement).focus();
     }

--- a/app/javascript/logs/components/NewLogEntryForm.vue
+++ b/app/javascript/logs/components/NewLogEntryForm.vue
@@ -43,7 +43,7 @@ div
 import { useVuelidate } from '@vuelidate/core';
 import { required } from '@vuelidate/validators';
 import { ElButton, ElDatePicker, ElInput } from 'element-plus';
-import { computed, onMounted, reactive, ref } from 'vue';
+import { computed, nextTick, onMounted, reactive, ref } from 'vue';
 
 import { useLogsStore } from '@/logs/store';
 import type { LogEntryDataValue } from '@/types';
@@ -126,7 +126,7 @@ onMounted(() => {
 });
 
 function focusLogEntryInput() {
-  setTimeout(() => {
+  nextTick(() => {
     if (logInput.value) {
       (logInput.value as typeof ElInput).focus();
     }

--- a/app/javascript/logs/store.ts
+++ b/app/javascript/logs/store.ts
@@ -1,5 +1,6 @@
 import { last, sortBy } from 'lodash-es';
 import { defineStore } from 'pinia';
+import { nextTick } from 'vue';
 
 import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { assert, typesafeAssign } from '@/lib/helpers';
@@ -134,8 +135,8 @@ export const useLogsStore = defineStore('logs', {
       await http.delete(api_log_path({ id: logToDelete.id }));
       toast(`Deleted "${logToDelete.name}" log.`);
       this.router.push({ name: 'logs-index' });
-      // we need to wait a tick so we don't remove the log while still on the log show page
-      setTimeout(() => {
+      // We need to wait a tick so we don't remove the log while still on the log show page.
+      nextTick(() => {
         this.logs = this.logs.filter((log) => log.id !== logToDelete.id);
       });
     },


### PR DESCRIPTION
The relevant Vue docs https://vuejs.org/api/general#nexttick don't explicitly contrast `setTimeout` with `nextTick`, but Perplexity had this to say:

> For Vue.js applications, nextTick is generally the preferred choice when you need to perform actions after DOM updates, as it's more reliable and efficient within the Vue ecosystem.

-- https://www.perplexity.ai/search/0c9c8fe9-5cd6-473e-acbb-9fd4b66cc1c7

So, this change replaces `setTimeout` usage in Vue components (and, in one case, in a Pinia store) in cases where `setTimeout` was being used to wait a tick (rather than to actually wait for a certain amount of time) to instead use `nextTick`.

One small downside of `nextTick` is that it needs to be imported, whereas `setTimeout` is globally available. Also, it will presumably cost us at least a tiny bit of page weight, though I imagine it's fairly negligible.