### PR TITLE
[logs] Scope CSS selector to not add dashes in timepicker [LOG-49]

### DIFF
--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -89,11 +89,9 @@ ol {
   }
 }
 
-ul {
-  li {
-    &::before {
-      content: '– ';
-    }
+.text-log-table td ul li {
+  &::before {
+    content: '– ';
   }
 }
 


### PR DESCRIPTION
This fixes a visual bug that was introduced by #6093 . There are still some remaining issues with the timepicker, but for now let's ship this improvement, at least.

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/9d8fadaf-511d-4aeb-8413-4908cae80ee2) | ![image](https://github.com/user-attachments/assets/f79b88dc-5886-4b40-8402-9d973ab0530b) |