### PR TITLE
Revert "[docker-compose/postgres] Bump Postgres from 18.1 to 18.4 (again)"

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     services:
       postgres:
-        image: postgres:18.4-alpine
+        image: postgres:18.1-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -214,7 +214,6 @@ services:
     env_file:
       - .env.postgres.local
     environment:
-      PGDATA: /var/lib/postgresql/data # https://claude.ai/share/e46327d7-b67e-417b-981c-143671025b7b
       POSTGRES_INITDB_ARGS: --auth=scram-sha-256
       POSTGRES_USER: david_runger
     healthcheck:
@@ -224,7 +223,7 @@ services:
       interval: 5m
       timeout: 1s
       retries: 1
-    image: postgres:18.4-alpine
+    image: postgres:18.1-alpine
     logging: *default-logging
     memswap_limit: 99G
     networks:


### PR DESCRIPTION
Reverts davidrunger/david_runger#8868

Problem:

```
docker compose logs postgres --since=3m
postgres-1  | The files belonging to this database system will be owned by user "postgres".
postgres-1  | This user must also own the server process.
postgres-1  | 
postgres-1  | The database cluster will be initialized with locale "en_US.utf8".
postgres-1  | The default database encoding has accordingly been set to "UTF8".
postgres-1  | The default text search configuration will be set to "english".
postgres-1  | 
postgres-1  | Data page checksums are enabled.
postgres-1  | 
postgres-1  | initdb: error: directory "/var/lib/postgresql/data" exists but is not empty
postgres-1  | initdb: hint: If you want to create a new database system, either remove or empty the directory "/var/lib/postgresql/data" or run initdb with an argument other than "/var/lib/postgresql/data".
```