### PR TITLE
[docker-compose/loki] Limit and rotate log files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -137,6 +137,7 @@ services:
     image: grafana/loki:latest
     expose:
       - '3100'
+    logging: *default-logging
     networks:
       - internal
     volumes:


### PR DESCRIPTION
https://claude.ai/share/94ceac70-da79-4d2b-8431-0e7fa961b664

I get a large log file that builds up on the server, and so I periodically have to dig it up and truncate it. Claude says the log file is for Loki. This change limits Loki to 500 MiB or so of log files, which should avoid the excessive disk usage issue.