### PR TITLE
Make default iOS status bar background color #ffffff

### DIFF
--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -6,7 +6,10 @@ class HomeController < ApplicationController
 
   def index
     skip_authorization
+
     @description = 'The personal website of web developer David Runger'
+    @ios_theme_color = '#0a0a0a'
+
     serve_prerender_with_fallback(
       filename: 'home.html',
       expected_content: 'Full stack web developer',

--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -8,6 +8,7 @@ class LogsController < ApplicationController
 
   def index
     @title = 'Logs'
+    @ios_theme_color = '#111111'
 
     bootstrap(**{
       current_user: current_user && UserSerializer::Basic.new(current_user),

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -29,7 +29,7 @@
     %link{rel: 'manifest', href: '/site.webmanifest'}
     %link{rel: 'mask-icon', href: '/safari-pinned-tab.svg', color: '#5bbad5'}
     %meta{name: 'msapplication-TileColor', content: '#00aba9'}
-    %meta{name: 'theme-color', content: @ios_theme_color || '#111111'}
+    %meta{name: 'theme-color', content: @ios_theme_color || '#ffffff'}
 
     = csrf_meta_tags
     = window_data_script_tag


### PR DESCRIPTION
... and customize it to `#111111` for logs and `#0a0a0a` for home.

A white background by default makes sense because actually most of our apps have a predominantly light theme, many/most with a pure white background.