### PR TITLE
[prune-docker-and-rebuild] Don't expect prometheus_exporter for now

### DIFF
--- a/bin/server/prune-docker-and-rebuild.sh
+++ b/bin/server/prune-docker-and-rebuild.sh
@@ -4,7 +4,7 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 # To minimize risk of accidental DB deletion, continue only if all expected
 # services are running.
-expected_num_services=14 # Increase back to 15 once prometheus_exporter is compatible with Ruby 4
+expected_num_services=14 # Increase back to 15 once prometheus_exporter is compatible with Ruby 4.
 actual_num_services=$(docker ps --filter status=running --quiet | wc -l)
 
 if [[ "$actual_num_services" -ne "$expected_num_services" ]] ; then

--- a/bin/server/prune-docker-and-rebuild.sh
+++ b/bin/server/prune-docker-and-rebuild.sh
@@ -4,7 +4,7 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 # To minimize risk of accidental DB deletion, continue only if all expected
 # services are running.
-expected_num_services=15
+expected_num_services=14 # Increase back to 15 once prometheus_exporter is compatible with Ruby 4
 actual_num_services=$(docker ps --filter status=running --quiet | wc -l)
 
 if [[ "$actual_num_services" -ne "$expected_num_services" ]] ; then


### PR DESCRIPTION
It seems to me that `prometheus_exporter` is not compatible with Ruby 4.

https://davidrunger.com/admin/deploys/2815

<img width="859" height="901" alt="image" src="https://github.com/user-attachments/assets/80b4f804-7029-484d-bb1b-adbaabcec2fa" />

To test: Run `bin/prometheus_exporter --bind 0.0.0.0` on local machine and then go to http://localhost:9394/metrics . On Ruby 4, this causes the `bin/prometheus_exporter` server to exit.