### PR TITLE
Specify RAILS_MAX_THREADS=1 in '.env.production'

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,4 @@
+# NOTE: This is overridden by `web` in `docker-compose.yml`.
+RAILS_MAX_THREADS=1
 # https://island94.org/2025/01/ruby-thread-contention-simply-gvl-queuing
 RUBY_THREAD_TIMESLICE=10

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ x-rails-config: &default-rails-config
   env_file:
     # NOTE: We need this to have DATABASE_URL in bin/docker-entrypoint.
     - .env.production.local
+  environment:
+    # CAUTION: `web` overrides all env vars listed here with its own `environment` section.
+    RAILS_MAX_THREADS: 1
   logging: *default-logging
   networks:
     - external

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,6 @@ x-rails-config: &default-rails-config
   env_file:
     # NOTE: We need this to have DATABASE_URL in bin/docker-entrypoint.
     - .env.production.local
-  environment:
-    # CAUTION: `web` overrides all env vars listed here with its own `environment` section.
-    RAILS_MAX_THREADS: 1
   logging: *default-logging
   networks:
     - external


### PR DESCRIPTION
This way, it's available when compiling assets, etc.

This should fix this deploy failure: https://github.com/davidrunger/david_runger/actions/runs/14154598594/job/39652251342

```
#21 [build  9/10] RUN DOCKER_BUILD=true   GIT_REV=3bccf1fe3a0d497a0970754e3928cd51694ea87c   SECRET_KEY_BASE_DUMMY=1   VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true   bundle exec rails assets:precompile > /dev/null
#21 3.178 bin/rails aborted!
#21 3.188 KeyError: key not found: "RAILS_MAX_THREADS" (KeyError)
#21 3.188 /app/config/database.yml:22:in 'fetch'
```