### PR TITLE
[Gemfile.lock] Add ruby platform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -771,6 +771,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin
+  ruby
   x86_64-darwin
   x86_64-linux-gnu
   x86_64-linux-musl


### PR DESCRIPTION
[ChatGPT says](https://chatgpt.com/share/69514d70-e528-8007-98ec-db43c9901d27) that this will prevent Dependabot from removing mini_portile2.