### PR TITLE
[renovate] Apply ':maintainLockFilesWeekly' only for 'npm'

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,6 @@
   "extends": [
     "config:recommended",
     "schedule:daily",
-    ":maintainLockFilesWeekly",
     ":prConcurrentLimitNone",
     ":prHourlyLimitNone"
   ],
@@ -12,6 +11,10 @@
     {
       "matchManagers": ["bundler"],
       "rangeStrategy": "update-lockfile"
+    },
+    {
+      "matchManagers": ["npm"],
+      "extends": [":maintainLockFilesWeekly"]
     }
   ],
   "rangeStrategy": "replace",


### PR DESCRIPTION
Gemini https://gemini.google.com/app/66c848b19d5b994d and ChatGPT https://chatgpt.com/c/68128c8c-99a8-8007-9545-b192f732532c claim that this will allow for PRs to update transitive bundler dependencies (though I am somewhat skeptical).