### PR TITLE
Have Tailwind scan app/controllers/ for classes to extract

### DIFF
--- a/app/assets/stylesheets/styles.css
+++ b/app/assets/stylesheets/styles.css
@@ -15,6 +15,7 @@
 @import './ui_framework/button';
 
 /* Specify sources manually, because otherwise classes are pulled from vendor/bundle/ in CI. */
+@source '../../../app/controllers';
 @source '../../../app/decorators';
 @source '../../../app/javascript';
 @source '../../../app/views';


### PR DESCRIPTION
We refer to Tailwind classes in controllers via the `Classable` concern, so we should be scanning these files for Tailwind classes. This change instructs Tailwind to do that.