### PR TITLE
Add 'vega' as a project dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "tailwindcss": "^4.0.17",
     "toastify-js": "^1.12.0",
     "unplugin-element-plus": "^0.9.1",
+    "vega": "^5.33.0",
     "vega-embed": "^6.29.0",
     "vue": "^3.5.13",
     "vue-chartjs": "^5.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -119,9 +119,12 @@ importers:
       unplugin-element-plus:
         specifier: ^0.9.1
         version: 0.9.1
+      vega:
+        specifier: ^5.33.0
+        version: 5.33.0
       vega-embed:
         specifier: ^6.29.0
-        version: 6.29.0(vega-lite@5.23.0(vega@5.31.0))(vega@5.31.0)
+        version: 6.29.0(vega-lite@5.23.0(vega@5.33.0))(vega@5.33.0)
       vue:
         specifier: ^3.5.13
         version: 3.5.13(typescript@5.8.2)
@@ -4156,8 +4159,8 @@ packages:
   vega-format@1.1.3:
     resolution: {integrity: sha512-wQhw7KR46wKJAip28FF/CicW+oiJaPAwMKdrxlnTA0Nv8Bf7bloRlc+O3kON4b4H1iALLr9KgRcYTOeXNs2MOA==}
 
-  vega-functions@5.16.0:
-    resolution: {integrity: sha512-uXjSDbbGcFLCQTZZI+OiZK0U+2dLWC26ONdO0g9RhPzXXzR3niPcFOA0bc/OeiHdTexqsLjOiXxR/K2BckB8gQ==}
+  vega-functions@5.18.0:
+    resolution: {integrity: sha512-+D+ey4bDAhZA2CChh7bRZrcqRUDevv05kd2z8xH+il7PbYQLrhi6g1zwvf8z3KpgGInFf5O13WuFK5DQGkz5lQ==}
 
   vega-geo@4.4.3:
     resolution: {integrity: sha512-+WnnzEPKIU1/xTFUK3EMu2htN35gp9usNZcC0ZFg2up1/Vqu6JyZsX0PIO51oXSIeXn9bwk6VgzlOmJUcx92tA==}
@@ -4181,8 +4184,8 @@ packages:
   vega-loader@4.5.3:
     resolution: {integrity: sha512-dUfIpxTLF2magoMaur+jXGvwMxjtdlDZaIS8lFj6N7IhUST6nIvBzuUlRM+zLYepI5GHtCLOnqdKU4XV0NggCA==}
 
-  vega-parser@6.4.1:
-    resolution: {integrity: sha512-ZjF5aQfRe3yD5e2zYZcWWkUn9zGzUonMIirWTp3S3UBCujz+aT0+Ls6wbHdAH6hCPj3PVVkSWuuLkGEIUpWqyQ==}
+  vega-parser@6.6.0:
+    resolution: {integrity: sha512-jltyrwCTtWeidi/6VotLCybhIl+ehwnzvFWYOdWNUP0z/EskdB64YmawNwjCjzTBMemeiQtY6sJPPbewYqe3Vg==}
 
   vega-projection@1.6.2:
     resolution: {integrity: sha512-3pcVaQL9R3Zfk6PzopLX6awzrQUeYOXJzlfLGP2Xd93mqUepBa6m/reVrTUoSFXA3v9lfK4W/PS2AcVzD/MIcQ==}
@@ -4223,8 +4226,8 @@ packages:
   vega-transforms@4.12.1:
     resolution: {integrity: sha512-Qxo+xeEEftY1jYyKgzOGc9NuW4/MqGm1YPZ5WrL9eXg2G0410Ne+xL/MFIjHF4hRX+3mgFF4Io2hPpfy/thjLg==}
 
