### PR TITLE
Automatically render select inputs as Tom Select typeaheads [ADM-7]

### DIFF
--- a/app/assets/stylesheets/active_admin.css
+++ b/app/assets/stylesheets/active_admin.css
@@ -6,3 +6,9 @@
 }
 
 @config '../../../tailwind-active_admin.config.js';
+
+/* Tom Select */
+.ts-control > input {
+  flex: 0 1 auto;
+  width: 1px;
+}

--- a/app/javascript/admin/tom_select.ts
+++ b/app/javascript/admin/tom_select.ts
@@ -1,0 +1,27 @@
+import TomSelect from 'tom-select';
+
+import 'tom-select/dist/css/tom-select.default.css';
+
+function initializeActiveAdminTomSelect() {
+  const selectsToInitialize = document.querySelectorAll(
+    'select[id^="q_"]:not(.tomselected)',
+  );
+
+  selectsToInitialize.forEach((selectEl) => {
+    if (selectEl instanceof HTMLSelectElement) {
+      new TomSelect(selectEl, {
+        create: false,
+        sortField: [
+          {
+            field: 'text',
+            direction: 'asc',
+          },
+        ],
+      });
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initializeActiveAdminTomSelect();
+});

--- a/app/javascript/admin_entrypoints/active_admin.ts
+++ b/app/javascript/admin_entrypoints/active_admin.ts
@@ -1,2 +1,3 @@
 import '@activeadmin/activeadmin';
+import '../admin/tom_select';
 import '../../../app/assets/stylesheets/active_admin.css';

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "strftime": "^0.10.3",
     "tailwindcss": "4.1.4",
     "toastify-js": "^1.12.0",
+    "tom-select": "^2.4.3",
     "unplugin-element-plus": "^0.9.1",
     "vega": "^6.1.2",
     "vega-embed": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,6 +113,9 @@ importers:
       toastify-js:
         specifier: ^1.12.0
         version: 1.12.0
+      tom-select:
+        specifier: ^2.4.3
+        version: 2.4.3
       unplugin-element-plus:
         specifier: ^0.9.1
         version: 0.9.1
@@ -689,6 +692,12 @@ packages:
 
   '@one-ini/wasm@0.1.1':
     resolution: {integrity: sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==}
+
+  '@orchidjs/sifter@1.1.0':
+    resolution: {integrity: sha512-mYwHCfr736cIWWdhhSZvDbf90AKt2xyrJspKFC3qyIJG1LtrJeJunYEqCGG4Aq2ijENbc4WkOjszcvNaIAS/pQ==}
+
+  '@orchidjs/unicode-variants@1.1.2':
+    resolution: {integrity: sha512-5DobW1CHgnBROOEpFlEXytED5OosEWESFvg/VYmH0143oXcijYTprRYJTs+55HzGM4IqxiLFSuqEzu9mPNwVsA==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -3982,6 +3991,9 @@ packages:
   token-stream@1.0.0:
     resolution: {integrity: sha512-VSsyNPPW74RpHwR8Fc21uubwHY7wMDeJLys2IX5zJNih+OnAnaifKHo+1LHT7DAdloQ7apeaaWg8l7qnf/TnEg==}
 
+  tom-select@2.4.3:
+    resolution: {integrity: sha512-MFFrMxP1bpnAMPbdvPCZk0KwYxLqhYZso39torcdoefeV/NThNyDu8dV96/INJ5XQVTL3O55+GqQ78Pkj5oCfw==}
+
   topojson-client@3.1.0:
     resolution: {integrity: sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==}
     hasBin: true
@@ -4975,6 +4987,12 @@ snapshots:
       fastq: 1.19.1
 
   '@one-ini/wasm@0.1.1': {}
+
+  '@orchidjs/sifter@1.1.0':
+    dependencies:
+      '@orchidjs/unicode-variants': 1.1.2
+
+  '@orchidjs/unicode-variants@1.1.2': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -8533,6 +8551,11 @@ snapshots:
   toastify-js@1.12.0: {}
 
   token-stream@1.0.0: {}
+
+  tom-select@2.4.3:
+    dependencies:
+      '@orchidjs/sifter': 1.1.0
+      '@orchidjs/unicode-variants': 1.1.2
 
   topojson-client@3.1.0:
     dependencies:


### PR DESCRIPTION
Some select dropdowns have (or might theoretically have in the future) enough options that I'm not sure it's a really good UX to have them be plain <select> elements. This change hacks ActiveAdmin so that all selects will be typeaheads, instead, using Tom Select.

![screen](https://github.com/user-attachments/assets/0866f5ee-3e6f-41ff-9e5c-4919e5f608bb)