### PR TITLE
[comments] Give dark mode Google SSO button a transparent background

### DIFF
--- a/app/javascript/custom_elements/google_sign_in_button.ts
+++ b/app/javascript/custom_elements/google_sign_in_button.ts
@@ -124,7 +124,7 @@ class GoogleSignInButton extends HTMLElement {
                 -webkit-user-select: none;
                 -ms-user-select: none;
                 -webkit-appearance: none;
-                background-color: #131314;
+                background-color: transparent;
                 background-image: none;
                 border: 1px solid #747775;
                 -webkit-border-radius: 4px;


### PR DESCRIPTION
It looks a lot better.

I don't know if this is technically permitted by Google. I think it is? I don't think they say "no modifications whatsoever to our suggested stylesheets". Even if it's not technically okay with Google, to be honest, I don't care.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/c91a3500-f642-4a34-81b0-81d8011fb9e1) | ![image](https://github.com/user-attachments/assets/a09a3332-d241-445f-9405-7b50060a9bab) |
