### PR TITLE
Don't decorate user in reply_created comment mailer

### DIFF
--- a/app/views/mailers/comment_mailer/reply_created.html.haml
+++ b/app/views/mailers/comment_mailer/reply_created.html.haml
@@ -1,4 +1,4 @@
-#{@reply_comment.user.decorate.public_name || 'Someone'} has replied to a comment that you made at
+#{@reply_comment.user.public_name || 'Someone'} has replied to a comment that you made at
 - url = DavidRunger.canonical_url(@reply_comment.path)
 = link_to(url, url)
 %span .


### PR DESCRIPTION
We were decorating it before because we were calling `public_name_with_fallback` (since deleted from UserDecorator), but now that -- as of this change https://github.com/davidrunger/david_runger/pull/6559/files#diff-c778e4312a19cee89f1b79069f124637c254bf49074e4650983cbcb1ab9c4e09L1 -- we are calling simply `public_name`, we no longer need the decoration.