### PR TITLE
[RunAnnotate] Ignore any git diff in 'app/javascript/'

### DIFF
--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -243,6 +243,7 @@ class Test::RequirementsResolver
     end,
     Test::Tasks::RunAnnotate => proc do
       !db_schema_changed? &&
+        !file_changed?(/annotate/) &&
         !diff_mentions?('annotate') &&
         !files_added_in?('app/models') &&
         !files_added_in?('app/serializers') &&

--- a/lib/test/tasks/run_annotate.rb
+++ b/lib/test/tasks/run_annotate.rb
@@ -6,9 +6,9 @@ class Test::Tasks::RunAnnotate < Pallets::Task
       bin/annotaterb models
     COMMAND
 
-    if !execute_system_command('git diff --exit-code')
+    if !execute_system_command('git diff --exit-code -- . ":(exclude)app/javascript/"')
       # Reset the git state, so it's clean for other test tasks.
-      execute_system_command('git checkout .')
+      execute_system_command('git checkout -- . ":(exclude)app/javascript/"')
     end
   end
 end


### PR DESCRIPTION
A diff in `app/javascript/` might be introduced if certain JavaScript test steps (e.g. typelizer generation) are running simultaneously, but we don't want such a diff to fail the `RunAnnotate` test step.

https://claude.ai/share/3033e949-a730-4f11-a297-c43dcec420f5