### PR TITLE
[comments] Confirm with user before deleting a comment [COM-7]

### DIFF
--- a/app/javascript/comments/components/Comment.vue
+++ b/app/javascript/comments/components/Comment.vue
@@ -8,7 +8,7 @@
     .time-since-creation(:title="comment.created_at") {{ timeSinceCreation }}
     .actions(v-if="isAuthor")
       button(@click="isEditing = !isEditing") {{ isEditing ? 'Cancel' : 'Edit' }}
-      button(@click="store.deleteComment(comment.id)") Delete
+      button(@click="handleCommentDelete(comment.id)") Delete
 
   template(v-if="isEditing")
     CommentForm(
@@ -134,6 +134,12 @@ function handleCommentUpdate(content: string) {
 function handleReplyCreate(content: string) {
   store.addComment(content, props.comment.id);
   showReplyForm.value = false;
+}
+
+function handleCommentDelete(commentId: number) {
+  if (confirm('Delete comment?')) {
+    store.deleteComment(commentId);
+  }
 }
 </script>
 

--- a/config/initializers/monkeypatches/warning.rb
+++ b/config/initializers/monkeypatches/warning.rb
@@ -1,0 +1,19 @@
+# In test, this monkeypatch stores warnings in a global `$warnings` variable (if
+# it is defined). This variable will be set before each RSpec test and checked
+# afterward, to make sure that no warnings were printed. If they were, then we
+# will fail the test. This ensures that warnings are caught by CI, rather than
+# being logged without anyone noticing (and fixing) them.
+
+if Rails.env.test?
+  module StoreWarningsInGlobalVariable
+    def warn(message, *_args, **_kwargs)
+      if defined?($warnings) && $warnings.respond_to?(:<<)
+        $warnings << message
+      end
+
+      super
+    end
+  end
+
+  Warning.prepend(StoreWarningsInGlobalVariable)
+end

--- a/config/initializers/monkeypatches/warning.rb
+++ b/config/initializers/monkeypatches/warning.rb
@@ -7,11 +7,13 @@
 if Rails.env.test?
   module StoreWarningsInGlobalVariable
     def warn(message, *_args, **_kwargs)
+      # :nocov:
       if defined?($warnings) && $warnings.respond_to?(:<<)
         $warnings << message
       end
 
       super
+      # :nocov:
     end
   end
 

--- a/spec/features/blog_spec.rb
+++ b/spec/features/blog_spec.rb
@@ -110,7 +110,9 @@ RSpec.describe 'Blog' do
 
           expect(page).to have_css('.comment', count: 2)
 
-          click_on('Delete')
+          accept_confirm do
+            click_on('Delete')
+          end
 
           # Because the comment has at least one reply, it is anonymized, rather
           # than fully deleted, so there are still two `.comment` elements.
@@ -119,7 +121,10 @@ RSpec.describe 'Blog' do
 
           Capybara.using_session('replier') do
             visit blog_url_path
-            click_on('Delete')
+
+            accept_confirm do
+              click_on('Delete')
+            end
 
             # Because the reply has no replies of its own, clicking "Delete" fully deletes it.
             expect(page).to have_css('.comment', count: 1)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -163,6 +163,15 @@ RSpec.configure do |config|
   config.include(MailSpecHelpers, type: :mailbox)
   config.include(MailSpecHelpers, type: :mailer)
 
+  # Fail spec if any warnings were registered. See config/initializers/monkeypatches/warning.rb.
+  config.around(:each) do |example|
+    $warnings = []
+
+    example.run
+
+    expect($warnings).to be_empty
+  end
+
   # rspec-retry options >>>
   config.verbose_retry = true
   config.display_try_failure_messages = true


### PR DESCRIPTION
Although it's sort of annoying to confirm, the user should not be at risk of losing a comment just because of a single misclick.

Also, monkeypatch `Warning` so that any warnings will fail specs. **Motivation:** When I didn't wrap the `click_on('Delete')` call in the spec in an `accept_confirm do ... end` block, the spec still passed, but it printed a warning. I don't want my code to generate warnings, and I want to be aware if it does. Failing a spec if it generates any warnings will help to accomplish those goals.