### PR TITLE
[monkeypatches/warning] Use extend rather than prepend

### DIFF
--- a/config/initializers/monkeypatches/warning.rb
+++ b/config/initializers/monkeypatches/warning.rb
@@ -19,5 +19,5 @@ if Rails.env.test?
     end
   end
 
-  Warning.prepend(StoredWarnings)
+  Warning.extend(StoredWarnings)
 end


### PR DESCRIPTION
The Ruby docs recommend `extend`:

> You should never redefine `Warning#warn` (the instance method), as that will then no longer provide a way to use the default behavior.

-- https://rubyapi.org/3.4/o/warning

I guess that warning doesn't really apply to what we were doing (`prepend`), since we did still have access to the default behavior (via `super`) even though we were overriding the instance method. But, still, it's probably a good idea to follow the docs's recommended practice, for the sake of consistency with other Ruby code, if nothing else.