### PR TITLE
[checkins/specs/features] Ensure unique emotional need name [CHK-4]

### DIFF
--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Check-Ins app' do
           end
 
           # Add an emotional need.
-          new_need_name = Faker::Emotion.unique.noun.capitalize
+          new_need_name = "#{Faker::Emotion.unique.noun.capitalize}-#{SecureRandom.alphanumeric(5)}"
           new_need_description = Faker::Company.unique.bs.capitalize
           fill_in('Name', with: new_need_name)
           fill_in('Description', with: new_need_description)


### PR DESCRIPTION
This change fixes spec flakiness that was introduced by #6670. That PR adds several emotional needs by default upon marriage creation, including e.g. `Affection`, which can also be generated by `Faker::Emotion.unique.noun.capitalize`, which would result in a uniqueness violation and cause the spec modified herein to fail. This change adds some random characters to the emotional need name to ensure that there will be no such collisions.