### PR TITLE
[ci] Pin Postgres and Redis versions in GitHub Action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     services:
       postgres:
-        image: postgres
+        image: postgres:18.0-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
@@ -33,7 +33,7 @@ jobs:
         ports:
           - 5432:5432
       redis:
-        image: redis
+        image: redis:8.2.1-alpine
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"


### PR DESCRIPTION
We will pin them using the same images that we reference in `docker-compose.yml`. This should do a better job of ensuring that success or failure of our tests accurately reflects successes or failures that would also be encountered in production.