### PR TITLE
[Dockerfile] Install specified bundler version for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ENV RAILS_ENV=${RAILS_ENV}
 # Use jemalloc for memory savings.
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
+# Ensure the correct Bundler version is installed.
+RUN gem install bundler -v $(ruby -rbundler -e 'puts Bundler::LockfileParser.new(File.read("Gemfile.lock")).bundler_version')
+
 # Set up for gem installation.
 ARG GEMS_DIRECTORY=vendor/bundle
 RUN bundle config set path "${GEMS_DIRECTORY}" && \
@@ -71,9 +74,6 @@ RUN DOCKER_BUILD=true \
   SECRET_KEY_BASE_DUMMY=1 \
   VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true \
   bundle exec rails assets:precompile > /dev/null
-
-# Ensure the correct Bundler version is installed.
-RUN gem install bundler -v $(ruby -rbundler -e 'puts Bundler::LockfileParser.new(File.read("Gemfile.lock")).bundler_version')
 
 # Precompile bootsnap code for faster boot times
 RUN bin/bootsnap precompile app/ lib/


### PR DESCRIPTION
... not just the build image.

We need the specified bundler version to boot Sidekiq. Attempts to boot Sidekiq in production currently fail on `main` with:

```
worker-1  | Activating bundler (~> 2.7) failed:
worker-1  | Could not find 'bundler' (~> 2.7) - did find: [bundler-2.6.9]
worker-1  | Checked in 'GEM_PATH=/root/.local/share/gem/ruby/3.4.0:/usr/local/lib/ruby/gems/3.4.0:/usr/local/bundle' , execute `gem env` for more information
worker-1  | 
worker-1  | To install the version of bundler this project requires, run `gem install bundler -v '~> 2.7'`
```