### PR TITLE
[StartPercy] Decrease first sleep from 20 to 8, interval from 4 to 1

### DIFF
--- a/lib/test/tasks/start_percy.rb
+++ b/lib/test/tasks/start_percy.rb
@@ -12,10 +12,10 @@ class Test::Tasks::StartPercy < Pallets::Task
 
       num_attempts.times do |index|
         sleep_time =
-          if total_sleep_time < 20
-            20
+          if total_sleep_time < 8
+            8
           else
-            4
+            1
           end
         total_sleep_time += sleep_time
         sleep(sleep_time)


### PR DESCRIPTION
https://github.com/davidrunger/david_runger/pull/8417#issuecomment-4088008606

Now that we are on Vite 8, JavaScript compiles way faster, so we need to try to end the `StartPercy` step more quickly, in order to be able to move on to feature specs sooner.

From this branch's CI run:

```
StartPercy : exited with 0 (took 15.518 seconds)
```

This is still pretty slow, and I think might still finish after compiling JavaScript, even with the changes in this PR to try to allow `StartPercy` to complete more quickly. It's a little sad that I think that just starting Percy will now be the blocker for starting feature tests (as opposed to compiling JavaScript previously being the blocker). Well, such is life, I guess. I can't think of any great solutions to this issue.