### PR TITLE
Add .ncurc.json file to have npm-check-updates ignore eslint packages

### DIFF
--- a/.ncurc.json
+++ b/.ncurc.json
@@ -1,0 +1,3 @@
+{
+  "reject": ["eslint", "@eslint/js"]
+}


### PR DESCRIPTION
`eslint` version 10 is not compatible with `eslint-plugin-import` (but `eslint` version 9, which we are currently on, is compatible), so we don't want to update `eslint` right now, but the command I run to update packages (`pnpx npm-check-updates --upgrade && pnpm install && pnpm update && pnpm dedupe`) would/does update it. This will tell `npm-check-updates` not to try to update `eslint` and `@eslint/js`.