### PR TITLE
[admin/events/index] Remove admin_user, ip, and stack_trace columns

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -6,12 +6,9 @@ ActiveAdmin.register(Event) do
     id_column
     column :type
     column :user
-    column :admin_user
     column :data
-    column :ip
     column :isp
     column :location
-    column :stack_trace
     column :created_at
     column :pretty_user_agent
   end


### PR DESCRIPTION
ActiveAdmin v4 doesn't fit as much into the index view. This will help make it possible to see the info of interest all at once.

## Before

Columns to the right of "ISP" must be scrolled into view.

![image](https://github.com/user-attachments/assets/77da0e45-a109-4d5c-92c4-cd940f04f06b)

## After

All columns of greatest interest can be seen without scrolling:

![image](https://github.com/user-attachments/assets/a36eb4ba-2e08-4379-a5e6-9dc416cbef1a)