### PR TITLE
[groceries] Confirm before changing store to public/private [GROC-40]

### DIFF
--- a/app/javascript/groceries/components/StoreHeader.vue
+++ b/app/javascript/groceries/components/StoreHeader.vue
@@ -64,12 +64,19 @@ const {
 const { debouncingOrWaitingOnNetwork } = storeToRefs(groceriesStore);
 
 function togglePrivacy() {
-  groceriesStore.updateStore({
-    store: props.store,
-    attributes: {
-      private: !props.store.private,
-    },
-  });
+  const targetState = props.store.private ? 'public' : 'private';
+  const confirmed = confirm(
+    `Are you sure that you want to make '${props.store.name}' ${targetState}?`,
+  );
+
+  if (confirmed) {
+    groceriesStore.updateStore({
+      store: props.store,
+      attributes: {
+        private: !props.store.private,
+      },
+    });
+  }
 }
 </script>
 


### PR DESCRIPTION
Prior to this change, a user might toggle the privacy with an accidental click/tap, and the user might not notice this unintended change. This can be bad going in either direction. Accidentally hiding a store can unintentionally hide it from one's spouse, inconveniencing the spouse. Accidentally making a store public might reveal information that the person wants to keep from their spouse.

Confirming the change will mostly prevent accidental changes of a store's privacy status. Since the public/private status of a store is not frequently changed, this little bit of additional friction is not a significant downside.