### PR TITLE
[dependabot] Update NPM packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,23 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: '/'
-    schedule:
-      interval: 'daily'
-      timezone: America/Chicago
   - package-ecosystem: bundler
     directory: '/'
     schedule:
       interval: 'daily'
+      time: '04:04'
       timezone: America/Chicago
     allow:
       - dependency-type: all
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '04:04'
+      timezone: America/Chicago
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: 'daily'
+      time: '04:04'
+      timezone: America/Chicago


### PR DESCRIPTION
Apparently it now works with pnpm 10 ( https://github.com/dependabot/dependabot-core/issues/ 11246#issuecomment-2913249989 ), though it sounds like there might be bugs ( https://github.com/dependabot/dependabot-core/issues/ 11246#issuecomment-2914886102 )?

Also, add `time` for all schedules, so that the updates are done at 4:04 AM CT each weekday.

Also, alphabetize by `package-ecosystem`.