### PR TITLE
[monkeypatches/rspec_wait_handler] Add explanatory overview comment

### DIFF
--- a/config/initializers/monkeypatches/rspec_wait_handler.rb
+++ b/config/initializers/monkeypatches/rspec_wait_handler.rb
@@ -1,3 +1,7 @@
+# This monkeypatch makes it so that the repeated calls (if the expectation is
+# not initially satisfied) in a `wait_for` block don't get flagged as an N + 1
+# query by Prosopite.
+
 if defined?(RSpec::Wait::Handler) && defined?(Prosopite)
   module RSpecWaitHandlerPatches
     # We are monkeypatching this method:


### PR DESCRIPTION
I was looking at this file and did not initially know/remember what it's purpose is. I think we should have an explanatory comment like that added in this change to make the purpose of this monkeypatch clear to anyone looking at it.