### PR TITLE
Add 'blog/*' and 'tmp/*' to ESLint ignore list

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,9 +27,11 @@ export default defineConfigWithVueTs(
       'app/javascript/types/bootstrap/*',
       'app/javascript/types/responses/*',
       'app/javascript/types/serializers/*',
+      'blog/*',
       'node_modules/*',
       'public/vite-admin/*',
       'public/vite/*',
+      'tmp/*',
     ],
   },
   {


### PR DESCRIPTION
(There was some stuff in `tmp/` related to `rubycritic` and `simple_cov`.)