### PR TITLE
[Gemfile] Remove outdated database_consistency version constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -99,8 +99,7 @@ group :test do
   gem 'capybara-shadowdom'
   gem 'climate_control'
   gem 'cuprite'
-  # Pinned because https://github.com/davidrunger/david_runger/pull/ 7826#issuecomment-3607932541 .
-  gem 'database_consistency', '< 3.1.0', require: false
+  gem 'database_consistency', require: false
   gem 'factory_bot_rails'
   gem 'faker'
   gem 'ferrum'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -803,7 +803,7 @@ DEPENDENCIES
   connection_pool
   csv
   cuprite
-  database_consistency (< 3.1.0)
+  database_consistency
   devise
   dotenv
   draper


### PR DESCRIPTION
Dependabot has been updating this, so it actually isn't constraining anything.

Original reason for the constraint: https://github.com/davidrunger/david_runger/pull/7826#issuecomment-3607932541

It seems that the issue I mentioned there has been fixed in the latest versions.