### PR TITLE
[checkins] Create emotional needs upon marriage creation [CHK-1]

### DIFF
--- a/app/actions/marriages/create.rb
+++ b/app/actions/marriages/create.rb
@@ -1,0 +1,28 @@
+class Marriages::Create < ApplicationAction
+  # rubocop:disable Layout/LineLength
+  DEFAULT_EMOTIONAL_NEEDS = {
+    'Affection' => 'The nonsexual expression of care through hugs, kisses, words, cards, and courtesies; creating an environment that clearly and repeatedly expresses care.',
+    'Sexual fulfillment' => 'A sexual experience that is predictably enjoyable and frequent enough for you.',
+    'Intimate conversation' => 'Talking about topics of personal interest, feelings, opinions, and plans.',
+    'Recreational companionship' => 'Leisure activities with at least one other person.',
+    'Honesty and openness' => 'Truthful and frank expressions of positive and negative feelings, events of the past, daily events and schedule, and plans for the future; not leaving a false impression.',
+    'Physical attractiveness' => 'Viewing physical traits of the opposite sex that are aesthetically and/or sexually pleasing.',
+    'Financial support' => 'Provision of the financial resources to house, feed, and clothe your family at a standard of living acceptable to you.',
+    'Domestic support' => 'Management of the household tasks and care of the children (if any are at home) that create a home environment that offers you a refuge from the stresses of life.',
+    'Family commitment' => 'Provision for the moral and educational development of your children within the family unit.',
+    'Admiration' => 'Being shown respect, value, and appreciation.',
+  }.freeze
+  # rubocop:enable Layout/LineLength
+
+  requires :proposer, User
+
+  def execute
+    ApplicationRecord.transaction do
+      marriage = Marriage.create!(partners: [proposer])
+
+      DEFAULT_EMOTIONAL_NEEDS.each do |name, description|
+        marriage.emotional_needs.create!(name:, description:)
+      end
+    end
+  end
+end

--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -31,7 +31,7 @@ class CheckInsController < ApplicationController
 
   def ensure_marriage
     if current_user.marriage.nil?
-      Marriage.create!(partners: [current_user])
+      Marriages::Create.run!(proposer: current_user)
       current_user.reload
     end
   end

--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe 'Check-Ins app' do
       context 'when JWT_SECRET is set' do
         before { expect(ENV.fetch('JWT_SECRET', nil)).to be_present }
 
-        it 'allows inviting spouse and accepting proposal, populates initial emotional needs', :rack_test_driver do
+        it 'allows inviting spouse and accepting proposal, populates initial emotional needs, and allows adding an emotional need', :rack_test_driver do
           visit check_ins_path
 
           expect(page).to have_text('Enter the email of your spouse')


### PR DESCRIPTION
This will provide a more useful and convenient starting point for users, rather than needing to come up with and enter a list of emotional needs themselves. Users may delete/change/add emotional needs, as they see fit, but I think a starting point will be useful, as an example, if nothing else.