### PR TITLE
[specs] Add and use new 'wait_until' helper (rather than sleeping)

### DIFF
--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe 'Home page', :prerendering_disabled do
 
     click_on('View Resume (pdf)')
 
-    sleep(0.1) # Sleep briefly to allow time for Event to be created.
+    wait_until { Event.count == event_count_before + 1 }
 
     # The event might not have been created, because the tracking is inherently flaky.
     if Event.count == event_count_before + 1

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -7,4 +7,17 @@ module SpecHelpers
     allow(Flipper).to receive(:enabled?).and_call_original
     allow(Flipper).to receive(:enabled?).with(feature_name).and_return(true)
   end
+
+  def wait_until
+    Prosopite.pause do
+      50.times do
+        if yield
+          return
+        else
+          puts('SLEEPIN!')
+          sleep(0.1)
+        end
+      end
+    end
+  end
 end

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -14,7 +14,6 @@ module SpecHelpers
         if yield
           return
         else
-          puts('SLEEPIN!')
           sleep(0.1)
         end
       end


### PR DESCRIPTION
This will make the spec both faster (since often we will not sleep at all) and also more reliable (since we can sleep up to 5 seconds, if needed). When testing this, a few times I did see `NameError: uninitialized constant Event`. Hopefully that is not something that we see again and it was just a result of some weirdness in how I was testing this.