### PR TITLE
[runger-config/spec-commands] Clear Redis DB 15 (not 10)

### DIFF
--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -4,5 +4,5 @@ spec-commands: |
   export RAILS_ENV=test PALLETS_CONCURRENCY=${PALLETS_CONCURRENCY:-6} DISABLE_SPRING=1
   export POSTGRES_USER=david_runger POSTGRES_HOST=localhost
   set -x
-  redis-cli -n 10 FLUSHDB
+  redis-cli -n 15 FLUSHDB
   bin/run-tests


### PR DESCRIPTION
This should have been changed along with this change: https://github.com/davidrunger/david_runger/pull/8111/changes#diff-cbb590755ada3445edcca49676dfba18c455676cacaf8ece020bbd0e57a69af8R12 . Updating it now.