### PR TITLE
[JsonSchemaValidator] Print schema on validation error [LOG-47]

### DIFF
--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -34,7 +34,7 @@ class JsonSchemaValidator
   memoize \
   def schema_validation_errors
     JSON::Validator.fully_validate(
-      absolute_schema_path,
+      schema,
       json_string_to_validate,
       validate_schema: true,
       clear_cache: true,
@@ -49,10 +49,15 @@ class JsonSchemaValidator
     raise
   rescue JSON::Schema::ValidationError
     # :nocov:
-    puts("Schema: #{File.read(absolute_schema_path)}")
+    puts("Schema: #{schema}")
 
     raise
     # :nocov:
+  end
+
+  memoize \
+  def schema
+    File.read(absolute_schema_path)
   end
 
   def json_string_to_validate

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -47,6 +47,12 @@ class JsonSchemaValidator
     facilitate_schema_provisioning_if_development
 
     raise
+  rescue JSON::Schema::ValidationError
+    # :nocov:
+    puts("Schema: #{File.read(absolute_schema_path)}")
+
+    raise
+    # :nocov:
   end
 
   def json_string_to_validate

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -41,7 +41,6 @@ class JsonSchemaValidator
     )
   rescue *[
     JSON::Schema::JsonParseError,
-    JSON::Schema::ReadFailed,
     JSON::Schema::SchemaParseError,
   ]
     facilitate_schema_provisioning_if_development

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -40,6 +40,7 @@ class JsonSchemaValidator
       clear_cache: true,
     )
   rescue *[
+    Errno::ENOENT,
     JSON::Schema::JsonParseError,
     JSON::Schema::SchemaParseError,
   ]

--- a/spec/controllers/api/base_controller_spec.rb
+++ b/spec/controllers/api/base_controller_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Api::BaseController, :without_verifying_authorization do
     subject(:get_index) { get(:index) }
 
     context 'when there is no JSON schema for the action' do
-      it 'raises a JSON::Schema::ReadFailed error' do
-        expect { get(:index) }.to raise_error(JSON::Schema::ReadFailed)
+      it 'raises an Errno::ENOENT error' do
+        expect { get(:index) }.to raise_error(Errno::ENOENT)
       end
     end
 


### PR DESCRIPTION
We had a spec flake with this error:

```
          JSON::Schema::ValidationError:
            The property '#/definitions/Root/properties/log_id/type' of type string did not match one or more of the required schemas
          # ./app/poros/json_schema_validator.rb:36:in 'JsonSchemaValidator#schema_validation_errors'
```

That validation error is _not_ forced/simulated/reproduced by changing this https://github.com/davidrunger/david_runger/blob/7614d554a63dc2d018241c28eb026ef9b9a57e93/spec/support/schemas/api/log_entries/index.json#L23 from `integer` to `string`, but it is forced/simulated/reproduced by changing it to `integerz`.

I am pretty much at a loss to explain what would have caused this flakiness, but, to increase our chances of being able to diagnose such flakiness, in the future, this change will print the schema in the event of such a validation error.

Relatedly, this change switches from providing a file path to the schema to instead provide the file's schema content directly. This ensures that, in the event that the schema is invalid, the schema that we print is indeed the schema that was used (and found to be invalid) by the `json-schema` gem.

This change won't actually fix the mysterious-to-me cause of the spec flakiness that is the subject of the linked ticket. However, I will let this change close that ticket, since hopefully this will at least significantly improve our hopes of diagnosing such flakiness, should it ever occur again in the future.