### PR TITLE
[groceries] Left-align multi-line store names [GROC-32]

### DIFF
--- a/app/assets/stylesheets/styles.css
+++ b/app/assets/stylesheets/styles.css
@@ -66,10 +66,6 @@ a {
   text-decoration: none;
 }
 
-button {
-  text-align: left;
-}
-
 .hidden-scrollbars {
   scrollbar-width: none; /* Firefox https://stackoverflow.com/a/38994837/4009384 */
 }

--- a/app/assets/stylesheets/styles.css
+++ b/app/assets/stylesheets/styles.css
@@ -66,6 +66,10 @@ a {
   text-decoration: none;
 }
 
+button {
+  text-align: left;
+}
+
 .hidden-scrollbars {
   scrollbar-width: none; /* Firefox https://stackoverflow.com/a/38994837/4009384 */
 }

--- a/app/javascript/groceries/components/StoreListEntry.vue
+++ b/app/javascript/groceries/components/StoreListEntry.vue
@@ -4,7 +4,7 @@
   @click="groceriesStore.selectStore({ store })"
 )
   .store-name
-    button {{ store.name }}
+    button.text-left {{ store.name }}
     LockIcon.ml-2(
       v-if="store.private"
       size="22"

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -159,7 +159,7 @@ RSpec.describe 'Groceries app' do
           expect(page).to have_vue_toast('Name has already been taken', type: :error)
           # Make sure that a duplicate store is not created in the sidebar.
           within('aside') do
-            count_of_store_name_in_page = page.text.scan(Regexp.escape(existing_store.name)).count
+            count_of_store_name_in_page = page.text.scan(existing_store.name).count
             expect(count_of_store_name_in_page).to eq(1)
           end
 

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -20,7 +20,7 @@ FixtureBuilder.configure do |fbuilder|
     admin_user = name(:admin_user, create(:admin_user, email: 'davidjrunger@gmail.com')).first
 
     # groceries
-    store = name(:store, create(:store, user:, name: 'A Pretty Long Store Name So It Wraps')).first
+    store = name(:store, create(:store, user:, name: 'A Long Store Name So It Wraps')).first
     name(:item, create(:item, :needed, store:, name: 'olive oil', needed: 2))
     create(:item, :unneeded, store:, name: 'apples')
 

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -20,7 +20,7 @@ FixtureBuilder.configure do |fbuilder|
     admin_user = name(:admin_user, create(:admin_user, email: 'davidjrunger@gmail.com')).first
 
     # groceries
-    store = name(:store, create(:store, user:, name: 'Target')).first
+    store = name(:store, create(:store, user:, name: 'A Pretty Long Store Name So It Wraps')).first
     name(:item, create(:item, :needed, store:, name: 'olive oil', needed: 2))
     create(:item, :unneeded, store:, name: 'apples')
 


### PR DESCRIPTION
Currently, they are centered, which is a bug. This change fixes that bug by left-aligning multi-line store names.

I believe that this bug was introduced by this change (changing the `a` tags to `button`s): https://github.com/davidrunger/david_runger/pull/6572/files#diff-fc5eab04a7c056b7e7891a8cc598b5456484ce37da496ecaa913a6b8098cd5a6R7

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/255cd2d9-8c35-4bb3-a1d6-728d7d58232d) | ![image](https://github.com/user-attachments/assets/cd3180e9-4a79-42e1-b0ba-48a04a39366b) |