### PR TITLE
[logs] Decrease margin from 8 to 2 on small screens [LOG-41]

### DIFF
--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 .text-center
   LogSelectorModal
-  RouterView.m-8(:key="$route.fullPath")
+  RouterView.m-2(:key="$route.fullPath" class="sm:m-8")
   footer.pb-4(v-if="!isSharedLogView")
     | Tip: {{ bootstrap.log_selector_keyboard_shortcut }} will open the log selector.
 </template>


### PR DESCRIPTION
Maybe this will get iOS Safari to stop zooming in on text logs. #6636 did not accomplish that goal.