### PR TITLE
Remove suggestion to go back to upstream pry-byebug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,9 +70,7 @@ group :development, :test do
   gem 'json-schema'
   gem 'listen'
   gem 'prosopite'
-  gem 'pry-byebug',
-    require: false,
-    github: 'davidrunger/pry-byebug'
+  gem 'pry-byebug', require: false, github: 'davidrunger/pry-byebug'
   gem 'rainbow'
   gem 'rubocop', require: false
   gem 'rubocop-capybara', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -70,7 +70,7 @@ group :development, :test do
   gem 'json-schema'
   gem 'listen'
   gem 'prosopite'
-  gem 'pry-byebug', # Go back to upstream if/when https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 is merged.
+  gem 'pry-byebug',
     require: false,
     github: 'davidrunger/pry-byebug'
   gem 'rainbow'


### PR DESCRIPTION
The mentioned PR ( https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 ) is not really the only advantage of using the `david_runger/pry-byebug` fork. Another advantage is that the fork uses `runger_byebug` rather than `byebug` (where `runger_byebug` has advantages, like this PR: https://github.com/davidrunger/runger_byebug/pull/10 ). Therefore, remove the suggestion to go back to the upstream `pry-byebug` after https://github.com/deivid-rodriguez/pry-byebug/pull/ 428 has been merged (which it just was, although it hasn't yet been released via RubyGems).