### PR TITLE
[test] Drop test DB when run locally before creating, loading schema

### DIFF
--- a/lib/test/tasks/setup_db.rb
+++ b/lib/test/tasks/setup_db.rb
@@ -2,6 +2,12 @@ class Test::Tasks::SetupDb < Pallets::Task
   include Test::TaskHelpers
 
   def run
+    # Drop the database when running locally to avoid error about pghero schema already existing.
+    if ENV.fetch('CI', false).blank?
+      execute_rake_task('db:environment:set')
+      execute_rake_task('db:drop')
+    end
+
     execute_rake_task('db:create')
     execute_rake_task('db:environment:set')
     execute_rake_task('db:schema:load')


### PR DESCRIPTION
When running `spec` locally, I was getting an error about the `pghero` schema already existing. This seems to avoid that error (locally). I think that this error doesn't occur in CI, because there is no preexisting DB in CI to drop, anyway.