### PR TITLE
Add missing keys to v-for loops where reasonably possible

### DIFF
--- a/app/javascript/check_ins/components/Ratings.vue
+++ b/app/javascript/check_ins/components/Ratings.vue
@@ -1,5 +1,8 @@
 <template lang="pug">
-.my-8(v-for="needSatisfactionRating in needSatisfactionRatings")
+.my-8(
+  v-for="needSatisfactionRating in needSatisfactionRatings"
+  :key="needSatisfactionRating.id"
+)
   .mb-2
     strong {{ needSatisfactionRating.emotional_need.name }}
     ElPopover(
@@ -21,6 +24,7 @@
   div
     EmojiButton(
       v-for="ratingValue in RATINGS_RANGE"
+      :key="ratingValue"
       :needSatisfactionRating="needSatisfactionRating"
       :ratingValue="ratingValue"
       :editable="editable"

--- a/app/javascript/logs/components/EditLogRemindersModal.vue
+++ b/app/javascript/logs/components/EditLogRemindersModal.vue
@@ -24,7 +24,10 @@ Modal(
         |
         |
         select(v-model="timeUnit")
-          option(v-for="timeUnit in timeUnitOptions") {{ timeUnit }}
+          option(
+            v-for="timeUnit in timeUnitOptions"
+            :key="timeUnit"
+          ) {{ timeUnit }}
         |
         | to create a log entry (if I haven't already done so).
       .flex.justify-center.mt-4

--- a/app/javascript/logs/components/LogSelectorModal.vue
+++ b/app/javascript/logs/components/LogSelectorModal.vue
@@ -14,7 +14,10 @@ Modal(
     @keydown.down="onArrowDown"
   )
   div
-    .log-link-container(v-for="log in rankedMatches")
+    .log-link-container(
+      v-for="log in rankedMatches"
+      :key="log.id"
+    )
       RouterLink.log-link(
         :to="{ name: 'log', params: { slug: log.slug } }"
         :class="{ 'font-bold': log === highlightedSearchable }"

--- a/app/javascript/logs/components/LogsIndex.vue
+++ b/app/javascript/logs/components/LogsIndex.vue
@@ -1,7 +1,10 @@
 <template lang="pug">
 section
   div
-    .log-link-container.m-2.text-2xl(v-for="log in logs")
+    .log-link-container.m-2.text-2xl(
+      v-for="log in logs"
+      :key="log.id"
+    )
       RouterLink.log-link(:to="{ name: 'log', params: { slug: log.slug } }") {{ log.name }}
   hr.my-8.border-gray
   NewLogForm

--- a/app/javascript/workout/components/WorkoutsTable.vue
+++ b/app/javascript/workout/components/WorkoutsTable.vue
@@ -8,7 +8,10 @@ table(v-if="workouts.length")
       th Rep totals
       th(v-if="isOwnWorkouts") Public
   tbody
-    tr(v-for="workout in workoutsSortedByCreatedAtDesc")
+    tr(
+      v-for="workout in workoutsSortedByCreatedAtDesc"
+      :key="workout.id"
+    )
       td {{ prettyTime(workout.created_at) }}
       td(v-if="!isOwnWorkouts") {{ workout.username }}
       td {{ (workout.time_in_seconds / 60).toFixed(1) }}


### PR DESCRIPTION
There are several places where we don't have a key available for the objects being iterated over that is guaranteed to be unique and also we cannot construct such a key from the object's properties. In these cases, I will just continue to omit the `key`, with the thinking that, while it might hurt performance, at least it will hopefully avoid bugs that would be caused by mutating and/or non-unique keys.