### PR TITLE
[nginx/traffic-advice] Set prefetch-proxy fraction to zero

### DIFF
--- a/config/nginx/nginxconfig.io/traffic-advice.conf
+++ b/config/nginx/nginxconfig.io/traffic-advice.conf
@@ -1,4 +1,4 @@
 location ~ ^/\.well-known/traffic-advice/?$ {
   default_type application/trafficadvice+json;
-  return 200 '[{"user_agent":"prefetch-proxy","fraction":1.0}]';
+  return 200 '[{"user_agent":"prefetch-proxy","fraction":0.0}]';
 }


### PR DESCRIPTION
https://x.com/i/grok?conversation=1906420724107206712

**Motivation:** The page content will depend on a user's cookies, which won't be included in the prefetch request. So, the user will need to fetch the page freshly for themselves, anyway. Therefore, there is not really any point in having Google do any prefetching.

One example is the home page, where we might render different flash messages to the user, depending on their cookies.

Another example is blog show pages, where the comments app will behave differently, depending on whether or not a user is signed in, and which user they are signed in as.

Prior to adding comments, I think that the blog content was truly static (not depending on a user's cookies), so it probably made sense before to enable prefetching, at least for blog pages.

However, now that we have comments, I think that we have almost no fully static content on the site. I guess that the privacy policy page is one example of truly static content. But I don't think that the upside of allowing Google to prefetch that page (and/or other static pages that might be on the site) is worth the downside risk of users not seeing the correct content.