### PR TITLE
[groceries] Prevent vertical scrolling of sidebar

### DIFF
--- a/app/controllers/concerns/classable.rb
+++ b/app/controllers/concerns/classable.rb
@@ -2,9 +2,11 @@ module Classable
   extend ActiveSupport::Concern
 
   included do
+    class_attribute :body_classes
     class_attribute :container_classes
     class_attribute :html_classes
 
+    helper_method :body_classes
     helper_method :container_classes
     helper_method :html_classes
   end

--- a/app/controllers/groceries_controller.rb
+++ b/app/controllers/groceries_controller.rb
@@ -1,4 +1,7 @@
 class GroceriesController < ApplicationController
+  self.body_classes = %w[flex flex-col h-dvh]
+  self.container_classes = %w[flex-1 overflow-auto]
+
   render_flash_messages_via_js(only: %i[index])
 
   def index

--- a/app/javascript/groceries/Groceries.vue
+++ b/app/javascript/groceries/Groceries.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-#groceries-app.flex.h-dvh
+#groceries-app.flex.h-full
   Sidebar
   main.flex-1.bg-cover
     Store(

--- a/app/javascript/groceries/components/Sidebar.vue
+++ b/app/javascript/groceries/components/Sidebar.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-aside.border-r.border-neutral-400.overflow-auto.hidden-scrollbars(
+aside.border-r.border-neutral-400.max-h-full.overflow-auto.hidden-scrollbars(
   :class="{ collapsed }"
 )
   .flex.flex-col.min-h-full

--- a/app/views/layouts/_logged_in_header.html.haml
+++ b/app/views/layouts/_logged_in_header.html.haml
@@ -1,4 +1,4 @@
-%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.px-3.max-w-dvw.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,var(--background-color)) leading-[31px]'}
+%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.shrink-0.px-3.max-w-dvw.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,var(--background-color)) leading-[31px]'}
   .flex-1.truncate{title: current_user.email}= current_user.email
   %div.flex.gap-4
     %div= link_to('My account', my_account_path, class: 'text-inherit!')

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -40,7 +40,7 @@
     = content_for(:extra_css)
     = content_for(:page_assets)
 
-  %body{class: class_names('sans-serif', user_signed_in? ? 'logged-in' : 'logged-out')}
+  %body{class: class_names('sans-serif', body_classes, user_signed_in? ? 'logged-in' : 'logged-out')}
     - if user_signed_in?
       - if admin_user_signed_in? && (current_user.email != current_admin_user.email)
         .text-center.p-2.bg-sky-200


### PR DESCRIPTION
This prevents vertical scrolling of the sidebar that was caused by the logged-in header introduced in #6614 .

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/48bf8900-1057-4fb4-a398-80467e9fbbdb) | ![image](https://github.com/user-attachments/assets/554a989d-5464-48e7-af9a-f227f1892bda) |