### PR TITLE
[specs/QuizParticipationsController] Ensure no name conflict [QUIZ-8]

### DIFF
--- a/spec/controllers/quiz_participations_controller_spec.rb
+++ b/spec/controllers/quiz_participations_controller_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe QuizParticipationsController do
       before { user.quiz_participations.where(quiz:).find_each(&:destroy!) }
 
       context 'when the user submits a name' do
-        let(:display_name) { 'Al' }
+        let(:display_name) { "#{Faker::Name.first_name}-#{SecureRandom.alphanumeric(5)}" }
 
         it 'creates a QuizParticipation for the user, does not set any flash alert message, and responds with a redirect to the quiz show page', :aggregate_failures do
           expect { post_create }.to change { user.reload.quiz_participations.size }.by(1)


### PR DESCRIPTION
I think that this spec could error if one of the fixture quiz participations -- for which a `display_name` name is generated by our factory as so: https://github.com/davidrunger/david_runger/blob/4625170716d5a4edfc8230221efbed457d7ffc1f/spec/factories/quiz_participations.rb#L22
-- happened to have a `display_name` of `'Al'`. The randomization added in this change should ensure that there will be no such collision.