### PR TITLE
Use different AWS credentials for uploading prerenders

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -189,5 +189,5 @@ jobs:
         run: bin/prerender
         env:
           CI: true
-          AWS_ACCESS_KEY_ID: '${{secrets.AWS_ACCESS_KEY_ID}}'
-          AWS_SECRET_ACCESS_KEY: '${{secrets.AWS_SECRET_ACCESS_KEY}}'
+          AWS_ACCESS_KEY_ID: '${{secrets.UPLOADS_CRUD_USER_AWS_ACCESS_KEY_ID}}'
+          AWS_SECRET_ACCESS_KEY: '${{secrets.UPLOADS_CRUD_USER_AWS_SECRET_ACCESS_KEY}}'

--- a/bin/prerender
+++ b/bin/prerender
@@ -68,8 +68,6 @@ class Prerenderer
       bucket('david-runger-uploads').
       object("prerenders/#{git_sha}/#{filename}").
       put(body:)
-  rescue => error
-    puts("Error uploading object: #{error.inspect}")
   end
 
   def html_for_prerendering(html)


### PR DESCRIPTION
The prerenders are uploaded to a different bucket (`david-runger-uploads`) than compiled assets and spec failure screenshots (`david-runger-test-uploads`), and a different set of credentials are needed to add objects to that bucket. This change provides those different credentials via new GitHub Actions secrets (`UPLOADS_CRUD_USER_AWS_ACCESS_KEY_ID`, `UPLOADS_CRUD_USER_AWS_SECRET_ACCESS_KEY`), though I am mapping these secrets to un-namespaced conventional AWS env vars (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`), since that is what our code and/or the library(s) we are using require.

Also, don't rescue errors that occur when trying to upload prerenders. If uploading fails, then we want the prerendering step to be marked in GitHub Actions as having failed.