### PR TITLE
[lib/test/runner] Stop using removed IO#ready? method

### DIFF
--- a/lib/test/runner.rb
+++ b/lib/test/runner.rb
@@ -81,11 +81,11 @@ class Test::Runner < Pallets::Workflow
         loop do
           # loop until the user hits enter (which will make `STDIN.ready?` true)
           sleep(0.1)
-          next if !$stdin.ready?
+          next if !$stdin.wait_readable(0)
 
           # take these actions once the user has hit enter (confirming that the setup looks good)
           @listener.stop # stop listening for further changes to `.tests.yml`
-          $stdin.gets while $stdin.ready? # pull/clear the user's input from STDIN
+          $stdin.gets while $stdin.wait_readable(0) # pull/clear the user's input from STDIN
           break
         end
       end

--- a/lib/test/runner.rb
+++ b/lib/test/runner.rb
@@ -79,7 +79,7 @@ class Test::Runner < Pallets::Workflow
         @listener.start
 
         loop do
-          # loop until the user hits enter (which will make `STDIN.ready?` true)
+          # Loop until the user hits enter (which will make `$stdin.wait_readable(0)` true).
           sleep(0.1)
           next if !$stdin.wait_readable(0)
 


### PR DESCRIPTION
`$stdin.wait_readable(0)` seems to do what `$stdin.ready?` was doing before. IO#ready? appears to have been removed in Ruby 4.0 (comparing https://docs.ruby-lang.org/en/3.4/IO.html#method-i-ready-3F and https://docs.ruby-lang.org/en/4.0/IO.html , though I see nothing about this change in the Ruby 4.0 release notes).