### PR TITLE
[ConvertSchemasToTs] Mention Ruby code in success message

### DIFF
--- a/lib/test/tasks/convert_schemas_to_ts.rb
+++ b/lib/test/tasks/convert_schemas_to_ts.rb
@@ -7,7 +7,7 @@ class Test::Tasks::ConvertSchemasToTs < Pallets::Task
     JsonSchemasToTypescript.write_files
 
     if execute_system_command('git diff --exit-code')
-      record_success_and_log_message('Wrote JSON schemas as types.')
+      record_success_and_log_message('JsonSchemasToTypescript.write_files completed successfully.')
     else
       # Reset the git state, so it's clean for other test tasks.
       execute_system_command('git checkout .')


### PR DESCRIPTION
This will parallel how we mention `JsonSchemasToTypescript.write_files` when starting the task.