### PR TITLE
Pin 'connection_pool' to '< 3' (i.e. v2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'blazer'
 gem 'bootsnap', require: false
 gem 'browser'
 gem 'chartkick'
-gem 'connection_pool'
+gem 'connection_pool', '< 3' # Unpin after https://github.com/rails/rails/pull/ 56292 is released.
 gem 'csv'
 gem 'devise'
 gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
       zeitwerk (>= 2.5.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -807,7 +807,7 @@ DEPENDENCIES
   chartkick
   climate_control
   cloudflare-rails
-  connection_pool
+  connection_pool (< 3)
   csv
   cuprite
   database_consistency
@@ -942,7 +942,7 @@ CHECKSUMS
   cloudflare-rails (7.0.0) sha256=9049b8305eab120e2d4ed9d04b42ce7030da5297fb62b0fa718b0a9e2d9af56c
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
-  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f


### PR DESCRIPTION
https://github.com/rails/rails/issues/ 56291#issuecomment-3613673436

Should fix this issue: https://github.com/davidrunger/david_runger/actions/runs/19972458342/job/57280544993

```
#37 [worker] resolving provenance for metadata file
#37 DONE 0.0s
+ bin/server/run-release-tasks
 Container david_runger-vector-1  Running
[...]
 Container david_runger-initialize_database-1  Started
/app/vendor/bundle/ruby/3.4.0/gems/connection_pool-3.0.2/lib/connection_pool.rb:48:in 'initialize': wrong number of arguments (given 1, expected 0) (ArgumentError)
	from /app/vendor/bundle/ruby/3.4.0/gems/activesupport-8.1.1/lib/active_support/cache/redis_cache_store.rb:163:in 'Class#new'
	from /app/vendor/bundle/ruby/3.4.0/gems/activesupport-8.1.1/lib/active_support/cache/redis_cache_store.rb:163:in 'ActiveSupport::Cache::RedisCacheStore#initialize'
	from /app/vendor/bundle/ruby/3.4.0/gems/activesupport-8.1.1/lib/active_support/cache.rb:91:in 'Class#new'
```