### PR TITLE
[docs/pg-upgrade] Don't list hidden files

### DIFF
--- a/docs/postgres-17-to-18-upgrade.sh
+++ b/docs/postgres-17-to-18-upgrade.sh
@@ -43,7 +43,7 @@ docker compose exec postgres pg_dumpall -U david_runger > backup.sql
 git status
 
 # Check that the backup file is approximately the expected size.
-ls -lah backup.sql
+ls -lh backup.sql
 
 # Bring down the database.
 docker compose down postgres


### PR DESCRIPTION
There's no point, since `backup.sql` is not hidden.