### PR TITLE
Remove 'omniauth-rails_csrf_protection' gem [DEV-249]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ gem 'loofah-activerecord'
 gem 'memo_wise'
 gem 'nokogiri'
 gem 'omniauth-google-oauth2'
-gem 'omniauth-rails_csrf_protection'
 gem 'paper_trail', # Source from RubyGems after https://github.com/paper-trail-gem/paper_trail/pull/1511 is released.
   github: 'davidrunger/paper_trail'
 gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,9 +442,6 @@ GEM
     omniauth-oauth2 (1.9.0)
       oauth2 (>= 2.0.2, < 3)
       omniauth (~> 2.0)
-    omniauth-rails_csrf_protection (2.0.1)
-      actionpack (>= 4.2)
-      omniauth (~> 2.0)
     optimist (3.2.1)
     orm_adapter (0.5.0)
     parallel (1.27.0)
@@ -814,7 +811,6 @@ DEPENDENCIES
   memo_wise
   nokogiri
   omniauth-google-oauth2
-  omniauth-rails_csrf_protection
   pallets!
   paper_trail!
   percy-capybara
@@ -1019,7 +1015,6 @@ CHECKSUMS
   omniauth (2.1.4) sha256=42a05b0496f0d22e1dd85d42aaf602f064e36bb47a6826a27ab55e5ba608763c
   omniauth-google-oauth2 (1.2.1) sha256=c81c50b680fc3372d0c18147cdaf9764a67ace9e7e4e6afe7b869a01fa1aaedd
   omniauth-oauth2 (1.9.0) sha256=ed15f6d9d20991807ce114cc5b9c1453bce3645b64e51c68c90cff5ff153fee8
-  omniauth-rails_csrf_protection (2.0.1) sha256=c6e3204d7e3925bb537cb52d50fdfc9f05293f1a9d87c5d4ab4ca3a39ba8c32d
   optimist (3.2.1) sha256=8cf8a0fd69f3aa24ab48885d3a666717c27bc3d9edd6e976e18b9d771e72e34e
   orm_adapter (0.5.0) sha256=aa5d0be5d540cbb46d3a93e88061f4ece6a25f6e97d6a47122beb84fe595e9b9
   pallets (0.11.0)

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
   config.action_dispatch.show_exceptions = :none
 
   # Disable request forgery protection in test environment.
-  config.action_controller.allow_forgery_protection = false
+  config.action_controller.allow_forgery_protection = true
 
   # Store uploaded files on the local file system in a temporary directory.
   config.active_storage.service = :local

--- a/config/initializers/omni_auth.rb
+++ b/config/initializers/omni_auth.rb
@@ -1,6 +1,10 @@
 # avoid OmniAuth output being sent to STDOUT during tests
 OmniAuth.config.logger = Rails.logger
 
+# https://github.com/cookpad/omniauth-rails_csrf_protection/pull/24#issuecomment-3492077627
+OmniAuth.config.request_validation_phase =
+  OmniAuth::AuthenticityTokenProtection.new(key: :_csrf_token)
+
 Rails.application.config.middleware.use(OmniAuth::Builder) do
   unless IS_DOCKER_BUILD
     provider(

--- a/spec/requests/users/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/users/omniauth_callbacks_controller_spec.rb
@@ -11,19 +11,16 @@ RSpec.describe Users::OmniauthCallbacksController do
 
     describe 'POST /auth/:provider without CSRF token' do
       around do |spec|
-        original_allow_forgery_protection = ActionController::Base.allow_forgery_protection
-        ActionController::Base.allow_forgery_protection = true
-
-        spec.run
-      ensure
-        ActionController::Base.allow_forgery_protection = original_allow_forgery_protection
+        ActionController::Base.with(allow_forgery_protection: true) do
+          spec.run
+        end
       end
 
       it 'redirects to `/auth/failure?[...]`' do
         post('/auth/google_oauth2')
         expect(response).to redirect_to(
           '/auth/failure' \
-          '?message=ActionController%3A%3AInvalidAuthenticityToken' \
+          '?message=Forbidden' \
           '&strategy=google_oauth2',
         )
       end


### PR DESCRIPTION
The gem is no longer needed to protect against CSRF, per this comment: https://github.com/cookpad/omniauth-rails_csrf_protection/pull/ 24#issuecomment-3492077627 .