### PR TITLE
[docs/pg-upgrade] Remove shebang and script options

### DIFF
--- a/docs/postgres-17-to-18-upgrade.sh
+++ b/docs/postgres-17-to-18-upgrade.sh
@@ -1,7 +1,3 @@
-#!/usr/bin/env bash
-
-set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
-
 # Make sure that PR to update docker-compose.yml to Postgres 18 is ready to merge.
 
 # Check git status.


### PR DESCRIPTION
These don't really make sense in this context, because this "script" is not actually meant to be run as a script all at once, but rather to be copy-pasted one command at a time into an SSH session on the server.