-  vega-typings@1.4.0:
-    resolution: {integrity: sha512-UTXjuasq0Q8uMuzz/qow4moVHFJ5atYdQu871QZJ/zgWY3Po4du3dIGBVQN4fYEv6seKhDvxpEFke2rqx81Wqw==}
+  vega-typings@1.5.0:
+    resolution: {integrity: sha512-tcZ2HwmiQEOXIGyBMP8sdCnoFoVqHn4KQ4H0MQiHwzFU1hb1EXURhfc+Uamthewk4h/9BICtAM3AFQMjBGpjQA==}
 
   vega-util@1.17.3:
     resolution: {integrity: sha512-nSNpZLUrRvFo46M5OK4O6x6f08WD1yOcEzHNlqivF+sDLSsVpstaF6fdJYwrbf/debFi2L9Tkp4gZQtssup9iQ==}
@@ -4232,8 +4235,8 @@ packages:
   vega-view-transforms@4.6.1:
     resolution: {integrity: sha512-RYlyMJu5kZV4XXjmyTQKADJWDB25SMHsiF+B1rbE1p+pmdQPlp5tGdPl9r5dUJOp3p8mSt/NGI8GPGucmPMxtw==}
 
-  vega-view@5.14.0:
-    resolution: {integrity: sha512-gg2ukCviKG6Nofmr0Y6hFbr9romRMzmXHe3ljNJ5QyRnkwmQ7HbTvXOyS9cZZ0VtuhSRw+uiyd0Pg+nep0IhwA==}
+  vega-view@5.16.0:
+    resolution: {integrity: sha512-Nxp1MEAY+8bphIm+7BeGFzWPoJnX9+hgvze6wqCAPoM69YiyVR0o0VK8M2EESIL+22+Owr0Fdy94hWHnmon5tQ==}
 
   vega-voronoi@4.2.4:
     resolution: {integrity: sha512-lWNimgJAXGeRFu2Pz8axOUqVf1moYhD+5yhBzDSmckE9I5jLOyZc/XvgFTXwFnsVkMd1QW1vxJa+y9yfUblzYw==}
@@ -4241,8 +4244,8 @@ packages:
   vega-wordcloud@4.1.6:
     resolution: {integrity: sha512-lFmF3u9/ozU0P+WqPjeThQfZm0PigdbXDwpIUCxczrCXKYJLYFmZuZLZR7cxtmpZ0/yuvRvAJ4g123LXbSZF8A==}
 
-  vega@5.31.0:
-    resolution: {integrity: sha512-ZZ+8kcKqCeRi7pBdS7kfBpfhV2gDpa6N950GKGWFw0QL4fH319A9o8FAJzdY8zK0WW0PKrivZSoRmK9fWUxnhg==}
+  vega@5.33.0:
+    resolution: {integrity: sha512-jNAGa7TxLojOpMMMrKMXXBos4K6AaLJbCgGDOw1YEkLRjUkh12pcf65J2lMSdEHjcEK47XXjKiOUVZ8L+MniBA==}
 
   vite-node@3.0.9:
     resolution: {integrity: sha512-w3Gdx7jDcuT9cNn9jExXgOyKmf5UOTb6WMHz8LGAm54eS1Elf5OuBhCxl6zJxGhEeIkgsE1WbHuoL0mj/UXqXg==}
@@ -8720,17 +8723,17 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  vega-embed@6.29.0(vega-lite@5.23.0(vega@5.31.0))(vega@5.31.0):
+  vega-embed@6.29.0(vega-lite@5.23.0(vega@5.33.0))(vega@5.33.0):
     dependencies:
       fast-json-patch: 3.1.1
       json-stringify-pretty-compact: 4.0.0
       semver: 7.7.1
       tslib: 2.8.1
-      vega: 5.31.0
+      vega: 5.33.0
       vega-interpreter: 1.2.0
-      vega-lite: 5.23.0(vega@5.31.0)
+      vega-lite: 5.23.0(vega@5.33.0)
       vega-schema-url-parser: 2.2.0
-      vega-themes: 2.15.0(vega-lite@5.23.0(vega@5.31.0))(vega@5.31.0)
+      vega-themes: 2.15.0(vega-lite@5.23.0(vega@5.33.0))(vega@5.33.0)
       vega-tooltip: 0.35.2
 
   vega-encode@4.10.2:
@@ -8771,7 +8774,7 @@ snapshots:
       vega-time: 2.1.3
       vega-util: 1.17.3
 
