### PR TITLE
[specs] Use separate Redis database numbers for Sidekiq [DEV-247]

### DIFF
--- a/app/poros/redis_options.rb
+++ b/app/poros/redis_options.rb
@@ -1,8 +1,13 @@
 class RedisOptions
   prepend Memoization
 
-  def initialize(db: nil)
-    @db = db || default_db_number
+  def initialize(db: nil, sidekiq: false)
+    @db =
+      if rails_test?
+        test_db_number(sidekiq:)
+      else
+        db || 0
+      end
   end
 
   memoize \
@@ -21,19 +26,23 @@ class RedisOptions
   end
 
   memoize \
-  def default_db_number
-    if defined?(Rails) && Rails.env.test?
-      # piggyback on the Postgres DB_SUFFIX ENV variable to choose a Redis DB number
+  def test_db_number(sidekiq:)
+    # piggyback on the Postgres DB_SUFFIX ENV variable to choose a Redis DB number
+    base_db_number =
       case ENV.fetch('DB_SUFFIX', nil)
       when '_unit', nil then 4
       when '_api' then 5
       when '_html' then 6
       when '_feature_a' then 7
-      when '_feature_c' then 9
+      when '_feature_c' then 8
       else raise('Unexpected DB_SUFFIX!')
       end
-    else
-      0
-    end
+
+    sidekiq ? base_db_number + 5 : base_db_number
+  end
+
+  memoize \
+  def rails_test?
+    defined?(Rails) && Rails.env.test?
   end
 end

--- a/app/poros/redis_options.rb
+++ b/app/poros/redis_options.rb
@@ -27,7 +27,7 @@ class RedisOptions
 
   memoize \
   def test_db_number(sidekiq:)
-    # piggyback on the Postgres DB_SUFFIX ENV variable to choose a Redis DB number
+    # Piggyback on the Postgres DB_SUFFIX ENV variable to choose a Redis DB number.
     base_db_number =
       case ENV.fetch('DB_SUFFIX', nil)
       when '_unit', nil then 4

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,9 +1,10 @@
 unless IS_DOCKER_BUILD
   Sidekiq.strict_args!
 
-  # We'll give Sidekiq db 1 (by default). The app uses db 0 for its direct uses.
+  # We'll give Sidekiq db 1 (by default, except in tests, where this is ignored).
+  # (The app uses db 0 for its direct uses.)
   db = Integer(ENV.fetch('REDIS_DATABASE_NUMBER', 1))
-  redis_options = RedisOptions.new(db:)
+  redis_options = RedisOptions.new(db:, sidekiq: true)
 
   Sidekiq.configure_client do |config|
     config.redis = { url: redis_options.url }

--- a/lib/test/run_pallets_tests.rb
+++ b/lib/test/run_pallets_tests.rb
@@ -9,7 +9,7 @@ Pallets.configure do |c|
 
   c.concurrency = concurrency
   c.max_failures = 0
-  c.backend_args = { url: 'redis://127.0.0.1:6379/10' } # use redis db #10 (to avoid conflicts)
+  c.backend_args = { url: 'redis://127.0.0.1:6379/15' } # Use redis db 15 (to avoid conflicts).
   c.middleware << Test::Middleware::ExitOnFailureMiddleware
   c.middleware << Test::Middleware::TaskResultTrackingMiddleware
 end

--- a/spec/poros/redis_options_spec.rb
+++ b/spec/poros/redis_options_spec.rb
@@ -25,15 +25,13 @@ RSpec.describe RedisOptions do
 
       let(:db_number) { 2 }
 
-      context 'when RAILS_ENV is "development"' do
-        around { |spec| ClimateControl.modify(RAILS_ENV: 'development') { spec.run } }
-
+      context 'when Rails.env is "development"', rails_env: 'development' do
         it 'returns a localhost URL with a database path' do
           expect(url).to eq('redis://localhost:6379/2')
         end
       end
 
-      context 'when RAILS_ENV is "production"' do
+      context 'when Rails.env is "production"', rails_env: 'production' do
         around { |spec| ClimateControl.modify(RAILS_ENV: 'production') { spec.run } }
 
         context 'when a REDIS_URL env var is present' do
@@ -49,57 +47,117 @@ RSpec.describe RedisOptions do
     end
   end
 
-  describe '#default_db_number' do
-    subject(:default_db_number) { redis_options.send(:default_db_number) }
+  describe '#test_db_number' do
+    subject(:test_db_number) { redis_options.send(:test_db_number, sidekiq:) }
 
-    context 'when not providing a database number' do
-      subject(:redis_options) { RedisOptions.new }
+    context 'when getting a DB number for Sidekiq' do
+      let(:sidekiq) { true }
 
-      context 'when DB_SUFFIX is _unit' do
-        around { |spec| ClimateControl.modify(DB_SUFFIX: '_unit') { spec.run } }
+      context 'when not providing a database number' do
+        subject(:redis_options) { RedisOptions.new }
 
