### PR TITLE
Remove support for auth tokens in query params [DEV-236]

### DIFF
--- a/app/controllers/concerns/token_authenticatable.rb
+++ b/app/controllers/concerns/token_authenticatable.rb
@@ -31,7 +31,7 @@ module TokenAuthenticatable
 
   memoize \
   def auth_token_secret
-    auth_token_secret = params[:auth_token] || auth_token_in_header
+    auth_token_secret = request.request_parameters[:auth_token] || auth_token_in_header
     # For AuthTokensController requests, the top-level `auth_token` param might be a hash, which we
     # don't want here.
     auth_token_secret.is_a?(String) ? auth_token_secret : nil

--- a/spec/controllers/concerns/token_authenticatable_spec.rb
+++ b/spec/controllers/concerns/token_authenticatable_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
     end
   end
 
-  subject(:get_index) { get(:index, params:) }
+  subject(:request_index) { public_send(http_method, :index, params:) }
 
   let(:auth_token) { AuthToken.first! }
+  let(:http_method) { :post }
 
   describe '#current_or_auth_token_user' do
     before do
@@ -29,7 +30,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
         end
 
         it 'is nil' do
-          get_index
+          request_index
 
           expect(controller.send(:current_or_auth_token_user)).to eq(nil)
         end
@@ -41,10 +42,26 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
         context 'when the AuthToken has a blank permitted_actions_list' do
           before { auth_token.update!(permitted_actions_list: nil) }
 
-          it "is the AuthToken's user" do
-            get_index
+          context 'when the auth_token is provided via a query param' do
+            # For GET, Rails will provide the `params` as query params.
+            let(:http_method) { :get }
 
-            expect(controller.send(:current_or_auth_token_user)).to eq(auth_token.user)
+            it 'is nil' do
+              request_index
+
+              expect(controller.send(:current_or_auth_token_user)).to eq(nil)
+            end
+          end
+
+          context 'when the auth_token is provided via a body param' do
+            # For POST, Rails will provide the `params` as body params.
+            let(:http_method) { :post }
+
+            it "is the AuthToken's user" do
+              request_index
+
+              expect(controller.send(:current_or_auth_token_user)).to eq(auth_token.user)
+            end
           end
         end
 
@@ -54,7 +71,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
           end
 
           it "is the AuthToken's user" do
-            get_index
+            request_index
 
             expect(controller.send(:current_or_auth_token_user)).to eq(auth_token.user)
           end
@@ -66,7 +83,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
           end
 
           it 'is nil' do
-            get_index
+            request_index
 
             expect(controller.send(:current_or_auth_token_user)).to eq(nil)
           end
@@ -80,7 +97,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
           before { auth_token.update!(permitted_actions_list: nil) }
 
           it "is the AuthToken's user" do
-            get_index
+            request_index
 
             expect(controller.send(:current_or_auth_token_user)).to eq(auth_token.user)
           end
@@ -92,7 +109,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
           end
 
           it "is the AuthToken's user" do
-            get_index
+            request_index
 
             expect(controller.send(:current_or_auth_token_user)).to eq(auth_token.user)
           end
@@ -104,7 +121,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
           end
 
           it 'is nil' do
-            get_index
+            request_index
 
             expect(controller.send(:current_or_auth_token_user)).to eq(nil)
           end

--- a/spec/controllers/log_entries_controller_spec.rb
+++ b/spec/controllers/log_entries_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe LogEntriesController do
   let(:user) { users(:user) }
 
   describe '#create' do
-    subject(:get_create) { get(:create, params:) }
+    subject(:post_create) { post(:create, params:) }
 
     let(:params) { { slug: log.slug } }
     let(:log) { user.logs.number.first! }
@@ -16,7 +16,7 @@ RSpec.describe LogEntriesController do
         let(:params) { super().merge(auth_token: user.auth_tokens.first!.secret) }
 
         it 'creates a log entry with the value of the `new_entry` query param' do
-          expect { get_create }.to change { log.log_entries.size }.by(1)
+          expect { post_create }.to change { log.log_entries.size }.by(1)
           log_entry = log.log_entries.order(:created_at).last!
           expect(log_entry.data).to eq(Float(params[:new_entry]))
         end
@@ -32,7 +32,7 @@ RSpec.describe LogEntriesController do
             let(:params) { super().merge(new_entry: "#{new_entry_data} #{new_entry_note}") }
 
             it 'creates a new log entry by splitting the `new_entry` param into data and note' do
-              expect { get_create }.to change { log.log_entries.size }.by(1)
+              expect { post_create }.to change { log.log_entries.size }.by(1)
               log_entry = log.log_entries.order(:created_at).last!
 
               expect(log_entry.data).to eq(new_entry_data)
@@ -46,7 +46,7 @@ RSpec.describe LogEntriesController do
         let(:params) { super().merge(auth_token: SecureRandom.uuid) }
 
         it 'raises an error and does not create a log entry' do
-          expect { get_create }.not_to change { log.reload.log_entries.size }
+          expect { post_create }.not_to change { log.reload.log_entries.size }
         end
       end
 
@@ -54,7 +54,7 @@ RSpec.describe LogEntriesController do
         let(:params) { super().merge(auth_token: '') }
 
         it 'does not create a log entry' do
-          expect { get_create }.not_to change { log.reload.log_entries.size }
+          expect { post_create }.not_to change { log.reload.log_entries.size }
         end
       end
     end
@@ -66,11 +66,11 @@ RSpec.describe LogEntriesController do
         let(:params) { super().merge(auth_token: user.auth_tokens.first!.secret) }
 
         it 'does not create a log_entry' do
-          expect { get_create }.not_to change { log.reload.log_entries.size }
+          expect { post_create }.not_to change { log.reload.log_entries.size }
         end
 
         it 'redirects to the logs index page' do
-          expect(get_create).to redirect_to(logs_path)
+          expect(post_create).to redirect_to(logs_path)
         end
       end
     end


### PR DESCRIPTION
Instead, the auth token must be provided via a body param or via a header.

**Motivation:** Since URLs are not encrypted, including query params in the URL is way too insecure and should never have been allowed. It could give access to any auth-token-authenticatable endpoints via a user's account to any actor able to intercept the URL.

I'm tempted to remove support for params altogether (even body params), and require that the auth token be provided via a header, but I guess that providing an auth token via a body param is fine. Although I sort of feel like a header is likely to be more secure (e.g. less likely to be logged or mass-assigned into a JSON blob of a record or something), I can't really prove that or even be very confident of it.