### PR TITLE
Use default branch of my 'paper_trail' fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,8 +34,7 @@ gem 'nokogiri'
 gem 'omniauth-google-oauth2'
 gem 'omniauth-rails_csrf_protection'
 gem 'paper_trail', # Source from RubyGems after https://github.com/paper-trail-gem/paper_trail/pull/1511 is released.
-  github: 'davidrunger/paper_trail',
-  branch: 'avoid-n+1-queries-in-version_limit-when-destroying'
+  github: 'davidrunger/paper_trail'
 gem 'pg'
 gem 'pghero'
 gem 'pg_query' # Used by `pghero` and `prosopite`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/davidrunger/paper_trail.git
-  revision: 2c8a96d4dfdca7c4a7a4d5e631d52ec30ed2762f
-  branch: avoid-n+1-queries-in-version_limit-when-destroying
+  revision: 1bbfc90661774699e082a615681d18a8fc2860f4
   specs:
     paper_trail (16.0.0)
       activerecord (>= 6.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: https://github.com/davidrunger/paper_trail.git
-  revision: 1bbfc90661774699e082a615681d18a8fc2860f4
+  revision: 33592b9c6cc4030b894e7dc923dce3223c682760
   specs:
     paper_trail (16.0.0)
       activerecord (>= 6.1)


### PR DESCRIPTION
`rm -rf /home/david/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/cache/bundler/git/paper_trail-e72cb6eaeabf85d79a95ce2079562f125a7ce183` and `bundle update paper_trail`

I have just merged the `avoid-n+1-queries-in-version_limit-when-destroying` branch (in https://github.com/davidrunger/paper_trail/pull/4) and also a few other branches into the primary branch (`master`), so we will continue to include that bugfix.

**Motivation:** Clean things up a little. Also, I'm not sure that `paper_trail` is very actively maintained, anymore. There are some various little signs that it's not. So, I might end up using my fork, indefinitely. In that case, I want things to be in a better state for modifications along multiple dimensions (e.g. running CI against Ruby 3.4), not just a single PR branch.