### PR TITLE
[prune-docker-and-rebuild] Expect prometheus_exporter again

### DIFF
--- a/bin/server/prune-docker-and-rebuild.sh
+++ b/bin/server/prune-docker-and-rebuild.sh
@@ -4,7 +4,7 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 # To minimize risk of accidental DB deletion, continue only if all expected
 # services are running.
-expected_num_services=14 # Increase back to 15 once prometheus_exporter is compatible with Ruby 4.
+expected_num_services=15
 actual_num_services=$(docker ps --filter status=running --quiet | wc -l)
 
 if [[ "$actual_num_services" -ne "$expected_num_services" ]] ; then


### PR DESCRIPTION
This reverts #7985 because prometheus_exporter was fixed for us by the PR #8082 (which bumped Ruby to 4.0.1, which included a fix for Kernel#sleep that had been affecting prometheus_exporter ( https://github.com/discourse/prometheus_exporter/issues/ 364 )).