### PR TITLE
Don't HTML-escape special characters with Loofah [DEV-229]

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -4,6 +4,10 @@ class ApplicationRecord < ActiveRecord::Base
   # from the `strip_attributes` gem https://github.com/rmm5t/strip_attributes
   strip_attributes
 
+  # For `loofah-activerecord`. https://www.rubydoc.info/gems/loofah-activerecord/2.0.0/Loofah/XssFoliate
+  # NOTE: Supposedly this makes our strings not guaranteed safe to render as HTML.
+  xss_foliate encode_special_chars: false
+
   class << self
     prepend Memoization
 

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -5,4 +5,14 @@ RSpec.describe Request do
 
   it { is_expected.to belong_to(:auth_token).optional }
   it { is_expected.to belong_to(:user).optional }
+
+  context 'when the ISP contains an ampersand' do
+    subject(:request) { create(:request, isp: isp_with_ampersand) }
+
+    let(:isp_with_ampersand) { 'AT&T' }
+
+    it 'does not HTML-escape the ampersand' do
+      expect(request.isp).to eq(isp_with_ampersand)
+    end
+  end
 end

--- a/spec/workers/save_request_spec.rb
+++ b/spec/workers/save_request_spec.rb
@@ -151,9 +151,7 @@ RSpec.describe SaveRequest do
             expect { perform }.to change { IpBlock.count }.by(1)
             ip_block = IpBlock.last!
             expect(ip_block.ip).to eq(request_ip)
-            expect(ip_block.reason).to eq(
-              JSON.dump(params).gsub('"', '&quot;'),
-            )
+            expect(ip_block.reason).to eq(JSON.dump(params))
           end
         end
       end


### PR DESCRIPTION
This fixes a bug introduced here: https://github.com/davidrunger/david_runger/pull/6549 .

According to [the `loofah-activerecord` documentation](https://www.rubydoc.info/gems/loofah-activerecord/2.0.0/Loofah/XssFoliate), the change in this PR (`xss_foliate encode_special_chars: false`) makes our strings unsafe to render as HTML:

```rb
    # when the final content is intended for non-html contexts,
    # such as plaintext email, you can turn off entity encoding
    # for all fields
    xss_foliate :encode_special_chars => false   # do *not* escape HTML entities in any field. NOTE THAT THE RESULT IS UNSAFE FOR RENDERING IN HTML CONTEXTS.
```

However, at least the strings should still be safer than before we added `loofah-activerecord`, when we were making no server-side attempt to escape HTML at all. Now, at least, Loofah will still strip HTML tags, etc for us.

In the relatively rare cases where we actually do render strings as HTML (in which case these strings without HTML-escaped characters will supposedly be dangerous), we should be protected by our CSP and also by using DOMPurify, so, to the extent that an attack can be smuggled in via unsafe characters (even with all of Loofah's other protections), hopefully we will still be safe.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/cba31c79-63df-4674-a957-922d8453bf1e) | ![image](https://github.com/user-attachments/assets/cfc667b1-075d-4485-b4e7-eea8ed3e4ad9) |