### PR TITLE
[specs/TrackAssetSizes] Pass other 'File.read' calls through

### DIFF
--- a/spec/poros/track_asset_sizes_spec.rb
+++ b/spec/poros/track_asset_sizes_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe TrackAssetSizes do
             }
           }
         JSON
+        allow(File).to receive(:read).and_call_original # pass other calls through
       end
 
       context 'when File sizes are returned' do


### PR DESCRIPTION
This should fix flakiness such as seen here https://github.com/davidrunger/david_runger/actions/runs/25536939415/job/74954547321 which can be reproduced consistently simply by running `bin/rspec spec/poros/track_asset_sizes_spec.rb:65` locally.

The issue which this change corrects was introduced by a change in `bootsnap` 1.24.2 , I think this: https://github.com/rails/bootsnap/pull/ 540/changes#diff-3c437e587def2320c202f146c6812fdfe2891f0f6afddd2592c7524972efb963R61 .