### PR TITLE
Bump Redis from 7.4.2 to 8.2.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,7 +44,7 @@ x-redis-config: &redis
     interval: 5m
     timeout: 1s
     retries: 1
-  image: redis:7.4.2-alpine
+  image: redis:8.2.1-alpine
   logging: *default-logging
   networks:
     - internal


### PR DESCRIPTION
Apparently there are noteworthy performance improvements in Redis 8.2.