### PR TITLE
Remove 'allow ... dependency-type: all' from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,5 +13,3 @@ updates:
       interval: cron
       cronjob: '4 4 * * *'
       timezone: America/Chicago
-    allow:
-      - dependency-type: all


### PR DESCRIPTION
Dependabot updates for gems don't seem to be working. I think that maybe we need to bust a cache or something?