### PR TITLE
Don't save admin login page URL as redirect_chain

### DIFF
--- a/app/controllers/concerns/redirectable.rb
+++ b/app/controllers/concerns/redirectable.rb
@@ -12,10 +12,11 @@ module Redirectable
   end
 
   def store_redirect_chain
-    if (redirect_chain =
-          params[:redirect_chain] ||
-          request.env['omniauth.origin'].presence
-       ) && redirect_chain != new_user_session_url
+    if (
+      redirect_chain =
+        params[:redirect_chain] ||
+        request.env['omniauth.origin'].presence
+    ) && !redirect_chain.in?([new_user_session_url, new_admin_user_session_url])
       session[:redirect_chain] = redirect_chain
     end
   end

--- a/app/views/shared/_sign_in_with_google.html.haml
+++ b/app/views/shared/_sign_in_with_google.html.haml
@@ -12,7 +12,7 @@
 
 .text-center.bg-white.w-85.mt-20.mx-auto.py-12.rounded-md
   = form_tag("/auth/google_oauth2?redirect_uri=#{url_base}/#{callback_type}/auth/google_oauth2/callback") do
-    = button_tag(image_tag('google-login.png', alt: 'Log in with Google'), type: :submit, class: 'google-login')
+    = button_tag(image_tag('google-login.png', alt: 'Sign in with Google'), type: :submit, class: 'google-login')
   %div
     or go to the
     #{link_to('home page', root_path)}.

--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -48,6 +48,39 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
               end
             end
           end
+
+          context 'when no User or AdminUser is logged in' do
+            before { Devise.sign_out_all_scopes }
+
+            context 'when there is an AdminUser and a User with the same stubbed_user_email' do
+              before { AdminUser.find_or_create_by!(email: user.email) }
+
+              context 'when the AdminUser has logged in' do
+                before do
+                  visit(new_admin_user_session_path)
+
+                  expect(page).to have_current_path(new_admin_user_session_path)
+
+                  click_on('Sign in with Google')
+
+                  expect(page).to have_text('You are beautiful')
+                end
+
+                context 'when the user tries to go to the My Account page' do
+                  it 'redirects the user to log in and, after successful login, redirects to the My Account page' do
+                    visit(my_account_path)
+
+                    expect(page).to have_current_path(new_user_session_path)
+
+                    click_on('Sign in with Google')
+
+                    expect(page).to have_current_path(my_account_path)
+                    expect(page).to have_text('My Account')
+                  end
+                end
+              end
+            end
+          end
         end
 
         context 'when the sub returned from Google does not match the google_sub in our database' do


### PR DESCRIPTION
I noticed this bug:

1. clear cookies
2. log in to admin
3. try to go to a user-facing page
4. be redirected to log in; do so

**Expect:** redirected to the user page that I was trying to access in step 3.

**Actual:** redirected to the admin dashboard.

This change fixes that bug. Now the User will be redirected to the User-facing page that they had tried to access, as expected and intended.