### PR TITLE
Rename linkifyAndSanitize => linkifiedAndSanitizedHtml

### DIFF
--- a/app/javascript/groceries/components/Item.vue
+++ b/app/javascript/groceries/components/Item.vue
@@ -23,7 +23,7 @@
       )
     template(v-else)
       span.item-name
-        span(v-html="linkifyAndSanitize(item.name)")
+        span(v-html="linkifiedAndSanitizedHtml(item.name)")
         |
         |
         a.js-link.text-neutral-400(@click="editItemName" class="hover:text-black")
@@ -47,7 +47,7 @@ import { EditIcon, MinusIcon, PlusIcon, XIcon } from 'vue-tabler-icons';
 import { useGroceriesStore } from '@/groceries/store';
 import type { Item } from '@/groceries/types';
 import { useCancellableInput } from '@/lib/composables/useCancellableInput';
-import { linkifyAndSanitize } from '@/lib/linkifyAndSanitize';
+import { linkifiedAndSanitizedHtml } from '@/lib/linkifiedAndSanitizedHtml';
 
 const ICON_SIZE = 17;
 

--- a/app/javascript/lib/linkifiedAndSanitizedHtml.ts
+++ b/app/javascript/lib/linkifiedAndSanitizedHtml.ts
@@ -3,6 +3,6 @@ import DOMPurify from 'dompurify';
 const httpUrlRegex =
   /(https?:\/\/(?:www\.)?[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b(?:[-a-zA-Z0-9()@:%_+.~#?&/=]*[a-zA-Z0-9/])(?:#[-a-zA-Z0-9()@:%_+.~#?&/=]*)?)/gi;
 
-export function linkifyAndSanitize(text: string): string {
+export function linkifiedAndSanitizedHtml(text: string): string {
   return DOMPurify.sanitize(text.replace(httpUrlRegex, '<a href="$1">$1</a>'));
 }


### PR DESCRIPTION
I try to name things that are used for their return value as nouns, and things that are used for their side effects as verbs. In that paradigm, since the function being modified herein is used for its return value, it should be named as a noun, which this change does.