### PR TITLE
[groceries] Add margin beneath items list [GROC-34]

### DIFF
--- a/app/javascript/groceries/components/Store.vue
+++ b/app/javascript/groceries/components/Store.vue
@@ -11,7 +11,7 @@
 
   NewItemForm(:store="store")
 
-  TransitionGroup.items-list.relative.mt-0.mb-0(
+  TransitionGroup.items-list.relative.mt-0.mb-8(
     name="appear-and-disappear-vertically-list"
     tag="ul"
   )


### PR DESCRIPTION
Having spacing beneath the list gives confidence that one has indeed scrolled to the bottom of the list and there aren't any other items hidden off the bottom off the viewport, which was a fear that I had when scrolling to the bottom of the list of grocery items when there was no padding beneath it.

| Before | After |
| - | - |
|  ![image](https://github.com/user-attachments/assets/691599e6-e075-4e2d-b48e-cc31d0589637) | ![image](https://github.com/user-attachments/assets/33d81f2a-6ac4-4671-939b-68ae7ff9b9c9) |