### PR TITLE
[link-checker] Remove trailing slash from expected LinkedIn URL

### DIFF
--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -32,7 +32,7 @@ class CheckLinks::Checker
   # rubocop:disable Style/MutableConstant
   STATUS_EXPECTATIONS = {
     'https://www.commonlit.org/' => [200, 403],
-    'https://www.linkedin.com/in/davidrunger/' => [200, 429, 999],
+    'https://www.linkedin.com/in/davidrunger' => [200, 429, 999],
     'https://www.termsfeed.com/privacy-policy-generator/' => [200, 403],
     'https://www.termsfeed.com/blog/cookies/#What_Are_Cookies' => [200, 403],
   }


### PR DESCRIPTION
I received this email this morning:

> We made a request to https://www.linkedin.com/in/davidrunger, which is linked from https://davidrunger.com/, and its response status was 999, but we expected it to be in [200]. 😕 

This change should fix that (i.e. make me stop receiving such emails).

This change should have been made as part of #8647.