### PR TITLE
[home/contact] Remove trailing slash from LinkedIn URL

### DIFF
--- a/app/javascript/home/components/Contact.vue
+++ b/app/javascript/home/components/Contact.vue
@@ -4,7 +4,7 @@ HomeSection(
   title="Contact me / Links"
 )
   p #[b Email:] #[a(href="mailto:davidjrunger@gmail.com") davidjrunger@gmail.com]
-  p #[b LinkedIn:] #[a(href="https://www.linkedin.com/in/davidrunger/") /in/davidrunger]
+  p #[b LinkedIn:] #[a(href="https://www.linkedin.com/in/davidrunger") /in/davidrunger]
   p #[b GitHub:] #[a(href="https://github.com/davidrunger") @davidrunger]
   p #[b Blog:] #[a(href="/blog") my tech blog]
 </template>


### PR DESCRIPTION
The trailing slash seems to cause a redirect in the link checker request.