### PR TITLE
[Dockerfile] Stop relying on 'bundle exec' to find gem executables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,7 +63,7 @@ RUN --mount=type=cache,sharing=private,target=/app/.cache/bundle \
   cp -ar /app/.cache/bundle "${GEMS_DIRECTORY}"
 RUN bundle config set --local path "${GEMS_DIRECTORY}"
 
-RUN bundle exec bootsnap precompile --gemfile
+RUN bundle exec $(bundle info --path bootsnap)/exe/bootsnap precompile --gemfile
 
 # Copy application code and compiled assets
 COPY . .
@@ -75,7 +75,7 @@ RUN DOCKER_BUILD=true \
   GIT_REV=${GIT_REV} \
   SECRET_KEY_BASE_DUMMY=1 \
   VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true \
-  bundle exec rails assets:precompile > /dev/null
+  bin/rails assets:precompile > /dev/null
 
 # Precompile bootsnap code for faster boot times
 RUN bin/bootsnap precompile app/ lib/


### PR DESCRIPTION
I think that the [upgrade to bundler v4](https://github.com/davidrunger/david_runger/pull/7860) somehow broke Docker builds? I guess that bundler v4 is somehow no longer compatible with the bundler configuration changes that we make during the Docker build process?

```
#20 [build 6/9] RUN bundle exec bootsnap precompile --gemfile
#20 0.568 bundler: command not found: bootsnap
#20 0.568 Install missing gem executables with `bundle install`
#20 ERROR: process "/bin/sh -c bundle exec bootsnap precompile --gemfile" did not complete successfully: exit code: 127
------
 > [build 6/9] RUN bundle exec bootsnap precompile --gemfile:
0.568 bundler: command not found: bootsnap
0.568 Install missing gem executables with `bundle install`
------
Dockerfile:66

--------------------

  64 |     RUN bundle config set --local path "${GEMS_DIRECTORY}"

  65 |     

  66 | >>> RUN bundle exec bootsnap precompile --gemfile

  67 |     

  68 |     # Copy application code and compiled assets

--------------------

failed to solve: process "/bin/sh -c bundle exec bootsnap precompile --gemfile" did not complete successfully: exit code: 127
```