### PR TITLE
[admin/requests/show] Replace 'raw' with 'safe_join'

### DIFF
--- a/app/admin/requests.rb
+++ b/app/admin/requests.rb
@@ -29,13 +29,12 @@ ActiveAdmin.register(Request) do
       row :location
       row :isp
       row :ip do |request|
-        # Users cannot arbitrarily set `request.ip`, so there should be no XSS risk here.
-        # rubocop:disable Rails/OutputSafety
-        raw(<<~CONTENT.squish)
-          #{request.ip}
-          (#{link_to('other requests', admin_requests_path(q: { ip_eq: request.ip }))})
-        CONTENT
-        # rubocop:enable Rails/OutputSafety
+        safe_join([
+          request.ip,
+          ' (',
+          link_to('other requests', admin_requests_path(q: { ip_eq: request.ip })),
+          ')',
+        ])
       end
       # simply calling `method` causes a bug (that gets interpreted as a Ruby "method" or something)
       row(:method) { |request| request.read_attribute(:method) }

--- a/spec/controllers/admin/requests_controller_spec.rb
+++ b/spec/controllers/admin/requests_controller_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe Admin::RequestsController do
 
         expect(response).to have_http_status(200)
       end
+
+      it 'displays the IP address with a link to other requests from that IP' do
+        get_show
+
+        expect(response.body).to have_text(request.ip)
+        expect(response.body).to have_link(
+          'other requests',
+          href: admin_requests_path(q: { ip_eq: request.ip }),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
It always feels dirty to use `raw`, so this change avoids that by using `safe_join`, instead, which is also nice because we no longer have to disable the `Rails/OutputSafety` RuboCop rule.