### PR TITLE
[api/comments/index] Don't assume presence of a referer

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -58,6 +58,6 @@ class Api::CommentsController < Api::BaseController
   end
 
   def referrer_without_query_params
-    Addressable::URI.parse(request.referer).path
+    Addressable::URI.parse(request.referer)&.path
   end
 end

--- a/spec/controllers/api/comments_controller_spec.rb
+++ b/spec/controllers/api/comments_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe Api::CommentsController do
+  describe '#index' do
+    subject(:get_index) { get(:index) }
+
+    before do
+      request.headers['Referer'] = referer
+    end
+
+    context 'when there is no referer' do
+      let(:referer) { nil }
+
+      it 'returns an empty array' do
+        get_index
+
+        expect(response.parsed_body).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
fixes rb#748
https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/748

An OpenAI bot made a request directly to api/comments#index without a referer header. That caused the above exception. This change avoids that exception; instead, an empty array will be returned.