### PR TITLE
Add spec covering ActiveSupport::Cache::RedisCacheStore [DEV-250]

### DIFF
--- a/spec/rails/active_support/cache/redis_cache_store_spec.rb
+++ b/spec/rails/active_support/cache/redis_cache_store_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe ActiveSupport::Cache::RedisCacheStore do
+  let(:redis_cache_store) { ActiveSupport::Cache::RedisCacheStore.new }
+
+  it 'writes and reads a value from the Redis cache store' do
+    key = "redis_cache_store_spec.rb-#{SecureRandom.alphanumeric}"
+    value = SecureRandom.alphanumeric
+
+    expect(redis_cache_store.write(key, value)).to eq(true)
+    expect(redis_cache_store.read(key)).to eq(value)
+
+    # Clean up
+    redis_cache_store.delete(key)
+  end
+end


### PR DESCRIPTION
This should avoid the need for PRs such as this: https://github.com/davidrunger/david_runger/pull/7847 .

Prior to this change, we were only using the `ActiveSupport::Cache::RedisCacheStore` in production, so any issues with it were not caught in CI. The spec added in this change reproduces the exception seen [here](https://github.com/davidrunger/david_runger/actions/runs/19997037377/job/57346251979) that was caused by [this PR](https://github.com/davidrunger/david_runger/pull/7846).