### PR TITLE
[specs/feature] Move registration of log-writing around block later

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -274,40 +274,6 @@ RSpec.configure do |config|
   end
   # <<< Prewarm browsers for feature specs
 
-  config.around(:each, type: :feature) do |example|
-    $test_log_string_io ||= StringIO.new
-    $test_log_string_io.reopen
-
-    $string_io_logger ||= ActiveSupport::Logger.new($test_log_string_io)
-    $string_io_logger.formatter = Rails.logger.formatter.dup
-    $string_io_logger.level = :debug
-
-    Rails.with(logger: $string_io_logger) do
-      Sidekiq.default_configuration.with(logger: $string_io_logger) do
-        # We can't just do ActiveRecord::Base.with(...) because `with` is an ActiveRecord method.
-        Object.instance_method(:with).bind_call(ActiveRecord::Base, logger: $string_io_logger) do
-          example.run
-        end
-      end
-    end
-
-    if example.exception
-      # Prepare file name and directory
-      timestamp = example.execution_result.started_at.in_time_zone.iso8601.tr(':', '-')
-      description_as_brief_file_name =
-        example.full_description.
-          parameterize.
-          last(50).
-          sub(/\A[^[:alnum:]]+/, '')
-      filename = "#{timestamp}-#{description_as_brief_file_name}.log"
-      log_dir = Rails.root.join('log/failed_feature_specs')
-      FileUtils.mkdir_p(log_dir)
-
-      # Write log file
-      File.write(log_dir.join(filename), $test_log_string_io.string)
-    end
-  end
-
   config.around(:each, :cache) do |spec|
     original_rails_cache = Rails.cache
     Rails.cache = ActiveSupport::Cache::MemoryStore.new
@@ -377,6 +343,43 @@ RSpec.configure do |config|
 
     expect(Cuprite::BrowserLogger.javascript_errors).to be_empty
     expect(Cuprite::BrowserLogger.javascript_logs).to be_empty
+  end
+
+  # NOTE: This `around` block should be registered after the block that checks
+  # for no JS errors or logs in `Cuprite::BrowserLogger`. This way, even if
+  # there are JS errors/logs, a log for the feature spec will still be written.
+  config.around(:each, type: :feature) do |example|
+    $test_log_string_io ||= StringIO.new
+    $test_log_string_io.reopen
+
+    $string_io_logger ||= ActiveSupport::Logger.new($test_log_string_io)
+    $string_io_logger.formatter = Rails.logger.formatter.dup
+    $string_io_logger.level = :debug
+
+    Rails.with(logger: $string_io_logger) do
+      Sidekiq.default_configuration.with(logger: $string_io_logger) do
+        # We can't just do ActiveRecord::Base.with(...) because `with` is an ActiveRecord method.
+        Object.instance_method(:with).bind_call(ActiveRecord::Base, logger: $string_io_logger) do
+          example.run
+        end
+      end
+    end
+
+    if example.exception
+      # Prepare file name and directory
+      timestamp = example.execution_result.started_at.in_time_zone.iso8601.tr(':', '-')
+      description_as_brief_file_name =
+        example.full_description.
+          parameterize.
+          last(50).
+          sub(/\A[^[:alnum:]]+/, '')
+      filename = "#{timestamp}-#{description_as_brief_file_name}.log"
+      log_dir = Rails.root.join('log/failed_feature_specs')
+      FileUtils.mkdir_p(log_dir)
+
+      # Write log file
+      File.write(log_dir.join(filename), $test_log_string_io.string)
+    end
   end
 
   config.before(:each, :rails_env) do |example|


### PR DESCRIPTION
By moving this log-writing `around` block after the block that checks that there were no JS logs or errors, we will write a log for the feature specs even if there is a JS error.

When these around blocks are registered in the other order (as previously), no logs are written when there is a JS error, as occurred in this run: https://github.com/davidrunger/david_runger/actions/runs/14159226663/job/39662402528 .