-        it 'returns 4' do
-          expect(default_db_number).to eq(4)
+        context 'when DB_SUFFIX is _unit' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_unit') { spec.run } }
+
+          it 'returns 9' do
+            expect(test_db_number).to eq(9)
+          end
+        end
+
+        context 'when DB_SUFFIX is _api' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_api') { spec.run } }
+
+          it 'returns 10' do
+            expect(test_db_number).to eq(10)
+          end
+        end
+
+        context 'when DB_SUFFIX is _html' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_html') { spec.run } }
+
+          it 'returns 11' do
+            expect(test_db_number).to eq(11)
+          end
+        end
+
+        context 'when DB_SUFFIX is _feature_a' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_a') { spec.run } }
+
+          it 'returns 12' do
+            expect(test_db_number).to eq(12)
+          end
+        end
+
+        context 'when DB_SUFFIX is _feature_c' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_c') { spec.run } }
+
+          it 'returns 13' do
+            expect(test_db_number).to eq(13)
+          end
+        end
+
+        context 'when DB_SUFFIX is _unexpected' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_unexpected') { spec.run } }
+
+          it 'raises an error' do
+            expect { test_db_number }.to raise_error('Unexpected DB_SUFFIX!')
+          end
         end
       end
+    end
 
-      context 'when DB_SUFFIX is _api' do
-        around { |spec| ClimateControl.modify(DB_SUFFIX: '_api') { spec.run } }
+    context 'when not getting a DB number for Sidekiq' do
+      let(:sidekiq) { false }
 
-        it 'returns 5' do
-          expect(default_db_number).to eq(5)
+      context 'when not providing a database number' do
+        subject(:redis_options) { RedisOptions.new }
+
+        context 'when DB_SUFFIX is _unit' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_unit') { spec.run } }
+
+          it 'returns 4' do
+            expect(test_db_number).to eq(4)
+          end
         end
-      end
 
-      context 'when DB_SUFFIX is _html' do
-        around { |spec| ClimateControl.modify(DB_SUFFIX: '_html') { spec.run } }
+        context 'when DB_SUFFIX is _api' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_api') { spec.run } }
 
-        it 'returns 6' do
-          expect(default_db_number).to eq(6)
+          it 'returns 5' do
+            expect(test_db_number).to eq(5)
+          end
         end
-      end
 
-      context 'when DB_SUFFIX is _feature_a' do
-        around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_a') { spec.run } }
+        context 'when DB_SUFFIX is _html' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_html') { spec.run } }
 
-        it 'returns 7' do
-          expect(default_db_number).to eq(7)
+          it 'returns 6' do
+            expect(test_db_number).to eq(6)
+          end
         end
-      end
 
-      context 'when DB_SUFFIX is _feature_c' do
-        around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_c') { spec.run } }
+        context 'when DB_SUFFIX is _feature_a' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_a') { spec.run } }
 
-        it 'returns 9' do
-          expect(default_db_number).to eq(9)
+          it 'returns 7' do
+            expect(test_db_number).to eq(7)
+          end
         end
-      end
 
-      context 'when DB_SUFFIX is _unexpected' do
-        around { |spec| ClimateControl.modify(DB_SUFFIX: '_unexpected') { spec.run } }
+        context 'when DB_SUFFIX is _feature_c' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_c') { spec.run } }
 
-        it 'raises an error' do
-          expect { default_db_number }.to raise_error('Unexpected DB_SUFFIX!')
+          it 'returns 8' do
+            expect(test_db_number).to eq(8)
+          end
+        end
+
+        context 'when DB_SUFFIX is _unexpected' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_unexpected') { spec.run } }
+
+          it 'raises an error' do
+            expect { test_db_number }.to raise_error('Unexpected DB_SUFFIX!')
+          end
         end
       end
     end

--- a/spec/workers/application_worker_spec.rb
+++ b/spec/workers/application_worker_spec.rb
@@ -64,7 +64,6 @@ RSpec.describe ApplicationWorker do
         end
 
         it "does not execute the worker's perform method" do
-          sleep(1)
           call_perform
           expect(StubbedTestJob.perform_was_called).to eq(false)
         end

--- a/spec/workers/application_worker_spec.rb
+++ b/spec/workers/application_worker_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe ApplicationWorker do
         end
 
         it "does not execute the worker's perform method" do
+          sleep(1)
           call_perform
           expect(StubbedTestJob.perform_was_called).to eq(false)
         end


### PR DESCRIPTION
Thanks to DeepSeek for figuring this out: https://chat.deepseek.com/share/5uj3nzq696am69gf5r . (I wish I'd have figured this out on my own, and I am somewhat ashamed that I didn't. I think part of the reason I didn't think of it is that I knew I was using separate databases for the _application_ Redis connection. Unfortunately, it didn't really occur to me that we need to do the same thing for the _Sidekiq_ Redis connections, too.)