### PR TITLE
Update SimpleCov comments and method name per its changes [DEV-257]

### DIFF
--- a/app/poros/json_schema_validator.rb
+++ b/app/poros/json_schema_validator.rb
@@ -99,7 +99,7 @@ class JsonSchemaValidator
 
   def facilitate_schema_provisioning
     if Rails.env.development?
-      # :nocov:
+      # simplecov:disable
       # Copy JSON data that was not validated/accepted to clipboard.
       string_to_copy =
         if @data.is_a?(String)
@@ -121,7 +121,7 @@ class JsonSchemaValidator
 
       # Open JSON-to-JSONSchema converter in browser.
       system('open https://jsonformatter.org/json-to-jsonschema', exception: true)
-      # :nocov:
+      # simplecov:enable
     end
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -54,9 +54,9 @@ Rails.application.configure do
 
   config.log_level =
     if ENV.fetch('TEST_LOGGING', nil) == '1'
-      # :nocov:
+      # simplecov:disable
       :debug
-    # :nocov:
+    # simplecov:enable
     else
       :warn
     end

--- a/config/initializers/0w_secret_key_base.rb
+++ b/config/initializers/0w_secret_key_base.rb
@@ -2,8 +2,8 @@ secret_key_base = ENV.fetch('SECRET_KEY_BASE', nil)
 
 if secret_key_base.present?
   DavidRunger::Application.config.secret_key_base = secret_key_base
-  # :nocov:
+  # simplecov:disable
 elsif ENV.fetch('SECRET_KEY_BASE_DUMMY', nil) != '1'
   fail('Could not find SECRET_KEY_BASE in ENV.')
-  # :nocov:
+  # simplecov:enable
 end

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -7,15 +7,15 @@
 Rails.application.configure do
   # Allow disabling CSP in development because it breaks Vue devtools in Firefox.
   if Rails.env.local? && ENV.key?('DISABLE_CSP')
-    # :nocov:
+    # simplecov:disable
     next
-    # :nocov:
+    # simplecov:enable
   end
 
   config.content_security_policy do |policy|
     extra_sources = []
     extra_connect_sources = []
-    # :nocov:
+    # simplecov:disable
     if Rails.env.development? || (Rails.env.test? && !ENV.key?('CI'))
       extra_sources << DavidRunger::CANONICAL_URL # allow assets from prod for local prerenders
       extra_connect_sources << 'ws://localhost:3000' # actioncable connections
@@ -41,7 +41,7 @@ Rails.application.configure do
     elsif Rails.env.production?
       extra_connect_sources << "wss://#{DavidRunger::CANONICAL_DOMAIN}" # for actioncable websockets
     end
-    # :nocov:
+    # simplecov:enable
 
     policy.default_src(:none)
     policy.base_uri(:self)

