### PR TITLE
Lower RAILS_MAX_THREADS from 2 to 1 except for web

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,3 +1,2 @@
-RAILS_MAX_THREADS=2
 # https://island94.org/2025/01/ruby-thread-contention-simply-gvl-queuing
 RUBY_THREAD_TIMESLICE=10

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,4 +91,7 @@ ENV GIT_REV=${GIT_REV}
 # Add ENV var to indicate that this is a Docker-built image.
 ENV DOCKER_BUILT=true
 
+# Specify prometheus_exporter Docker Compose host/service name.
+ENV PROMETHEUS_EXPORTER_HOST=rails_metrics
+
 ENTRYPOINT ["/app/bin/docker-entrypoint"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,8 @@ x-rails-config: &default-rails-config
     # NOTE: We need this to have DATABASE_URL in bin/docker-entrypoint.
     - .env.production.local
   environment:
-    PROMETHEUS_EXPORTER_HOST: rails_metrics
+    # CAUTION: `web` overrides all env vars listed here with its own `environment` section.
+    RAILS_MAX_THREADS: 1
   logging: *default-logging
   networks:
     - external
@@ -332,6 +333,8 @@ services:
           memory: 99G
         reservations:
           memory: 230M
+    environment:
+      RAILS_MAX_THREADS: 2
     expose:
       - '3000'
     healthcheck:


### PR DESCRIPTION
**Motivation:** Even with our 2 GiB of memory on Hetzner, swap usage continues to be a bit of a problem. I'm hoping that this change (decreasing the RAILS_MAX_THREADS from 2 to 1 for the `worker` service) will decrease memory usage by the `worker` dyno to a helpful extent. Really low Sidekiq latency is not important for the app, so lowering the Sidekiq thread count to 1 should not be a problem.

As part of this change, move `PROMETHEUS_EXPORTER_HOST` to the `Dockerfile`, so that we don't have to worry about overwriting it (problematic) or redefining it (annoying) in the `web` service when we override the `environment` section.