### PR TITLE
[logs] Make "log selector" a clickable button [LOG-42]

### DIFF
--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -3,7 +3,10 @@
   LogSelectorModal
   RouterView.m-2(:key="$route.fullPath" class="sm:m-8")
   footer.pb-4(v-if="!isSharedLogView")
-    | Tip: {{ bootstrap.log_selector_keyboard_shortcut }} will open the log selector.
+    | Tip: {{ bootstrap.log_selector_keyboard_shortcut }} will open the
+    |
+    button(@click="openLogSelector") log selector
+    | .
 </template>
 
 <script setup lang="ts">
@@ -30,6 +33,10 @@ const { isSharedLogView, selectedLog } = storeToRefs(logsStore);
 removeQueryParams(); // remove query params such as `new_entry` and `auth_token`
 renderBootstrappedToasts();
 
+function openLogSelector() {
+  modalStore.showModal({ modalName: 'log-selector' });
+}
+
 onMounted(() => {
   if (!isSharedLogView.value) {
     // If we are viewing a specific log, we want to ensure that the log entries for that log are
@@ -46,7 +53,7 @@ onMounted(() => {
         (event.metaKey === true || event.ctrlKey === true) // Meta for macOS, Ctrl for Windows/Linux
       ) {
         event.preventDefault(); // Prevent default behavior for the shortcut
-        modalStore.showModal({ modalName: 'log-selector' });
+        openLogSelector();
       }
     });
   }

--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -5,7 +5,7 @@
   footer.pb-4(v-if="!isSharedLogView")
     | Tip: {{ bootstrap.log_selector_keyboard_shortcut }} will open the
     |
-    button(@click="openLogSelector") log selector
+    button.text-blue-400(@click="openLogSelector") log selector
     | .
 </template>
 

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe 'Logs app' do
     context 'when user has multiple logs' do
       before { expect(user.logs.size).to be >= 2 }
 
-      it 'renders the logs app and allows the user to view a log' do
+      it 'renders the logs app, allows the user to view a log, and allows switching to another log' do
         visit logs_path
 
         expect(page).to have_text(user.email)
@@ -73,6 +73,13 @@ RSpec.describe 'Logs app' do
         expect(page).to have_current_path("/logs/#{log.slug}")
         expect(page).to have_text(log.name)
         expect(page).not_to have_text(other_log.name)
+
+        click_on('log selector')
+        click_on(other_log.name)
+
+        expect(page).to have_current_path("/logs/#{other_log.slug}")
+        expect(page).to have_text(other_log.name)
+        expect(page).not_to have_text(log.name)
       end
     end
 


### PR DESCRIPTION
This will make it possible for users to switch from one log to another if they are using a mobile device where they cannot perform the keyboard shortcut to open the log selector.