### PR TITLE
Set 'apple-mobile-web-app-capable' meta tag to 'yes'

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -29,6 +29,7 @@
     %link{rel: 'manifest', href: '/site.webmanifest'}
     %link{rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#5bbad5'}
     %meta{name: 'msapplication-TileColor', content: '#00aba9'}
+    %meta{name: 'apple-mobile-web-app-capable', content: 'yes'}
     %meta{name: 'apple-mobile-web-app-status-bar-style', content: 'black'}
 
     = csrf_meta_tags


### PR DESCRIPTION
This is a follow-up to #6620 , which doesn't seem to have worked. Maybe that's because of this, regarding the `apple-mobile-web-app-status-bar-style` meta tag which that PR sets:

> This meta tag has no effect unless you first specify full-screen mode as described in apple-mobile-web-app-capable.

-- https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariHTMLRef/Articles/MetaTags.html#//apple_ref/doc/uid/TP40008193-SW3

Therefore, let's try setting the `apple-mobile-web-app-capable` meta tag to `yes`.

If this doesn't work, then I'll probably just delete both the `apple-mobile-web-app-capable` and the `apple-mobile-web-app-status-bar-style` meta tags.

I don't like developing for Apple devices/software.