### PR TITLE
Provide 'apple-mobile-web-app-status-bar-style' meta tag w/ 'black'

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -29,7 +29,7 @@
     %link{rel: 'manifest', href: '/site.webmanifest'}
     %link{rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#5bbad5'}
     %meta{name: 'msapplication-TileColor', content: '#00aba9'}
-    %meta{name: 'theme-color', content: '#ffffff'}
+    %meta{name: 'apple-mobile-web-app-status-bar-style', content: 'black'}
 
     = csrf_meta_tags
     = window_data_script_tag


### PR DESCRIPTION
This will supposedly make the status bar white text on a black background. I think that this will look a little better for the groceries app and especially the logs app.

Also, remove the `name: 'theme-color', content: '#ffffff'` meta tag, which seems like the opposite of our goal of moving toward a darker theme.

I don't want to bother with trying to test this locally, so I am just going to deploy to production and hope it works.

I based this change on a few articles I looked at, like this one: https://medium.com/appscope/changing-the-ios-status-bar-of-your-progressive-web-app-9fc8fbe8e6ab .

One interesting note is that, in iOS, for some reason the home page already has white text on a black background in the status bar (?), but other apps like logs and groceries do not.

I continue to dislike developing for iOS. They don't seem to have prominent documentation.