### PR TITLE
Add Retry module and use it to retry errors in 'bin/prerender'

### DIFF
--- a/bin/prerender
+++ b/bin/prerender
@@ -9,25 +9,30 @@ require 'dotenv/load' if ENV.fetch('CI', nil) != 'true'
 require 'ferrum'
 require 'nokogiri'
 
+require_relative '../lib/retry.rb'
+
 class Prerenderer
   def initialize
-    @browser = Ferrum::Browser.new(process_timeout: 20, timeout: 60)
-  rescue Ferrum::ProcessTimeoutError => error
-    puts("Rescued error: #{error}.")
-    puts('Retrying...')
-    retry
+    assign_new_browser
   end
 
   def prerender(url:, filename:, expected_text:)
-    url = Addressable::URI.parse(url)
-    url.query_values = (url.query_values || {}).merge(prerender: 'true')
+    Retry.retrying do
+      url = Addressable::URI.parse(url)
+      url.query_values = (url.query_values || {}).merge(prerender: 'true')
 
-    render_page_content(url: url.to_s, expected_text:)
+      render_page_content(url: url.to_s, expected_text:)
 
-    upload_prerender_to_s3(
-      filename:,
-      body: html_for_prerendering("<!DOCTYPE html>\n#{@browser.body}"),
-    )
+      upload_prerender_to_s3(
+        filename:,
+        body: html_for_prerendering("<!DOCTYPE html>\n#{@browser.body}"),
+      )
+    rescue
+      quit_browser
+      assign_new_browser
+
+      raise # This will be rescued (and maybe re-raised) by `Retry.retrying`.
+    end
   end
 
   def quit_browser
@@ -35,6 +40,12 @@ class Prerenderer
   end
 
   private
+
+  def assign_new_browser
+    Retry.retrying(errors: [Ferrum::ProcessTimeoutError]) do
+      @browser = Ferrum::Browser.new(process_timeout: 20, timeout: 2.0)
+    end
+  end
 
   def render_page_content(url:, expected_text:)
     @browser.goto(url)

--- a/lib/retry.rb
+++ b/lib/retry.rb
@@ -1,0 +1,39 @@
+require 'active_support'
+require 'active_support/logger'
+require 'active_support/tagged_logging'
+require 'memo_wise'
+
+module Retry
+  class << self
+    prepend MemoWise
+
+    def retrying(times: 2, errors: [StandardError])
+      retries = 0
+
+      begin
+        yield
+      rescue *errors => error
+        logger.info("Error: #{error.class} - #{error.message}")
+
+        if retries < times
+          logger.info('Retrying...')
+          retries += 1
+          retry
+        else
+          logger.info('Retries exhausted; raising.')
+          raise(error)
+        end
+      end
+    end
+
+    memo_wise \
+    def logger
+      ActiveSupport::Logger.new($stdout).tap do |logger|
+        logger.formatter = ActiveSupport::Logger::SimpleFormatter.new
+      end.then do |logger|
+        ActiveSupport::TaggedLogging.new(logger)
+      end.
+        tagged(name)
+    end
+  end
+end

--- a/lib/test/task_helpers.rb
+++ b/lib/test/task_helpers.rb
@@ -5,15 +5,6 @@ module Test::TaskHelpers
 
   private
 
-  def logger
-    ActiveSupport::Logger.new($stdout).tap do |logger|
-      logger.formatter = ActiveSupport::Logger::SimpleFormatter.new
-    end.then do |logger|
-      ActiveSupport::TaggedLogging.new(logger)
-    end.
-      tagged(self.class.name.delete_prefix('Test::Tasks::'))
-  end
-
   def execute_system_command(command, env_vars = {}, log_stdout_only_on_failure: false)
     command = command.squish
     puts(<<~LOG.squish)

--- a/spec/lib/retry_spec.rb
+++ b/spec/lib/retry_spec.rb
@@ -67,21 +67,6 @@ RSpec.describe Retry do
     end
 
     context 'when specifying an :errors option' do
-      context 'when an error of a class not listed in :errors is raised' do
-        let(:result) do
-          Retry.retrying(errors: [ArgumentError]) do
-            @call_count += 1
-            raise(not_handled_error_message)
-          end
-        end
-        let(:not_handled_error_message) { 'This error type is not handled' }
-
-        it 'does not retry' do
-          expect { result }.to raise_error(RuntimeError, not_handled_error_message)
-          expect(@call_count).to eq(1) # No retries
-        end
-      end
-
       context 'when an error of a class listed in :errors is raised' do
         let(:result) do
           Retry.retrying(times: 1, errors: [ArgumentError]) do
@@ -94,6 +79,21 @@ RSpec.describe Retry do
         it 'retries' do
           expect { result }.to raise_error(ArgumentError, handled_error_message)
           expect(@call_count).to eq(2) # Original + 1 retry
+        end
+      end
+
+      context 'when an error of a class not listed in :errors is raised' do
+        let(:result) do
+          Retry.retrying(errors: [ArgumentError]) do
+            @call_count += 1
+            raise(not_handled_error_message)
+          end
+        end
+        let(:not_handled_error_message) { 'This error type is not handled' }
+
+        it 'does not retry' do
+          expect { result }.to raise_error(RuntimeError, not_handled_error_message)
+          expect(@call_count).to eq(1) # No retries
         end
       end
     end

