### PR TITLE
[AuthTokens] Allow scoping to specific action(s) [DEV-222]

### DIFF
--- a/app/controllers/auth_tokens_controller.rb
+++ b/app/controllers/auth_tokens_controller.rb
@@ -23,7 +23,7 @@ class AuthTokensController < ApplicationController
   private
 
   def auth_token_params
-    params.expect(auth_token: %i[name secret])
+    params.expect(auth_token: %i[name permitted_actions_list secret])
   end
 
   def set_auth_token

--- a/app/controllers/concerns/request_recordable.rb
+++ b/app/controllers/concerns/request_recordable.rb
@@ -36,7 +36,7 @@ module RequestRecordable
       filtered_params:,
       admin_user: current_admin_user,
       user: current_user,
-      auth_token:,
+      auth_token: auth_token_valid_for_action,
       request_time: @request_time,
     ).request_data
   end

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -13,6 +13,7 @@ module TokenAuthenticatable
 
       if auth_token&.valid_for?(controller_action)
         auth_token.update!(last_used_at: Time.current)
+
         auth_token
       end
     end

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -2,13 +2,14 @@
 #
 # Table name: auth_tokens
 #
-#  created_at   :datetime         not null
-#  id           :bigint           not null, primary key
-#  last_used_at :datetime
-#  name         :text
-#  secret       :text             not null
-#  updated_at   :datetime         not null
-#  user_id      :bigint           not null
+#  created_at             :datetime         not null
+#  id                     :bigint           not null, primary key
+#  last_used_at           :datetime
+#  name                   :text
+#  permitted_actions_list :text
+#  secret                 :text             not null
+#  updated_at             :datetime         not null
+#  user_id                :bigint           not null
 #
 # Indexes
 #

--- a/app/models/auth_token.rb
+++ b/app/models/auth_token.rb
@@ -16,10 +16,21 @@
 #  index_auth_tokens_on_user_id_and_secret  (user_id,secret) UNIQUE
 #
 class AuthToken < ApplicationRecord
+  prepend Memoization
+
   validates :secret, presence: true, uniqueness: { scope: :user_id }
 
   belongs_to :user
   has_many :requests, dependent: :nullify
 
   has_paper_trail_for_all_events
+
+  memoize \
+  def permitted_actions
+    permitted_actions_list&.split(/[,\s]+/)&.compact_blank || []
+  end
+
+  def valid_for?(controller_action)
+    permitted_actions.blank? || controller_action.in?(permitted_actions)
+  end
 end

--- a/app/views/my_account/edit.html.haml
+++ b/app/views/my_account/edit.html.haml
@@ -1,21 +1,27 @@
-%div.my-8
-  %h2.h3 Auth tokens (advanced feature; safe to ignore)
-  - current_user.auth_tokens.each do |auth_token|
-    %div.mt-2
-      = form_with(model: auth_token, class: 'inline') do |form|
-        %span
-          = form.label :secret, 'Secret (required)'
-          = form.text_field :secret
+%h2.h3 Auth tokens (advanced feature; safe to ignore)
 
-        %span.ml-8
-          = form.label :name, 'Name (optional)'
-          = form.text_field :name
+.mt-4
+  = button_to('Create New Auth Token', auth_tokens_path(method: :post), class: 'btn-primary')
 
-        %span.ml-8
-          = form.submit('Update Auth Token', class: 'btn-primary')
+- current_user.auth_tokens.reorder(:created_at).each do |auth_token|
+  .mt-10
+    = form_with(model: auth_token, class: 'inline') do |form|
+      .my-2
+        = form.label :secret, 'Secret (required)'
+        = form.text_field :secret
 
-      = button_to('Destroy Auth Token', auth_token_path(auth_token),
-        method: :delete, class: 'btn-danger')
+      .my-2
+        = form.label :name, 'Name (optional)'
+        = form.text_field :name
 
-  %div.mt-4
-    = button_to('Create New Auth Token', auth_tokens_path(method: :post), class: 'btn-primary')
+      .my-2
+        %div
+          = form.label :permitted_actions_list, 'Permitted actions (optional). ', class: 'block'
+          %small A comma- and/or whitespace-separated list of controller actions (in the form `api/csp_results#create`) for which this auth token may be used as an authorization mechanism. Note: A blank list means that the AuthToken is valid for all controller actions.
+        = form.textarea :permitted_actions_list, rows: 2, class: 'w-full'
+
+      .my-2
+        = form.submit('Update Auth Token', class: 'btn-primary')
+
+    = button_to('Destroy Auth Token', auth_token_path(auth_token),
+      method: :delete, class: 'btn-danger')

--- a/db/migrate/20250325233233_add_permitted_actions_list_to_auth_tokens.rb
+++ b/db/migrate/20250325233233_add_permitted_actions_list_to_auth_tokens.rb
@@ -1,0 +1,15 @@
+class AddPermittedActionsListToAuthTokens < ActiveRecord::Migration[8.0]
+  def change
+    add_column(
+      :auth_tokens,
+      :permitted_actions_list,
+      :text,
+      comment: <<~COMMENT.squish,
+        A comma- and/or whitespace-separated list of controller actions (in the
+        form `api/csp_results#create`) for which the auth token may be used
+        as an authorization mechanism. Note: A blank list means that the
+        AuthToken is valid for all controller actions.
+      COMMENT
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_03_15_194328) do
+ActiveRecord::Schema[8.0].define(version: 2025_03_25_233233) do
   create_schema "pghero"
 
   # These are extensions that must be enabled in order to support this database
@@ -82,6 +82,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_03_15_194328) do
     t.datetime "last_used_at", precision: nil
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "permitted_actions_list", comment: "A comma- and/or whitespace-separated list of controller actions (in the form `api/csp_results#create`) for which the auth token may be used as an authorization mechanism. Note: A blank list means that the AuthToken is valid for all controller actions."
     t.index ["secret"], name: "index_auth_tokens_on_secret"
     t.index ["user_id", "secret"], name: "index_auth_tokens_on_user_id_and_secret", unique: true
   end

--- a/spec/factories/auth_tokens.rb
+++ b/spec/factories/auth_tokens.rb
@@ -2,13 +2,14 @@
 #
 # Table name: auth_tokens
 #
-#  created_at   :datetime         not null
-#  id           :bigint           not null, primary key
-#  last_used_at :datetime
-#  name         :text
-#  secret       :text             not null
-#  updated_at   :datetime         not null
-#  user_id      :bigint           not null
+#  created_at             :datetime         not null
+#  id                     :bigint           not null, primary key
+#  last_used_at           :datetime
+#  name                   :text
+#  permitted_actions_list :text
+#  secret                 :text             not null
+#  updated_at             :datetime         not null
+#  user_id                :bigint           not null
 #
 # Indexes
 #


### PR DESCRIPTION
Users will have to enter strings like `api/csp_results#create`, which is a not great UI at all, but it's fine for now, considering that I will be the only person ever to use this feature.

Limiting a token in this way will significantly decrease the extent of the security loss if a user's token is ever compromised.