### PR TITLE
Render quiz participant names as text

### DIFF
--- a/app/javascript/entrypoints/quizzes.ts
+++ b/app/javascript/entrypoints/quizzes.ts
@@ -5,6 +5,7 @@ import actionCableConsumer from '@/channels/consumer';
 import { loadAsyncPartials } from '@/lib/async_partial';
 import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { assert } from '@/lib/helpers';
+import { addNewParticipant } from '@/quizzes/addNewParticipant';
 import type { Intersection, Quiz, UserSerializerBasic } from '@/types';
 import { QuizShowBootstrap } from '@/types/bootstrap/QuizShowBootstrap';
 
@@ -89,15 +90,6 @@ actionCableConsumer.subscriptions.create(
   },
 );
 
-function getDangerouslyById(id: string) {
-  const el = assert(document.getElementById(id));
-
-  if (el === null)
-    throw new Error(`Element with id '${id}' could not be found!`);
-
-  return el;
-}
-
 function refresh() {
   Turbo.cache.clear();
   Turbo.visit(window.location.pathname, { action: 'replace' });
@@ -114,18 +106,5 @@ function addNewAnswerer(newAnswererName: string) {
     );
 
     matchedLi.classList.add('font-bold');
-  }
-}
-
-function addNewParticipant(newParticipantName: string) {
-  const quizParticipationsList = getDangerouslyById('quiz_participations');
-
-  const existingListing = Array.from(
-    quizParticipationsList.querySelectorAll('li'),
-  ).find((el) => el.innerText === newParticipantName);
-  if (!existingListing) {
-    const newListItem = document.createElement('li');
-    newListItem.innerHTML = newParticipantName;
-    quizParticipationsList.appendChild(newListItem);
   }
 }

--- a/app/javascript/quizzes/addNewParticipant.test.ts
+++ b/app/javascript/quizzes/addNewParticipant.test.ts
@@ -1,0 +1,14 @@
+import { addNewParticipant } from './addNewParticipant';
+
+test('renders a participant name as text', () => {
+  document.body.innerHTML = '<ol id="quiz_participations"></ol>';
+  const participantName =
+    'Tester<img src=x onerror="document.body.dataset.compromised = true">';
+
+  addNewParticipant(participantName);
+
+  const newListItem = document.querySelector('#quiz_participations li');
+  expect(newListItem?.textContent).toEqual(participantName);
+  expect(newListItem?.children).toHaveLength(0);
+  expect(document.body.dataset.compromised).toBeUndefined();
+});

--- a/app/javascript/quizzes/addNewParticipant.ts
+++ b/app/javascript/quizzes/addNewParticipant.ts
@@ -1,0 +1,16 @@
+import { assert } from '@/lib/helpers';
+
+export function addNewParticipant(newParticipantName: string) {
+  const quizParticipationsList = assert(
+    document.getElementById('quiz_participations'),
+  );
+
+  const existingListing = Array.from(
+    quizParticipationsList.querySelectorAll('li'),
+  ).find((el) => el.innerText === newParticipantName);
+  if (!existingListing) {
+    const newListItem = document.createElement('li');
+    newListItem.textContent = newParticipantName;
+    quizParticipationsList.appendChild(newListItem);
+  }
+}


### PR DESCRIPTION
Quiz participant names arrive over Action Cable and are untrusted. Render them with textContent instead of innerHTML so markup is displayed literally rather than parsed and executed.

xss_foliate already sanitizes display_name before validation, but the client should not rely on that protection alone. Text-only rendering provides defense in depth if the model-level sanitization is bypassed, removed, or changed.

Extract the participant-list update into a testable module and add regression coverage for a hostile display name.

Authored by Codex (`gpt-5.6-sol xhigh`).