### PR TITLE
[specs/application-worker] Simplify 'lock_obtained?' check

### DIFF
--- a/spec/workers/application_worker_spec.rb
+++ b/spec/workers/application_worker_spec.rb
@@ -54,14 +54,7 @@ RSpec.describe ApplicationWorker do
 
       context 'when a lock for that job + arguments is already in redis' do
         # Checking #lock_obtained? sets the lock (if it's not already set):
-        before do
-          if worker.send(:lock_obtained?, []) != 'OK'
-            Sidekiq.redis do |conn|
-              remaining_milliseconds = conn.call('pttl', worker.send(:lock_key, []))
-              fail "#{remaining_milliseconds} milliseconds are still on lock"
-            end
-          end
-        end
+        before { expect(worker.send(:lock_obtained?, [])).to eq('OK') }
 
         it "does not execute the worker's perform method" do
           call_perform


### PR DESCRIPTION
The check in question, including logging of milliseconds remaining on any lock that might unexpectedly be present, was added in #8110 for the purpose of narrowing in on the cause of spec flakiness. However, I think that we eliminated that spec flakiness in #8111 , and thus the slightly lengthy and complicated check that we added is no longer worth it. This change simplifies the check to simply use RSpec's `expect`.