### PR TITLE
[spec/features/logs] Fix flakiness with 'wait_for' [LOG-51]

### DIFF
--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -98,10 +98,10 @@ RSpec.describe 'Logs app' do
             number_log.log_entries.reorder(:created_at).last!
 
           expect {
-            wait_for {
+            wait_for do
               click_on(delete_last_entry_text)
               page.has_css?('.el-popconfirm')
-            }.to eq(true)
+            end.to eq(true)
 
             within('.el-popconfirm') do
               click_on('Yes')

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -98,11 +98,15 @@ RSpec.describe 'Logs app' do
             number_log.log_entries.reorder(:created_at).last!
 
           expect {
-            sleep(0.05) # Give 50 ms for ElPopconfirm click handler to bind.
-            click_on(delete_last_entry_text)
+            wait_for {
+              click_on(delete_last_entry_text)
+              page.has_css?('.el-popconfirm')
+            }.to eq(true)
+
             within('.el-popconfirm') do
               click_on('Yes')
             end
+
             wait_for { LogEntry.find_by(id: most_recent_log_entry.id) }.to eq(nil)
           }.to change {
             LogEntry.find_by(id: most_recent_log_entry.id)


### PR DESCRIPTION
It seems that, for some reason, the ElPopconfirm click handler takes a long time to bind (sometimes even longer than the 50 millisecond sleep (added in #6156) that we were waiting prior to this change).

The `wait_for` seems to remove the flakiness (though sometimes this is by clicking the button multiple times, which is a little concerning, since we don't want a user to have to click the button multiple times, but hopefully the user won't be clicking the button as rapidly as our automated test is).