### PR TITLE
[groceries] Include store name in page title [GROC-38]

### DIFF
--- a/app/javascript/groceries/components/Store.vue
+++ b/app/javascript/groceries/components/Store.vue
@@ -44,10 +44,13 @@ import ManageCheckInStoresModal from './ManageCheckInStoresModal.vue';
 import NewItemForm from './NewItemForm.vue';
 import StoreHeader from './StoreHeader.vue';
 import StoreNotes from './StoreNotes.vue';
+import { useTitle } from '@vueuse/core';
 
 const props = defineProps({
   store: object<Store>().isRequired,
 });
+
+useTitle(() => `${props.store.name} - Groceries - David Runger`);
 
 const groceriesStore = useGroceriesStore();
 const modalStore = useModalStore();

--- a/app/javascript/groceries/components/Store.vue
+++ b/app/javascript/groceries/components/Store.vue
@@ -28,6 +28,7 @@
 </template>
 
 <script setup lang="ts">
+import { useTitle } from '@vueuse/core';
 import { ElButton } from 'element-plus';
 import { computed } from 'vue';
 import { object } from 'vue-types';
@@ -44,7 +45,6 @@ import ManageCheckInStoresModal from './ManageCheckInStoresModal.vue';
 import NewItemForm from './NewItemForm.vue';
 import StoreHeader from './StoreHeader.vue';
 import StoreNotes from './StoreNotes.vue';
-import { useTitle } from '@vueuse/core';
 
 const props = defineProps({
   store: object<Store>().isRequired,

--- a/lib/test/tasks/run_file_size_checks.rb
+++ b/lib/test/tasks/run_file_size_checks.rb
@@ -19,7 +19,7 @@ class Test::Tasks::RunFileSizeChecks < Pallets::Task
     'emoji_picker*.js' => (337..347),
     'google_sign_in_button*.js' => (1..11),
     'groceries*.css' => (48..58),
-    'groceries*.js' => (308..318),
+    'groceries*.js' => (317..327),
     'home*.css' => (13..23),
     'home*.js' => (252..262),
     'logs*.css' => (101..111),

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -204,6 +204,27 @@ RSpec.describe 'Groceries app' do
           end
         end
       end
+
+      context 'when switching between stores' do
+        before { expect(user.stores.size).to be >= 2 }
+
+        let!(:most_recent_store) { user.stores.reorder(viewed_at: :desc).first! }
+        let!(:other_store) { user.stores.reorder(viewed_at: :desc).second! }
+
+        it 'includes the store name in the page title' do
+          visit groceries_path
+
+          expect(page).to have_css('h1', text: most_recent_store.name)
+          expect(page).to have_title("#{most_recent_store.name} - Groceries - David Runger")
+
+          within('aside') do
+            click_on(other_store.name)
+          end
+
+          expect(page).to have_css('h1', text: other_store.name)
+          expect(page).to have_title("#{other_store.name} - Groceries - David Runger")
+        end
+      end
     end
   end
 

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -20,6 +20,7 @@ FixtureBuilder.configure do |fbuilder|
     admin_user = name(:admin_user, create(:admin_user, email: 'davidjrunger@gmail.com')).first
 
     # groceries
+    create(:store, user:, name: 'Another Store')
     store = name(:store, create(:store, user:, name: 'A Long Store Name So It Wraps')).first
     name(:item, create(:item, :needed, store:, name: 'olive oil', needed: 2))
     create(:item, :unneeded, store:, name: 'apples')


### PR DESCRIPTION
The name of the currently selected store is useful context when e.g. looking at a tab title in one's browser.