### PR TITLE
[dependabot] Increase open PR limit from 5 (default) to 999

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,15 +9,18 @@ updates:
       timezone: America/Chicago
     allow:
       - dependency-type: all
+    open-pull-requests-limit: 999
   - package-ecosystem: github-actions
     directory: '/'
     schedule:
       interval: cron
       cronjob: '4 4 * * *'
       timezone: America/Chicago
+    open-pull-requests-limit: 999
   - package-ecosystem: npm
     directory: '/'
     schedule:
       interval: cron
       cronjob: '4 4 * * *'
       timezone: America/Chicago
+    open-pull-requests-limit: 999


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#open-pull-requests-limit-