### PR TITLE
[comments] Render dark Google SSO button if user prefers [COM-8]

### DIFF
--- a/app/javascript/comments/Comments.vue
+++ b/app/javascript/comments/Comments.vue
@@ -5,7 +5,7 @@
   template(v-if="store.currentUser")
     CommentForm(@submit="store.addComment")
   template(v-else)
-    p #[GoogleLoginButton.google-login-form(:origin="googleLoginOrigin")] to add a comment.
+    p #[GoogleLoginButton.google-login-form.dark-mode-supported(:origin="googleLoginOrigin")] to add a comment.
 
   .comments
     template(v-if="store.comments.length")

--- a/app/javascript/custom_elements/google_sign_in_button.ts
+++ b/app/javascript/custom_elements/google_sign_in_button.ts
@@ -116,6 +116,117 @@ class GoogleSignInButton extends HTMLElement {
             background-color: #303030;
             opacity: 8%;
           }
+
+          @media (prefers-color-scheme: dark) {
+            .gsi-material-button {
+              -moz-user-select: none;
+              -webkit-user-select: none;
+              -ms-user-select: none;
+              -webkit-appearance: none;
+              background-color: #131314;
+              background-image: none;
+              border: 1px solid #747775;
+              -webkit-border-radius: 4px;
+              border-radius: 4px;
+              -webkit-box-sizing: border-box;
+              box-sizing: border-box;
+              color: #e3e3e3;
+              cursor: pointer;
+              font-family: 'Roboto', arial, sans-serif;
+              font-size: 14px;
+              height: 40px;
+              letter-spacing: 0.25px;
+              outline: none;
+              overflow: hidden;
+              padding: 0 12px;
+              position: relative;
+              text-align: center;
+              -webkit-transition: background-color .218s, border-color .218s, box-shadow .218s;
+              transition: background-color .218s, border-color .218s, box-shadow .218s;
+              vertical-align: middle;
+              white-space: nowrap;
+              width: auto;
+              max-width: 400px;
+              min-width: min-content;
+              border-color: #8e918f;
+            }
+
+            .gsi-material-button .gsi-material-button-icon {
+              height: 20px;
+              margin-right: 12px;
+              min-width: 20px;
+              width: 20px;
+            }
+
+            .gsi-material-button .gsi-material-button-content-wrapper {
+              -webkit-align-items: center;
+              align-items: center;
+              display: flex;
+              -webkit-flex-direction: row;
+              flex-direction: row;
+              -webkit-flex-wrap: nowrap;
+              flex-wrap: nowrap;
+              height: 100%;
+              justify-content: space-between;
+              position: relative;
+              width: 100%;
+            }
+
+            .gsi-material-button .gsi-material-button-contents {
+              -webkit-flex-grow: 1;
+              flex-grow: 1;
+              font-family: 'Roboto', arial, sans-serif;
+              font-weight: 500;
+              overflow: hidden;
+              text-overflow: ellipsis;
+              vertical-align: top;
+            }
+
+            .gsi-material-button .gsi-material-button-state {
+              -webkit-transition: opacity .218s;
+              transition: opacity .218s;
+              bottom: 0;
+              left: 0;
+              opacity: 0;
+              position: absolute;
+              right: 0;
+              top: 0;
+            }
+
+            .gsi-material-button:disabled {
+              cursor: default;
+              background-color: #13131461;
+              border-color: #8e918f1f;
+            }
+
+            .gsi-material-button:disabled .gsi-material-button-state {
+              background-color: #e3e3e31f;
+            }
+
+            .gsi-material-button:disabled .gsi-material-button-contents {
+              opacity: 38%;
+            }
+
+            .gsi-material-button:disabled .gsi-material-button-icon {
+              opacity: 38%;
+            }
+
+            .gsi-material-button:not(:disabled):active .gsi-material-button-state,
+            .gsi-material-button:not(:disabled):focus .gsi-material-button-state {
+              background-color: white;
+              opacity: 12%;
+            }
+
+            .gsi-material-button:not(:disabled):hover {
+              -webkit-box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
+              box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
+            }
+
+            .gsi-material-button:not(:disabled):hover .gsi-material-button-state {
+              background-color: white;
+              opacity: 8%;
+            }
+          }
         </style>
 
         <form class="gsi-form" method="post">

