### PR TITLE
Use system Chromium for Percy

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -62,15 +62,9 @@ jobs:
       - name: Set GIT_REV environment variable
         uses: ./.github/actions/git_rev
 
-      - name: Set PERCY_BROWSER_EXECUTABLE env var to system Chromium
+      - name: Set PERCY_BROWSER_EXECUTABLE env var to system Chrome browser
         run: |
-          CHROME_PATH=$(which google-chrome || which chromium-browser || which chromium)
-          echo "which google-chrome"
-          which google-chrome
-          echo "which chromium-browser"
-          which chromium-browser
-          echo "which chromium"
-          which chromium
+          CHROME_PATH=$(which google-chrome)
           echo "PERCY_BROWSER_EXECUTABLE=$CHROME_PATH" >> $GITHUB_ENV
 
       - name: Print context info

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -62,6 +62,17 @@ jobs:
       - name: Set GIT_REV environment variable
         uses: ./.github/actions/git_rev
 
+      - name: Set PERCY_BROWSER_EXECUTABLE env var to system Chromium
+        run: |
+          CHROME_PATH=$(which google-chrome || which chromium-browser || which chromium)
+          echo "which google-chrome"
+          which google-chrome
+          echo "which chromium-browser"
+          which chromium-browser
+          echo "which chromium"
+          which chromium
+          echo "PERCY_BROWSER_EXECUTABLE=$CHROME_PATH" >> $GITHUB_ENV
+
       - name: Print context info
         run: |
           echo "Branch: ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"

--- a/lib/test/tasks/start_percy.rb
+++ b/lib/test/tasks/start_percy.rb
@@ -7,15 +7,15 @@ class Test::Tasks::StartPercy < Pallets::Task
 
       # Make up to 20 attempts to verify that Percy is running. (It tends to
       # take particularly long if there is a new Chromium version to download.)
-      num_attempts = 20
+      num_attempts = 30
       total_sleep_time = 0
 
       num_attempts.times do |index|
         sleep_time =
-          if total_sleep_time < 8
-            8
+          if total_sleep_time < 5
+            5
           else
-            1
+            0.5
           end
         total_sleep_time += sleep_time
         sleep(sleep_time)

--- a/lib/test/tasks/start_percy.rb
+++ b/lib/test/tasks/start_percy.rb
@@ -7,13 +7,13 @@ class Test::Tasks::StartPercy < Pallets::Task
 
       # Make up to 20 attempts to verify that Percy is running. (It tends to
       # take particularly long if there is a new Chromium version to download.)
-      num_attempts = 30
+      num_attempts = 32
       total_sleep_time = 0
 
       num_attempts.times do |index|
         sleep_time =
-          if total_sleep_time < 5
-            5
+          if total_sleep_time < 4
+            4
           else
             0.5
           end

--- a/lib/test/tasks/start_percy.rb
+++ b/lib/test/tasks/start_percy.rb
@@ -7,13 +7,13 @@ class Test::Tasks::StartPercy < Pallets::Task
 
       # Make up to 20 attempts to verify that Percy is running. (It tends to
       # take particularly long if there is a new Chromium version to download.)
-      num_attempts = 32
+      num_attempts = 36
       total_sleep_time = 0
 
       num_attempts.times do |index|
         sleep_time =
-          if total_sleep_time < 4
-            4
+          if total_sleep_time < 2
+            2
           else
             0.5
           end


### PR DESCRIPTION
This might make the Percy startup time faster, by never needing to download Chromium (?). Currently Percy startup (including, I think, Chromium download) is the bottleneck/blocker for starting system specs (since Vite moved from Rollup to the much faster Rolldown for JavaScript asset compilation). This should skip Chromium download, which will hopefully save a little time. I think that Chrome startup is still the slowest step, though, which, unfortunately, this doesn't help with. But I think it's worth seeing if we save a second or two, on average.

https://claude.ai/share/4de1324d-f882-4507-b3c5-3ec21f42c72e