### PR TITLE
[ApplicationPolicy] Require a user for create? and new?

### DIFF
--- a/app/controllers/api/ci_step_results/bulk_creations_controller.rb
+++ b/app/controllers/api/ci_step_results/bulk_creations_controller.rb
@@ -1,4 +1,6 @@
 class Api::CiStepResults::BulkCreationsController < Api::BaseController
+  allow_auth_token_authorization
+
   def create
     authorize(CiStepResult)
 

--- a/app/controllers/api/log_entries_controller.rb
+++ b/app/controllers/api/log_entries_controller.rb
@@ -1,4 +1,6 @@
 class Api::LogEntriesController < Api::BaseController
+  allow_auth_token_authorization
+
   skip_before_action :authenticate_user!, only: %i[index]
 
   def create

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,15 +26,25 @@ class ApplicationController < ActionController::Base
 
   rescue_from(*AUTHORIZATION_ERROR_MESSAGES.keys, with: :user_not_authorized)
 
-  def self.require_admin_user!
-    skip_before_action(:authenticate_user!)
-    before_action(:authenticate_admin_user!)
+  class << self
+    def allow_auth_token_authorization
+      class_eval do
+        def pundit_user
+          current_or_auth_token_user
+        end
+      end
+    end
 
-    class_eval do
-      private
+    def require_admin_user!
+      skip_before_action(:authenticate_user!)
+      before_action(:authenticate_admin_user!)
 
-      def pundit_user
-        current_admin_user
+      class_eval do
+        private
+
+        def pundit_user
+          current_admin_user
+        end
       end
     end
   end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -17,7 +17,7 @@ class ApplicationPolicy
   end
 
   def create?
-    true
+    @user.is_a?(User)
   end
 
   def new?

--- a/app/policies/event_policy.rb
+++ b/app/policies/event_policy.rb
@@ -1,2 +1,5 @@
 class EventPolicy < ApplicationPolicy
+  def create?
+    true
+  end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,8 @@
 class UserPolicy < ApplicationPolicy
+  def create?
+    true
+  end
+
   def show?
     own_record?
   end

--- a/app/policies/webhook_email_forward_policy.rb
+++ b/app/policies/webhook_email_forward_policy.rb
@@ -1,2 +1,5 @@
 class WebhookEmailForwardPolicy < ApplicationPolicy
+  def create?
+    true
+  end
 end

--- a/spec/controllers/api/webhook_email_forwards_controller_spec.rb
+++ b/spec/controllers/api/webhook_email_forwards_controller_spec.rb
@@ -21,10 +21,12 @@ RSpec.describe Api::WebhookEmailForwardsController do
         let(:alert_title) { 'CPU usage is high!' }
         let(:alert_body) { '<html><head></head><body><p>CPU problem!</p></body></html>' }
 
-        it 'sends an HTML email to the AuthToken user with the title as the subject and the message as the body' do
+        it 'responds with :created and sends an HTML email to the AuthToken user with the title as the subject and the message as the body' do
           with_inline_sidekiq do
             post_create
           end
+
+          expect(response).to have_http_status(:created)
 
           # Check that email was sent with expected properties.
           expect(ActionMailer::Base.deliveries.size).to eq(1)

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -1,13 +1,24 @@
 RSpec.describe ApplicationPolicy do
   subject(:policy) { ApplicationPolicy.new(user, workout) }
 
-  let(:workout) { user.workouts.first! }
+  let(:workout) { user&.workouts&.first! }
   let(:user) { users(:user) }
 
   # rubocop:disable RSpec/EmptyLineAfterSubject
   describe '#index?' do
     subject(:index?) { policy.index? }
-    specify { expect(index?).to eq(true) }
+
+    context 'when there is a user' do
+      let(:user) { users(:user) }
+
+      specify { expect(index?).to eq(true) }
+    end
+
+    context 'when there is no user' do
+      let(:user) { nil }
+
+      specify { expect(index?).to eq(false) }
+    end
   end
 
   describe '#show?' do
@@ -17,12 +28,34 @@ RSpec.describe ApplicationPolicy do
 
   describe '#create?' do
     subject(:create?) { policy.create? }
-    specify { expect(create?).to eq(true) }
+
+    context 'when there is a user' do
+      let(:user) { users(:user) }
+
+      specify { expect(create?).to eq(true) }
+    end
+
+    context 'when there is no user' do
+      let(:user) { nil }
+
+      specify { expect(create?).to eq(false) }
+    end
   end
 
   describe '#new?' do
     subject(:new?) { policy.new? }
-    specify { expect(new?).to eq(true) }
+
+    context 'when there is a user' do
+      let(:user) { users(:user) }
+
+      specify { expect(new?).to eq(true) }
+    end
+
+    context 'when there is no user' do
+      let(:user) { nil }
+
+      specify { expect(new?).to eq(false) }
+    end
   end
 
   describe '#update?' do


### PR DESCRIPTION
We usually want to know who has created the relevant record and who owns it.

There are some cases where we now need to pass an AuthToken-authenticated user, which is accomplished via the new `allow_auth_token_authorization` controller class method.

There are some exceptions to this, which are reflected by the changes herein, where, for some specific policies (EventPolicy, UserPolicy, WebhookEmailForwardPolicy), we continue with `created?` always returning `true` (even if there is no user).