### PR TITLE
Move allow_auth_token_authorization to TokenAuthenticatable [DEV-235]

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -29,14 +29,6 @@ class ApplicationController < ActionController::Base
   rescue_from(*AUTHORIZATION_ERROR_MESSAGES.keys, with: :user_not_authorized)
 
   class << self
-    def allow_auth_token_authorization
-      class_eval do
-        def pundit_user
-          current_or_auth_token_user
-        end
-      end
-    end
-
     def require_admin_user!
       skip_before_action(:authenticate_user!)
       before_action(:authenticate_admin_user!)

--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -4,6 +4,16 @@ module TokenAuthenticatable
 
   class InvalidToken < StandardError ; end
 
+  module ClassMethods
+    def allow_auth_token_authorization
+      class_eval do
+        def pundit_user
+          current_or_auth_token_user
+        end
+      end
+    end
+  end
+
   private
 
   memoize \


### PR DESCRIPTION
That just seems like the appropriate (more narrowly scoped / more specifically relevant) place for it, versus having it in `ApplicationController` directly.