### PR TITLE
[JsonSchemaValidator] Add debugging print statements in test

### DIFF
--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -44,6 +44,12 @@ class JsonSchemaValidator
     JSON::Schema::JsonParseError,
     JSON::Schema::SchemaParseError,
   ]
+    if Rails.env.test?
+      puts("absolute_schema_path: #{absolute_schema_path}")
+      puts("schema: #{schema rescue nil}")
+      puts("File.read(absolute_schema_path): #{File.read(absolute_schema_path) rescue nil}")
+    end
+
     facilitate_schema_provisioning_if_development
 
     raise


### PR DESCRIPTION
I'm having a hard time understanding this recent flake on `main`:

```
Failures:

  1) Check-Ins app when user is signed in when the user is in a marriage with a partner when the marriage has emotional need(s) allows creating a check-in, rating need fulfillment, viewing partner's ratings, etc
     Failure/Error: 
       JSON::Validator.fully_validate(
         schema,
         json_string_to_validate,
         validate_schema: true,
         clear_cache: true,
       )

     ActionView::Template::Error:
       Read of file at /home/runner/work/david_runger/david_runger/5c432dd5-b228-5109-bdae-e3e84d8682aa failed
     # ./app/poros/json_schema_validator.rb:36:in 'JsonSchemaValidator#schema_validation_errors'
     # ./app/poros/json_schema_validator.rb:19:in 'JsonSchemaValidator#validated_data'
     # ./app/controllers/concerns/schema_validatable.rb:19:in 'SchemaValidatable#schema_validated_data'
     # ./app/controllers/concerns/schema_validatable.rb:5:in 'ApplicationController::HelperMethods#schema_validated_data'
     # ./app/helpers/window_data_helper.rb:6:in 'WindowDataHelper#window_data_script_tag'
     # ./app/views/layouts/application.html.haml:35:in '_app_views_layouts_application_html_haml___1326116097245287362_29648'
     # ./lib/middleware/early.rb:11:in 'Middleware::Early#call'
     # ------------------
     # --- Caused by: ---
     # Errno::ENOENT:
     #   No such file or directory @ rb_sysopen - /home/runner/work/david_runger/david_runger/5c432dd5-b228-5109-bdae-e3e84d8682aa
     #   ./app/poros/json_schema_validator.rb:36:in 'JsonSchemaValidator#schema_validation_errors'

Finished in 25.55 seconds (files took 8.21 seconds to load)
15 examples, 1 failure

Failed examples:

rspec ./spec/features/check_ins_spec.rb:80 # Check-Ins app when user is signed in when the user is in a marriage with a partner when the marriage has emotional need(s) allows creating a check-in, rating need fulfillment, viewing partner's ratings, etc
```

-- https://github.com/davidrunger/david_runger/actions/runs/14342945083/job/40206488991

To try to give some more insight if such a failure occurs again, this change adds some debugging print statements in the test environment.