### PR TITLE
Disable prerendering if a user is signed in [HOME-22]

### DIFF
--- a/app/controllers/concerns/prerenderable.rb
+++ b/app/controllers/concerns/prerenderable.rb
@@ -5,6 +5,9 @@ module Prerenderable
     if params.key?('prerender')
       Rails.logger.info('Skipping prerendered content because a prerender param is present.')
       instance_eval(&fallback)
+    elsif user_signed_in?
+      Rails.logger.debug('Skipping prerendered content because a user is signed in.')
+      instance_eval(&fallback)
     elsif (prerendered_html = prerendered_html(filename))
       if prerendered_html.include?(expected_content)
         # rubocop:disable Rails/OutputSafety

--- a/spec/controllers/concerns/prerenderable_spec.rb
+++ b/spec/controllers/concerns/prerenderable_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe Prerenderable, :without_verifying_authorization do
   before do
     stub_const('EXPECTED_CONTENT', 'Great page text!')
-    stub_const('LIVE_RENDERED_PAGE_TEXT', 'Good morning, Vietnam!')
+    stub_const('LIVE_RENDERED_PAGE_TEXT', 'We are live!')
   end
 
   controller(ApplicationController) do
@@ -52,9 +52,24 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
           HTML
         end
 
-        it 'serves the prerendered page' do
-          get_index
-          expect(response.body).to have_text(page_text)
+        context 'when no user is signed in' do
+          before { sign_out(:user) }
+
+          it 'serves the prerendered page' do
+            get_index
+
+            expect(response.body).to have_text(page_text)
+          end
+        end
+
+        context 'when a user is signed in' do
+          before { sign_in(users(:user)) }
+
+          it 'live-renders the page' do
+            get_index
+
+            expect(response.body).to have_text(LIVE_RENDERED_PAGE_TEXT)
+          end
         end
 
         context 'when the prerender does not include the expected content' do


### PR DESCRIPTION
Currently, no logged-in header appears on the home page, even if a user is logged in. I believe that this is because of prerendering. To avoid this issue (and other present or future issues that might be caused by differences between the HTML that should be served to a logged-in user vs the prerendered HTML that is generated without a logged-in user), this change modifies the Prerenderable concern to not use a prerender if a user is signed in.