### PR TITLE
Use Dependabot (not Renovate) for gem and GitHub Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: cron
+      cronjob: '4 4 * * *'
+      timezone: America/Chicago
+  - package-ecosystem: bundler
+    directory: '/'
+    schedule:
+      interval: cron
+      cronjob: '4 4 * * *'
+      timezone: America/Chicago
+    allow:
+      - dependency-type: all

--- a/renovate.json
+++ b/renovate.json
@@ -10,19 +10,6 @@
   ],
   "packageRules": [
     {
-      "matchManagers": ["bundler"],
-      "rangeStrategy": "update-lockfile"
-    },
-    {
-      "matchManagers": ["bundler"],
-      "matchUpdateTypes": ["lockFileMaintenance"],
-      "groupName": "bundler lock file maintenance",
-      "groupSlug": "bundler-lockfile",
-      "description": "Group bundler lock file maintenance updates",
-      "commitMessageAction": "Update",
-      "commitMessageTopic": "bundler lock file"
-    },
-    {
       "matchManagers": ["npm"],
       "matchUpdateTypes": ["lockFileMaintenance"],
       "groupName": "npm lock file maintenance",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabledManagers": ["bundler", "github-actions", "npm"],
+  "enabledManagers": ["npm"],
   "extends": [
     "config:recommended",
     "schedule:daily",


### PR DESCRIPTION
There are a number of things about Renovate that I don't really like, especially the fact that (I think) it doesn't update transitive dependencies (except for security issues, I think?).

I am sticking with Renovate for (p)npm updates, though, because Dependabot doesn't yet support pnpm v10.