### PR TITLE
[CheckLinks::Checker] Expect possible 429 for GitHub file links

### DIFF
--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -23,6 +23,11 @@ class CheckLinks::Checker
     https://github.com/davidrunger/blog/edit/main/src/_posts/
   ].map(&:freeze).freeze
   REDIRECTING_URL_REGEX = /\A(#{redirecting_url_prefixes.map { Regexp.escape(it) }.join('|')}).+/
+  URL_STATUS_EXPECTATIONS = [
+    [LOGGED_IN_DAVID_RUNGER_DOT_COM_REGEX, 302],
+    [REDIRECTING_URL_REGEX, 302],
+    [%r{\Ahttps://github\.com/.+/blob/.+}, [200, 429]],
+  ].freeze
   # rubocop:disable Style/MutableConstant
   STATUS_EXPECTATIONS = {
     'https://www.commonlit.org/' => [200, 403],
@@ -32,14 +37,7 @@ class CheckLinks::Checker
   }
   STATUS_EXPECTATIONS.default_proc =
     proc do |_hash, url|
-      if (
-        url.match?(LOGGED_IN_DAVID_RUNGER_DOT_COM_REGEX) ||
-          url.match?(REDIRECTING_URL_REGEX)
-      )
-        302
-      else
-        200
-      end
+      URL_STATUS_EXPECTATIONS.find { url.match?(it.first) }&.last || 200
     end
   STATUS_EXPECTATIONS.freeze
   # rubocop:enable Style/MutableConstant

--- a/spec/workers/check_links/checker_spec.rb
+++ b/spec/workers/check_links/checker_spec.rb
@@ -102,6 +102,40 @@ RSpec.describe CheckLinks::Checker do
       end
     end
 
+    context 'when requesting a GitHub file URL' do
+      let(:url) { 'https://github.com/davidrunger/david_runger/blob/main/docs/postgres-17-to-18-upgrade.sh' }
+
+      context 'when the link returns 200' do
+        let(:status) { 200 }
+
+        it 'does not mark the failure in Redis' do
+          expect { perform }.not_to change {
+            $redis_pool.with { it.call('get', redis_failure_key) }
+          }.from(nil)
+        end
+      end
+
+      context 'when the link returns 429' do
+        let(:status) { 429 }
+
+        it 'does not mark the failure in Redis' do
+          expect { perform }.not_to change {
+            $redis_pool.with { it.call('get', redis_failure_key) }
+          }.from(nil)
+        end
+      end
+
+      context 'when the link returns 404' do
+        let(:status) { 404 }
+
+        it 'marks the failure in Redis' do
+          expect { perform }.to change {
+            $redis_pool.with { it.call('get', redis_failure_key) }
+          }.from(nil).to('1')
+        end
+      end
+    end
+
     describe 'cacheing', :cache do
       let(:different_target_url) { 'https://davidrunger.com/a-different-checked-url' }
 


### PR DESCRIPTION
I guess that they recently changed their rate limiting policy to not permit any requests from Hetzner machines for individual files or something.

<img width="1197" height="1019" alt="image" src="https://github.com/user-attachments/assets/cde8b766-2f7a-48ce-b10c-58aacb60758f" />