### PR TITLE
[groceries] Move item immediately when its status changes [GROC-35]

### DIFF
--- a/app/javascript/groceries/components/CheckInItem.vue
+++ b/app/javascript/groceries/components/CheckInItem.vue
@@ -46,13 +46,12 @@ const props = defineProps({
   item: object<Item>().isRequired,
 });
 
-const MOVE_TIMEOUT = 500;
 const MOVING_TO_STATUS_TO_CLASS_MAP = {
   'in-cart': 'bg-green-200',
   needed: 'bg-orange-200',
   skipped: 'bg-red-200',
 };
-const CLEAR_BACKGROUND_COLOR_TIMEOUT = 1200;
+const CLEAR_BACKGROUND_COLOR_TIMEOUT = 2000;
 
 const groceriesStore = useGroceriesStore();
 
@@ -65,19 +64,15 @@ function aboutToMoveToClass() {
 }
 
 function moveTo(checkInStatus: CheckInStatus) {
-  if (props.item.aboutToMoveTo) return;
-
   groceriesStore.setItemAboutToMoveTo({
     item: props.item,
     aboutToMoveTo: checkInStatus,
   });
 
-  setTimeout(() => {
-    groceriesStore.setItemCheckInStatus({
-      item: props.item,
-      checkInStatus,
-    });
-  }, MOVE_TIMEOUT);
+  groceriesStore.setItemCheckInStatus({
+    item: props.item,
+    checkInStatus,
+  });
 
   setTimeout(() => {
     groceriesStore.setItemAboutToMoveTo({


### PR DESCRIPTION
Prior to this change, we had a delay before we move an item in the groceries check-in list after its status has been changed (e.g. by checking it). The idea was that this would make it easier to confirm that the correct item had been ticked (since the item stays in the same place for a moment, with a background color that indicates its new status). However, I think it's not worth it. The delay makes it hard to check multiple items off in quick succession, which is something that I sometimes want to do. Therefore, this change removes the delay.