### PR TITLE
[logs/mobile] Don't autofocus input for graph logs [LOG-43]

### DIFF
--- a/app/javascript/logs/components/NewLogEntryForm.vue
+++ b/app/javascript/logs/components/NewLogEntryForm.vue
@@ -46,6 +46,7 @@ import { ElButton, ElDatePicker, ElInput } from 'element-plus';
 import { computed, nextTick, onMounted, reactive, ref } from 'vue';
 import { object } from 'vue-types';
 
+import { isMobileDevice } from '@/lib/is_mobile_device';
 import { isArrayOfNumbers } from '@/lib/type_predicates';
 import { useLogsStore } from '@/logs/store';
 import { type Log } from '@/logs/types';
@@ -126,7 +127,11 @@ const mostRecentLogEntryValues = computed((): Array<LogEntryDataValue> => {
 });
 
 onMounted(() => {
-  focusLogEntryInput();
+  // NOTE: Don't focus numeric logs on mobile because it scrolls the graph out
+  // of the viewport.
+  if (!(isMobileDevice() && isNumeric.value)) {
+    focusLogEntryInput();
+  }
 });
 
 function focusLogEntryInput() {


### PR DESCRIPTION
Bug: When viewing a log with a graph (i.e. not text) on mobile, the whole graph does not initially appear in the viewport

Cause: This is because of autofocusing the input. This causes the keyboard to open up (decreasing the screen size) and also for the page to scroll to focus the input (scrolling some of the graph out of the view).

Solution: As a solution, we will not autofocus the input when viewing a log with a graph on a mobile device.