### PR TITLE
[dependabot] Change schedule to "interval: 'daily'"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,12 @@ updates:
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: cron
-      cronjob: '4 4 * * *'
+      interval: 'daily'
       timezone: America/Chicago
   - package-ecosystem: bundler
     directory: '/'
     schedule:
-      interval: cron
-      cronjob: '4 4 * * *'
+      interval: 'daily'
       timezone: America/Chicago
     allow:
       - dependency-type: all


### PR DESCRIPTION
I'm hoping that this will fix dependabot, which currently seems to be at least partially broken. The downside is that we won't get PRs on weekends, but it's better than not getting any gem update PRs, which seems to be the current situation.