### PR TITLE
[check-links/checker] Don't cache nil

### DIFF
--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -78,7 +78,7 @@ class CheckLinks::Checker
 
   memoize \
   def response(url)
-    Rails.cache.fetch(cache_key(url), expires_in: 6.hours) do
+    Rails.cache.fetch(cache_key(url), expires_in: 6.hours, skip_nil: true) do
       Rails.error.handle(severity: :info, context: { url: }) do
         Faraday.new.get do |request|
           request.url(url)

--- a/spec/workers/check_links/checker_spec.rb
+++ b/spec/workers/check_links/checker_spec.rb
@@ -173,40 +173,66 @@ RSpec.describe CheckLinks::Checker do
     describe 'cacheing', :cache do
       let(:different_target_url) { 'https://davidrunger.com/a-different-checked-url' }
 
-      before do
-        stub_request(:get, different_target_url).
-          to_return(status: 200, body: '', headers: {})
+      context 'when the request returns a result' do
+        before do
+          stub_request(:get, different_target_url).
+            to_return(status: 200, body: '', headers: {})
 
-        CheckLinks::Checker.new.perform(previously_checked_url, 'https://davidrunger.com/blog')
-
-        expect(stubbed_request).
-          to have_been_requested.
-          times(number_of_requests_for_url_before_perform)
-      end
-
-      context 'when another CheckLinks::Checker ran recently for the same URL' do
-        let(:previously_checked_url) { url }
-        let(:number_of_requests_for_url_before_perform) { 1 }
-
-        it 'does not request the URL again' do
-          perform
+          CheckLinks::Checker.new.perform(previously_checked_url, 'https://davidrunger.com/blog')
 
           expect(stubbed_request).
             to have_been_requested.
             times(number_of_requests_for_url_before_perform)
         end
+
+        context 'when another CheckLinks::Checker ran recently for the same URL' do
+          let(:previously_checked_url) { url }
+          let(:number_of_requests_for_url_before_perform) { 1 }
+
+          it 'does not request the URL again' do
+            perform
+
+            expect(stubbed_request).
+              to have_been_requested.
+              times(number_of_requests_for_url_before_perform)
+          end
+        end
+
+        context 'when another CheckLinks::Checker has not run recently for the same URL' do
+          let(:previously_checked_url) { different_target_url }
+          let(:number_of_requests_for_url_before_perform) { 0 }
+
+          it 'requests the URL' do
+            perform
+
+            expect(stubbed_request).
+              to have_been_requested.
+              times(number_of_requests_for_url_before_perform + 1)
+          end
+        end
       end
 
-      context 'when another CheckLinks::Checker has not run recently for the same URL' do
-        let(:previously_checked_url) { different_target_url }
-        let(:number_of_requests_for_url_before_perform) { 0 }
+      context 'when the URL fetch raises a connection error' do
+        before do
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Faraday::Connection).
+            to receive(:get).
+            and_raise(Faraday::ConnectionFailed, 'Operation timed out')
+          # rubocop:enable RSpec/AnyInstance
+        end
 
-        it 'requests the URL' do
-          perform
+        it 'does not cache the nil response, so the URL is retried on next check' do
+          CheckLinks::Checker.new.perform(url, page_source_url)
 
-          expect(stubbed_request).
-            to have_been_requested.
-            times(number_of_requests_for_url_before_perform + 1)
+          # rubocop:disable RSpec/AnyInstance
+          allow_any_instance_of(Faraday::Connection).
+            to receive(:get).
+            and_call_original
+          # rubocop:enable RSpec/AnyInstance
+
+          CheckLinks::Checker.new.perform(url, page_source_url)
+
+          expect(stubbed_request).to have_been_requested.times(1)
         end
       end
     end


### PR DESCRIPTION
I got 7 emails this morning saying this:

> We made a request to https://github.com/davidrunger/blog/, which is > linked from > https://davidrunger.com/blog/automatically-compiling-crystal-for-development-tooling, > and its response status was nil, but we expected it to be in [200].

One request timed out (raising an error which was handled https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/745/occurrence/460349223747#detail ), resulting in `nil` being cached. I think we don't want to cache `nil`. I think we should retry requests to this URL, in the hope that it will work on later attempts.