### PR TITLE
[specs/ApplicationWorker] Verify lock set in before block [DEV-247]

### DIFF
--- a/spec/workers/application_worker_spec.rb
+++ b/spec/workers/application_worker_spec.rb
@@ -53,7 +53,8 @@ RSpec.describe ApplicationWorker do
       end
 
       context 'when a lock for that job + arguments is already in redis' do
-        before { worker.send(:lock_obtained?, []) } # this sets the lock
+        # Checking #lock_obtained? sets the lock (if it's not already set):
+        before { expect(worker.send(:lock_obtained?, [])).to eq('OK') }
 
         it "does not execute the worker's perform method" do
           call_perform

--- a/spec/workers/application_worker_spec.rb
+++ b/spec/workers/application_worker_spec.rb
@@ -54,7 +54,14 @@ RSpec.describe ApplicationWorker do
 
       context 'when a lock for that job + arguments is already in redis' do
         # Checking #lock_obtained? sets the lock (if it's not already set):
-        before { expect(worker.send(:lock_obtained?, [])).to eq('OK') }
+        before do
+          if worker.send(:lock_obtained?, []) != 'OK'
+            Sidekiq.redis do |conn|
+              remaining_milliseconds = conn.call('pttl', worker.send(:lock_key, []))
+              fail "#{remaining_milliseconds} milliseconds are still on lock"
+            end
+          end
+        end
 
         it "does not execute the worker's perform method" do
           call_perform


### PR DESCRIPTION
I don't expect this to actually fix the flakiness that is the subject of DEV-247, but hopefully this additional expectation will narrow down the possible causes, if this spec does flake again.

If there already is a lock (which I suspect might somehow be what is happening to cause this flakiness?), then `worker.send(:lock_obtained?, [])` will return `nil` rather than `'OK'`, and this check that we are adding in the `before` block will raise an error.