### PR TITLE
[logs] Increase font size of input, textarea, select to 16px [LOG-41]

### DIFF
--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -54,6 +54,20 @@ onMounted(() => {
 </script>
 
 <style lang="scss">
+@use 'css/sass_variables' as *;
+
+@media screen and (max-width: $small-screen-breakpoint) {
+  // Use id selector to give high specificity.
+  #container {
+    // Prevent iOS Safari from auto-zooming by making font size >= 16px.
+    input,
+    textarea,
+    select {
+      font-size: 16px;
+    }
+  }
+}
+
 :root {
   --main-bg-color: #111;
 


### PR DESCRIPTION
With #6636 and #6637 having failed, this is yet another attempt to get iOS Safari not to automatically zoom in on logs.