### PR TITLE
[specs/home] Click resume link twice [HOME-23]

### DIFF
--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -59,9 +59,15 @@ RSpec.describe 'Home page', :prerendering_disabled do
     # External link click tracking >>>
     event_count_before = Event.count
 
+    # Click the resume link twice, because the event tracking as the page
+    # unloads is intrinsically flaky (not just in test, but also for real).
+    # Clicking the link twice makes the chance of flaky failures much smaller
+    # (and low enough that we might never see a flake again).
+    click_on('View Resume (pdf)')
+    page.driver.go_back
     click_on('View Resume (pdf)')
 
-    wait_for { Event.count }.to eq(event_count_before + 1)
+    wait_for { Event.count }.to be_between(event_count_before + 1, event_count_before + 2)
 
     new_event = Event.reorder(:created_at).last!
 


### PR DESCRIPTION
With this change, in the home feature spec where it tests `external_link_click` event tracking, we will now click the resume link twice (rather than once, as before), because the event tracking as the page unloads is intrinsically flaky (not just in test, but also for real users, I think). Clicking the link twice makes the chance of flaky failures much smaller (and low enough that we might never see a flake again). We expect that two events will usually now be created. Rarely, one event might be created. Even more rarely, no events might be created, in which case this spec will fail. But, as mentioned, hopefully this will be so rare that we might never see this spec flake ever again.