### PR TITLE
[modal] Move v-if to element within the 'transition'

### DIFF
--- a/app/javascript/components/Modal.vue
+++ b/app/javascript/components/Modal.vue
@@ -1,9 +1,9 @@
 <template lang="pug">
 transition(
   name="modal"
-  v-if="showingModal({ modalName: name })"
 )
   .modal-mask.fixed.flex.flex-col.items-center.justify-center.w-full.top-0.left-0.h-screen.z-10(
+    v-if="showingModal({ modalName: name })"
     ref="mask"
     @click="handleClickMask"
   )

--- a/app/javascript/components/Modal.vue
+++ b/app/javascript/components/Modal.vue
@@ -1,7 +1,5 @@
 <template lang="pug">
-transition(
-  name="modal"
-)
+transition(name="modal")
   .modal-mask.fixed.flex.flex-col.items-center.justify-center.w-full.top-0.left-0.h-screen.z-10(
     v-if="showingModal({ modalName: name })"
     ref="mask"


### PR DESCRIPTION
Before, with `v-if` on the `transition` itself, the transition effect(s) were not occurring.