### PR TITLE
[specs/check-ins] Wait for CheckIn creation via UI change [CHK-5]

### DIFF
--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -86,6 +86,9 @@ RSpec.describe 'Check-Ins app' do
 
           click_on('Create a new check-in')
 
+          # Wait for navigation to the show page of the new CheckIn.
+          expect(page).to have_text(/Marriage Check-In #\d+/)
+
           check_in = CheckIn.order(:created_at).last!
           expect(page).to have_current_path(check_in_path(check_in))
 


### PR DESCRIPTION
This should ensure that the `check_in = CheckIn.order(:created_at).last!` (which comes just next in the spec modified herein) will be queried only after the new `CheckIn` has indeed been created. I believe that not doing this previously was the cause of the flakiness that is the subject of CHK-5.