### PR TITLE
[logged-in-header] Use line height to avoid scrollbars [DEV-240]

### DIFF
--- a/app/javascript/home/Home.vue
+++ b/app/javascript/home/Home.vue
@@ -78,7 +78,8 @@ function setScrollToFragmentTimeouts() {
 
 <style lang="scss">
 :root {
-  --user-header-height: calc(var(--spacing) * 8);
+  // NOTE: This corresponds to the total height of the header in _logged_in_header.html.haml .
+  --user-header-height: 32px;
   --main-bg-color: var(--color-neutral-950);
   --main-text-color: var(--color-neutral-100);
 }

--- a/app/views/layouts/_logged_in_header.html.haml
+++ b/app/views/layouts/_logged_in_header.html.haml
@@ -1,4 +1,4 @@
-%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.px-3.leading-8.max-w-dvw.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,var(--background-color))'}
+%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.px-3.max-w-dvw.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,var(--background-color)) leading-[31px]'}
   .flex-1.truncate{title: current_user.email}= current_user.email
   %div.flex.gap-4
     %div= link_to('My account', my_account_path, class: 'text-inherit!')

--- a/app/views/layouts/_logged_in_header.html.haml
+++ b/app/views/layouts/_logged_in_header.html.haml
@@ -1,4 +1,4 @@
-%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.py-2.px-3.max-w-dvw.overflow-scroll.h-8.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,var(--background-color))'}
+%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.px-3.leading-8.max-w-dvw.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,var(--background-color))'}
   .flex-1.truncate{title: current_user.email}= current_user.email
   %div.flex.gap-4
     %div= link_to('My account', my_account_path, class: 'text-inherit!')


### PR DESCRIPTION
... rather than height.

Also, remove vertical padding and overflow-scroll.

This makes it not have terrible looking scrollbars on Chrome.

| Before (in Chrome) | After (in Chrome) |
| - | - |
| ![image](https://github.com/user-attachments/assets/39c1155d-f69e-4300-9423-9158b7ef3dcb) | ![image](https://github.com/user-attachments/assets/6a7357be-8e61-4d1c-95df-cf1a38b810cf) |