### PR TITLE
Bump cadvisor from 0.49.2 to 0.52.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ services:
     cpu_shares: 512
     expose:
       - '8080'
-    image: gcr.io/cadvisor/cadvisor:v0.49.2
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
     networks:
       - internal
     volumes:


### PR DESCRIPTION
I'd like to just use a `latest` tag, but it seems that the `latest` tag is currently stuck back at v0.49.1 for some reason.