### PR TITLE
[dependabot] Switch to cron scheduling

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,20 +4,20 @@ updates:
   - package-ecosystem: bundler
     directory: '/'
     schedule:
-      interval: 'daily'
-      time: '04:04'
+      interval: cron
+      cronjob: '4 4 * * *'
       timezone: America/Chicago
     allow:
       - dependency-type: all
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
-      interval: 'daily'
-      time: '04:04'
+      interval: cron
+      cronjob: '4 4 * * *'
       timezone: America/Chicago
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: 'daily'
-      time: '04:04'
+      interval: cron
+      cronjob: '4 4 * * *'
       timezone: America/Chicago


### PR DESCRIPTION
This way, we will get Dependabot updates on weekend days, not just weekdays.

Note: We have used cron syntax before, but switched off of it in #6806 , hoping to fix Dependabot, which I think worked? Hopefully Dependabot will keep working, even after this change, and we can simply go forward in our ideal state.