### PR TITLE
Allow asset export to write app-public volume

### DIFF
--- a/bin/server/deploy.sh
+++ b/bin/server/deploy.sh
@@ -48,7 +48,10 @@ if ! docker compose ps -q nginx | grep -q . ; then
 fi
 
 # Copy fully built out public/ directory from web to nginx via app-public volume.
+# This trusted, one-off container needs root access to the Docker-managed volume. The
+# long-running web and worker containers continue to use the image's unprivileged user.
 docker run --rm \
+  --user 0:0 \
   --mount source=david_runger_app-public,target=/app-public \
   --entrypoint cp david_runger-web -r /app/public/. /app-public/
 


### PR DESCRIPTION
The attachment hardening change (#9016) set the final application image to USER app. Docker run inherits that image user even when deploy.sh replaces the entrypoint with cp, so the asset-export container no longer had permission to create or replace files in the existing root-owned app-public volume. Deployment consequently stopped before the rolling web update.

Run only this trusted, short-lived asset-copy container as UID/GID 0:0. This restores compatibility with the Docker-managed volume and its existing root-owned contents without changing ownership of the application image or making the volume broadly writable.

The long-running web, worker, clock, metrics, and release-task containers continue to inherit the unprivileged app user. NGINX also continues to mount app-public read-only, so the original container hardening remains intact outside this narrowly scoped deployment operation.

Validate the script with bash syntax checking and ShellCheck, and exercise the updated cp command against an ephemeral root-owned mount using the hardened production image.