--- a/app/javascript/custom_elements/google_sign_in_button.ts
+++ b/app/javascript/custom_elements/google_sign_in_button.ts
@@ -118,113 +118,115 @@ class GoogleSignInButton extends HTMLElement {
           }
 
           @media (prefers-color-scheme: dark) {
-            .gsi-material-button {
-              -moz-user-select: none;
-              -webkit-user-select: none;
-              -ms-user-select: none;
-              -webkit-appearance: none;
-              background-color: #131314;
-              background-image: none;
-              border: 1px solid #747775;
-              -webkit-border-radius: 4px;
-              border-radius: 4px;
-              -webkit-box-sizing: border-box;
-              box-sizing: border-box;
-              color: #e3e3e3;
-              cursor: pointer;
-              font-family: 'Roboto', arial, sans-serif;
-              font-size: 14px;
-              height: 40px;
-              letter-spacing: 0.25px;
-              outline: none;
-              overflow: hidden;
-              padding: 0 12px;
-              position: relative;
-              text-align: center;
-              -webkit-transition: background-color .218s, border-color .218s, box-shadow .218s;
-              transition: background-color .218s, border-color .218s, box-shadow .218s;
-              vertical-align: middle;
-              white-space: nowrap;
-              width: auto;
-              max-width: 400px;
-              min-width: min-content;
-              border-color: #8e918f;
-            }
+            :host(.dark-mode-supported) {
+              .gsi-material-button {
+                -moz-user-select: none;
+                -webkit-user-select: none;
+                -ms-user-select: none;
+                -webkit-appearance: none;
+                background-color: #131314;
+                background-image: none;
+                border: 1px solid #747775;
+                -webkit-border-radius: 4px;
+                border-radius: 4px;
+                -webkit-box-sizing: border-box;
+                box-sizing: border-box;
+                color: #e3e3e3;
+                cursor: pointer;
+                font-family: 'Roboto', arial, sans-serif;
+                font-size: 14px;
+                height: 40px;
+                letter-spacing: 0.25px;
+                outline: none;
+                overflow: hidden;
+                padding: 0 12px;
+                position: relative;
+                text-align: center;
+                -webkit-transition: background-color .218s, border-color .218s, box-shadow .218s;
+                transition: background-color .218s, border-color .218s, box-shadow .218s;
+                vertical-align: middle;
+                white-space: nowrap;
+                width: auto;
+                max-width: 400px;
+                min-width: min-content;
+                border-color: #8e918f;
+              }
 
-            .gsi-material-button .gsi-material-button-icon {
-              height: 20px;
-              margin-right: 12px;
-              min-width: 20px;
-              width: 20px;
-            }
+              .gsi-material-button .gsi-material-button-icon {
+                height: 20px;
+                margin-right: 12px;
+                min-width: 20px;
+                width: 20px;
+              }
 
-            .gsi-material-button .gsi-material-button-content-wrapper {
-              -webkit-align-items: center;
-              align-items: center;
-              display: flex;
-              -webkit-flex-direction: row;
-              flex-direction: row;
-              -webkit-flex-wrap: nowrap;
-              flex-wrap: nowrap;
-              height: 100%;
-              justify-content: space-between;
-              position: relative;
-              width: 100%;
-            }
+              .gsi-material-button .gsi-material-button-content-wrapper {
+                -webkit-align-items: center;
+                align-items: center;
+                display: flex;
+                -webkit-flex-direction: row;
+                flex-direction: row;
+                -webkit-flex-wrap: nowrap;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: space-between;
+                position: relative;
+                width: 100%;
+              }
 
-            .gsi-material-button .gsi-material-button-contents {
-              -webkit-flex-grow: 1;
-              flex-grow: 1;
-              font-family: 'Roboto', arial, sans-serif;
-              font-weight: 500;
-              overflow: hidden;
-              text-overflow: ellipsis;
-              vertical-align: top;
-            }
+              .gsi-material-button .gsi-material-button-contents {
+                -webkit-flex-grow: 1;
+                flex-grow: 1;
+                font-family: 'Roboto', arial, sans-serif;
+                font-weight: 500;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                vertical-align: top;
+              }
 
-            .gsi-material-button .gsi-material-button-state {
-              -webkit-transition: opacity .218s;
-              transition: opacity .218s;
-              bottom: 0;
-              left: 0;
-              opacity: 0;
-              position: absolute;
-              right: 0;
-              top: 0;
-            }
+              .gsi-material-button .gsi-material-button-state {
+                -webkit-transition: opacity .218s;
+                transition: opacity .218s;
+                bottom: 0;
+                left: 0;
+                opacity: 0;
+                position: absolute;
+                right: 0;
+                top: 0;
+              }
 
-            .gsi-material-button:disabled {
-              cursor: default;
-              background-color: #13131461;
-              border-color: #8e918f1f;
-            }
+              .gsi-material-button:disabled {
+                cursor: default;
+                background-color: #13131461;
+                border-color: #8e918f1f;
+              }
 
-            .gsi-material-button:disabled .gsi-material-button-state {
-              background-color: #e3e3e31f;
-            }
+              .gsi-material-button:disabled .gsi-material-button-state {
+                background-color: #e3e3e31f;
+              }
 
-            .gsi-material-button:disabled .gsi-material-button-contents {
-              opacity: 38%;
-            }
+              .gsi-material-button:disabled .gsi-material-button-contents {
+                opacity: 38%;
+              }
 
-            .gsi-material-button:disabled .gsi-material-button-icon {
-              opacity: 38%;
-            }
+              .gsi-material-button:disabled .gsi-material-button-icon {
+                opacity: 38%;
+              }
 
-            .gsi-material-button:not(:disabled):active .gsi-material-button-state,
-            .gsi-material-button:not(:disabled):focus .gsi-material-button-state {
-              background-color: white;
-              opacity: 12%;
-            }
+              .gsi-material-button:not(:disabled):active .gsi-material-button-state,
+              .gsi-material-button:not(:disabled):focus .gsi-material-button-state {
+                background-color: white;
+                opacity: 12%;
+              }
 
-            .gsi-material-button:not(:disabled):hover {
-              -webkit-box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
-              box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
-            }
+              .gsi-material-button:not(:disabled):hover {
+                -webkit-box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
+                box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
+              }
 
-            .gsi-material-button:not(:disabled):hover .gsi-material-button-state {
-              background-color: white;
-              opacity: 8%;
+              .gsi-material-button:not(:disabled):hover .gsi-material-button-state {
+                background-color: white;
+                opacity: 8%;
+              }
             }
           }
         </style>


### PR DESCRIPTION
It doesn't look amazing, and just on pure aesthetics I think it looks a bit worse than a light mode SSO button. For this reason, I was going to not go ahead with this. However, a downside of the light mode SSO button is that it stands out sort of a lot and it is kind of a visual distraction. It can draw one's eye away from the article text as one gets near the end of the article. That's why I am going ahead with this change.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/eec902f9-97b4-49a0-9166-da803c022d29) | ![image](https://github.com/user-attachments/assets/29babfa5-6c79-41ac-af79-38248c307426) |