### PR TITLE
[Dockerfile] Copy Gemfile.lock before reading it for bundler install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,9 @@ ENV RAILS_ENV=${RAILS_ENV}
 # Use jemalloc for memory savings.
 ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
+# Copy gem and Ruby info files.
+COPY Gemfile Gemfile.lock .ruby-version ./
+
 # Ensure the correct Bundler version is installed.
 RUN gem install bundler -v $(ruby -rbundler -e 'puts Bundler::LockfileParser.new(File.read("Gemfile.lock")).bundler_version')
 
@@ -54,7 +57,6 @@ RUN \
   bundle config set --local clean 1 && \
   bundle config set --local deployment 1 && \
   bundle config set --local path /app/.cache/bundle
-COPY Gemfile Gemfile.lock .ruby-version ./
 RUN --mount=type=cache,sharing=private,target=/app/.cache/bundle \
   bundle install && \
   mkdir vendor && \


### PR DESCRIPTION
Fixes this https://github.com/davidrunger/david_runger/actions/runs/16352215989/job/46201788692 :

```
#12 [base 7/8] RUN gem install bundler -v $(ruby -rbundler -e 'puts Bundler::LockfileParser.new(File.read("Gemfile.lock")).bundler_version')
#12 0.460 -e:1:in 'IO.read': No such file or directory @ rb_sysopen - Gemfile.lock (Errno::ENOENT)
#12 0.460 	from -e:1:in '<main>'
#12 0.660 ERROR:  While executing gem ... (Gem::OptionParser::MissingArgument)
#12 0.660     missing argument: -v
#12 0.660 	/usr/local/lib/ruby/3.4.0/rubygems/command.rb:444:in 'Gem::Command#handle_options'
#12 0.660 	/usr/local/lib/ruby/3.4.0/rubygems/command.rb:312:in 'Gem::Command#invoke_with_build_args'
#12 0.660 	/usr/local/lib/ruby/3.4.0/rubygems/command_manager.rb:253:in 'Gem::CommandManager#invoke_command'
#12 0.660 	/usr/local/lib/ruby/3.4.0/rubygems/command_manager.rb:194:in 'Gem::CommandManager#process_args'
#12 0.660 	/usr/local/lib/ruby/3.4.0/rubygems/command_manager.rb:152:in 'Gem::CommandManager#run'
#12 0.660 	/usr/local/lib/ruby/3.4.0/rubygems/gem_runner.rb:57:in 'Gem::GemRunner#run'
#12 0.660 	/usr/local/bin/gem:12:in '<main>'
#12 ERROR: process "/bin/sh -c gem install bundler -v $(ruby -rbundler -e 'puts Bundler::LockfileParser.new(File.read(\"Gemfile.lock\")).bundler_version')" did not complete successfully: exit code: 1
------
 > [base 7/8] RUN gem install bundler -v $(ruby -rbundler -e 'puts Bundler::LockfileParser.new(File.read("Gemfile.lock")).bundler_version'):
0.460 	from -e:1:in '<main>'
0.660 ERROR:  While executing gem ... (Gem::OptionParser::MissingArgument)
0.660     missing argument: -v
```