### PR TITLE
[prerender] Increase timeout from 2 seconds to 20 seconds [DEV-231]

### DIFF
--- a/bin/prerender
+++ b/bin/prerender
@@ -43,7 +43,7 @@ class Prerenderer
 
   def assign_new_browser
     Retry.retrying(errors: [Ferrum::ProcessTimeoutError]) do
-      @browser = Ferrum::Browser.new(process_timeout: 20, timeout: 2.0)
+      @browser = Ferrum::Browser.new(process_timeout: 20, timeout: 20)
     end
   end
 


### PR DESCRIPTION
The `2.0` seconds timeout was just for temporary local experimentation, but I accidentally committed it in #6504. The 2 second timeout was the cause of some recent prerendering failures, I think. Hopefully this fix (in conjunction with the retrying added in #6504) will make prerenders reliable.