### PR TITLE
[specs/admin-login] Remove unneeded admin dashboard reload [DEV-239]

### DIFF
--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -10,9 +10,10 @@ RSpec.describe 'Logging in as an AdminUser via Google auth' do
 
       expect(page).to have_css('google-sign-in-button')
 
-      expect { click_sign_in_with_google }.not_to change { AdminUser.count }
-
-      visit(admin_root_path)
+      expect {
+        click_sign_in_with_google
+        expect(page).to have_current_path(admin_root_path)
+      }.not_to change { AdminUser.count }
 
       expect(page).to have_text('David Runger Admin Dashboard')
       expect(page).to have_text('Admin Tools')


### PR DESCRIPTION
In the [flaky][1] spec modified herein, we were calling `click_sign_in_with_google` and then also calling `visit(admin_root_path)`.

[1]: https://github.com/davidrunger/david_runger/actions/runs/14188499026/job/39748029811?pr=6625

However, the `visit(admin_root_path)` was unnecessary and redundant, because logging in will redirect to `admin_root_path`, anyway.

Additionally, I think that this unneeded `visit(admin_root_path)` call is actually probably why this spec flaked recently. I think that probably the `visit(admin_root_path)` call happened quickly enough after `click_sign_in_with_google` that `visit(admin_root_path)` actually cancelled the `click_sign_in_with_google` form submission that would have logged in the AdminUser. As a result, when the AdminUser then tried to visit the `admin_root_path`, they weren't logged in (as the spec expects them to be), causing the spec failure.

So, I think that removing the unnecessary `visit(admin_root_path)` will hopefully eliminate the flakiness in this spec. It should also make the spec a tiny bit faster.

Also, while looking at this spec, it seems to me that there was a risk of a false negative in the `expect { click_sign_in_with_google }.not_to change { AdminUser.count }` expectation, since just clicking `click_sign_in_with_google` might not _immediately_ create a new AdminUser (since the request must go through the browser and be processed by the server). To ensure that the web request has completed before we check that `AdminUser.count` has not changed, this change adds a new `expect(page).to have_current_path(admin_root_path)` expectation into the block that is being verified to not change `AdminUser.count`.