### PR TITLE
[auth-tokens] Update last_used_at right after finding the AuthToken

### DIFF
--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -10,7 +10,9 @@ module TokenAuthenticatable
   def auth_token
     return nil if auth_token_secret.blank?
 
-    AuthToken.find_by(secret: auth_token_secret)
+    AuthToken.find_by(secret: auth_token_secret).tap do |auth_token|
+      auth_token.update!(last_used_at: Time.current)
+    end
   end
 
   memoize \
@@ -45,8 +47,6 @@ module TokenAuthenticatable
     if auth_token.blank?
       raise(InvalidToken)
     end
-
-    auth_token.update!(last_used_at: Time.current)
 
     true
   end

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -11,7 +11,7 @@ module TokenAuthenticatable
     return nil if auth_token_secret.blank?
 
     AuthToken.find_by(secret: auth_token_secret).tap do |auth_token|
-      auth_token.update!(last_used_at: Time.current)
+      auth_token&.update!(last_used_at: Time.current)
     end
   end
 


### PR DESCRIPTION
Before, we were updating `last_used_at` in `verify_valid_auth_token!`. This doesn't seem to me like the best place to do it, since, at least theoretically, the auth token might be used to authenticate a request but not have `verify_valid_auth_token!` called upon it. We currently call `verify_valid_auth_token!` in only one place, in `verify_authenticity_token`, which is used when guarding against CSRF attacks. But we might theoretically (though I guess one would hope not) disable CSRF protection for an endpoint, and yet use an AuthToken for authentication. This change moves the `auth_token.update!(last_used_at: Time.current)` call to a more logical location where (better aligned with the concept of "being used", i.e. being accessed), even in such a scenario, the AuthToken's `last_used_at` timestamp would still be updated.