### PR TITLE
[logs/text] Increase size of 'Edit' and 'Delete' buttons [LOG-48]

### DIFF
--- a/app/javascript/logs/components/EditableTextLogRow.vue
+++ b/app/javascript/logs/components/EditableTextLogRow.vue
@@ -122,6 +122,10 @@ async function updateLogEntry() {
   .el-button.el-button + .el-button {
     margin-left: 0;
   }
+
+  .el-button.el-button {
+    font-size: 20px;
+  }
 }
 
 :deep(pre) {


### PR DESCRIPTION
... on mobile.

Currently, it's fairly difficult to confidently click the "Edit" button on mobile, because it is small and also pretty scrunched up against the "Delete" button. Increasing the font size, which this change does, should make it easier to confidently click the desired button.

| Before | After |
| - | - |
|  ![image](https://github.com/user-attachments/assets/52b48d58-c1ff-4375-966c-17f969306bd2) |  ![image](https://github.com/user-attachments/assets/37c79d11-9574-4aff-9177-81a4d9d11147) |