### PR TITLE
[groceries] Use 'max-h-full' to constrain store height [GROC-36]

### DIFF
--- a/app/javascript/groceries/components/Store.vue
+++ b/app/javascript/groceries/components/Store.vue
@@ -1,5 +1,5 @@
 <template lang="pug">
-.store-container.overflow-auto.hidden-scrollbars.pt-2.pl-8.pr-4
+.overflow-auto.hidden-scrollbars.pt-2.pl-8.pr-4.max-h-full
   StoreHeader(:store="store")
 
   ElButton.mr-2.mt-2(
@@ -63,10 +63,3 @@ function initializeTripCheckIn() {
   modalStore.showModal({ modalName: 'check-in-shopping-trip' });
 }
 </script>
-
-<style lang="scss" scoped>
-.store-container {
-  max-height: 97vh; // fallback for browsers that don't yet support `dvh` units
-  max-height: 97dvh;
-}
-</style>

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Groceries app' do
         # by a bug in cuprite (namely that focus and blur events are of type
         # Event rather than FocusEvent). github.com/rubycdp/cuprite/pull/ 272
         fill_in('newItemName', with: new_item_name)
-        first('.store-container button', text: 'Add').click
+        find(:button, 'Add item').click
 
         expect(page).not_to have_spinner
         expect(find(:fillable_field, 'newItemName').value).to eq('')


### PR DESCRIPTION
... rather than `max-height: 97dvh`.

This fixes a visual bug wherein a white space could appear at the bottom of the page (if there were many stores and/or many grocery items).

| Before | After |
| - | - |
|  ![image](https://github.com/user-attachments/assets/af47deda-a09b-4892-921f-cb19ec3c8bca) |  ![image](https://github.com/user-attachments/assets/274ab7c1-6114-46ad-b6e9-0e1458d54abb) |