### PR TITLE
Upload prerenders to 'david-runger-test-uploads' bucket [DEV-228]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -189,5 +189,5 @@ jobs:
         run: bin/prerender
         env:
           CI: true
-          AWS_ACCESS_KEY_ID: '${{secrets.UPLOADS_CRUD_USER_AWS_ACCESS_KEY_ID}}'
-          AWS_SECRET_ACCESS_KEY: '${{secrets.UPLOADS_CRUD_USER_AWS_SECRET_ACCESS_KEY}}'
+          AWS_ACCESS_KEY_ID: '${{secrets.AWS_ACCESS_KEY_ID}}'
+          AWS_SECRET_ACCESS_KEY: '${{secrets.AWS_SECRET_ACCESS_KEY}}'

--- a/app/poros/prerender_utils.rb
+++ b/app/poros/prerender_utils.rb
@@ -6,7 +6,7 @@ module PrerenderUtils
 
     def transformed_s3_content(git_rev:, filename:)
       Aws::S3::Resource.new(region: 'us-east-1').
-        bucket('david-runger-uploads').
+        bucket('david-runger-test-uploads').
         object("prerenders/#{git_rev}/#{filename}").
         get.body.read.
         then { html_with_absolutized_asset_paths(it) }

--- a/bin/prerender
+++ b/bin/prerender
@@ -65,7 +65,7 @@ class Prerenderer
     raise('Could not determine git SHA!') if git_sha.empty?
 
     Aws::S3::Resource.new(region: 'us-east-1').
-      bucket('david-runger-uploads').
+      bucket('david-runger-test-uploads').
       object("prerenders/#{git_sha}/#{filename}").
       put(body:)
   end

--- a/spec/controllers/concerns/prerenderable_spec.rb
+++ b/spec/controllers/concerns/prerenderable_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
         before do
           stub_request(
             :get,
-            'https://david-runger-uploads.s3.amazonaws.com/' \
+            'https://david-runger-test-uploads.s3.amazonaws.com/' \
             "prerenders/#{commit_sha}/home.html",
           ).to_return(status: 200, headers: {}, body: <<~HTML)
             <!doctype html>


### PR DESCRIPTION
Prior to this change, we uploaded prerenders to the `david-runger-uploads` bucket.

However, I don't think that really makes sense. Why not upload them to `david-runger-test-uploads`?

`david-runger-test-uploads` is publicly readable, so even though we set up our S3 / AWS stuff in production (in which environment the prerenders will need to be downloaded) to use credentials for the `david-runger-uploads-crud-user` AWS IAM user (which has access to the `david-runger-uploads` S3 bucket), our S3 client in production should also still be able to read prerenders that were uploaded to `david-runger-test-uploads` (since, again, that bucket is publicly readable).

It should be fine to upload prerenders to a publicly readable bucket. They contain no secret info. Anyone can ultimately access the prerenders just by requesting https://davidrunger.com/ .

Therefore, this change switches from uploading prerenders to `david-runger-uploads` and instead now uploads them to `david-runger-test-uploads`.

This change has the advantage of not needing to give any step in our CI process access to the production assets that are stored in the `david-runger-uploads bucket`.

Additionally, this change simplifies things by allowing us just to use a single set of AWS credentials in CI, making [this change][1] unnecessary (hence it is reverted in this PR) and allowing us to delete those secrets from the GitHub Actions secrets.