### PR TITLE
[monkeypatches/warning] Store warnings in module attribute

### DIFF
--- a/config/initializers/monkeypatches/warning.rb
+++ b/config/initializers/monkeypatches/warning.rb
@@ -5,11 +5,13 @@
 # being logged without anyone noticing (and fixing) them.
 
 if Rails.env.test?
-  module StoreWarningsInGlobalVariable
+  module StoredWarnings
+    mattr_accessor :warnings
+
     def warn(message, *_args, **_kwargs)
       # :nocov:
-      if defined?($warnings) && $warnings.respond_to?(:<<)
-        $warnings << message
+      if StoredWarnings.warnings.respond_to?(:<<)
+        StoredWarnings.warnings << message
       end
 
       super
@@ -17,5 +19,5 @@ if Rails.env.test?
     end
   end
 
-  Warning.prepend(StoreWarningsInGlobalVariable)
+  Warning.prepend(StoredWarnings)
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -176,11 +176,11 @@ RSpec.configure do |config|
 
   # Fail spec if any warnings were registered. See config/initializers/monkeypatches/warning.rb.
   config.around(:each) do |example|
-    $warnings = []
+    StoredWarnings.warnings = []
 
     example.run
 
-    expect($warnings).to be_empty
+    expect(StoredWarnings.warnings).to be_empty
   end
 
   # rspec-retry options >>>


### PR DESCRIPTION
... rather than in a global variable.

**Motivation:** It's best to avoid global variables, whenever reasonably possible. One never knows when some gem or some other part of our code might also want to modify a `$warnings` global variable. By namespacing the warnings within the `StoredWarnings` module, we hugely reduce the risk of that sort of accidental contamination between different parts of the code having different purposes for a global variable.