### PR TITLE
[admin/events/show] Link to requests for an event's IP

### DIFF
--- a/app/admin/events.rb
+++ b/app/admin/events.rb
@@ -20,7 +20,14 @@ ActiveAdmin.register(Event) do
       row :user
       row :admin_user
       row :data
-      row :ip
+      row :ip do |event|
+        safe_join([
+          event.ip,
+          ' (',
+          link_to('requests', admin_requests_path(q: { ip_eq: event.ip })),
+          ')',
+        ])
+      end
       row :isp
       row :location
       row :stack_trace

--- a/spec/controllers/admin/events_controller_spec.rb
+++ b/spec/controllers/admin/events_controller_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe(Admin::EventsController) do
         get_show
         expect(response).to have_http_status(200)
       end
+
+      it 'displays the IP address with a link to requests from that IP' do
+        get_show
+
+        expect(response.body).to have_text(event.ip)
+        expect(response.body).to have_link(
+          'requests',
+          href: admin_requests_path(q: { ip_eq: event.ip }),
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Sometimes I want to see what other requests the IP might have made or look at information only available in requests, like a referrer.