### PR TITLE
[spec/features/blog] Prevent OAuth session race [BLOG-31]

### DIFF
--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -31,6 +31,10 @@ class Api::CommentsController < Api::BaseController
   end
 
   def index
+    # This read-only request can race with an OAuth request that updates the cookie-backed session.
+    # Do not let this response overwrite newer session data with the session that it received.
+    request.session_options[:skip] = true
+
     authorize(Comment)
 
     comments =

--- a/spec/controllers/api/comments_controller_spec.rb
+++ b/spec/controllers/api/comments_controller_spec.rb
@@ -14,6 +14,12 @@ RSpec.describe Api::CommentsController do
 
         expect(response.parsed_body).to eq([])
       end
+
+      it 'does not write the read-only request session back to the client' do
+        get_index
+
+        expect(request.session_options[:skip]).to eq(true)
+      end
     end
   end
 end


### PR DESCRIPTION
The comments index is read-only, but the cookie-backed Rack session can still be committed when the request finishes. If that response races with the OmniAuth request, it can overwrite the newer session containing omniauth.origin and make the callback fall back to the root path.

Skip committing the session for GET /api/comments and cover that contract in the controller spec. This preserves the OAuth return location without changing the comments response or the sign-in flow.

References:

- https://rack.github.io/rack/2.2/Rack/Session/Abstract/Persisted.html
- https://github.com/rack/rack-session/blob/main/lib/rack/session/abstract/id.rb
- https://github.com/omniauth/omniauth/wiki/Integration-Testing

Codex (by OpenAI) did pretty much all of the work, using `gpt-5.6-sol xhigh`. This was one of my first times using Codex to make a code change, and I am quite impressed and pleased by how well it worked.