### PR TITLE
[logs] Add some padding beneath the keyboard shortcut tip [LOG-40]

### DIFF
--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -2,7 +2,7 @@
 .text-center
   LogSelectorModal
   RouterView.m-8(:key="$route.fullPath")
-  footer.mb-4(v-if="!isSharedLogView")
+  footer.pb-4(v-if="!isSharedLogView")
     | Tip: {{ bootstrap.log_selector_keyboard_shortcut }} will open the log selector.
 </template>
 


### PR DESCRIPTION
This change fixes a visual bug: there was no padding beneath the keyboard shortcut tip in the logs app. This bug was only noticeable on short screens and/or with many logs. This change fixes the bug by changing the margin bottom beneath the tip to a padding bottom. The margin bottom was having no effect when the tip was the last element on the page.