### PR TITLE
[JsonSchemaValidator] Rescue JSON::Schema::ReadFailed

### DIFF
--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -46,7 +46,7 @@ class JsonSchemaValidator
     JSON::Schema::SchemaParseError,
   ]
     if Rails.env.test?
-      puts("absolute_schema_path: #{absolute_schema_path}")
+      puts("absolute_schema_path: #{absolute_schema_path rescue nil}")
       puts("schema: #{schema rescue nil}")
       puts("File.read(absolute_schema_path): #{File.read(absolute_schema_path) rescue nil}")
     end

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -42,6 +42,7 @@ class JsonSchemaValidator
   rescue *[
     Errno::ENOENT,
     JSON::Schema::JsonParseError,
+    JSON::Schema::ReadFailed,
     JSON::Schema::SchemaParseError,
   ]
     if Rails.env.test?

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -18,7 +18,7 @@ class JsonSchemaValidator
         !(universal_bootstrap_data? && !schema_file_exists?) &&
         schema_validation_errors.present?
     )
-      facilitate_schema_provisioning_if_development
+      print_debug_info_or_facilitate_schema_provisioning
 
       raise(
         NonconformingData,
@@ -45,13 +45,7 @@ class JsonSchemaValidator
     JSON::Schema::ReadFailed,
     JSON::Schema::SchemaParseError,
   ]
-    if Rails.env.test?
-      puts("absolute_schema_path: #{absolute_schema_path rescue nil}")
-      puts("schema: #{schema rescue nil}")
-      puts("File.read(absolute_schema_path): #{File.read(absolute_schema_path) rescue nil}")
-    end
-
-    facilitate_schema_provisioning_if_development
+    print_debug_info_or_facilitate_schema_provisioning
 
     raise
   rescue JSON::Schema::ValidationError
@@ -116,7 +110,15 @@ class JsonSchemaValidator
     @controller_action.start_with?('api/')
   end
 
-  def facilitate_schema_provisioning_if_development
+  def print_debug_info_or_facilitate_schema_provisioning
+    if Rails.env.test?
+      # :nocov:
+      puts("absolute_schema_path: #{absolute_schema_path rescue nil}")
+      puts("schema: #{schema rescue nil}")
+      puts("File.read(absolute_schema_path): #{File.read(absolute_schema_path) rescue nil}")
+      # :nocov:
+    end
+
     if Rails.env.development?
       # :nocov:
       # Copy JSON data that was not validated/accepted to clipboard.


### PR DESCRIPTION
... to print debugging info and re-raise.

Hopefully this will give insight into flakes like this:

```
Randomized with seed 43709
Pre-warming domain_restricted_cuprite Cuprite browser...
domain_restricted_cuprite Cuprite browser visited about:blank successfully.
....JavaScript error: SyntaxError: Failed to execute 'json' on 'Response': Unexpected token 'P', "Puma caugh"... is not valid JSON
  from u.<computed> in app/javascript/assets/shim-zD6-VK5O.js
./spec/features/blog_spec.rb:58:shows the blog article content and allows making comments, replying to comments, editing comments, and deleting comments
F  HTML screenshot: https://david-runger-test-uploads.s3.amazonaws.com/failure-screenshots/screenshot_2025-04-10-15-52-54.403.html
  Image screenshot: https://david-runger-test-uploads.s3.amazonaws.com/failure-screenshots/screenshot_2025-04-10-15-52-54.403.png
........

Failures:

  1) Blog when a blog article with a #comments div exists in the blog/ directory when OmniAuth test mode is enabled and OmniAuth is mocked for an email not yet registered as a User when the replying user is at least 1 minute old when the public_name of the user initially has a singe quote shows the blog article content and allows making comments, replying to comments, editing comments, and deleting comments
     Got 1 failure and 1 other error:

     1.1) Failure/Error: 
            JSON::Validator.fully_validate(
              schema,
              json_string_to_validate,
              validate_schema: true,
              clear_cache: true,
            )

          JSON::Schema::ReadFailed:
            Read of file at /home/runner/work/david_runger/david_runger/71be4a26-edc4-5cdf-b6c9-03f64f03e6a4 failed
          # ./app/poros/json_schema_validator.rb:36:in 'JsonSchemaValidator#schema_validation_errors'
          # ./app/poros/json_schema_validator.rb:19:in 'JsonSchemaValidator#validated_data'
          # ./app/controllers/concerns/schema_validatable.rb:19:in 'SchemaValidatable#schema_validated_data'
          # ./app/controllers/api/base_controller.rb:3:in 'Api::BaseController#render_schema_json'
          # ./app/controllers/api/my_account_controller.rb:7:in 'Api::MyAccountController#update'
          # ./lib/middleware/early.rb:11:in 'Middleware::Early#call'
          # ------------------
          # --- Caused by: ---
          # Capybara::CapybaraError:
          #   Your application server raised an error - It has been raised in your test code because Capybara.raise_server_errors == true
          #   ./spec/features/blog_spec.rb:123:in 'block (6 levels) in <top (required)>'

     1.2) Failure/Error: expect(Cuprite::BrowserLogger.javascript_errors).to be_empty

                                 Expected ["SyntaxError: Failed to execute 'json' on 'Response': Unexpected token 'P', \"Puma caugh\"... is not valid JSON"]
            to return a truthy result for empty? or emptys?
          # ./spec/spec_helper.rb:344:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:190:in 'block (2 levels) in <top (required)>'
          # ./spec/spec_helper.rb:181:in 'block (2 levels) in <top (required)>'

Finished in 19.02 seconds (files took 8.91 seconds to load)
13 examples, 1 failure

Failed examples:

rspec ./spec/features/blog_spec.rb:58 # Blog when a blog article with a #comments div exists in the blog/ directory when OmniAuth test mode is enabled and OmniAuth is mocked for an email not yet registered as a User when the replying user is at least 1 minute old when the public_name of the user initially has a singe quote shows the blog article content and allows making comments, replying to comments, editing comments, and deleting comments

Randomized with seed 43709
```

-- https://github.com/davidrunger/david_runger/actions/runs/14384837061/job/40337502456