### PR TITLE
[error-subscriber] Send request metadata

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,6 +21,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :authenticate_user!
+  before_action :set_error_context
   before_action :set_paper_trail_whodunnit
   before_action :set_browser_uuid
   before_action :set_controller_action_in_context
@@ -73,6 +74,10 @@ class ApplicationController < ActionController::Base
 
   def set_controller_action_in_context
     ActiveSupport::ExecutionContext[:controller_action] = controller_action
+  end
+
+  def set_error_context
+    Rails.error.set_context(request:)
   end
 
   def set_browser_uuid

--- a/config/initializers/error_subscriber.rb
+++ b/config/initializers/error_subscriber.rb
@@ -1,4 +1,6 @@
 class ErrorSubscriber
+  include Rollbar::RequestDataExtractor
+
   SEVERITY_TO_METHOD = {
     error: :error,
     warning: :warn,
@@ -8,6 +10,10 @@ class ErrorSubscriber
   def report(error, **kwargs)
     # Instead, we'll use the controller_action (set via set_controller_action_in_context).
     kwargs[:context] = kwargs[:context].except(:controller)
+
+    if (request = kwargs.dig(:context, :request))
+      kwargs[:context][:request] = extract_request_data_from_rack(request.env)
+    end
 
     if error.class.name.start_with?('Sidekiq::JobRetry::')
       # Only write a log line because the Rollbar integration will automatically send to Rollbar.

--- a/config/initializers/error_subscriber.rb
+++ b/config/initializers/error_subscriber.rb
@@ -11,7 +11,7 @@ class ErrorSubscriber
     # Instead, we'll use the controller_action (set via set_controller_action_in_context).
     kwargs[:context] = kwargs[:context].except(:controller)
 
-    if (request = kwargs.dig(:context, :request))
+    if (request = kwargs.dig(:context, :request) && request.is_a?(ActionDispatch::Request))
       kwargs[:context][:request] = extract_request_data_from_rack(request.env)
     end
 

--- a/config/initializers/error_subscriber.rb
+++ b/config/initializers/error_subscriber.rb
@@ -11,7 +11,7 @@ class ErrorSubscriber
     # Instead, we'll use the controller_action (set via set_controller_action_in_context).
     kwargs[:context] = kwargs[:context].except(:controller)
 
-    if (request = kwargs.dig(:context, :request) && request.is_a?(ActionDispatch::Request))
+    if ((request = kwargs.dig(:context, :request)) && request.is_a?(ActionDispatch::Request))
       kwargs[:context][:request] = extract_request_data_from_rack(request.env)
     end
 

--- a/spec/features/error_handling_spec.rb
+++ b/spec/features/error_handling_spec.rb
@@ -15,13 +15,17 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
 
           expect(page).to have_text("The page you were looking for doesn't exist.")
           expect(page.status_code).to be(404)
-          expect(Rails.logger).
-            to have_received(:warn).
-            with(%r{#{Regexp.escape(<<~WARN_LOG.squish)}})
-              [error-report:warning] ActionController::RoutingError :
-              No route matches [GET] "/this-path-does-not-exist" |
-              handled=true source=application controller_action="errors#not_found"
-            WARN_LOG
+          expect(Rails.logger).to have_received(:warn).with(
+            a_string_including(
+              '[error-report:warning]',
+              'ActionController::RoutingError',
+              'No route matches [GET] "/this-path-does-not-exist"',
+              'handled=true',
+              'source=application',
+              %r{request={url: ".+", .+, request_id: ".+"}},
+              'controller_action="errors#not_found"',
+            ),
+          )
         end
       end
 
@@ -42,12 +46,15 @@ RSpec.describe 'Handling exceptions', :rack_test_driver do
           expect(page).to have_css('h1', text: 'Sorry, something went wrong.')
           expect(page.status_code).to be(500)
           expect(page).not_to have_text(error_message)
-          expect(Rails.logger).to have_received(:error).with(<<~ERROR_LOG.squish)
-            [error-report:error] StandardError : A BrowserSupportChecker
-            instance could not be initialized! |
-            handled=false source=application.action_dispatch
-            controller_action="home#upgrade_browser"
-          ERROR_LOG
+          expect(Rails.logger).to have_received(:error).with(
+            a_string_including(
+              '[error-report:error] StandardError : A BrowserSupportChecker',
+              'instance could not be initialized! |',
+              'handled=false source=application.action_dispatch',
+              %r{request={url: ".+", .+, request_id: ".+"}},
+              'controller_action="home#upgrade_browser"',
+            ),
+          )
           expect(Rails.logger).to have_received(:add).with(
             Logger::ERROR,
             /StandardError \(#{error_message}\)/,


### PR DESCRIPTION
I think that this will add info about the request like user agent and request id that is currently not being sent to Rollbar for exceptions.