### PR TITLE
Add & use loofah-activerecord to sanitize all strings in DB [DEV-224]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,7 @@ gem 'json'
 gem 'js-routes', require: false
 gem 'jwt'
 gem 'lograge'
+gem 'loofah-activerecord'
 gem 'memo_wise'
 gem 'nokogiri'
 gem 'omniauth-google-oauth2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -384,6 +384,8 @@ GEM
     loofah (2.24.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    loofah-activerecord (2.0.0)
+      loofah (>= 1.0.0)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -812,6 +814,7 @@ DEPENDENCIES
   letter_opener
   listen
   lograge
+  loofah-activerecord
   memo_wise
   nokogiri
   omniauth-google-oauth2
@@ -996,6 +999,7 @@ CHECKSUMS
   logger (1.6.6) sha256=dd618d24e637715472732e7eed02e33cfbdf56deaad225edd0f1f89d38024017
   lograge (0.14.0) sha256=42371a75823775f166f727639f5ddce73dd149452a55fc94b90c303213dc9ae1
   loofah (2.24.0) sha256=61e6a710883abb8210887f3dc868cf3ed66594c509d9ff6987621efa6651ee1e
+  loofah-activerecord (2.0.0) sha256=f7daf13d7c7c5a3972d8e9ddd413021ac35bc5ac35d170c44b0eda81255e59ee
   mail (2.8.1) sha256=ec3b9fadcf2b3755c78785cb17bc9a0ca9ee9857108a64b6f5cfc9c0b5bfc9ad
   marcel (1.0.4) sha256=0d5649feb64b8f19f3d3468b96c680bae9746335d02194270287868a661516a4
   matrix (0.4.2) sha256=71083ccbd67a14a43bfa78d3e4dc0f4b503b9cc18e5b4b1d686dc0f9ef7c4cc0

--- a/config/initializers/loofah.rb
+++ b/config/initializers/loofah.rb
@@ -1,0 +1,1 @@
+Loofah::XssFoliate.xss_foliate_all_models

--- a/spec/workers/save_request_spec.rb
+++ b/spec/workers/save_request_spec.rb
@@ -147,11 +147,13 @@ RSpec.describe SaveRequest do
         context 'when ip-api.com responds with info about the requesting IP' do
           before { MockIpApi.stub_request(request_ip) }
 
-          it 'creates an IpBlock' do
+          it 'creates an IpBlock with HTML-escaping by Loofah' do
             expect { perform }.to change { IpBlock.count }.by(1)
             ip_block = IpBlock.last!
             expect(ip_block.ip).to eq(request_ip)
-            expect(ip_block.reason).to eq(JSON.dump(params))
+            expect(ip_block.reason).to eq(
+              JSON.dump(params).gsub('"', '&quot;'),
+            )
           end
         end
       end


### PR DESCRIPTION
https://github.com/flavorjones/loofah-activerecord
https://www.rubydoc.info/gems/loofah-activerecord/2.0.0/Loofah/XssFoliate

Sanitizing all strings before they are saved to the database will provide an additional layer of protection against XSS attacks. The more layers of protection, the better!, since one never knows when any given layer of protection will fail or be circumvented.