### PR TITLE
[BlogController] Give 'sub!' replacement via block [BLOG-29]

### DIFF
--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -96,21 +96,12 @@ class BlogController < ApplicationController
   def blog_html_with_additions(absolute_path)
     html = File.read(absolute_path)
 
-    html.sub!(
-      '</head>',
-      "#{helpers.csrf_meta_tags}#{helpers.window_data_script_tag}</head>",
-    )
+    html.sub!('</head>') { "#{helpers.csrf_meta_tags}#{helpers.window_data_script_tag}</head>" }
 
-    html.sub!(
-      '</body>',
-      "#{helpers.ts_tag('comments')}</body>",
-    )
+    html.sub!('</body>') { "#{helpers.ts_tag('comments')}</body>" }
 
     if params[:action] == 'show'
-      html.sub!(
-        '</head>',
-        "#{helpers.ts_tag('styles')}</head>",
-      )
+      html.sub!('</head>') { "#{helpers.ts_tag('styles')}</head>" }
     end
 
     # rubocop:disable Rails/OutputSafety


### PR DESCRIPTION
This avoids quite the little gotcha when a user's name includes a single quote:

https://rubyapi.org/3.4/o/string#class-String-label-Substitution+Methods :

> Note that within the string `replacement` [...] you may refer to some special match variables using these combinations: [...] `\'` corresponds to `$'`, which contains the string after the match.

We did not intend to have this behavior. The result was that a lot of the HTML would be copied into the `html` variable twice (e.g. it would have two closing `</html>` tags), and in general it messed up the HTML content.

Providing the replacement string instead as the return value of a block avoids this issue.