### PR TITLE
Prevent email attachment path traversal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -86,8 +86,17 @@ RUN bin/bootsnap precompile app/ lib/
 # Return to base image for final stage of app image build
 FROM base
 
+# Run the application as an unprivileged user. Application code remains owned by root;
+# only directories that Rails needs to write to at runtime are writable by this user.
+RUN groupadd --system app && \
+  useradd --system --gid app --home-dir /app --shell /usr/sbin/nologin app
+
 # Copy everything added to the app WORKDIR: gems, application code, skedjewel, compiled assets.
-COPY --from=build /app /app
+COPY --chown=0:0 --from=build /app /app
+
+RUN mkdir -p log tmp && \
+  find /app -xdev -perm /002 -exec chmod o-w {} + && \
+  chown -R app:app log tmp
 
 # Add GIT_REV env var permanently to the image
 ARG GIT_REV
@@ -98,5 +107,7 @@ ENV DOCKER_BUILT=true
 
 # Specify prometheus_exporter Docker Compose host/service name.
 ENV PROMETHEUS_EXPORTER_HOST=rails_metrics
+
+USER app
 
 ENTRYPOINT ["/app/bin/docker-entrypoint"]

--- a/app/mailers/reply_forwarding_mailer.rb
+++ b/app/mailers/reply_forwarding_mailer.rb
@@ -10,13 +10,14 @@ class ReplyForwardingMailer < ApplicationMailer
 
       if is_attachment
         inbound_email_mail = Mail.new(inbound_email.raw_email_blob.download)
-        attachments[inbound_email_mail.filename] = inbound_email_mail.decoded
+        attachments[safe_attachment_filename(inbound_email_mail.filename)] =
+          inbound_email_mail.decoded
       end
 
       if has_attachments
         inbound_email_attachments = Mail.new(inbound_email.raw_email_blob.download).attachments
         inbound_email_attachments.each do |attachment|
-          attachments[attachment.filename] = attachment.decoded
+          attachments[safe_attachment_filename(attachment.filename)] = attachment.decoded
         end
       end
     end
@@ -28,4 +29,10 @@ class ReplyForwardingMailer < ApplicationMailer
     )
   end
   # rubocop:enable Metrics/ParameterLists
+
+  private
+
+  def safe_attachment_filename(filename)
+    Email::AttachmentFilename.sanitize(filename)
+  end
 end

--- a/lib/email/attachment_filename.rb
+++ b/lib/email/attachment_filename.rb
@@ -1,0 +1,20 @@
+class Email::AttachmentFilename
+  FALLBACK = 'attachment'
+
+  class << self
+    def sanitize(filename)
+      basename = File.basename(utf8_filename(filename).delete("\0").tr('\\', '/'))
+      sanitized_basename = ActiveStorage::Filename.new(basename).sanitized.gsub(/[[:cntrl:]]/, '-')
+
+      return FALLBACK if sanitized_basename.blank? || sanitized_basename.in?(['.', '..'])
+
+      sanitized_basename
+    end
+
+    private
+
+    def utf8_filename(filename)
+      filename.to_s.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: '�')
+    end
+  end
+end

--- a/lib/email/mailgun_via_http.rb
+++ b/lib/email/mailgun_via_http.rb
@@ -1,3 +1,5 @@
+require 'stringio'
+
 # rubocop:disable Style/ClassAndModuleChildren
 module Email
   class MailgunViaHttp
@@ -26,7 +28,7 @@ module Email
         LOG
       end
 
-      delete_attachments
+      nil
     end
 
     private
@@ -46,12 +48,6 @@ module Email
     end
 
     memoize \
-    def attachments_tmp_directory
-      # use random directory for thread safety (so users' emails don't conflict w/ each other)
-      "tmp/attachments/#{Time.zone.today.iso8601}/#{SecureRandom.alphanumeric(5)}"
-    end
-
-    memoize \
     def post_body(mail)
       body = {
         to: safe_to_value(mail),
@@ -62,18 +58,18 @@ module Email
       }
 
       if mail.has_attachments?
-        body[:attachment] = []
-        FileUtils.mkdir_p(attachments_tmp_directory)
-        mail.attachments.each do |attachment|
-          file = File.new("#{attachments_tmp_directory}/#{attachment.filename}", 'w+b')
-          file.write(attachment.body.to_s)
-          file.rewind
-          body[:attachment] <<
-            Faraday::Multipart::FilePart.new(file, 'application/octet-stream')
-        end
+        body[:attachment] = mail.attachments.map { |attachment| file_part(attachment) }
       end
 
       body
+    end
+
+    def file_part(attachment)
+      Faraday::Multipart::FilePart.new(
+        StringIO.new(attachment.body.to_s),
+        'application/octet-stream',
+        AttachmentFilename.sanitize(attachment.filename),
+      )
     end
 
     def safe_to_value(mail)
@@ -87,11 +83,6 @@ module Email
       else
         fail("You *actually* tried to send an email to #{recipients}!")
       end
-    end
-
-    def delete_attachments
-      FileUtils.rm_rf(attachments_tmp_directory)
-      nil
     end
   end
 end

