### PR TITLE
Remove h4, h6 classes from reminder and sharing buttons [LOG-39]

### DIFF
--- a/app/javascript/logs/components/Log.vue
+++ b/app/javascript/logs/components/Log.vue
@@ -36,16 +36,16 @@ div
       ElButton.multi-line(
         @click="modalStore.showModal({ modalName: 'edit-log-sharing-settings' })"
       )
-        .h4 Sharing settings
-        .h6
+        div Sharing settings
+        small
           span(v-if="log.publicly_viewable") Viewable by any user
           span(v-else) Shared with {{ assert(log.log_shares).length }} emails
     .mt-2
       ElButton.multi-line(
         @click="modalStore.showModal({ modalName: 'edit-log-reminder-schedule' })"
       )
-        .h4 Reminder settings
-        .h6
+        div Reminder settings
+        small
           span(v-if="log.reminder_time_in_seconds")
             | {{ (log.reminder_time_in_seconds / (60 * 60)).toFixed() }} hours
           span(v-else) No reminders


### PR DESCRIPTION
This fixes a visual bug that was introduced by this change: https://github.com/davidrunger/david_runger/pull/6572/files#diff-06ee6254c66bde187cba5b5d4ee5dcabd8dc6c0210867bf6f2080275e5d6b207R36 .

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/1699b76c-fb49-4609-9fbc-7c736aa80aad) | ![image](https://github.com/user-attachments/assets/9f5b5a87-0391-4ea8-953c-bcd2d474acdf) |