### PR TITLE
Remove all remaining usage of Rails credentials [DEV-223]

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-config/credentials/*.yml.enc diff=rails_credentials
-config/credentials.yml.enc diff=rails_credentials

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -119,6 +119,8 @@ jobs:
           # The hostname used to communicate with the Redis service container
           REDIS_HOST: redis
           REDIS_PORT: 6379
+          AWS_ACCESS_KEY_ID: '${{secrets.AWS_ACCESS_KEY_ID}}'
+          AWS_SECRET_ACCESS_KEY: '${{secrets.AWS_SECRET_ACCESS_KEY}}'
           CI_STEP_RESULTS_HOST: '${{secrets.CI_STEP_RESULTS_HOST}}'
           CI_STEP_RESULTS_AUTH_TOKEN: '${{secrets.CI_STEP_RESULTS_AUTH_TOKEN}}'
           PERCY_TOKEN: '${{secrets.PERCY_TOKEN}}'

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,8 +1,6 @@
 Aws.config.update(
   credentials: Aws::Credentials.new(
-    ENV['AWS_ACCESS_KEY_ID'].presence ||
-      Rails.application.credentials.aws&.dig(:access_key_id),
-    ENV['AWS_SECRET_ACCESS_KEY'].presence ||
-      Rails.application.credentials.aws&.dig(:secret_access_key),
+    ENV['AWS_ACCESS_KEY_ID'].presence,
+    ENV['AWS_SECRET_ACCESS_KEY'].presence,
   ),
 )

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -5,7 +5,7 @@ local:
 amazon:
   service: NamespacedS3
   namespace: active_storage_uploads
-  access_key_id: <%= Rails.application.credentials.aws&.dig(:access_key_id) || ENV['AWS_ACCESS_KEY_ID'] %>
-  secret_access_key: <%= Rails.application.credentials.aws&.dig(:secret_access_key) || ENV['AWS_SECRET_ACCESS_KEY'] %>
+  access_key_id: <%= ENV['AWS_ACCESS_KEY_ID'] %>
+  secret_access_key: <%= ENV['AWS_SECRET_ACCESS_KEY'] %>
   bucket: david-runger-uploads<%= Rails.env.local? ? "-#{Rails.env}" : '' %>
   region: us-east-1

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -2,7 +2,6 @@ RSpec.describe 'Home page', :prerendering_disabled do
   it 'says "David Runger / Full stack web developer" and tracks scrolling and clicks on external links' do
     visit root_path
 
-    expect(page).to have_text('This is an intentionally caused spec failure!')
     expect(page).to have_text(<<~HEADLINE, normalize_ws: false)
       David Runger
       Full stack web developer

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe 'Home page', :prerendering_disabled do
   it 'says "David Runger / Full stack web developer" and tracks scrolling and clicks on external links' do
     visit root_path
 
+    expect(page).to have_text('This is an intentionally caused spec failure!')
     expect(page).to have_text(<<~HEADLINE, normalize_ws: false)
       David Runger
       Full stack web developer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,8 +80,8 @@ OmniAuth.config.test_mode = true
 if SpecHelper.is_ci?
   Capybara::Screenshot.s3_configuration = {
     s3_client_credentials: {
-      access_key_id: Rails.application.credentials.aws![:access_key_id],
-      secret_access_key: Rails.application.credentials.aws![:secret_access_key],
+      access_key_id: ENV.fetch('AWS_ACCESS_KEY_ID'),
+      secret_access_key: ENV.fetch('AWS_SECRET_ACCESS_KEY'),
       region: 'us-east-1',
     },
     bucket_name: 'david-runger-test-uploads',


### PR DESCRIPTION
The only place where we were still using Rails credentials was in the test environment, to upload screenshots from failed feature specs and to upload compiled assets. This change removes that usage and replaces it with ENV vars stored in GitHub Actions secrets.

I don't have the credentials any longer to decrypt the encrypted test credentials in order to transfer them to GitHub Actions secrets, so instead I have generated new ones (and deleted the old ones), which is probably a good idea, anyway (to keep the secrets somewhat fresher, in case the previous secrets might have been leaked at some point).