--- a/spec/lib/email/attachment_filename_spec.rb
+++ b/spec/lib/email/attachment_filename_spec.rb
@@ -1,0 +1,29 @@
+RSpec.describe Email::AttachmentFilename do
+  describe '.sanitize' do
+    subject(:sanitized_filename) { described_class.sanitize(filename) }
+
+    context 'when the filename contains Unix path traversal' do
+      let(:filename) { '../../../../app/views/mailers/admin_mailer/user_created.html.haml' }
+
+      it { is_expected.to eq('user_created.html.haml') }
+    end
+
+    context 'when the filename contains Windows path traversal' do
+      let(:filename) { '..\\..\\secrets.txt' }
+
+      it { is_expected.to eq('secrets.txt') }
+    end
+
+    context 'when the filename contains unsafe header characters' do
+      let(:filename) { " report\r\n:name?.txt\0 " }
+
+      it { is_expected.to eq('report---name-.txt') }
+    end
+
+    context 'when the filename does not identify a file' do
+      let(:filename) { '..' }
+
+      it { is_expected.to eq('attachment') }
+    end
+  end
+end

--- a/spec/lib/email/mailgun_via_http_spec.rb
+++ b/spec/lib/email/mailgun_via_http_spec.rb
@@ -75,6 +75,27 @@ RSpec.describe Email::MailgunViaHttp do
         expect(post_body[:html]).to eq('<div></div>')
       end
     end
+
+    context 'when an attachment filename contains path traversal' do
+      let(:attachment_filename) { '../../../../app/views/malicious.html.haml' }
+      let(:mail) do
+        Mail.new.tap do |message|
+          message.from = 'sender@example.com'
+          message.to = 'davidjrunger@gmail.com'
+          message.subject = 'Attachment'
+          message.add_file(filename: attachment_filename, content: 'safe content')
+        end
+      end
+
+      it 'uploads the attachment from memory with a sanitized display filename' do
+        file_part = post_body.fetch(:attachment).sole
+
+        expect(file_part.original_filename).to eq('malicious.html.haml')
+        expect(file_part.io).to be_a(StringIO)
+        expect(file_part.io.string).to eq('safe content')
+        expect(file_part.local_path).to eq('local.path')
+      end
+    end
   end
 
   describe '#safe_to_value' do

--- a/spec/mailers/reply_forwarding_mailer_spec.rb
+++ b/spec/mailers/reply_forwarding_mailer_spec.rb
@@ -47,6 +47,8 @@ RSpec.describe ReplyForwardingMailer do
     context 'when there are attachments' do
       let(:has_attachments) { true }
 
+      let(:attachment_filename) { 'random.txt' }
+
       before do
         inbound_email = ActionMailbox::InboundEmail.create!(
           message_id:,
@@ -70,8 +72,9 @@ RSpec.describe ReplyForwardingMailer do
           "----==_mimepart_7291c2b9a328_126b3616c510df\r\nContent-Type: text/plain;\r\n " \
           "charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\nattachment body\r\n" \
           "----==_mimepart_7291c2b9a328_126b3616c510df\r\nContent-Type: text/plain;\r\n " \
-          "charset=UTF-8;\r\n filename=random.txt\r\nContent-Transfer-Encoding: 7bit\r\n" \
-          "Content-Disposition: attachment;\r\n filename=random.txt\r\n\r\nAttachment content." \
+          "charset=UTF-8;\r\n filename=\"#{attachment_filename}\"\r\n" \
+          "Content-Transfer-Encoding: 7bit\r\nContent-Disposition: attachment;\r\n " \
+          "filename=\"#{attachment_filename}\"\r\n\r\nAttachment content." \
           "\r\n\r\n----==_mimepart_7291c2b9a328_126b3616c510df--\r\n",
         )
         # rubocop:enable RSpec/AnyInstance
@@ -79,6 +82,16 @@ RSpec.describe ReplyForwardingMailer do
 
       it 'includes the attachments' do
         expect(mail.attachments.size).to eq(1)
+      end
+
+      context 'when the attachment filename contains path traversal' do
+        let(:attachment_filename) do
+          '../../../../app/views/mailers/admin_mailer/user_created.html.haml'
+        end
+
+        it 'forwards the attachment with only its sanitized basename' do
+          expect(mail.attachments.first.filename).to eq('user_created.html.haml')
+        end
       end
     end
 


### PR DESCRIPTION
Inbound reply attachments retain sender-controlled MIME filenames. The Mailgun HTTP delivery adapter previously interpolated those names beneath tmp/attachments without constraining the resulting path. A filename containing ../ components could therefore escape the temporary directory and overwrite application code or a mail template. Because the container also ran as root, triggering an overwritten Haml template could lead to arbitrary Ruby execution with access to application secrets and data.

Introduce a shared attachment filename policy that converts invalid input to UTF-8, removes NUL bytes, normalizes Unix and Windows separators, keeps only the basename, replaces unsafe/control characters, and supplies a safe fallback. Apply it both when the inbound attachment is forwarded and again when the outbound multipart request is assembled, so neither boundary trusts an external filename.

Eliminate the vulnerable filesystem operation entirely by wrapping attachment data in StringIO and giving Faraday a separately sanitized display filename. No attacker-controlled attachment filename is now used as a local path.

Add container-level defense in depth by running the final image as an unprivileged app user. Keep application code root-owned and non-world-writable while granting the runtime user write access only to log and tmp.

Add regression coverage for Unix and Windows traversal, unsafe header characters, fallback names, inbound forwarding, and in-memory Mailgun uploads.

Written by Codex (`gpt-5.6-sol xhigh`).