### PR TITLE
Sanitize HTML returned by (herein renamed) 'linkifyAndSanitize'

### DIFF
--- a/app/javascript/groceries/components/Item.vue
+++ b/app/javascript/groceries/components/Item.vue
@@ -23,7 +23,7 @@
       )
     template(v-else)
       span.item-name
-        span(v-html="linkify(item.name)")
+        span(v-html="linkifyAndSanitize(item.name)")
         |
         |
         a.js-link.text-neutral-400(@click="editItemName" class="hover:text-black")
@@ -47,7 +47,7 @@ import { EditIcon, MinusIcon, PlusIcon, XIcon } from 'vue-tabler-icons';
 import { useGroceriesStore } from '@/groceries/store';
 import type { Item } from '@/groceries/types';
 import { useCancellableInput } from '@/lib/composables/useCancellableInput';
-import { linkify } from '@/lib/linkify';
+import { linkifyAndSanitize } from '@/lib/linkifyAndSanitize';
 
 const ICON_SIZE = 17;
 

--- a/app/javascript/lib/linkifyAndSanitize.ts
+++ b/app/javascript/lib/linkifyAndSanitize.ts
@@ -1,6 +1,8 @@
+import DOMPurify from 'dompurify';
+
 const httpUrlRegex =
   /(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*[a-zA-Z0-9/])(?:#[-a-zA-Z0-9()@:%_+.~#?&/=]*)?)/gi;
 
-export function linkify(text: string): string {
-  return text.replace(httpUrlRegex, '<a href="$1">$1</a>');
+export function linkifyAndSanitize(text: string): string {
+  return DOMPurify.sanitize(text.replace(httpUrlRegex, '<a href="$1">$1</a>'));
 }

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -18,7 +18,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'emoji_picker*.css' => (8..18),
     'emoji_picker*.js' => (322..332),
     'groceries*.css' => (60..70),
-    'groceries*.js' => (302..312),
+    'groceries*.js' => (325..335),
     'home*.css' => (13..23),
     'home*.js' => (247..257),
     'logs*.css' => (101..111),


### PR DESCRIPTION
Since the HTML returned by the function formerly known as `linkify` and now known as `linkifyAndSanitize` will often be dangerously inserted into the DOM using `v-html`, sanitizing the linkified HTML by default will provide a layer of protection against XSS attacks.

In fact, if it weren't for our Content Security Policy (CSP), we would have had an XSS vulnerability here! Thank goodness that we do have a pretty strong CSP that provides broad protection against XSS attacks. But it's good to have multiple, redundant layers of protection, rather than relying on any single layer of protection, which is why I think that this change is very much worth making, regardless of the fact that it's not patching an actual XSS vulnerability.