### PR TITLE
[monkeypatches/warning] Remove shovel method check

### DIFF
--- a/config/initializers/monkeypatches/warning.rb
+++ b/config/initializers/monkeypatches/warning.rb
@@ -10,9 +10,8 @@ if Rails.env.test?
 
     def warn(message, *_args, **_kwargs)
       # :nocov:
-      if StoredWarnings.warnings.respond_to?(:<<) &&
-          # See https://github.com/percy/cli/pull/ 2203 ; remove the below after that is released.
-          message.exclude?('UTF-8 string passed as BINARY')
+      # See https://github.com/percy/cli/pull/ 2203 ; remove the below after that is released.
+      if message.exclude?('UTF-8 string passed as BINARY')
         StoredWarnings.warnings << message
       end
 


### PR DESCRIPTION
I think that this check is a legacy of how this monkeypatch was originally introduced using a global variable. Now that the warnings array is created via `mattr_accessor :warnings`, I don't think we need this check anymore (if we ever really did).