### PR TITLE
[logs/text] Increase font size on mobile from 14px to 16px [LOG-41]

### DIFF
--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -119,6 +119,11 @@ table.text-log-table {
   color: #aaa;
   font-size: 14px;
 
+  @media screen and (max-width: $small-screen-breakpoint) {
+    // Prevent iOS Safari from auto-zooming by making font size >= 16px.
+    font-size: 16px;
+  }
+
   tr {
     border-top: 1px solid #999;
 

--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -53,6 +53,8 @@ const sortedLogEntries = computed((): Array<TextLogEntry> => {
 </script>
 
 <style lang="scss">
+@use 'css/sass_variables' as *;
+
 ol,
 ul {
   $li-indent: 17px;


### PR DESCRIPTION
Supposedly this will make iOS Safari stop automatically zooming in on text logs. https://chatgpt.com/c/67ec9865-d538-8007-91d9-3ef47b369887