### PR TITLE
[emoji-picker] Redirect back to emoji picker after login [EMO-13]

### DIFF
--- a/app/javascript/comments/Comments.vue
+++ b/app/javascript/comments/Comments.vue
@@ -5,7 +5,7 @@
   template(v-if="store.currentUser")
     CommentForm(@submit="store.addComment")
   template(v-else)
-    p #[GoogleLoginButton.google-login-form.dark-mode-supported(:origin="windowLocationWithHash('comments')")] to add a comment.
+    p #[GoogleLoginButton.dark-mode-supported(:origin="windowLocationWithHash('comments')")] to add a comment.
 
   .mt-8
     template(v-if="store.comments.length")

--- a/app/javascript/emoji_picker/EmojiPicker.vue
+++ b/app/javascript/emoji_picker/EmojiPicker.vue
@@ -22,11 +22,7 @@
 
   BoostsForm(v-if="bootstrap.current_user")
   .flex.justify-center(v-else)
-    .mt-8.max-w-sm
-      b Tip:
-      span.
-        #[a(:href="new_user_session_path()")  log in] to customize
-        which search keywords are associated with which emojis.
+    .mt-8.max-w-sm #[GoogleLoginButton(:origin="googleLoginOrigin")] to customize which search keywords are associated with which emojis.
 </template>
 
 <script setup lang="ts">
@@ -34,6 +30,7 @@ import { refDebounced } from '@vueuse/core';
 import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { POSITION } from 'vue-toastification';
 
+import GoogleLoginButton from '@/components/GoogleLoginButton.vue';
 import BoostsForm from '@/emoji_picker/components/BoostsForm.vue';
 import CopiedEmojiToast from '@/emoji_picker/components/CopiedEmojiToast.vue';
 import { emojiData } from '@/emoji_picker/emoji_data';
@@ -41,7 +38,6 @@ import { type Bootstrap } from '@/emoji_picker/types';
 import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { useFuzzyTypeahead } from '@/lib/composables/useFuzzyTypeahead';
 import { vueToast } from '@/lib/vue_toasts';
-import { new_user_session_path } from '@/rails_assets/routes';
 import type { EmojiData } from '@/types';
 
 const bootstrap = untypedBootstrap as Bootstrap;
@@ -65,6 +61,8 @@ const { highlightedSearchable, onArrowDown, onArrowUp, topRankedMatches } =
       useExtendedSearch: true,
     },
   });
+
+const googleLoginOrigin = window.location.href;
 
 function handleKeydown(event: KeyboardEvent) {
   switch (event.key) {

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -16,7 +16,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'copy_to_clipboard*.css' => (0..10),
     'copy_to_clipboard*.js' => (2..12),
     'emoji_picker*.css' => (8..18),
-    'emoji_picker*.js' => (327..337),
+    'emoji_picker*.js' => (337..347),
     'google_sign_in_button*.js' => (1..11),
     'groceries*.css' => (48..58),
     'groceries*.js' => (303..313),

--- a/spec/features/emoji_picker_spec.rb
+++ b/spec/features/emoji_picker_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Emoji Picker' do
   let(:add_a_boost_text) { 'Add a boost' }
-  let(:log_in_for_boosting_text) { /Tip: log in to customize .* search keywords/ }
+  let(:log_in_for_boosting_text) { /to customize .* search keywords/ }
 
   context 'when not logged in' do
     before { Devise.sign_out_all_scopes }

--- a/spec/features/emoji_picker_spec.rb
+++ b/spec/features/emoji_picker_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Emoji Picker' do
       expect(page.first('li')).to have_text(/\A💜purple heart\z/)
 
       # Check that tip about logging in is shown, and boosting interface is not.
+      expect(page).to have_css('google-sign-in-button')
       expect(page).to have_text(log_in_for_boosting_text)
       expect(page).not_to have_text(add_a_boost_text)
     end
@@ -31,6 +32,7 @@ RSpec.describe 'Emoji Picker' do
       expect(page.first('li')).to have_text(/\A💜purple heart\z/)
 
       # Check that page does not have tip about logging in (as user is already logged in).
+      expect(page).not_to have_css('google-sign-in-button')
       expect(page).not_to have_text(log_in_for_boosting_text)
 
       # Add a boost.


### PR DESCRIPTION
Also, provide a button to log in directly, rather than going through the `new_user_session_path`.