### PR TITLE
Pluralize the path from 'workout' to 'workouts' [WORK-5]

### DIFF
--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -2,7 +2,7 @@ class WorkoutsController < ApplicationController
   def index
     authorize(Workout)
     @title = 'Workouts'
-    @description = 'Plan and execute timed workouts and track them over time.'
+    @description = 'Execute timed workouts and track them over time.'
     bootstrap(
       current_user: UserSerializer::WithDefaultWorkout.new(current_user),
       workouts: WorkoutSerializer.new(

--- a/app/controllers/workouts_controller.rb
+++ b/app/controllers/workouts_controller.rb
@@ -1,8 +1,8 @@
 class WorkoutsController < ApplicationController
   def index
     authorize(Workout)
-    @title = 'Workout'
-    @description = 'Plan and execute a timed workout'
+    @title = 'Workouts'
+    @description = 'Plan and execute timed workouts and track them over time.'
     bootstrap(
       current_user: UserSerializer::WithDefaultWorkout.new(current_user),
       workouts: WorkoutSerializer.new(

--- a/app/javascript/home/components/Projects.vue
+++ b/app/javascript/home/components/Projects.vue
@@ -18,7 +18,7 @@ HomeSection(
 
         li #[a(:href="groceries_path()") Groceries]* - Simplify and streamline your family's grocery shopping with a collaborative, mobile-friendly, real-time (WebSockets-enabled) list.
 
-        li #[a(:href="workout_path()") Workout]* - An app for tracking workouts over time, and to stay on-pace within a workout.
+        li #[a(:href="workouts_path()") Workout]* - An app for tracking workouts over time, and to stay on-pace within a workout.
 
         li #[a(:href="logs_path()") Logs]* - Track anything you like using various log types: text, number, duration, or counter.
 
@@ -179,7 +179,7 @@ import {
   groceries_path,
   logs_path,
   quizzes_path,
-  workout_path,
+  workouts_path,
 } from '@/rails_assets/routes';
 
 import HomeSection from './HomeSection.vue';

--- a/app/javascript/home/components/Projects.vue
+++ b/app/javascript/home/components/Projects.vue
@@ -18,7 +18,7 @@ HomeSection(
 
         li #[a(:href="groceries_path()") Groceries]* - Simplify and streamline your family's grocery shopping with a collaborative, mobile-friendly, real-time (WebSockets-enabled) list.
 
-        li #[a(:href="workouts_path()") Workout]* - An app for tracking workouts over time, and to stay on-pace within a workout.
+        li #[a(:href="workouts_path()") Workouts]* - An app for tracking workouts over time, and to stay on-pace within a workout.
 
         li #[a(:href="logs_path()") Logs]* - Track anything you like using various log types: text, number, duration, or counter.
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,8 +21,8 @@ Rails.application.routes.draw do
   get 'emoji-picker', to: 'emoji_picker#index'
 
   get 'groceries', to: 'groceries#index'
-  get 'workout', to: 'workouts#index'
-  get 'workouts', to: redirect('workout')
+  get 'workouts', to: 'workouts#index'
+  get 'workout', to: redirect('workouts')
   resources :logs, only: %i[index], param: :slug do
     member do
       get :download

--- a/spec/controllers/workouts_controller_spec.rb
+++ b/spec/controllers/workouts_controller_spec.rb
@@ -7,16 +7,11 @@ RSpec.describe WorkoutsController do
     context 'when logged in' do
       before { sign_in(user) }
 
-      it 'responds with 200' do
+      it 'responds with 200 and has a title including "Workouts"' do
         get_index
 
         expect(response).to have_http_status(200)
-      end
-
-      it 'has a title including "Workout"' do
-        get_index
-
-        expect(response.body).to have_title(/\AWorkout - David Runger\z/)
+        expect(response.body).to have_title(/\AWorkouts - David Runger\z/)
       end
     end
 

--- a/spec/features/workout_spec.rb
+++ b/spec/features/workout_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'Workout app' do
       let(:exercise_2_reps) { 5 }
 
       it 'renders the new-workout form preloaded with their default workout and shows past workouts of the user and public workouts of others' do
-        visit workout_path
+        visit workouts_path
 
         # Form for a new workout:
         expect(page).to have_text('New Workout')
@@ -57,7 +57,7 @@ RSpec.describe 'Workout app' do
 
       context 'when the user initializes a workout and makes time and exercise count adjustments' do
         it 'adjusts the workout schedule/count table and default workout completion form values in accordance with the adjustments' do
-          visit workout_path
+          visit workouts_path
 
           click_on('Initialize Workout!')
 


### PR DESCRIPTION
Since "workouts" (plural) is a part of the functionality of this app (tracking one's workouts over time, and viewing the workouts of others), I think it makes more sense to name the path using that plural. Even when one is doing a workout (i.e. focusing on a single workout), it's still "within the context" of plural workouts; we are creating a workout that will be added to the collection of workouts, and it is one of the many _workouts_ that one might do. This is basically why it makes sense for Rails controller names to be plural, even though they have "show" actions (and others that act on only one record at a time). For this reason, I think we should make "workouts" the path name, which this change does.