### PR TITLE
Refactor groceries Item to use new useCancellableInput composable

### DIFF
--- a/app/javascript/lib/composables/useCancellableInput.ts
+++ b/app/javascript/lib/composables/useCancellableInput.ts
@@ -1,0 +1,67 @@
+import { nextTick, ref, Ref } from 'vue';
+
+interface UseCancellableInputOptions {
+  onUpdate: (newValue: string) => void;
+}
+
+interface UseCancellableInputReturn {
+  editableRef: Ref<string>;
+  isEditing: Ref<boolean>;
+  startEditing: (initialValue: string) => void;
+  inputRef: Ref<HTMLInputElement | null>;
+  inputEventHandlers: {
+    onBlur: () => void;
+    onKeydown: (event: KeyboardEvent) => void;
+  };
+}
+
+export function useCancellableInput(
+  options: UseCancellableInputOptions,
+): UseCancellableInputReturn {
+  const { onUpdate } = options;
+
+  const isEditing = ref<boolean>(false);
+  const editableRef = ref<string>('');
+  const inputRef = ref<HTMLInputElement | null>(null);
+  let originalValue = '';
+
+  function startEditing(initialValue: string): void {
+    originalValue = initialValue;
+    editableRef.value = initialValue;
+    isEditing.value = true;
+
+    nextTick(() => {
+      if (inputRef.value) {
+        inputRef.value.focus();
+      }
+    });
+  }
+
+  function saveChanges(): void {
+    isEditing.value = false;
+    onUpdate(editableRef.value);
+  }
+
+  function cancelEditing(): void {
+    isEditing.value = false;
+  }
+
+  const inputEventHandlers = {
+    onBlur: saveChanges,
+    onKeydown: (event: KeyboardEvent) => {
+      if (event.key === 'Enter') {
+        saveChanges();
+      } else if (event.key === 'Escape') {
+        cancelEditing();
+      }
+    },
+  };
+
+  return {
+    editableRef,
+    isEditing,
+    startEditing,
+    inputRef,
+    inputEventHandlers,
+  };
+}

--- a/app/javascript/lib/composables/useCancellableInput.ts
+++ b/app/javascript/lib/composables/useCancellableInput.ts
@@ -23,10 +23,8 @@ export function useCancellableInput(
   const isEditing = ref<boolean>(false);
   const editableRef = ref<string>('');
   const inputRef = ref<HTMLInputElement | null>(null);
-  let originalValue = '';
 
   function startEditing(initialValue: string): void {
-    originalValue = initialValue;
     editableRef.value = initialValue;
     isEditing.value = true;
 


### PR DESCRIPTION
https://claude.ai/chat/8ca7086a-7ac9-4db4-9ac7-be648d113a92

**Motivation:** I want to be able to use this composable to do https://davidrunger.atlassian.net/browse/GROC- 28 . But, to keep the changes smaller and more focused, for now, I'm just implementing the `useCancellableInput` composable and using it to refactor the existing functionality of the `Item` groceries component.