### PR TITLE
[vite] Remove unsupported maxParallelFileOps rollup build option

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,17 +9,6 @@ import FullReload from 'vite-plugin-full-reload';
 import RubyPlugin from 'vite-plugin-ruby';
 
 export default defineConfig(({ mode }) => ({
-  build: {
-    rollupOptions: {
-      maxParallelFileOps:
-        (
-          process.env.CI &&
-          process.env.VITE_RUBY_PUBLIC_OUTPUT_DIR == 'vite-admin'
-        ) ?
-          1
-        : 3,
-    },
-  },
   // https://github.com/vitejs/vite/issues/ 18164#issuecomment-2365310242
   css: {
     preprocessorOptions: {


### PR DESCRIPTION
I guess Vite uses rolldown, now (not rollup anymore), and I guess rolldown doesn't support this option, so this change removes it.

We have been getting this warning in builds:

```
Warning: Invalid input options (1 issue found)
- For the "maxParallelFileOps". Invalid key: Expected never but received "maxParallelFileOps". 
```

e.g. here: https://github.com/davidrunger/david_runger/actions/runs/25963129225/job/76321820344 .

As noted when I added what this change removes ( #6147 / 8eddd1d89198d577fe232af9123360cb6854773d ), it didn't obviously help anything, so I think that the fact that this setting is not supported probably isn't a major loss. Now Vite builds are so fast, anyway (since Vite 8 or something, I guess whenever it switched to rolldown), that whatever little gain we might have been getting here is surely dwarfed by those time savings.