### PR TITLE
[events] Send data with JSON header even when using sendBeacon

### DIFF
--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -10,9 +10,9 @@ class Api::EventsController < Api::BaseController
 
     event = Event.create_with_stack_trace!(
       admin_user: current_admin_user,
-      data: payload_data[:data],
+      data: params[:data],
       ip: request.remote_ip,
-      type: payload_data[:type],
+      type: params[:type],
       user: current_user,
       user_agent: request.user_agent,
     )
@@ -20,11 +20,5 @@ class Api::EventsController < Api::BaseController
     FetchIpInfoForRecord.perform_async(event.class.name, event.id)
 
     head :created
-  end
-
-  private
-
-  def payload_data
-    JSON.parse(request.raw_post).with_indifferent_access
   end
 end

--- a/app/javascript/lib/events.ts
+++ b/app/javascript/lib/events.ts
@@ -15,7 +15,10 @@ export function trackEvent(
   if (options.useSendBeacon) {
     // NOTE: uBlock Origin (and probably others) block sendBeacon requests, so
     // this tracking is not 100% reliable.
-    navigator.sendBeacon(_api_events_path, JSON.stringify(payload));
+    navigator.sendBeacon(
+      _api_events_path,
+      new Blob([JSON.stringify(payload)], { type: 'application/json' }),
+    );
   } else {
     http.post(_api_events_path, payload);
   }


### PR DESCRIPTION
This will cause Rails to parse the request body into `params`, eliminating the need to parse the body JSON data manually, as we had been doing until this change.

https://chatgpt.com/share/69703d1f-8bd8-8007-8d65-7cb8bd486924