### PR TITLE
[emoji-picker] Disable autocomplete [EMO-14]

### DIFF
--- a/app/javascript/emoji_picker/EmojiPicker.vue
+++ b/app/javascript/emoji_picker/EmojiPicker.vue
@@ -7,6 +7,7 @@
       name="Search for an emoji"
       type="text"
       autofocus
+      autocomplete="off"
       v-model="query"
     )
 


### PR DESCRIPTION
The autocomplete suggestions can make it hard to see one or more of the emoji search results.