### PR TITLE
[home/about] Update LHH link

### DIFF
--- a/app/javascript/home/components/About.vue
+++ b/app/javascript/home/components/About.vue
@@ -23,7 +23,7 @@ HomeSection(
 
         p I love the Ruby programming language, the Rails web development framework, and the RSpec testing library. These are well-designed tools with strong supporting ecosystems that allow me to work efficiently and to have fun doing it.
 
-        p I have been a support engineer at #[a(href="https://www.commonlit.org/") CommonLit], a software engineer and support engineer at Hired (now part of #[a(href="https://www.lhh.com/us/en/hired/") LHH]), a web development boot camp teaching assistant at #[a(href="https://www.appacademy.io/") App&nbsp;Academy], a high school math teacher, a public bus driver, and a long haul truck driver.
+        p I have been a support engineer at #[a(href="https://www.commonlit.org/") CommonLit], a software engineer and support engineer at Hired (now part of #[a(href="https://www.lhh.com/en-us/about-us/our-story") LHH]), a web development boot camp teaching assistant at #[a(href="https://www.appacademy.io/") App&nbsp;Academy], a high school math teacher, a public bus driver, and a long haul truck driver.
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
> **Link to https://www.lhh.com/us/en/hired/ did not return expected status**
>
> We made a request to https://www.lhh.com/us/en/hired/, which is linked from https://davidrunger.com/, and its response status was 301, but we expected it to be in [200].

The redirect was to the link added in this change.