--- a/config/initializers/githooks_check.rb
+++ b/config/initializers/githooks_check.rb
@@ -1,4 +1,4 @@
-# :nocov:
+# simplecov:disable
 if (
   Rails.env.local? &&
     ENV['SKIP_GITHOOKS_CHECK'].blank? &&
@@ -14,4 +14,4 @@ if (
 
   exit(1) # rubocop:disable Rails/Exit
 end
-# :nocov:
+# simplecov:enable

--- a/config/initializers/http_logger.rb
+++ b/config/initializers/http_logger.rb
@@ -1,7 +1,7 @@
 if Rails.env.development? && !IS_DOCKER
-  # :nocov:
+  # simplecov:disable
   HttpLogger.configure do |config|
     config.log_headers = true
   end
-  # :nocov:
+  # simplecov:enable
 end

--- a/config/initializers/monkeypatches/rspec_wait_handler.rb
+++ b/config/initializers/monkeypatches/rspec_wait_handler.rb
@@ -21,14 +21,14 @@ if defined?(RSpec::Wait::Handler) && defined?(Prosopite)
             matcher.respond_to?(:supports_block_expectations?) &&
             matcher.supports_block_expectations?
           )
-            # :nocov:
+            # simplecov:disable
             grandfather_method.call(
               target,
               matcher,
               message,
               &block
             )
-            # :nocov:
+            # simplecov:enable
           else
             grandfather_method.call(
               target.call,

--- a/config/initializers/monkeypatches/warning.rb
+++ b/config/initializers/monkeypatches/warning.rb
@@ -13,13 +13,13 @@ if Rails.env.test?
     ].freeze
 
     def warn(message, *_args, **_kwargs)
-      # :nocov:
+      # simplecov:disable
       unless IGNORED_WARNINGS.any? { message.include?(it) } # rubocop:disable Style/ArrayIntersect
         StoredWarnings.warnings << message
       end
 
       super
-      # :nocov:
+      # simplecov:enable
     end
   end
 

--- a/config/initializers/prometheus_exporter.rb
+++ b/config/initializers/prometheus_exporter.rb
@@ -1,7 +1,7 @@
 if IS_DOCKER_BUILT
-  # :nocov:
+  # simplecov:disable
   require 'prometheus_exporter/middleware'
 
   Rails.application.middleware.unshift(PrometheusExporter::Middleware, instrument: :prepend)
-  # :nocov:
+  # simplecov:enable
 end

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -3,14 +3,14 @@ Rollbar.configure do |config|
 
   access_token =
     case Rails.env
-    # :nocov:
+    # simplecov:disable
     when 'production'
       if IS_DOCKER_BUILD
         nil
       else
         ENV.fetch('ROLLBAR_ACCESS_TOKEN')
       end
-    # :nocov:
+    # simplecov:enable
     else ENV.fetch('ROLLBAR_ACCESS_TOKEN', nil)
     end
 

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -11,7 +11,7 @@ unless IS_DOCKER_BUILD
   end
 
   Sidekiq.configure_server do |config|
-    # :nocov:
+    # simplecov:disable
     config.redis = { url: redis_options.url }
 
     require 'sidekiq_ext/job_logger'
@@ -42,6 +42,6 @@ unless IS_DOCKER_BUILD
         chain.add(Prosopite::Middleware::Sidekiq)
       end
     end
-    # :nocov:
+    # simplecov:enable
   end
 end

--- a/config/spring.rb
+++ b/config/spring.rb
@@ -1,7 +1,7 @@
 # https://github.com/rails/spring-watcher-listen/issues/15#issuecomment-567603693
 module SpringWatcherListenIgnorer
   def start
-    # :nocov:
+    # simplecov:disable
     super
     listener.ignore(%r{
       ^(
@@ -16,7 +16,7 @@ module SpringWatcherListenIgnorer
       tmp/
       )
     }x)
-    # :nocov:
+    # simplecov:enable
   end
 end
 Spring::Watcher::Listen.prepend(SpringWatcherListenIgnorer)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ SimpleCov.start do
   end
   # rubocop:enable Rails/Present
   # rubocop:disable RSpec/Pending
-  skip(%r{(^|/)tools/})
+  skip(%r{(^|/)tools/(?!custom_cops/)})
   # rubocop:enable RSpec/Pending
   enable_coverage(:branch) if !SpecHelper.is_ci? # Codecov doesn't respect `nocov-else` etc comments
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,8 +24,7 @@ SimpleCov.start do
   end
   # rubocop:enable Rails/Present
   # rubocop:disable RSpec/Pending
-  skip(%r{^/spec/})
-  skip(%r{^/tools/})
+  skip(%r{(^|/)tools/})
   # rubocop:enable RSpec/Pending
   enable_coverage(:branch) if !SpecHelper.is_ci? # Codecov doesn't respect `nocov-else` etc comments
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -24,7 +24,7 @@ SimpleCov.start do
   end
   # rubocop:enable Rails/Present
   # rubocop:disable RSpec/Pending
-  skip(%r{(^|/)tools/(?!custom_cops/)})
+  skip(%r{^tools/(?!custom_cops/)})
   # rubocop:enable RSpec/Pending
   enable_coverage(:branch) if !SpecHelper.is_ci? # Codecov doesn't respect `nocov-else` etc comments
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,8 +23,10 @@ SimpleCov.start do
     )
   end
   # rubocop:enable Rails/Present
-  add_filter(%r{^/spec/})
-  add_filter(%r{^/tools/(?!custom_cops/)})
+  # rubocop:disable RSpec/Pending
+  skip(%r{^/spec/})
+  skip(%r{^/tools/(?!custom_cops/)})
+  # rubocop:enable RSpec/Pending
   enable_coverage(:branch) if !SpecHelper.is_ci? # Codecov doesn't respect `nocov-else` etc comments
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,7 +25,7 @@ SimpleCov.start do
   # rubocop:enable Rails/Present
   # rubocop:disable RSpec/Pending
   skip(%r{^/spec/})
-  skip(%r{^/tools/(?!custom_cops/)})
+  skip(%r{^/tools/})
   # rubocop:enable RSpec/Pending
   enable_coverage(:branch) if !SpecHelper.is_ci? # Codecov doesn't respect `nocov-else` etc comments
 end


### PR DESCRIPTION
> [DEPRECATION] `SimpleCov.add_filter` is deprecated. Replace with `SimpleCov.skip` (same arguments, same behavior). Example: `SimpleCov.skip /^\/spec\//`.

> [DEPRECATION] `# :nocov:` is deprecated and will be removed in a future release. Replace with `# simplecov:disable` / `# simplecov:enable` block comments.