### PR TITLE
[CheckLinks::Checker] Expect possible 403 for appacademy.io

### DIFF
--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -26,6 +26,7 @@ class CheckLinks::Checker
   URL_STATUS_EXPECTATIONS = [
     [LOGGED_IN_DAVID_RUNGER_DOT_COM_REGEX, 302],
     [REDIRECTING_URL_REGEX, 302],
+    [%r{\Ahttps://www.appacademy.io/\z}, [200, 403]],
     [%r{\Ahttps://github\.com/.+/blob/.+}, [200, 429]],
   ].freeze
   # rubocop:disable Style/MutableConstant

--- a/spec/workers/check_links/checker_spec.rb
+++ b/spec/workers/check_links/checker_spec.rb
@@ -136,6 +136,40 @@ RSpec.describe CheckLinks::Checker do
       end
     end
 
+    context 'when requesting appacademy.io' do
+      let(:url) { 'https://www.appacademy.io/' }
+
+      context 'when the link returns 200' do
+        let(:status) { 200 }
+
+        it 'does not mark the failure in Redis' do
+          expect { perform }.not_to change {
+            $redis_pool.with { it.call('get', redis_failure_key) }
+          }.from(nil)
+        end
+      end
+
+      context 'when the link returns 403' do
+        let(:status) { 403 }
+
+        it 'does not mark the failure in Redis' do
+          expect { perform }.not_to change {
+            $redis_pool.with { it.call('get', redis_failure_key) }
+          }.from(nil)
+        end
+      end
+
+      context 'when the link returns 302' do
+        let(:status) { 302 }
+
+        it 'marks the failure in Redis' do
+          expect { perform }.to change {
+            $redis_pool.with { it.call('get', redis_failure_key) }
+          }.from(nil).to('1')
+        end
+      end
+    end
+
     describe 'cacheing', :cache do
       let(:different_target_url) { 'https://davidrunger.com/a-different-checked-url' }
 


### PR DESCRIPTION
> We made a request to https://www.appacademy.io/, which is linked from https://davidrunger.com/, and its response status was 403, but we expected it to be in [200].

I guess that maybe they are blocking Hetzner or something. (403 is "Forbidden".)

<img width="777" height="156" alt="image" src="https://github.com/user-attachments/assets/a2550c7c-3747-4b75-bfd8-be921065ac83" />