### PR TITLE
Migrate from `json-schema` gem to `json_schemer`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -67,7 +67,7 @@ group :development, :test do
   gem 'annotaterb', require: false
   gem 'immigrant'
   gem 'isolator'
-  gem 'json-schema'
+  gem 'json_schemer'
   gem 'listen'
   gem 'prosopite'
   gem 'pry-byebug', require: false, github: 'davidrunger/pry-byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,6 +309,7 @@ GEM
       activesupport (>= 5.1)
       haml (>= 4.0.6)
       railties (>= 5.1)
+    hana (1.3.7)
     has_scope (0.8.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
@@ -340,9 +341,11 @@ GEM
       railties (>= 5)
       sorbet-runtime
     json (2.10.2)
-    json-schema (5.1.1)
-      addressable (~> 2.8)
-      bigdecimal (~> 3.1)
+    json_schemer (2.4.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     jwt (2.10.1)
       base64
     kaminari (1.2.2)
@@ -686,6 +689,7 @@ GEM
       simplecov (~> 0.19)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
+    simpleidn (0.2.3)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -800,7 +804,7 @@ DEPENDENCIES
   isolator
   js-routes
   json
-  json-schema
+  json_schemer
   jwt
   launchy
   letter_opener
@@ -961,6 +965,7 @@ CHECKSUMS
   google-protobuf (4.30.2-x86_64-linux) sha256=c96993d98732ea185d98279f6c76e130eb9595437dda39610b3398c9e348518e
   haml (6.3.0) sha256=8e6eb87d869639e348852009e74a2a1663d79663ed7e7dbcb38beb1f12bcdd97
   haml-rails (2.1.0) sha256=273ba0189e2f82ce4b2385019dd9138884017e3103cc2eaebeee7f45186f59ea
+  hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   has_scope (0.8.2) sha256=48cd53d684aecd55d3ede060b3c1da37bbbcab58e273d99936e271fe6d125a54
   hashdiff (1.1.2) sha256=2c30eeded6ed3dce8401d2b5b99e6963fe5f14ed85e60dd9e33c545a44b71a77
   hashid-rails (1.4.1) sha256=cc14a9c16a6320a39f1b84a01c6b66ab934526cec9680118292f3c17370053e3
@@ -976,7 +981,7 @@ CHECKSUMS
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   js-routes (2.3.5) sha256=8279fd3be49916309dfeaee546d659b97986e3edbb47332902e688992b143a4d
   json (2.10.2) sha256=34e0eada93022b2a0a3345bb0b5efddb6e9ff5be7c48e409cfb54ff8a36a8b06
-  json-schema (5.1.1) sha256=b3829ad9bcdfc5010d8a160c4c2bebb8fed8d05d22de65648f6ba646b071f9bf
+  json_schemer (2.4.0) sha256=56cb6117bb5748d925b33ad3f415b513d41d25d0bbf57fe63c0a78ff05597c24
   jwt (2.10.1) sha256=e6424ae1d813f63e761a04d6284e10e7ec531d6f701917fadcd0d9b2deaf1cc5
   kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
   kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
@@ -1114,6 +1119,7 @@ CHECKSUMS
   simplecov-cobertura (2.1.0) sha256=2c6532e34df2e38a379d72cef9a05c3b16c64ce90566beebc6887801c4ad3f02
   simplecov-html (0.13.1) sha256=5dab0b7ee612e60e9887ad57693832fdf4695b4c0c859eaea5f95c18791ef10b
   simplecov_json_formatter (0.1.4) sha256=529418fbe8de1713ac2b2d612aa3daa56d316975d307244399fa4838c601b428
+  simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   snaky_hash (2.0.1) sha256=1ac87ec157fcfe7a460e821e0cd48ae1e6f5e3e082ab520f03f31a9259dbdc31
   sniffer (0.5.0) sha256=cd040cc51929c04749b20baa4dd8f5985174210e13437491f4923b8de27e1359
   sorbet-runtime (0.5.12003) sha256=bd15e072619138091001fe056fe0ddad2835e164ece8ece890f9fac90f1bc5d4

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -18,7 +18,7 @@ class JsonSchemaValidator
         !(universal_bootstrap_data? && !schema_file_exists?) &&
         schema_validation_errors.present?
     )
-      print_debug_info_or_facilitate_schema_provisioning
+      facilitate_schema_provisioning
 
       raise(
         NonconformingData,
@@ -33,36 +33,18 @@ class JsonSchemaValidator
 
   memoize \
   def schema_validation_errors
-    JSON::Validator.fully_validate(
-      schema,
-      json_string_to_validate,
-      validate_schema: true,
-      clear_cache: true,
-    )
+    JSONSchemer.schema(schema).validate(JSON.parse(@data.to_json)).pluck('error')
   rescue *[
     Errno::ENOENT,
-    JSON::Schema::JsonParseError,
-    JSON::Schema::ReadFailed,
-    JSON::Schema::SchemaParseError,
   ]
-    print_debug_info_or_facilitate_schema_provisioning
+    facilitate_schema_provisioning
 
     raise
-  rescue JSON::Schema::ValidationError
-    # :nocov:
-    puts("Schema: #{schema}")
-
-    raise
-    # :nocov:
   end
 
   memoize \
   def schema
     File.read(absolute_schema_path)
-  end
-
-  def json_string_to_validate
-    @data.is_a?(String) ? @data : @data.to_json
   end
 
   memoize \
@@ -110,15 +92,7 @@ class JsonSchemaValidator
     @controller_action.start_with?('api/')
   end
 
-  def print_debug_info_or_facilitate_schema_provisioning
-    if Rails.env.test?
-      # :nocov:
-      puts("absolute_schema_path: #{absolute_schema_path rescue nil}")
-      puts("schema: #{schema rescue nil}")
-      puts("File.read(absolute_schema_path): #{File.read(absolute_schema_path) rescue nil}")
-      # :nocov:
-    end
-
+  def facilitate_schema_provisioning
     if Rails.env.development?
       # :nocov:
       # Copy JSON data that was not validated/accepted to clipboard.

--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -33,7 +33,7 @@ class JsonSchemaValidator
 
   memoize \
   def schema_validation_errors
-    JSONSchemer.schema(schema).validate(JSON.parse(@data.to_json)).pluck('error')
+    JSONSchemer.schema(schema).validate(object_to_validate).pluck('error')
   rescue *[
     Errno::ENOENT,
   ]
@@ -45,6 +45,11 @@ class JsonSchemaValidator
   memoize \
   def schema
     File.read(absolute_schema_path)
+  end
+
+  memoize \
+  def object_to_validate
+    @data.is_a?(String) ? JSON.parse(@data) : JSON.parse(@data.to_json)
   end
 
   memoize \

--- a/spec/support/matchers/match_schema.rb
+++ b/spec/support/matchers/match_schema.rb
@@ -1,7 +1,7 @@
 RSpec::Matchers.define(:match_schema) do |schema|
   schema_path = "spec/support/schemas/#{schema}.json"
   match do |json|
-    JSON::Validator.fully_validate(schema_path, json, strict: true, validate_schema: true).empty?
+    JSONSchemer.schema(File.read(schema_path)).validate(JSON.parse(json)).to_a.empty?
   end
 
   failure_message do |json|


### PR DESCRIPTION
Per https://github.com/voxpupuli/json-schema/issues/ 423 , the `json-schema` gem is no longer very actively maintained. It seems that `json_schemer` is more actively maintained. I am hoping that `json_schemer` won't have the issues with flakiness that we have been seeing lately (and, based on this hope, I am deleting the print debugging statements that I had recently added).