### PR TITLE
[logs] Center form inputs for non-text logs [LOG-44]

### DIFF
--- a/app/javascript/logs/components/NewLogEntryForm.vue
+++ b/app/javascript/logs/components/NewLogEntryForm.vue
@@ -2,7 +2,7 @@
 div
   form.px-2(
     @submit.prevent="postNewLogEntry(formData.newLogEntryData)"
-    :class="log.data_type"
+    :class="[log.data_type, { 'flex flex-wrap justify-center': !isText }]"
   )
     .mb-2(v-if="isCounter")
       ElButton(
@@ -19,7 +19,7 @@ div
           ref="logInput"
           :type="inputType"
         )
-    div(:class="{ 'mt-2': isText }")
+    div(:class="{ 'mt-2': isText, 'w-[200px]': !isText }")
       ElDatePicker(
         :class="{ 'mb-2': isNumeric }"
         v-model="formData.newLogEntryCreatedAt"
@@ -167,6 +167,7 @@ form.duration {
 }
 
 :deep(.el-input__wrapper) {
+  flex-grow: revert;
   width: 200px;
 }
 


### PR DESCRIPTION
Having the text log form be the same as the non-text log form is sort of rough, since they have pretty different styling and even different form elements. But it's probably better than duplicating a bunch of logic code between them. But the best of all might be to extract a composable with the shared logic, while allowing the templates and styling to be separate.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/3bfd8146-3133-42cb-8744-8ed6136b0e29) | ![image](https://github.com/user-attachments/assets/1ddcedf0-74ef-42c4-b15e-c35c7df820c8) |