### PR TITLE
Remove renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
-}


### PR DESCRIPTION
There's a lot to like about renovate, but I was having some trouble getting it to respect the `renovate.json` config when running it locally. (I ultimately specified `RENOVATE_CONFIG_FILE=/home/david/code/david_runger/renovate.json`, but it seems like this shouldn't be necessary.) And also it doesn't pull updates from the dependencies' changelogs, as dependabot does, which is a big missing feature.

So, I think I am just going to wait for dependabot to hopefully eventually include pnpm 10 support, and update things myself, in the meantime, using `pnpx npm-check-updates --interactive`.