### PR TITLE
Increase max number of matching emojis from 10 to 80 [EMO-12]

### DIFF
--- a/app/javascript/emoji_picker/EmojiPicker.vue
+++ b/app/javascript/emoji_picker/EmojiPicker.vue
@@ -52,7 +52,7 @@ const { highlightedSearchable, onArrowDown, onArrowUp, topRankedMatches } =
   useFuzzyTypeahead({
     searchables: emojiData,
     query: queryDebounced,
-    maxMatches: 10,
+    maxMatches: 80,
     fuseOptions: {
       keys: [
         'name',


### PR DESCRIPTION
Sometimes, the emoji that I'm looking for isn't in the top 10 results. I want a way to access the emoji I'm targeting, even when it's not in the top 10 results. While I do think it is definitely possible for a query to return the desired emoji somewhere in results 11-80, I don't think it's really likely at all for the targeted emoji to be in results 80+. In the 81st result and beyond, the matching emojis begin to be quite unrelated to the entered query, to the point that I don't think it's worth including them.