### PR TITLE
[loki] Configure log level (warn) via command, not config file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,13 +135,15 @@ services:
   loki:
     cpu_shares: 512
     image: grafana/loki:latest
+    command:
+      - -config.file=/etc/loki/local-config.yaml
+      - -log.level=warn
     expose:
       - '3100'
     logging: *default-logging
     networks:
       - internal
     volumes:
-      - ./loki-config.yaml:/etc/loki/local-config.yaml
       - loki-data:/loki
   nginx:
     cpu_shares: 4096

--- a/loki-config.yaml
+++ b/loki-config.yaml
@@ -1,2 +1,0 @@
-server:
-  log_level: warn


### PR DESCRIPTION
The config file seems to require certain configs (e.g. `schema_config`) to be provided that I don't want to provide.

https://claude.ai/share/7981a788-53f6-48f5-a7ea-0ee3bce2a079