--- a/spec/lib/retry_spec.rb
+++ b/spec/lib/retry_spec.rb
@@ -1,0 +1,115 @@
+RSpec.describe Retry do
+  # rubocop:disable RSpec/InstanceVariable
+  describe '.retrying' do
+    let(:logger) { instance_double(ActiveSupport::Logger) }
+
+    before do
+      allow(Retry).to receive(:logger).and_return(logger)
+      allow(logger).to receive(:info)
+      @call_count = 0
+    end
+
+    context 'when the block succeeds on the first attempt' do
+      let(:result) do
+        Retry.retrying do
+          success_message
+        end
+      end
+      let(:success_message) { 'success' }
+
+      it 'returns the result of the block and logs nothing' do
+        expect(result).to eq(success_message)
+        expect(logger).not_to have_received(:info)
+      end
+    end
+
+    context 'when the block fails the first time but succeeds on retry' do
+      let(:result) do
+        Retry.retrying do
+          @call_count += 1
+
+          if @call_count == 1
+            raise(StandardError, first_attempt_failure_message)
+          else
+            success_on_retry_message
+          end
+        end
+      end
+      let(:first_attempt_failure_message) { 'first attempt failed' }
+      let(:success_on_retry_message) { 'success on retry' }
+
+      it 'retries and returns the successful result' do
+        expect(result).to eq(success_on_retry_message)
+        expect(@call_count).to eq(2)
+        expect(logger).to have_received(:info).
+          with("Error: StandardError - #{first_attempt_failure_message}")
+        expect(logger).to have_received(:info).with('Retrying...')
+      end
+    end
+
+    context 'when the block fails on all attempts' do
+      let(:result) do
+        Retry.retrying do
+          @call_count += 1
+          raise(StandardError, "Attempt #{@call_count} failed")
+        end
+      end
+
+      it 'retries twice (three tries total) and re-raises the last error' do
+        expect { result }.to raise_error(StandardError, 'Attempt 3 failed')
+        expect(@call_count).to eq(3)
+        expect(logger).to have_received(:info).with('Error: StandardError - Attempt 1 failed')
+        expect(logger).to have_received(:info).with('Error: StandardError - Attempt 2 failed')
+        expect(logger).to have_received(:info).with('Error: StandardError - Attempt 3 failed')
+        expect(logger).to have_received(:info).with('Retrying...').twice
+        expect(logger).to have_received(:info).with('Retries exhausted; raising.')
+      end
+    end
+
+    context 'when specifying an :errors option' do
+      context 'when an error of a class not listed in :errors is raised' do
+        let(:result) do
+          Retry.retrying(errors: [ArgumentError]) do
+            @call_count += 1
+            raise(not_handled_error_message)
+          end
+        end
+        let(:not_handled_error_message) { 'This error type is not handled' }
+
+        it 'does not retry' do
+          expect { result }.to raise_error(RuntimeError, not_handled_error_message)
+          expect(@call_count).to eq(1) # No retries
+        end
+      end
+
+      context 'when an error of a class listed in :errors is raised' do
+        let(:result) do
+          Retry.retrying(times: 1, errors: [ArgumentError]) do
+            @call_count += 1
+            raise(ArgumentError, handled_error_message)
+          end
+        end
+        let(:handled_error_message) { 'This error type is handled' }
+
+        it 'retries' do
+          expect { result }.to raise_error(ArgumentError, handled_error_message)
+          expect(@call_count).to eq(2) # Original + 1 retry
+        end
+      end
+    end
+  end
+  # rubocop:enable RSpec/InstanceVariable
+
+  describe '.logger' do
+    it 'returns a tagged logger' do
+      expect(Retry.logger).to be_a(ActiveSupport::TaggedLogging)
+    end
+
+    it 'uses MemoWise to cache the logger' do
+      first_logger = Retry.logger
+      second_logger = Retry.logger
+
+      expect(first_logger).to be(second_logger)
+    end
+  end
+end


### PR DESCRIPTION
I'm hoping to avoid errors like these failing prerendering (which then triggers an email to me from UptimeRobot about the site being down):

```
/home/runner/work/david_runger/david_runger/vendor/bundle/ruby/3.4.0/gems/ferrum-0.15/lib/ferrum/page.rb:118:in 'Ferrum::Page#go_to': Request to [https://davidrunger.com?prerender=true](https://davidrunger.com/?prerender=true) reached server, but there are still pending connections: https://davidrunger.com/vite/assets/is_mobile_device-DGfD92Br.js, https://davidrunger.com/vite/assets/helpers-X2NtxM42.js, https://davidrunger.com/vite/assets/index-JJ6K2_ci.js, https://davidrunger.com/vite/assets/_baseFlatten-Du46FJxm.js (Ferrum::PendingConnectionsError)
	from /opt/hostedtoolcache/Ruby/3.4.2/x64/lib/ruby/3.4.0/forwardable.rb:240:in 'Ferrum::Browser#goto'
	from bin/prerender:40:in 'Prerenderer#render_page_content'
	from bin/prerender:25:in 'Prerenderer#prerender'
	from bin/prerender:71:in '<main>'
```

https://github.com/davidrunger/david_runger/actions/runs/14025246696/job/39262794920