### PR TITLE
[gitignore] Add '/app/javascript/node_modules/.vite/vitest/'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@
 
 # NGINX
 /config/nginx/conf.d/require-valid-host.conf
+
+# vitest
+/app/javascript/node_modules/.vite/vitest/


### PR DESCRIPTION
I guess that this directory (which, further nested, contains a `results.json` file) gets generated by the `RunVitest` test step. We don't want it to be noted as a git diff.

https://claude.ai/share/661997cc-88d0-4840-b2be-18f7aeecc3ae