### PR TITLE
[specs] Verify empty flash, status, and redirect location [QUIZ-7]

### DIFF
--- a/spec/controllers/quiz_participations_controller_spec.rb
+++ b/spec/controllers/quiz_participations_controller_spec.rb
@@ -15,8 +15,11 @@ RSpec.describe QuizParticipationsController do
       context 'when the user submits a name' do
         let(:display_name) { 'Al' }
 
-        it 'creates a QuizParticipation for the user' do
+        it 'creates a QuizParticipation for the user, does not set any flash alert message, and responds with a redirect to the quiz show page', :aggregate_failures do
           expect { post_create }.to change { user.reload.quiz_participations.size }.by(1)
+          expect(flash[:alert]).to be_blank
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(quiz_path(quiz))
         end
       end
 


### PR DESCRIPTION
I don't expect that this will resolve the flakiness that is the subject of QUIZ-7, but it might narrow down the cause of the problem, by revealing some additional information (such as an unexpected flash error message, an unexpected response status, and/or an unexpected redirect location), if that spec ever flakes again. I am pretty mystified as to how it ever flaked.