### PR TITLE
[puma] Update 'on_worker_boot' hook to 'before_worker_boot'

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -57,7 +57,7 @@ if worker_count > 0
   # This directive tells Puma to first boot the application and load code
   # before forking the application. This takes advantage of Copy On Write
   # process behavior so workers use less memory. If you use this option
-  # you need to make sure to reconnect any threads in the `on_worker_boot`
+  # you need to make sure to reconnect any threads in the `before_worker_boot`
   # block.
   #
   preload_app!
@@ -70,14 +70,14 @@ if worker_count > 0
     ActiveRecord::Base.connection_pool.disconnect! if defined?(ActiveRecord)
   end
 
-  # The code in the `on_worker_boot` will be called if you are using
+  # The code in the `before_worker_boot` will be called if you are using
   # clustered mode by specifying a number of `workers`. After each worker
   # process is booted, this block will be run. If you are using the `preload_app!`
   # option, you will want to use this block to reconnect to any threads
   # or connections that may have been created at application boot, as Ruby
   # cannot share connections between processes.
   #
-  on_worker_boot do
+  before_worker_boot do
     ActiveRecord::Base.establish_connection if defined?(ActiveRecord)
   end
 end


### PR DESCRIPTION
https://github.com/puma/puma/releases/tag/v7.0.0

Follow-up to #7289 . (This change ideally would have been made in that PR.)