### PR TITLE
[logs/text] Don't receive 'Enter' input from quick selector [LOG-46]

### DIFF
--- a/app/javascript/logs/components/LogSelectorModal.vue
+++ b/app/javascript/logs/components/LogSelectorModal.vue
@@ -9,7 +9,7 @@ Modal(
     type="text"
     v-model="query"
     ref="logSearchInput"
-    @keydown.enter="selectHighlightedLog"
+    @keydown.enter.prevent="selectHighlightedLog"
     @keydown.up="onArrowUp"
     @keydown.down="onArrowDown"
   )


### PR DESCRIPTION
This change fixes a bug wherein selecting a text log from the logs quick selector by pressing the 'Enter' key would also populate the log's text input with a newline.

I'm not sure how long this bug has been live. If it hasn't been present from the initial implementation of this feature (and I don't think it has been? I couldn't have missed such a relatively significant bug for so long, could I?), then I'm curious when it was introduced, and how. But I don't have those answers right now.