### PR TITLE
Use modal store to track keydown listener registration [DEV-232]

### DIFF
--- a/app/javascript/components/Modal.vue
+++ b/app/javascript/components/Modal.vue
@@ -31,9 +31,9 @@ const mask = ref(null);
 
 const { showingModal } = storeToRefs(modalStore);
 
-if (!window.davidrunger.modalKeydownListenerRegistered) {
+if (!modalStore.keydownListenerRegistered) {
   window.addEventListener('keydown', handleKeydown);
-  window.davidrunger.modalKeydownListenerRegistered = true;
+  modalStore.keydownListenerRegistered = true;
 }
 
 onUnmounted(() => {

--- a/app/javascript/groceries/components/CheckInItem.vue
+++ b/app/javascript/groceries/components/CheckInItem.vue
@@ -34,7 +34,7 @@ li.flex.items-center.break-word.mb-2(:class="aboutToMoveToClass()")
 </template>
 
 <script setup lang="ts">
-import { ElButton } from 'element-plus';
+import { ElButton, ElTooltip } from 'element-plus';
 import { storeToRefs } from 'pinia';
 import { HeartFilledIcon } from 'vue-tabler-icons';
 import { object } from 'vue-types';

--- a/app/javascript/lib/index.d.ts
+++ b/app/javascript/lib/index.d.ts
@@ -4,7 +4,6 @@ declare global {
       bootstrap: object;
       connectedToLogEntriesChannel?: boolean;
       env: 'development' | 'test' | 'production';
-      modalKeydownListenerRegistered: boolean;
     };
   }
 }

--- a/app/javascript/lib/modal/store.ts
+++ b/app/javascript/lib/modal/store.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 
 export const useModalStore = defineStore('modal', {
   state: () => ({
+    keydownListenerRegistered: false,
     modalsShowing: [] as Array<string>,
   }),
 

--- a/app/javascript/logs/components/NewLogEntryForm.vue
+++ b/app/javascript/logs/components/NewLogEntryForm.vue
@@ -48,7 +48,7 @@ import { object } from 'vue-types';
 
 import { isArrayOfNumbers } from '@/lib/type_predicates';
 import { useLogsStore } from '@/logs/store';
-import { Log } from '@/logs/types';
+import { type Log } from '@/logs/types';
 import type { LogEntryDataValue } from '@/types';
 
 const MAX_RECENT_LOG_ENTRY_VALUES = 5;


### PR DESCRIPTION
... rather than using globally accessible and mutatable `window.davidrunger`.

Also, add mostly unrelated `ElTooltip` import (noticed while testing the primary change).

Also, add mostly unrelated `type` for `Log` import (which I noticed the absence of was breaking the logs app in development when testing).