### PR TITLE
Use PascalCase for all Vue template component references [DEV-221]

### DIFF
--- a/app/javascript/check_ins/components/Ratings.vue
+++ b/app/javascript/check_ins/components/Ratings.vue
@@ -2,7 +2,7 @@
 .my-8(v-for="needSatisfactionRating in needSatisfactionRatings")
   .mb-2
     strong {{ needSatisfactionRating.emotional_need.name }}
-    el-popover(
+    ElPopover(
       placement="top-end"
       trigger="click"
     )

--- a/app/javascript/groceries/components/CheckInItem.vue
+++ b/app/javascript/groceries/components/CheckInItem.vue
@@ -19,13 +19,13 @@ li.flex.items-center.break-word.mb-2(:class="aboutToMoveToClass()")
     )
       HeartFilledIcon.text-red-500
     span {{ ' ' }}
-    el-button(
+    ElButton(
       v-if="item.checkInStatus === 'skipped'"
       link
       type="primary"
       @click="moveTo('needed')"
     ) Unskip
-    el-button(
+    ElButton(
       v-else
       link
       type="primary"

--- a/app/javascript/groceries/components/CheckInModal.vue
+++ b/app/javascript/groceries/components/CheckInModal.vue
@@ -8,7 +8,7 @@ Modal(
     .flex.flex-col.max-h-full
       .shrink-0.flex.items-center.mb-3
         span Stores: {{ checkInStoreNames }}
-        el-button.choose-stores.ml-2(
+        ElButton.choose-stores.ml-2(
           link
           type="primary"
           @click="manageCheckInStores"
@@ -31,12 +31,12 @@ Modal(
         )
 
       .shrink-0.flex.justify-around.mt-4
-        el-button(
+        ElButton(
           @click="modalStore.hideModal({ modalName: 'check-in-shopping-trip' })"
           type="primary"
           link
         ) Cancel
-        el-button(
+        ElButton(
           @click="handleTripCheckinModalSubmit"
           type="primary"
           plain

--- a/app/javascript/groceries/components/LoggedInHeader.vue
+++ b/app/javascript/groceries/components/LoggedInHeader.vue
@@ -1,15 +1,15 @@
 <template lang="pug">
-el-menu
-  el-sub-menu(index="1")
+ElMenu
+  ElSubMenu(index="1")
     template(v-slot:title) Account
-    el-menu-item.email(
+    ElMenuItem.email(
       index="1-1"
       :disabled="true"
     ) {{ currentUser.email }}
     a(:href="my_account_path()")
-      el-menu-item(index="1-2") My Account
+      ElMenuItem(index="1-2") My Account
     a.js-link(@click="signOut")
-      el-menu-item(index="1-3") Sign Out
+      ElMenuItem(index="1-3") Sign Out
 </template>
 
 <script setup lang="ts">

--- a/app/javascript/groceries/components/ManageCheckInStoresModal.vue
+++ b/app/javascript/groceries/components/ManageCheckInStoresModal.vue
@@ -12,7 +12,7 @@ Modal(
       Spouse's stores
     CheckInStoreList(:stores="groceriesStore.sortedSpouseStores")
     .flex.justify-around.mt-4
-      el-button(
+      ElButton(
         @click="modalStore.hideModal({ modalName: 'manage-check-in-stores' })"
         type="primary"
       ) Done

--- a/app/javascript/groceries/components/NewItemForm.vue
+++ b/app/javascript/groceries/components/NewItemForm.vue
@@ -4,14 +4,14 @@ form.flex(
   @submit.prevent="postNewItem"
 )
   .float-left
-    el-input.item-name-input.max-w-60(
+    ElInput.item-name-input.max-w-60(
       placeholder="Add an item"
       type="text"
       v-model="formData.newItemName"
       name="newItemName"
     )
   .ml-2
-    el-button.button.button-outline(
+    ElButton.button.button-outline(
       native-type="submit"
       :disabled="v$.$invalid"
     ) Add

--- a/app/javascript/groceries/components/Sidebar.vue
+++ b/app/javascript/groceries/components/Sidebar.vue
@@ -8,19 +8,19 @@ aside.border-r.border-neutral-400.overflow-auto.hidden-scrollbars(
         @click="collapsed = !collapsed"
         :class="{ 'rotated-180': expanded }"
       )
-        arrow-bar-right-icon(size="29")
+        ArrowBarRightIcon(size="29")
     LoggedInHeader.mb-2
     nav
       .store-lists-container.pb-4
         form.add-store.flex(@submit.prevent="handleNewStoreSubmission()")
           .flex-1.mr-2
-            el-input(
+            ElInput(
               type="text"
               v-model="formData.newStoreName"
               name="newStoreName"
               placeholder="Add a store"
             )
-          el-button(
+          ElButton(
             native-type="submit"
             :disabled="postingStore || v$.$invalid"
           ) Add

--- a/app/javascript/groceries/components/Store.vue
+++ b/app/javascript/groceries/components/Store.vue
@@ -2,7 +2,7 @@
 .store-container.overflow-auto.hidden-scrollbars.pt-2.pl-8.pr-4
   StoreHeader(:store="store")
 
-  el-button.mr-2.mt-2(
+  ElButton.mr-2.mt-2(
     @click="initializeTripCheckIn"
     :size="isMobileDevice() ? 'small' : 'default'"
   ) Check in items

--- a/app/javascript/groceries/components/StoreHeader.vue
+++ b/app/javascript/groceries/components/StoreHeader.vue
@@ -15,12 +15,12 @@ h2.store-name.my-4
   )
     EditIcon(size="27")
   span(v-if="store.own_store")
-    el-button.ml-2(
+    ElButton.ml-2(
       v-if="store.private"
       size="small"
       @click="togglePrivacy"
     ) Make public
-    el-button.ml-2(
+    ElButton.ml-2(
       v-else
       size="small"
       @click="togglePrivacy"

--- a/app/javascript/groceries/components/StoreListEntry.vue
+++ b/app/javascript/groceries/components/StoreListEntry.vue
@@ -5,7 +5,7 @@
 )
   .store-name
     a {{ store.name }}
-    lock-icon.ml-2(
+    LockIcon.ml-2(
       v-if="store.private"
       size="22"
     )

--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -4,7 +4,7 @@ div
     div {{ currentUser.email }}
   .text-center
     LogSelectorModal
-    router-view.m-8(:key="$route.fullPath")
+    RouterView.m-8(:key="$route.fullPath")
     footer.mb-4(v-if="!isSharedLogView")
       | Tip: {{ bootstrap.log_selector_keyboard_shortcut }} will open the log selector.
 </template>

--- a/app/javascript/logs/components/EditLogRemindersModal.vue
+++ b/app/javascript/logs/components/EditLogRemindersModal.vue
@@ -11,7 +11,7 @@ Modal(
       .my-2(v-if="log.reminder_time_in_seconds")
         | Current setting: every {{ reminderTimeInHours }} hours
         span.ml-2
-          el-button(
+          ElButton(
             @click="cancelReminders"
             type="primary"
             link
@@ -29,13 +29,13 @@ Modal(
         | to create a log entry (if I haven't already done so).
       .flex.justify-center.mt-4
         .mr-8
-          el-button(
+          ElButton(
             @click="updateLog"
             type="primary"
             plain
           ) Save
         div
-          el-button(
+          ElButton(
             @click="modalStore.hideModal({ modalName: 'edit-log-reminder-schedule' })"
             type="primary"
             link

--- a/app/javascript/logs/components/EditLogSharingSettingsModal.vue
+++ b/app/javascript/logs/components/EditLogSharingSettingsModal.vue
@@ -8,33 +8,33 @@ Modal(
   slot
     h3.font-bold.mb-4 Sharing
     div
-      el-checkbox(
+      ElCheckbox(
         v-model="publiclyViewable"
         @change="savePubliclyViewableChange"
       ) Publicly viewable
     div(v-if="!publiclyViewable")
-      el-tag(
+      ElTag(
         :key="logShare.email"
         v-for="logShare in logSharesSortedByLowercasedEmail"
         closable
         :disable-transitions="false"
         @close="handleLogShareDeletion(logShare)"
       ) {{ logShare.email }}
-      el-input.input-new-tag(
+      ElInput.input-new-tag(
         v-if="inputVisible"
         v-model="inputValue"
         ref="saveTagInput"
         @keyup.enter.native="handleLogShareCreation"
         @blur="handleLogShareCreation"
       )
-      el-button.button-new-tag(
+      ElButton.button-new-tag(
         v-else
         size="small"
         @click="showInput"
       ) + Share with email
     .mt-2 Shareable link: {{ shareableUrl }}
     div
-      el-button(
+      ElButton(
         size="small"
         @click="copyShareableUrlToClipboard"
       )

--- a/app/javascript/logs/components/EditableTextLogRow.vue
+++ b/app/javascript/logs/components/EditableTextLogRow.vue
@@ -3,7 +3,7 @@ tr
   td(v-html="formattedCreatedAt")
 
   td(v-if="editing")
-    el-input(
+    ElInput(
       v-model="newPlaintext"
       type="textarea"
       ref="textInput"
@@ -14,27 +14,27 @@ tr
   )
 
   td(v-if="editing")
-    el-button(
+    ElButton(
       @click="updateLogEntry"
       size="small"
     ) Save
-    el-button(
+    ElButton(
       @click="cancelEditing"
       size="small"
     ) Cancel
   td(v-else)
     .flex.flex-wrap.items-center.justify-center.gap-1
-      el-button(
+      ElButton(
         @click="editing = true"
         link
         type="primary"
       ) Edit
-      el-popconfirm(
+      ElPopconfirm(
         title="Delete this log entry?"
         @confirm="destroyLogEntry"
       )
         template(#reference)
-          el-button(
+          ElButton(
             link
             type="danger"
           ) Delete

--- a/app/javascript/logs/components/Log.vue
+++ b/app/javascript/logs/components/Log.vue
@@ -20,20 +20,20 @@ div
       :log="log"
     )
     .mt-2(v-if="showDeleteLastEntryButton")
-      el-popconfirm(
+      ElPopconfirm(
         title="Delete the last log entry?"
         @confirm="destroyLastEntry"
       )
         template(#reference)
-          el-button Delete last entry
+          ElButton Delete last entry
     .mt-2
-      el-button(
+      ElButton(
         tag="a"
         :href="download_log_path(log.slug)"
         download
       ) Download CSV
     .mt-2
-      el-button.multi-line(
+      ElButton.multi-line(
         @click="modalStore.showModal({ modalName: 'edit-log-sharing-settings' })"
       )
         .h4 Sharing settings
@@ -41,7 +41,7 @@ div
           span(v-if="log.publicly_viewable") Viewable by any user
           span(v-else) Shared with {{ assert(log.log_shares).length }} emails
     .mt-2
-      el-button.multi-line(
+      ElButton.multi-line(
         @click="modalStore.showModal({ modalName: 'edit-log-reminder-schedule' })"
       )
         .h4 Reminder settings
@@ -50,7 +50,7 @@ div
             | {{ (log.reminder_time_in_seconds / (60 * 60)).toFixed() }} hours
           span(v-else) No reminders
     .mt-2
-      el-button(@click="destroyLog") Delete log
+      ElButton(@click="destroyLog") Delete log
 
   EditLogSharingSettingsModal
 

--- a/app/javascript/logs/components/LogSelectorModal.vue
+++ b/app/javascript/logs/components/LogSelectorModal.vue
@@ -15,7 +15,7 @@ Modal(
   )
   div
     .log-link-container(v-for="log in rankedMatches")
-      router-link.log-link(
+      RouterLink.log-link(
         :to="{ name: 'log', params: { slug: log.slug } }"
         :class="{ 'font-bold': log === highlightedSearchable }"
       ) {{ log.name }}

--- a/app/javascript/logs/components/LogsIndex.vue
+++ b/app/javascript/logs/components/LogsIndex.vue
@@ -2,7 +2,7 @@
 section
   div
     .log-link-container.m-2.text-2xl(v-for="log in logs")
-    RouterLink.log-link(:to="{ name: 'log', params: { slug: log.slug } }") {{ log.name }}
+      RouterLink.log-link(:to="{ name: 'log', params: { slug: log.slug } }") {{ log.name }}
   hr.my-8.border-gray
   NewLogForm
 </template>

--- a/app/javascript/logs/components/LogsIndex.vue
+++ b/app/javascript/logs/components/LogsIndex.vue
@@ -2,7 +2,7 @@
 section
   div
     .log-link-container.m-2.text-2xl(v-for="log in logs")
-      router-link.log-link(:to="{ name: 'log', params: { slug: log.slug } }") {{ log.name }}
+    RouterLink.log-link(:to="{ name: 'log', params: { slug: log.slug } }") {{ log.name }}
   hr.my-8.border-gray
   NewLogForm
 </template>

--- a/app/javascript/logs/components/NewLogEntryForm.vue
+++ b/app/javascript/logs/components/NewLogEntryForm.vue
@@ -5,14 +5,14 @@ div
     :class="log.data_type"
   )
     .mb-2(v-if="isCounter")
-      el-button(
+      ElButton(
         v-for="logEntryValue in mostRecentLogEntryValues"
         :key="logEntryValue"
         @click="postNewLogEntry(logEntryValue)"
       ) {{ logEntryValue }}
     .flex.justify-center
       .w-full.max-w-4xl
-        el-input.new-log-input.mb-2(
+        ElInput.new-log-input.mb-2(
           :placeholder="log.data_label"
           v-model="formData.newLogEntryData"
           name="log.data_label"
@@ -20,20 +20,20 @@ div
           :type="inputType"
         )
     div(:class="{ 'mt-2': isText }")
-      el-date-picker(
+      ElDatePicker(
         :class="{ 'mb-2': isNumeric }"
         v-model="formData.newLogEntryCreatedAt"
         type="datetime"
         placeholder="Backdate (optional)"
       )
-      el-input.new-log-input(
+      ElInput.new-log-input(
         :class="{ 'mb-2': isNumeric }"
         v-if="isDuration || isNumber"
         placeholder="Note (optional)"
         v-model="formData.newLogEntryNote"
         type="text"
       )
-      el-button(
+      ElButton(
         native-type="submit"
         :disabled="v$.$invalid"
       ) Add

--- a/app/javascript/logs/components/NewLogForm.vue
+++ b/app/javascript/logs/components/NewLogForm.vue
@@ -5,36 +5,36 @@ div
     div(style="width: 400px")
       form.px-2(@submit.prevent="createLog")
         .mb-2
-          el-input(
+          ElInput(
             placeholder="Name"
             v-model="newLog.name"
             name="newLog.name"
           )
-        el-input.mb-2(
+        ElInput.mb-2(
           type="textarea"
           placeholder="Details/Description (optional)"
           v-model="newLog.description"
           name="newLog.description"
         )
         .mb-2
-          el-input(
+          ElInput(
             placeholder="Label (e.g. Weight, Run time, etc)"
             v-model="newLog.data_label"
             name="newLog.data_label"
           )
         .mb-2
-          el-select(
+          ElSelect(
             placeholder="Type"
             v-model="newLog.data_type"
             name="newLog.data_type"
           )
-            el-option(
+            ElOption(
               v-for="dataType in logInputTypes"
               :key="dataType.data_type"
               :label="dataType.label"
               :value="dataType.data_type"
             )
-        el-button(
+        ElButton(
           native-type="submit"
           :disabled="postingLog"
         ) Create

--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -10,7 +10,7 @@ div
           :logEntry="logEntry"
           :class="{ 'transition-none!': index !== 0 }"
         )
-  el-button(
+  ElButton(
     v-if="!showAllEntries"
     @click="showAllEntries = true"
   ).

--- a/app/javascript/workout/components/ConfirmWorkoutModal.vue
+++ b/app/javascript/workout/components/ConfirmWorkoutModal.vue
@@ -17,14 +17,14 @@ Modal(
           v-model.number="repTotals[exercise]"
         )
     div
-      el-checkbox(v-model="publiclyViewable") Publicly viewable
+      ElCheckbox(v-model="publiclyViewable") Publicly viewable
     .flex.justify-around.mt-4
-      el-button(
+      ElButton(
         @click="modalStore.hideModal({ modalName })"
         type="primary"
         link
       ) Cancel
-      el-button(
+      ElButton(
         type="primary"
         @click="saveWorkout"
       ) Save workout

--- a/app/javascript/workout/components/NewWorkoutForm.vue
+++ b/app/javascript/workout/components/NewWorkoutForm.vue
@@ -4,7 +4,7 @@ form
   .my-2
     label
       | Minutes
-      el-input(
+      ElInput(
         v-model.number="workoutsStore.workout.minutes"
         name="minutes"
         type="number"
@@ -13,7 +13,7 @@ form
   .my-2
     label
       | Sets
-      el-input(
+      ElInput(
         v-model.number="workoutsStore.workout.numberOfSets"
         name="numberOfSets"
         type="number"
@@ -22,7 +22,7 @@ form
     .col.col-6
       label
         | Exercise
-        el-input(
+        ElInput(
           v-model="exercise.name"
           :name="`exercise-${index}-name`"
           type="text"
@@ -30,20 +30,20 @@ form
     .col.col-5
       label
         | Reps per set
-        el-input(
+        ElInput(
           v-model.number="exercise.reps"
           :name="`exercise-${index}-reps`"
           type="number"
         )
     .col.col-1.flex.flex-col.items-center.justify-end
-      el-button(
+      ElButton(
         type="danger"
         @click="removeExercise(index)"
       ) X
   .my-2.text-center
-    el-button(@click="workout.exercises.push({})") Add exercise
+    ElButton(@click="workout.exercises.push({})") Add exercise
   .mt-4.text-center
-    el-button(
+    ElButton(
       type="primary"
       @click="workoutsStore.initializeWorkout()"
     ) Initialize Workout!

--- a/app/javascript/workout/components/WorkoutPlan.vue
+++ b/app/javascript/workout/components/WorkoutPlan.vue
@@ -1,11 +1,11 @@
 <template lang="pug">
 .text-center.pb-8
   .pt-6.pb-4
-    el-switch(
+    ElSwitch(
       v-model="editMode"
       active-text="Edit mode"
     )
-    el-switch.ml-8(
+    ElSwitch.ml-8(
       v-model="soundEnabled"
       active-text="Sound"
     )

--- a/app/javascript/workout/components/WorkoutsTable.vue
+++ b/app/javascript/workout/components/WorkoutsTable.vue
@@ -14,7 +14,7 @@ table(v-if="workouts.length")
       td {{ (workout.time_in_seconds / 60).toFixed(1) }}
       td {{ prettyObject(workout.rep_totals) }}
       td(v-if="isOwnWorkouts")
-        el-checkbox(
+        ElCheckbox(
           v-model="workout.publicly_viewable"
           @change="savePubliclyViewableChange(workout)"
         )


### PR DESCRIPTION
I am already mostly using PascalCase for my own Vue components, but I have been using kebab-case for many/all Element Plus components, and some others. This change switches to PascalCase for all components (including Element Plus components).

The [Vue style guide][1] mentions some advantages of PascalCase over kebab-case in templates:

> PascalCase has a few advantages over kebab-case:
>
> - Editors can autocomplete component names in templates, because PascalCase is also used in JavaScript.
>
> - `<MyComponent>` is more visually distinct from a single-word HTML element than `<my-component>`, because there are two character differences (the two capitals), rather than just one (a hyphen).
>
> - If you use any non-Vue custom elements in your templates, such as a web component, PascalCase ensures that your Vue components remain distinctly visible.

[1]: https://vuejs.org/style-guide/rules-strongly-recommended.html#component-name-casing-in-templates

These all make sense to me and seem worthwhile.

The third point is relevant because it would enable something like this to distinguish web components from Vue components: https://vuejs.org/guide/extras/web-components#example-vite-config 

```js
// vite.config.js
import vue from '@vitejs/plugin-vue'

export default {
  plugins: [
    vue({
      template: {
        compilerOptions: {
          // treat all tags with a dash as custom elements
          isCustomElement: (tag) => tag.includes('-')
        }
      }
    })
  ]
}
```

... which is relevant because I am thinking about using a web component to do https://davidrunger.atlassian.net/browse/DEV- 220 .