### PR TITLE
[comments] Load styles.css so that we can use Tailwind [COM-9]

### DIFF
--- a/app/assets/stylesheets/tailwind_overrides.css
+++ b/app/assets/stylesheets/tailwind_overrides.css
@@ -86,10 +86,5 @@
     select {
       @apply border;
     }
-
-    input,
-    textarea {
-      background-color: revert;
-    }
   }
 }

--- a/app/javascript/comments/Comments.vue
+++ b/app/javascript/comments/Comments.vue
@@ -7,7 +7,7 @@
   template(v-else)
     p #[GoogleLoginButton.google-login-form.dark-mode-supported(:origin="googleLoginOrigin")] to add a comment.
 
-  .comments
+  .mt-8
     template(v-if="store.comments.length")
       Comment(
         v-for="comment in store.comments"
@@ -50,17 +50,9 @@ const googleLoginOrigin = [
 </script>
 
 <style scoped>
-.google-login-form {
-  display: inline;
-}
-
 .comments-container {
   width: 90%;
   margin: 24px auto 0;
-}
-
-.comments {
-  margin-top: 2rem;
 }
 
 .no-comments {

--- a/app/javascript/groceries/Groceries.vue
+++ b/app/javascript/groceries/Groceries.vue
@@ -129,4 +129,9 @@ main {
     font-size: 16px;
   }
 }
+
+input,
+textarea {
+  background-color: revert;
+}
 </style>

--- a/spec/controllers/blog_controller_spec.rb
+++ b/spec/controllers/blog_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe(BlogController) do
         let(:format) { nil }
 
         context 'when the requested file exists in the blog/ directory' do
-          let(:show_content) { 'it is the best language ever' }
+          let(:show_content) { '</head>it is the best language ever' }
 
           around do |example|
             with_blog_file("#{slug}.html", show_content) do
@@ -49,11 +49,12 @@ RSpec.describe(BlogController) do
             end
           end
 
-          it 'responds with 200 and the show file content' do
+          it 'responds with 200 and the show file content (with additions, such as a styles.css stylesheet tag)' do
             get_show
 
             expect(response).to have_http_status(200)
-            expect(response.body).to eq(show_content)
+            expect(response.body).to match(/\bstyles\b/)
+            expect(response.body).to end_with(show_content)
           end
         end
 


### PR DESCRIPTION
It feels like sort of a weird quirk (and it's also sort of annoying / a lost opportunity) that, prior to this change, I could not use Tailwind classes to style components in the comments app. This change fixes that by injecting the styles.css style sheet into blog #show pages (the only ones where we currently render the comments app). This will add some unnecessary page weight, but I guess that's true of every page where we load the Tailwind styles, so it's not a new/unique problem, and styles.css is currently compiling to just 20.2 kB uncompressed and 6.3 kB gzipped, which is not so much, and also I believe that CSS is not as costly to the browser to process as JavaScript, compared byte-for-byte.