-  vega-functions@5.16.0:
+  vega-functions@5.18.0:
     dependencies:
       d3-array: 3.2.4
       d3-color: 3.1.0
@@ -8821,11 +8824,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  vega-lite@5.23.0(vega@5.31.0):
+  vega-lite@5.23.0(vega@5.33.0):
     dependencies:
       json-stringify-pretty-compact: 4.0.0
       tslib: 2.8.1
-      vega: 5.31.0
+      vega: 5.33.0
       vega-event-selector: 3.0.1
       vega-expression: 5.1.2
       vega-util: 1.17.3
@@ -8841,11 +8844,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  vega-parser@6.4.1:
+  vega-parser@6.6.0:
     dependencies:
       vega-dataflow: 5.7.7
       vega-event-selector: 3.0.1
-      vega-functions: 5.16.0
+      vega-functions: 5.18.0
       vega-scale: 7.4.2
       vega-util: 1.17.3
     transitivePeerDependencies:
@@ -8905,10 +8908,10 @@ snapshots:
     dependencies:
       d3-array: 3.2.4
 
-  vega-themes@2.15.0(vega-lite@5.23.0(vega@5.31.0))(vega@5.31.0):
+  vega-themes@2.15.0(vega-lite@5.23.0(vega@5.33.0))(vega@5.33.0):
     dependencies:
-      vega: 5.31.0
-      vega-lite: 5.23.0(vega@5.31.0)
+      vega: 5.33.0
+      vega-lite: 5.23.0(vega@5.33.0)
 
   vega-time@2.1.3:
     dependencies:
@@ -8932,7 +8935,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  vega-typings@1.4.0:
+  vega-typings@1.5.0:
     dependencies:
       '@types/geojson': 7946.0.4
       vega-event-selector: 3.0.1
@@ -8949,13 +8952,13 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  vega-view@5.14.0:
+  vega-view@5.16.0:
     dependencies:
       d3-array: 3.2.4
       d3-timer: 3.0.1
       vega-dataflow: 5.7.7
       vega-format: 1.1.3
-      vega-functions: 5.16.0
+      vega-functions: 5.18.0
       vega-runtime: 6.2.1
       vega-scenegraph: 4.13.1
       vega-util: 1.17.3
@@ -8980,21 +8983,21 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  vega@5.31.0:
+  vega@5.33.0:
     dependencies:
       vega-crossfilter: 4.1.3
       vega-dataflow: 5.7.7
       vega-encode: 4.10.2
       vega-event-selector: 3.0.1
-      vega-expression: 5.1.2
+      vega-expression: 5.2.0
       vega-force: 4.2.2
       vega-format: 1.1.3
-      vega-functions: 5.16.0
+      vega-functions: 5.18.0
       vega-geo: 4.4.3
       vega-hierarchy: 4.1.3
       vega-label: 1.3.1
       vega-loader: 4.5.3
-      vega-parser: 6.4.1
+      vega-parser: 6.6.0
       vega-projection: 1.6.2
       vega-regression: 1.3.1
       vega-runtime: 6.2.1
@@ -9003,9 +9006,9 @@ snapshots:
       vega-statistics: 1.9.0
       vega-time: 2.1.3
       vega-transforms: 4.12.1
-      vega-typings: 1.4.0
+      vega-typings: 1.5.0
       vega-util: 1.17.3
-      vega-view: 5.14.0
+      vega-view: 5.16.0
       vega-view-transforms: 4.6.1
       vega-voronoi: 4.2.4
       vega-wordcloud: 4.1.6


### PR DESCRIPTION
`pnpm add vega@^5.33.0` `pnpm dedupe`

For some reason that neither ChatGPT ( https://chatgpt.com/c/67e6dfd3-7698-8007-bef4-9ddacb32b057 ) nor Grok ( https://x.com/i/grok?conversation=1905682567421891006 ) can explain to me, this seems to be necessary in order to update it, which I think will resolve a security issue: https://github.com/davidrunger/david_runger/security/dependabot/109 . This also updates `vega-functions`, resolving this issue: https://github.com/davidrunger/david_runger/security/dependabot/108 .