### PR TITLE
[logs/text] Scope some ol/ul/li CSS selectors to in '.text-log-table'

### DIFF
--- a/app/javascript/logs/components/data_renderers/TextLog.vue
+++ b/app/javascript/logs/components/data_renderers/TextLog.vue
@@ -55,43 +55,47 @@ const sortedLogEntries = computed((): Array<TextLogEntry> => {
 <style lang="scss">
 @use 'css/sass_variables' as *;
 
-ol,
-ul {
-  $li-indent: 17px;
+.text-log-table {
+  ol,
+  ul {
+    $li-indent: 17px;
 
-  &:not(:first-child) {
-    margin-top: 16px;
-  }
-
-  li {
-    &:not(:first-of-type) {
-      margin-top: 0.5em;
+    &:not(:first-child) {
+      margin-top: 16px;
     }
 
-    display: block;
-    margin-left: $li-indent;
+    li {
+      &:not(:first-of-type) {
+        margin-top: 0.5em;
+      }
 
-    &::before {
-      margin-left: -1 * $li-indent;
-      position: absolute;
+      display: block;
+      margin-left: $li-indent;
+
+      &::before {
+        margin-left: -1 * $li-indent;
+        position: absolute;
+      }
     }
   }
-}
 
-ol {
-  counter-reset: item;
+  ol {
+    counter-reset: item;
 
-  li {
-    &::before {
-      content: counter(item) '. ';
-      counter-increment: item;
+    li {
+      &::before {
+        content: counter(item) '. ';
+        counter-increment: item;
+      }
     }
   }
-}
 
-.text-log-table td ul li {
-  &::before {
-    content: '– ';
+  ul {
+    li {
+      &::before {
+        content: '– ';
+      }
+    }
   }
 }
 


### PR DESCRIPTION
| Before | After |
| - | - |
|  ![image](https://github.com/user-attachments/assets/5db14d86-0b2d-4466-ae29-5040ed4501cd) | ![image](https://github.com/user-attachments/assets/46918888-99b8-47eb-bb72-499d6b397d7b) |