### PR TITLE
Revert "Bump connection_pool from 2.5.5 to 3.0.2"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'blazer'
 gem 'bootsnap', require: false
 gem 'browser'
 gem 'chartkick'
-gem 'connection_pool', '< 4' # Unpin after https://github.com/rails/rails/pull/ 56292 is released.
+gem 'connection_pool', '< 3' # Unpin after https://github.com/rails/rails/pull/ 56292 is released.
 gem 'csv'
 gem 'devise'
 gem 'dotenv'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,7 +200,7 @@ GEM
       zeitwerk (>= 2.5.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.5)
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -807,7 +807,7 @@ DEPENDENCIES
   chartkick
   climate_control
   cloudflare-rails
-  connection_pool (< 4)
+  connection_pool (< 3)
   csv
   cuprite
   database_consistency
@@ -942,7 +942,7 @@ CHECKSUMS
   cloudflare-rails (7.0.0) sha256=9049b8305eab120e2d4ed9d04b42ce7030da5297fb62b0fa718b0a9e2d9af56c
   coderay (1.1.3) sha256=dc530018a4684512f8f38143cd2a096c9f02a1fc2459edcfe534787a7fc77d4b
   concurrent-ruby (1.3.5) sha256=813b3e37aca6df2a21a3b9f1d497f8cbab24a2b94cab325bffe65ee0f6cbebc6
-  connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
+  connection_pool (2.5.5) sha256=e54ff92855753df1fd7c59fa04a398833355f27dd14c074f8c83a05f72a716ad
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
   csv (3.3.5) sha256=6e5134ac3383ef728b7f02725d9872934f523cb40b961479f69cf3afa6c8e73f


### PR DESCRIPTION
Reverts davidrunger/david_runger#7846

`connection_pool` v3 is not compatible with the currently released Rails Redis cache adapter. This only gets caught when deploying to production, though, because currently I guess that cache adapter is not covered by any tests.