### PR TITLE
[FetchIpInfoForRecord] Handle unexpected string response from API

### DIFF
--- a/app/workers/fetch_ip_info_for_record.rb
+++ b/app/workers/fetch_ip_info_for_record.rb
@@ -4,6 +4,8 @@ class FetchIpInfoForRecord
 
   LOCAL_IPS = %w[::1 127.0.0.1].map(&:freeze).freeze
 
+  class UnexpectedIpApiResponse < StandardError; end
+
   def perform(class_name, record_id)
     record = class_name.safe_constantize.find(record_id)
     write_location_info(record)
@@ -29,6 +31,15 @@ class FetchIpInfoForRecord
     Rails.logger.info("Querying ip-api.com for info about IP address '#{ip}'")
     # we'd have to pay to use https :( so just use http
     raw_ip_info_from_api = Faraday.json_connection.get("http://ip-api.com/json/#{ip}").body
+
+    unless raw_ip_info_from_api.is_a?(Hash)
+      raise(
+        UnexpectedIpApiResponse,
+        "ip-api.com returned an unexpected response for IP '#{ip}': " \
+        "#{raw_ip_info_from_api.inspect}",
+      )
+    end
+
     isp, city, state, country = raw_ip_info_from_api.values_at(*%w[isp city region countryCode])
 
     {

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -50,6 +50,7 @@ Rollbar.configure do |config|
     'ActionController::RoutingError' => 'info',
     'ActionDispatch::Http::MimeNegotiation::InvalidType' => 'info',
     'ActionDispatch::RemoteIp::IpSpoofAttackError' => 'info',
+    'FetchIpInfoForRecord::UnexpectedIpApiResponse' => 'info',
   )
   #
   # You can also specify a callable, which will be called with the exception instance.

--- a/spec/workers/fetch_ip_info_for_record_spec.rb
+++ b/spec/workers/fetch_ip_info_for_record_spec.rb
@@ -37,6 +37,17 @@ RSpec.describe FetchIpInfoForRecord do
           perform
         end
       end
+
+      context 'when ip-api.com returns an unexpected non-Hash response' do
+        before do
+          stub_request(:get, "http://ip-api.com/json/#{request.ip}").
+            to_return(status: 200, body: 'Service Unavailable', headers: {})
+        end
+
+        it 'raises UnexpectedIpApiResponse so Sidekiq will retry the job and the error can be sent to Rollbar with a non-error severity' do
+          expect { perform }.to raise_error(FetchIpInfoForRecord::UnexpectedIpApiResponse)
+        end
+      end
     end
 
     context 'when class_name is "IpBlock"' do


### PR DESCRIPTION
fixes rb#771

https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/771

https://claude.ai/share/6cc63d07-72f1-4b28-8aa7-39336e40f25a

I think that this can happen if ip-api.com is having issues and returns an error or something. I think retrying will eventually fix the issue. That seemed to happen in the one occurrence of rb#771 so far, at least (since the relevant `Request` record now has a location associated with it).