### PR TITLE
[nginx] Remove OCSP stapling config to stop NGINX warning [DEV-252]

### DIFF
--- a/config/nginx/nginx.conf
+++ b/config/nginx/nginx.conf
@@ -94,12 +94,6 @@ http {
     # Mozilla Modern configuration
     ssl_protocols          TLSv1.3;
 
-    # OCSP Stapling
-    ssl_stapling           on;
-    ssl_stapling_verify    on;
-    resolver               1.1.1.1 1.0.0.1 8.8.8.8 8.8.4.4 208.67.222.222 208.67.220.220 valid=60s;
-    resolver_timeout       2s;
-
     # Connection header for WebSocket reverse proxy
     map $http_upgrade $connection_upgrade {
         default upgrade;


### PR DESCRIPTION
https://claude.ai/chat/f77632d1-4008-46d4-88aa-d2c9456de82f

A warning is printed during deploys:

```
2026/02/24 15:40:15 [warn] 5402#5402: "ssl_stapling" ignored, no OCSP responder URL in the certificate "/etc/letsencrypt/live/davidrunger.com/fullchain.pem"
nginx: [warn] "ssl_stapling" ignored, no OCSP responder URL in the certificate "/etc/letsencrypt/live/davidrunger.com/fullchain.pem"
```

By deleting the lines from our NGINX config in this change, we lose nothing functional, just a feature that was never working anyway.