### PR TITLE
[docker-compose/nginx] Bump nginx from 1.27.0 to 1.27.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -162,7 +162,7 @@ services:
       interval: 5m
       timeout: 3s
       retries: 1
-    image: nginx:1.27.0-alpine
+    image: nginx:1.27.4-alpine
     logging: *default-logging
     memswap_limit: 99G
     networks:


### PR DESCRIPTION
I think that I will need to manually run `docker compose up --detach --force-recreate nginx` after this deploys, since `nginx` it is in the `nondefault` Docker Compose profile.