### PR TITLE
Avoid N+1 queries when accepting proposals

### DIFF
--- a/app/actions/proposals/accept.rb
+++ b/app/actions/proposals/accept.rb
@@ -13,6 +13,7 @@ class Proposals::Accept < ApplicationAction
 
   def destroy_other_proposee_marriages
     Marriage.
+      with_eager_loading_for_destroy.
       joins(:memberships).
       where(marriage_memberships: { user_id: proposee }).
       find_each(&:destroy!)

--- a/app/models/marriage.rb
+++ b/app/models/marriage.rb
@@ -13,4 +13,14 @@ class Marriage < ApplicationRecord
   has_many :partners, through: :memberships, source: :user
 
   has_paper_trail
+
+  class << self
+    def with_eager_loading_for_destroy
+      includes(
+        :memberships,
+        check_ins: %i[check_in_submissions need_satisfaction_ratings],
+        emotional_needs: :need_satisfaction_ratings,
+      )
+    end
+  end
 end

--- a/spec/actions/proposals/accept_spec.rb
+++ b/spec/actions/proposals/accept_spec.rb
@@ -28,5 +28,30 @@ RSpec.describe Proposals::Accept do
         }.from(nil).to(Marriage)
       end
     end
+
+    context "when the proposee's marriage has dependent check-in data" do
+      let!(:proposer) { create(:user) }
+      let!(:proposee) { create(:user) }
+      let!(:proposee_marriage) do
+        Marriages::Create.run!(proposer: proposee)
+        proposee.reload.marriage
+      end
+      let!(:check_in) { CheckIns::Create.run!(marriage: proposee_marriage).check_in }
+
+      it 'destroys the marriage and its dependent records without N+1 queries' do
+        expect(proposee_marriage.emotional_needs.size).
+          to eq(Marriages::Create::DEFAULT_EMOTIONAL_NEEDS.size)
+        expect(check_in.need_satisfaction_ratings.size).
+          to eq(Marriages::Create::DEFAULT_EMOTIONAL_NEEDS.size)
+
+        expect {
+          expect(run).to be_success
+        }.to change {
+          Marriage.exists?(proposee_marriage.id)
+        }.from(true).to(false).and change {
+          NeedSatisfactionRating.where(check_in:).count
+        }.to(0)
+      end
+    end
   end
 end


### PR DESCRIPTION
Proposal acceptance destroys the proposee existing marriage before joining the proposer marriage. That dependent cascade walks check-ins and emotional needs; without preloading, each emotional need separately loads its satisfaction ratings, which Prosopite reports as an N+1 query.

Add a reusable Marriage eager-loading scope covering memberships, check-ins, submissions, emotional needs, and satisfaction ratings. Apply it to the existing acceptance query so Rails can destroy the complete dependent graph from loaded associations.

Add a Prosopite-backed action regression that creates the default emotional needs and check-in ratings, verifies the old marriage and ratings are deleted, and keeps the fix independent from the recipient-bound proposal redesign.