### PR TITLE
[specs/logs] Wait for LogEntry deletion before checking it [LOG-50]

### DIFF
--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe 'Logs app' do
             within('.el-popconfirm') do
               click_on('Yes')
             end
+            wait_for { LogEntry.find_by(id: most_recent_log_entry.id) }.to eq(nil)
           }.to change {
             LogEntry.find_by(id: most_recent_log_entry.id)
           }.from(LogEntry).to(nil)


### PR DESCRIPTION
Prior to this change, if the controller was a little slow to delete the log entry, then the expectation might be checked prior to the deletion actually occurring, causing the spec to flake/fail. Adding this `wait_for` call should avoid this source of flakiness.

The usual "best practice" would be to check something in the UI using a Capybara waiting matcher to confirm that the LogEntry has been deleted, but the problem is that the LogEntry is rendered only as part of a graph via a `canvas` element, I think, so I think it would be difficult (impossible?) to check for that using Capybara. So, we'll do this, instead.