### PR TITLE
Stop setting RAILS_MASTER_KEY env var in CI

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -125,7 +125,6 @@ jobs:
           CI_STEP_RESULTS_AUTH_TOKEN: '${{secrets.CI_STEP_RESULTS_AUTH_TOKEN}}'
           PERCY_TOKEN: '${{secrets.PERCY_TOKEN}}'
           CODECOV_TOKEN: '${{secrets.CODECOV_TOKEN}}'
-          RAILS_MASTER_KEY: '${{secrets.RAILS_MASTER_KEY}}'
 
       - name: Save failed feature spec logs
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2


### PR DESCRIPTION
Since https://github.com/davidrunger/david_runger/pull/6555 (in which PR this change probably ideally would have been made), I think we have no need for a `RAILS_MASTER_KEY` anymore, in any environment. Previously, we were using it to decrypt Rails credentials. However, we aren't using Rails credentials in any environment anymore. Therefore, this change stops setting that ENV var in CI. Assuming that this PR's build and deploy goes smoothly, I will then also delete the corresponding GitHub Actions secret.