### PR TITLE
Secure marriage proposal acceptance

### DIFF
--- a/app/actions/proposals/accept.rb
+++ b/app/actions/proposals/accept.rb
@@ -1,41 +1,108 @@
 class Proposals::Accept < ApplicationAction
-  prepend Memoization
-
-  requires :encoded_token, String
+  requires :proposal, Proposal
   requires :proposee, User
 
+  fails_with :unavailable
+
   def execute
-    destroy_other_proposee_marriages
-    marriage.partners << proposee
+    ApplicationRecord.transaction do
+      proposal.lock!
+
+      locked_users =
+        User.
+          where(id: [proposal.proposer_id, proposee.id]).
+          order(:id).
+          lock.
+          index_by(&:id)
+      locked_proposer = locked_users.fetch(proposal.proposer_id)
+      locked_proposee = locked_users.fetch(proposee.id)
+
+      user_memberships =
+        MarriageMembership.
+          where(user_id: locked_users.keys).
+          order(:id).
+          lock.
+          index_by(&:user_id)
+      marriages =
+        Marriage.
+          where(id: user_memberships.values.map(&:marriage_id)).
+          order(:id).
+          lock.
+          index_by(&:id)
+      marriage_memberships =
+        MarriageMembership.
+          where(marriage_id: marriages.keys).
+          order(:id).
+          lock.
+          to_a
+
+      proposer_marriage = marriages[user_memberships[locked_proposer.id]&.marriage_id]
+      proposee_marriage = marriages[user_memberships[locked_proposee.id]&.marriage_id]
+
+      unavailable_message = unavailable_message(
+        locked_proposer:,
+        locked_proposee:,
+        marriage_memberships:,
+        proposer_marriage:,
+        proposee_marriage:,
+      )
+
+      if unavailable_message
+        result.unavailable!(unavailable_message)
+      else
+        accept_proposal!(
+          locked_proposer:,
+          locked_proposee:,
+          proposer_marriage:,
+          proposee_marriage:,
+        )
+      end
+    end
   end
 
   private
 
-  def destroy_other_proposee_marriages
-    Marriage.
-      with_eager_loading_for_destroy.
-      joins(:memberships).
-      where(marriage_memberships: { user_id: proposee }).
-      find_each(&:destroy!)
+  def unavailable_message(
+    locked_proposer:,
+    locked_proposee:,
+    marriage_memberships:,
+    proposer_marriage:,
+    proposee_marriage:
+  )
+    return 'This proposal has already been accepted.' if proposal.accepted_at.present?
+
+    if !proposal.proposee_email.casecmp?(locked_proposee.email)
+      return 'This proposal was sent to a different email address.'
+    end
+
+    if locked_proposer == locked_proposee
+      return 'You cannot accept your own proposal.'
+    end
+
+    target_marriage_is_full =
+      proposer_marriage.present? &&
+      proposer_marriage != proposee_marriage &&
+      marriage_memberships.count { it.marriage_id == proposer_marriage.id } >= 2
+
+    if target_marriage_is_full
+      return "#{locked_proposer.email}'s marriage already has two partners."
+    end
+
+    nil
   end
 
-  memoize \
-  def marriage
-    proposer.marriage || Marriage.create!(partners: [proposer])
+  def accept_proposal!(locked_proposer:, locked_proposee:, proposer_marriage:, proposee_marriage:)
+    target_marriage = proposer_marriage || Marriage.create!(partners: [locked_proposer])
+
+    if proposee_marriage != target_marriage
+      destroy_marriage!(proposee_marriage) if proposee_marriage
+      target_marriage.partners << locked_proposee
+    end
+
+    proposal.update!(accepted_at: Time.current)
   end
 
-  memoize \
-  def proposer
-    User.find(proposer_id)
-  end
-
-  memoize \
-  def proposer_id
-    JWT.decode(
-      encoded_token,
-      ENV.fetch('JWT_SECRET'),
-      true,
-      { algorithm: 'HS512' },
-    ).dig(0, 'proposer_id')
+  def destroy_marriage!(marriage)
+    Marriage.with_eager_loading_for_destroy.find(marriage.id).destroy!
   end
 end

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -1,18 +1,52 @@
 class ProposalsController < ApplicationController
+  self.container_classes = %w[p-8]
+
+  before_action :set_proposal, only: %i[accept confirm]
+
   def create
-    authorize(Marriage, :propose?)
-    ProposalMailer.proposal_created(current_user.id, params[:spouse_email]).deliver_later
-    flash[:notice] = 'Invitation sent.'
+    authorize(Proposal)
+
+    proposal = current_user.sent_proposals.pending.find_or_create_by(
+      proposee_email: params[:spouse_email],
+    )
+
+    if proposal.persisted?
+      ProposalMailer.proposal_created(proposal.id).deliver_later
+      flash[:notice] = 'Invitation sent.'
+    else
+      flash[:alert] = proposal.errors.full_messages.to_sentence
+    end
+
     redirect_to(redirect_location || check_ins_path)
   end
 
+  def confirm
+    authorize(@proposal)
+    @title = 'Confirm marriage proposal'
+  end
+
   def accept
-    authorize(Marriage, :create?)
-    Proposals::Accept.new(
-      encoded_token: params[:token],
+    authorize(@proposal)
+    result = Proposals::Accept.new(
+      proposal: @proposal,
       proposee: current_user,
-    ).run!
-    flash[:notice] = 'Marriage created.'
+    ).run
+
+    if result.success?
+      flash[:notice] = 'Marriage created.'
+    else
+      flash[:alert] = result.error_message
+    end
+
     redirect_to(check_ins_path)
+  end
+
+  private
+
+  def set_proposal
+    @proposal =
+      Proposal.
+        includes(proposer: :marriage).
+        find_by!(public_id: params.expect(:public_id))
   end
 end

--- a/app/mailers/proposal_mailer.rb
+++ b/app/mailers/proposal_mailer.rb
@@ -1,9 +1,9 @@
 class ProposalMailer < ApplicationMailer
-  def proposal_created(proposer_id, proposee_email)
-    @proposer = User.find(proposer_id)
-    @token = JWT.encode({ proposer_id: }, ENV.fetch('JWT_SECRET'), 'HS512')
+  def proposal_created(proposal_id)
+    @proposal = Proposal.find(proposal_id)
+    @proposer = @proposal.proposer
     mail(
-      to: proposee_email,
+      to: @proposal.proposee_email,
       subject: %(#{@proposer.email} wants you to join their marriage on davidrunger.com),
     )
   end

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -1,0 +1,42 @@
+# == Schema Information
+#
+# Table name: proposals
+#
+#  accepted_at    :datetime
+#  created_at     :datetime         not null
+#  id             :bigint           not null, primary key
+#  proposee_email :string           not null
+#  proposer_id    :bigint           not null
+#  public_id      :string           not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_proposals_on_proposer_id  (proposer_id)
+#  index_proposals_on_public_id    (public_id) UNIQUE
+#  uniq_pending_proposals          (proposer_id,proposee_email) UNIQUE WHERE (accepted_at IS NULL)
+#
+class Proposal < ApplicationRecord
+  belongs_to :proposer, class_name: 'User', inverse_of: :sent_proposals
+
+  has_secure_token :public_id
+
+  normalizes :proposee_email, with: ->(email) { email.downcase }
+
+  validates :proposee_email, presence: true, email_format: true
+  validates(
+    :proposee_email,
+    uniqueness: {
+      scope: :proposer_id,
+      conditions: -> { where(accepted_at: nil) },
+    },
+    if: -> { accepted_at.nil? },
+  )
+  validates :public_id, presence: true, uniqueness: true
+
+  scope :pending, -> { where(accepted_at: nil) }
+
+  def to_param
+    public_id
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,7 +16,7 @@
 class User < ApplicationRecord
   prepend Memoization
 
-  validates :email, presence: true, uniqueness: true, format: { with: /\A\S+@\S+\.\S+\z/ }
+  validates :email, presence: true, uniqueness: true, email_format: true
 
   has_many :auth_tokens, dependent: :destroy
   has_many :logs, dependent: :destroy
@@ -29,6 +29,13 @@ class User < ApplicationRecord
     inverse_of: :participant,
   )
   has_many :requests, dependent: :destroy
+  has_many(
+    :sent_proposals,
+    dependent: :destroy,
+    foreign_key: 'proposer_id',
+    inverse_of: :proposer,
+    class_name: 'Proposal',
+  )
   has_many :stores, dependent: :destroy
   has_many :items, through: :stores # must come after has_many :stores declaration
   has_many :log_entries, through: :logs

--- a/app/policies/marriage_policy.rb
+++ b/app/policies/marriage_policy.rb
@@ -5,10 +5,6 @@ class MarriagePolicy < ApplicationPolicy
     end
   end
 
-  def propose?
-    true
-  end
-
   def show_groceries?
     [@user.id, @user.spouse.id].sort == @record.partners.ids.sort
   end

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -1,0 +1,19 @@
+class ProposalPolicy < ApplicationPolicy
+  def create?
+    user.spouse.nil?
+  end
+
+  def confirm?
+    intended_recipient?
+  end
+
+  def accept?
+    intended_recipient?
+  end
+
+  private
+
+  def intended_recipient?
+    record.proposee_email.casecmp?(user.email)
+  end
+end

--- a/app/validators/email_format_validator.rb
+++ b/app/validators/email_format_validator.rb
@@ -1,0 +1,11 @@
+class EmailFormatValidator < ActiveModel::EachValidator
+  REGEXP = /\A\S+@\S+\.\S+\z/
+
+  def validate_each(record, attribute, value)
+    return if value.blank?
+
+    if !REGEXP.match?(value.to_s)
+      record.errors.add(attribute, :invalid, value:)
+    end
+  end
+end

--- a/app/views/mailers/proposal_mailer/proposal_created.html.haml
+++ b/app/views/mailers/proposal_mailer/proposal_created.html.haml
@@ -2,6 +2,6 @@
   #{@proposer.email} wants you to join their marriage on davidrunger.com.
 
 %p
-  %b= link_to('Click here', accept_proposals_url(token: @token))
+  %b= link_to('Click here', confirm_proposal_url(@proposal))
 
   to accept the invitation.

--- a/app/views/proposals/confirm.html.haml
+++ b/app/views/proposals/confirm.html.haml
@@ -1,0 +1,18 @@
+%h1 Confirm marriage proposal
+
+%p
+  %b= @proposal.proposer.email
+  wants you to join their marriage on davidrunger.com.
+
+- if @proposal.accepted_at.present?
+  %p This proposal has already been accepted.
+- else
+  - if current_user.spouse.present? && current_user.marriage != @proposal.proposer.marriage
+    %p
+      %b Warning:
+      Accepting this proposal will delete your existing marriage and its associated check-in data.
+
+  = button_to('Accept proposal',
+    accept_proposal_path(@proposal),
+    method: :post,
+    class: 'btn-primary')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,9 +40,10 @@ Rails.application.routes.draw do
   %w[check_in check-ins check-in checkins checkin].each do |path|
     get path, to: redirect('check_ins')
   end
-  resources :proposals, only: %i[create] do
-    collection do
-      get :accept
+  resources :proposals, only: %i[create], param: :public_id do
+    member do
+      get :confirm
+      post :accept
     end
   end
   resource :marriage, only: %i[new show]

--- a/db/migrate/20260805120000_create_proposals.rb
+++ b/db/migrate/20260805120000_create_proposals.rb
@@ -1,0 +1,21 @@
+class CreateProposals < ActiveRecord::Migration[8.1]
+  def change
+    create_table :proposals do |t|
+      t.references :proposer, null: false, foreign_key: { to_table: :users }
+      t.string :proposee_email, null: false
+      t.string :public_id, null: false
+      t.datetime :accepted_at
+
+      t.timestamps
+    end
+
+    add_index :proposals, :public_id, unique: true
+    add_index(
+      :proposals,
+      %i[proposer_id proposee_email],
+      unique: true,
+      where: 'accepted_at IS NULL',
+      name: 'uniq_pending_proposals',
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_03_151208) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -365,6 +365,18 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_151208) do
     t.index ["database", "captured_at"], name: "index_pghero_space_stats_on_database_and_captured_at"
   end
 
+  create_table "proposals", force: :cascade do |t|
+    t.datetime "accepted_at"
+    t.datetime "created_at", null: false
+    t.string "proposee_email", null: false
+    t.bigint "proposer_id", null: false
+    t.string "public_id", null: false
+    t.datetime "updated_at", null: false
+    t.index ["proposer_id", "proposee_email"], name: "uniq_pending_proposals", unique: true, where: "(accepted_at IS NULL)"
+    t.index ["proposer_id"], name: "index_proposals_on_proposer_id"
+    t.index ["public_id"], name: "index_proposals_on_public_id", unique: true
+  end
+
   create_table "quiz_participations", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "display_name", null: false
@@ -528,6 +540,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_151208) do
   add_foreign_key "need_satisfaction_ratings", "check_ins"
   add_foreign_key "need_satisfaction_ratings", "emotional_needs"
   add_foreign_key "need_satisfaction_ratings", "users"
+  add_foreign_key "proposals", "users", column: "proposer_id"
   add_foreign_key "quiz_participations", "quizzes"
   add_foreign_key "quiz_participations", "users", column: "participant_id"
   add_foreign_key "quiz_question_answer_selections", "quiz_participations", column: "participation_id"

--- a/spec/actions/proposals/accept_spec.rb
+++ b/spec/actions/proposals/accept_spec.rb
@@ -1,57 +1,187 @@
 RSpec.describe Proposals::Accept do
-  subject(:action) do
-    Proposals::Accept.new(
-      encoded_token:
-        JWT.encode(
-          { proposer_id: proposer.id },
-          ENV.fetch('JWT_SECRET'),
-          'HS512',
-        ),
+  subject(:run) do
+    described_class.new(
+      proposal:,
       proposee:,
-    )
+    ).run
   end
 
-  let!(:proposer) { users(:user) }
-  let!(:proposee) { User.where.missing(:marriage).except(proposer).first! }
+  let(:proposer) { create(:user) }
+  let(:proposee) { create(:user) }
+  let!(:proposal) { create(:proposal, proposer:, proposee_email: proposee.email) }
 
-  describe '#run' do
-    subject(:run) { action.run }
+  context 'when the proposal can be accepted' do
+    let!(:proposer_marriage) { create(:marriage, partners: [proposer]) }
+    let!(:proposee_marriage) { create(:marriage, partners: [proposee]) }
 
-    context 'when the proposer has deleted their marriage' do
-      before { proposer&.marriage&.destroy! }
-
-      it 'creates a new marriage with proposer and proposee as partners' do
-        expect {
-          run
-        }.to change {
-          proposer.reload.marriage
-        }.from(nil).to(Marriage)
-      end
+    it "replaces the proposee's marriage with the proposer's marriage" do
+      expect {
+        expect(run).to be_success
+      }.to change {
+        Marriage.exists?(proposee_marriage.id)
+      }.from(true).to(false).and change {
+        proposer_marriage.reload.partners.order(:id).to_a
+      }.from([proposer]).to([proposer, proposee].sort_by(&:id))
     end
 
-    context "when the proposee's marriage has dependent check-in data" do
-      let!(:proposer) { create(:user) }
-      let!(:proposee) { create(:user) }
-      let!(:proposee_marriage) do
-        Marriages::Create.run!(proposer: proposee)
-        proposee.reload.marriage
-      end
-      let!(:check_in) { CheckIns::Create.run!(marriage: proposee_marriage).check_in }
+    it 'marks the proposal as accepted' do
+      expect {
+        run
+      }.to change {
+        proposal.reload.accepted_at
+      }.from(nil)
+    end
+  end
 
-      it 'destroys the marriage and its dependent records without N+1 queries' do
-        expect(proposee_marriage.emotional_needs.size).
-          to eq(Marriages::Create::DEFAULT_EMOTIONAL_NEEDS.size)
-        expect(check_in.need_satisfaction_ratings.size).
-          to eq(Marriages::Create::DEFAULT_EMOTIONAL_NEEDS.size)
+  context 'when the proposer does not have a marriage' do
+    let!(:proposee_marriage) { create(:marriage, partners: [proposee]) }
 
-        expect {
-          expect(run).to be_success
-        }.to change {
-          Marriage.exists?(proposee_marriage.id)
-        }.from(true).to(false).and change {
-          NeedSatisfactionRating.where(check_in:).count
-        }.to(0)
-      end
+    it 'creates a new marriage for the proposer and proposee' do
+      expect {
+        expect(run).to be_success
+      }.to change {
+        proposer.reload.marriage
+      }.from(nil).to(Marriage)
+
+      expect(proposer.marriage.partners.order(:id)).to eq([proposer, proposee].sort_by(&:id))
+      expect(Marriage.exists?(proposee_marriage.id)).to eq(false)
+    end
+  end
+
+  context "when the proposee's marriage has dependent check-in data" do
+    let!(:proposer_marriage) { create(:marriage, partners: [proposer]) }
+    let!(:proposee_marriage) do
+      Marriages::Create.run!(proposer: proposee)
+      proposee.reload.marriage
+    end
+    let!(:check_in) { CheckIns::Create.run!(marriage: proposee_marriage).check_in }
+
+    it 'destroys the marriage and all dependent records without N+1 queries' do
+      expect(proposee_marriage.emotional_needs.size).
+        to eq(Marriages::Create::DEFAULT_EMOTIONAL_NEEDS.size)
+      expect(check_in.need_satisfaction_ratings.size).
+        to eq(Marriages::Create::DEFAULT_EMOTIONAL_NEEDS.size)
+
+      expect {
+        expect(run).to be_success
+      }.to change {
+        Marriage.exists?(proposee_marriage.id)
+      }.from(true).to(false).and change {
+        NeedSatisfactionRating.where(check_in:).count
+      }.to(0)
+
+      expect(proposer_marriage.reload.partners).to contain_exactly(proposer, proposee)
+    end
+  end
+
+  context 'when the proposer and proposee are already in the same marriage' do
+    let!(:marriage) { create(:marriage, partners: [proposer, proposee]) }
+
+    it 'marks the proposal accepted without replacing the marriage' do
+      expect {
+        expect(run).to be_success
+      }.not_to change {
+        proposer.reload.marriage.id
+      }.from(marriage.id)
+
+      expect(proposal.reload.accepted_at).to be_present
+    end
+  end
+
+  context 'when the proposal has already been accepted' do
+    before { proposal.update!(accepted_at: 1.minute.ago) }
+
+    let!(:proposee_marriage) { create(:marriage, partners: [proposee]) }
+
+    it 'rejects the replay without changing the proposee marriage' do
+      expect {
+        expect(run).not_to be_success
+      }.not_to change {
+        proposee.reload.marriage.id
+      }.from(proposee_marriage.id)
+
+      expect(run.error_message).to eq('This proposal has already been accepted.')
+    end
+  end
+
+  context 'when the proposal was sent to a different user' do
+    let(:proposee) { create(:user) }
+
+    before { proposal.update!(proposee_email: create(:user).email) }
+
+    it 'rejects the proposal before changing any marriage' do
+      expect(run).not_to be_success
+      expect(run.error_message).to eq('This proposal was sent to a different email address.')
+      expect(proposal.reload.accepted_at).to be_nil
+    end
+  end
+
+  context 'when the proposer tries to accept their own proposal' do
+    let(:proposee) { proposer }
+
+    it 'rejects the proposal' do
+      expect(run).not_to be_success
+      expect(run.error_message).to eq('You cannot accept your own proposal.')
+      expect(proposal.reload.accepted_at).to be_nil
+    end
+  end
+
+  context "when the proposer's marriage already has two partners" do
+    let!(:proposer_marriage) { create(:marriage, partners: [proposer, create(:user)]) }
+    let!(:proposee_marriage) { create(:marriage, partners: [proposee]) }
+
+    it "rejects the proposal before destroying the proposee's marriage" do
+      expect {
+        expect(run).not_to be_success
+      }.not_to change {
+        proposee.reload.marriage.id
+      }.from(proposee_marriage.id)
+
+      expect(run.error_message).
+        to eq("#{proposer.email}'s marriage already has two partners.")
+      expect(proposer.reload.marriage).to eq(proposer_marriage)
+      expect(proposal.reload.accepted_at).to be_nil
+    end
+  end
+
+  context 'when marking the proposal accepted fails' do
+    let!(:proposer_marriage) { create(:marriage, partners: [proposer]) }
+    let!(:proposee_marriage) { create(:marriage, partners: [proposee]) }
+
+    before do
+      allow(proposal).
+        to receive(:update!).
+        and_raise(ActiveRecord::RecordInvalid.new(proposal))
+    end
+
+    it 'rolls back all relationship changes' do
+      expect {
+        run
+      }.to raise_error(ActiveRecord::RecordInvalid)
+
+      expect(proposer_marriage.reload.partners).to contain_exactly(proposer)
+      expect(proposee_marriage.reload.partners).to contain_exactly(proposee)
+      expect(proposal.reload.accepted_at).to be_nil
+    end
+  end
+
+  context 'when a later relationship change follows a successful acceptance' do
+    let!(:proposer_marriage) { create(:marriage, partners: [proposer]) }
+
+    it 'cannot replay the accepted proposal to destroy the later relationship' do
+      expect(run).to be_success
+      proposer_marriage.reload.destroy!
+      later_marriage = create(:marriage, partners: [proposee, create(:user)])
+
+      replay_result =
+        described_class.new(
+          proposal: proposal.reload,
+          proposee: proposee.reload,
+        ).run
+
+      expect(replay_result).not_to be_success
+      expect(replay_result.error_message).to eq('This proposal has already been accepted.')
+      expect(proposee.reload.marriage).to eq(later_marriage)
     end
   end
 end

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -1,52 +1,221 @@
 RSpec.describe(ProposalsController) do
-  describe '#accept' do
-    subject(:get_accept) { get(:accept, params:) }
+  let(:proposer) { create(:user) }
+  let(:proposee) { create(:user) }
 
-    let(:params) do
-      {
-        token: JWT.encode(
-          { proposer_id: proposer.id },
-          ENV.fetch('JWT_SECRET'),
-          'HS512',
-        ),
-      }
+  describe '#create' do
+    subject(:post_create) do
+      post(:create, params: { spouse_email: proposee_email })
     end
-    let(:proposer) { users(:single_user) }
-    let(:proposee) { users(:user) }
 
-    context 'when JWT_SECRET is set' do
-      before { expect(ENV.fetch('JWT_SECRET', nil)).to be_present }
+    let(:proposee_email) { proposee.email.upcase }
+    let(:delivery) { instance_double(ActionMailer::MessageDelivery, deliver_later: true) }
 
-      context 'when the proposer and proposee each have their own (unpartnered) marriages' do
-        before do
-          proposer.marriage&.destroy!
-          create(:marriage, partners: [proposer])
-          proposee.marriage&.destroy!
-          create(:marriage, partners: [proposee])
+    before do
+      sign_in(proposer)
+      allow(ProposalMailer).to receive(:proposal_created).and_return(delivery)
+    end
+
+    it 'creates a normalized, recipient-bound proposal and sends it' do
+      expect {
+        post_create
+      }.to change {
+        proposer.sent_proposals.count
+      }.by(1)
+
+      proposal = proposer.sent_proposals.last!
+      expect(proposal.proposee_email).to eq(proposee.email)
+      expect(ProposalMailer).to have_received(:proposal_created).with(proposal.id)
+      expect(flash[:notice]).to eq('Invitation sent.')
+      expect(response).to redirect_to(check_ins_path)
+    end
+
+    context 'when the same proposal is already pending' do
+      let!(:existing_proposal) do
+        create(:proposal, proposer:, proposee_email: proposee.email)
+      end
+
+      it 'resends the existing proposal instead of creating another one' do
+        expect {
+          post_create
+        }.not_to change {
+          proposer.sent_proposals.count
+        }
+
+        expect(ProposalMailer).to have_received(:proposal_created).with(existing_proposal.id)
+        expect(flash[:notice]).to eq('Invitation sent.')
+      end
+    end
+
+    context 'when the email address is invalid' do
+      let(:proposee_email) { 'not-an-email-address' }
+
+      it 'does not persist or send a proposal' do
+        expect {
+          post_create
+        }.not_to change {
+          Proposal.count
+        }
+
+        expect(ProposalMailer).not_to have_received(:proposal_created)
+        expect(flash[:alert]).to eq('Proposee email is invalid')
+      end
+    end
+
+    context 'when the proposer already has a spouse' do
+      before { create(:marriage, partners: [proposer, create(:user)]) }
+
+      it 'does not create or send a proposal' do
+        expect {
+          post_create
+        }.not_to change {
+          Proposal.count
+        }
+
+        expect(ProposalMailer).not_to have_received(:proposal_created)
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action.')
+      end
+    end
+  end
+
+  describe '#confirm' do
+    subject(:get_confirm) do
+      get(:confirm, params: { public_id: proposal.public_id })
+    end
+
+    let!(:proposal) { create(:proposal, proposer:, proposee_email: proposee.email) }
+    let(:existing_marriage_warning) do
+      'Warning: Accepting this proposal will delete your existing marriage and its associated ' \
+        'check-in data.'
+    end
+
+    context 'when the intended proposee is signed in' do
+      before { sign_in(proposee) }
+
+      it 'renders a read-only confirmation page' do
+        expect {
+          get_confirm
+        }.not_to change {
+          proposal.reload.accepted_at
+        }
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to have_text(proposer.email)
+        expect(response.body).to have_button('Accept proposal')
+      end
+
+      context 'when the proposee does not have an existing marriage' do
+        before { expect(proposee.marriage).to be_nil }
+
+        it 'does not show the existing marriage warning' do
+          get_confirm
+
+          expect(response.body).not_to have_text(existing_marriage_warning)
         end
+      end
 
-        let!(:proposer_marriage) { proposer.reload.marriage }
-        let!(:proposee_marriage_id) { proposee.reload.marriage.id }
+      context 'when the proposee has a solo marriage' do
+        before { create(:marriage, partners: [proposee]) }
 
-        context 'when the proposee is signed in' do
-          before { sign_in(proposee) }
+        it 'does not show the existing marriage warning' do
+          get_confirm
 
-          it "destroys the proposee's preexisting marriage" do
-            expect {
-              get_accept
-            }.to change {
-              Marriage.find_by(id: proposee_marriage_id)
-            }.from(Marriage).to(nil)
-          end
-
-          it "adds the proposee to the proposer's marriage" do
-            expect {
-              get_accept
-            }.to change {
-              proposer_marriage.reload.partners.compact.sort
-            }.from([proposer]).to([proposer, proposee].sort)
-          end
+          expect(response.body).not_to have_text(existing_marriage_warning)
         end
+      end
+
+      context 'when accepting would replace an existing partnered marriage' do
+        before { create(:marriage, partners: [proposee, create(:user)]) }
+
+        it 'warns that the existing marriage data will be deleted' do
+          get_confirm
+
+          expect(response.body).to have_text(existing_marriage_warning)
+        end
+      end
+
+      context 'when the proposal has already been accepted' do
+        before { proposal.update!(accepted_at: 1.minute.ago) }
+
+        it 'shows that the proposal was accepted without an acceptance button' do
+          get_confirm
+
+          expect(response.body).to have_text('This proposal has already been accepted.')
+          expect(response.body).not_to have_button('Accept proposal')
+        end
+      end
+    end
+
+    context 'when a different user is signed in' do
+      before { sign_in(create(:user)) }
+
+      it 'does not disclose the proposal' do
+        get_confirm
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action.')
+      end
+    end
+
+    context 'when the proposee is not signed in' do
+      it 'redirects to sign in while preserving the identifier in the return path' do
+        get_confirm
+
+        expect(response).to redirect_to(new_user_session_path)
+        expect(session['user_return_to']).to eq(confirm_proposal_path(proposal))
+      end
+    end
+  end
+
+  describe '#accept' do
+    subject(:post_accept) do
+      post(:accept, params: { public_id: proposal.public_id })
+    end
+
+    let!(:proposal) { create(:proposal, proposer:, proposee_email: proposee.email) }
+    let!(:proposer_marriage) { create(:marriage, partners: [proposer]) }
+
+    context 'when the intended proposee is signed in' do
+      before { sign_in(proposee) }
+
+      it 'accepts the proposal via POST' do
+        expect {
+          post_accept
+        }.to change {
+          proposal.reload.accepted_at
+        }.from(nil)
+
+        expect(proposer_marriage.reload.partners).to contain_exactly(proposer, proposee)
+        expect(flash[:notice]).to eq('Marriage created.')
+        expect(response).to redirect_to(check_ins_path)
+      end
+
+      context "when the proposer's marriage is already full" do
+        before { proposer_marriage.partners << create(:user) }
+
+        it 'reports the validation failure without accepting the proposal' do
+          post_accept
+
+          expect(proposal.reload.accepted_at).to be_nil
+          expect(flash[:alert]).
+            to eq("#{proposer.email}'s marriage already has two partners.")
+          expect(response).to redirect_to(check_ins_path)
+        end
+      end
+    end
+
+    context 'when a different user is signed in' do
+      before { sign_in(create(:user)) }
+
+      it 'does not accept the proposal' do
+        expect {
+          post_accept
+        }.not_to change {
+          proposal.reload.accepted_at
+        }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action.')
       end
     end
   end

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -1,0 +1,24 @@
+# == Schema Information
+#
+# Table name: proposals
+#
+#  accepted_at    :datetime
+#  created_at     :datetime         not null
+#  id             :bigint           not null, primary key
+#  proposee_email :string           not null
+#  proposer_id    :bigint           not null
+#  public_id      :string           not null
+#  updated_at     :datetime         not null
+#
+# Indexes
+#
+#  index_proposals_on_proposer_id  (proposer_id)
+#  index_proposals_on_public_id    (public_id) UNIQUE
+#  uniq_pending_proposals          (proposer_id,proposee_email) UNIQUE WHERE (accepted_at IS NULL)
+#
+FactoryBot.define do
+  factory :proposal do
+    association :proposer, factory: :user
+    proposee_email { Faker::Internet.email }
+  end
+end

--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -12,58 +12,57 @@ RSpec.describe 'Check-Ins app' do
 
       let(:proposee) { User.where.not(id: user).first! }
 
-      context 'when JWT_SECRET is set' do
-        before { expect(ENV.fetch('JWT_SECRET', nil)).to be_present }
+      it 'allows inviting spouse and accepting proposal, populates initial emotional needs, and allows adding an emotional need', :rack_test_driver do
+        visit check_ins_path
 
-        it 'allows inviting spouse and accepting proposal, populates initial emotional needs, and allows adding an emotional need', :rack_test_driver do
-          visit check_ins_path
+        expect(page).to have_text('Enter the email of your spouse')
 
-          expect(page).to have_text('Enter the email of your spouse')
+        fill_in('spouse_email', with: proposee.email)
 
-          fill_in('spouse_email', with: proposee.email)
-
-          with_inline_sidekiq do
-            activate_feature!(:disable_fetch_ip_info_for_request_worker)
-            num_emails_before = ActionMailer::Base.deliveries.size
-            click_on('Submit')
-            wait_for { ActionMailer::Base.deliveries.size }.to eq(num_emails_before + 1)
-          end
-
-          expect(page).to have_flash_message('Invitation sent.')
-
-          # View default emotional needs.
-          click_on('Click here')
-          Marriages::Create::DEFAULT_EMOTIONAL_NEEDS.each do |name, description|
-            expect(page).to have_text(name)
-            expect(page).to have_text(description)
-          end
-
-          # Add an emotional need.
-          new_need_name = "#{Faker::Emotion.unique.noun.capitalize}-#{SecureRandom.alphanumeric(5)}"
-          new_need_description = Faker::Company.unique.bs.capitalize
-          fill_in('Name', with: new_need_name)
-          fill_in('Description', with: new_need_description)
-          click_on('Create Emotional need')
-
-          expect(page).to have_text("#{new_need_name} (#{new_need_description})")
-
-          # log in proposee and accept the proposal
-          Capybara.using_session('proposee') do
-            wait_for do
-              sign_in(proposee)
-              sign_in_confirmed_via_my_account?(proposee)
-            end.to eq(true)
-
-            open_email(proposee.email)
-            # rubocop:disable RungerStyle/ClickAmbiguously
-            current_email.click_link('Click here', href: %r{/proposals/accept\?token=.+})
-            # rubocop:enable RungerStyle/ClickAmbiguously
-            expect(page).to have_text('Marriage created.')
-          end
-
-          expect(user.reload.spouse).to eq(proposee)
-          expect(proposee.reload.spouse).to eq(user)
+        with_inline_sidekiq do
+          activate_feature!(:disable_fetch_ip_info_for_request_worker)
+          num_emails_before = ActionMailer::Base.deliveries.size
+          click_on('Submit')
+          wait_for { ActionMailer::Base.deliveries.size }.to eq(num_emails_before + 1)
         end
+
+        expect(page).to have_flash_message('Invitation sent.')
+
+        # View default emotional needs.
+        click_on('Click here')
+        Marriages::Create::DEFAULT_EMOTIONAL_NEEDS.each do |name, description|
+          expect(page).to have_text(name)
+          expect(page).to have_text(description)
+        end
+
+        # Add an emotional need.
+        new_need_name = "#{Faker::Emotion.unique.noun.capitalize}-#{SecureRandom.alphanumeric(5)}"
+        new_need_description = Faker::Company.unique.bs.capitalize
+        fill_in('Name', with: new_need_name)
+        fill_in('Description', with: new_need_description)
+        click_on('Create Emotional need')
+
+        expect(page).to have_text("#{new_need_name} (#{new_need_description})")
+
+        # log in proposee and accept the proposal
+        Capybara.using_session('proposee') do
+          wait_for do
+            sign_in(proposee)
+            sign_in_confirmed_via_my_account?(proposee)
+          end.to eq(true)
+
+          open_email(proposee.email)
+          # rubocop:disable RungerStyle/ClickAmbiguously
+          current_email.click_link('Click here', href: %r{/proposals/.+/confirm})
+          # rubocop:enable RungerStyle/ClickAmbiguously
+          expect(page).to have_text("#{user.email} wants you to join their marriage")
+          expect(page).to have_button('Accept proposal')
+          click_on('Accept proposal')
+          expect(page).to have_text('Marriage created.')
+        end
+
+        expect(user.reload.spouse).to eq(proposee)
+        expect(proposee.reload.spouse).to eq(user)
       end
     end
 

--- a/spec/mailers/proposal_mailer_spec.rb
+++ b/spec/mailers/proposal_mailer_spec.rb
@@ -1,0 +1,18 @@
+RSpec.describe ProposalMailer do
+  describe '#proposal_created' do
+    subject(:mail) { described_class.proposal_created(proposal.id) }
+
+    let(:proposal) { create(:proposal) }
+
+    it 'sends the proposal to its intended recipient' do
+      expect(mail.to).to eq([proposal.proposee_email])
+      expect(mail.subject).
+        to eq("#{proposal.proposer.email} wants you to join their marriage on davidrunger.com")
+    end
+
+    it 'links to the recipient-bound confirmation page without a query string' do
+      expect(mail.body.to_s).to include(confirm_proposal_url(proposal))
+      expect(mail.body.to_s).not_to include('token=')
+    end
+  end
+end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe Proposal do
+  describe 'creation' do
+    subject(:proposal) do
+      create(
+        :proposal,
+        proposee_email: '  Proposed.Spouse@Example.COM  ',
+      )
+    end
+
+    it 'normalizes the proposee email and generates a public identifier' do
+      expect(proposal.proposee_email).to eq('proposed.spouse@example.com')
+      expect(proposal.public_id).to be_present
+      expect(proposal.to_param).to eq(proposal.public_id)
+    end
+  end
+
+  describe '.pending' do
+    let!(:pending_proposal) { create(:proposal) }
+
+    before { create(:proposal, accepted_at: 1.minute.ago) }
+
+    it 'returns only proposals that have not been accepted' do
+      expect(described_class.pending).to contain_exactly(pending_proposal)
+    end
+  end
+
+  describe 'proposee email format' do
+    it 'rejects an invalid email address' do
+      proposal = build(:proposal, proposee_email: 'not-an-email-address')
+
+      expect(proposal).not_to be_valid
+      expect(proposal.errors.full_messages_for(:proposee_email)).
+        to eq(['Proposee email is invalid'])
+    end
+
+    it 'leaves blank email addresses to presence validation' do
+      proposal = build(:proposal, proposee_email: '')
+
+      expect(proposal).not_to be_valid
+      expect(proposal.errors.full_messages_for(:proposee_email)).
+        to eq(["Proposee email can't be blank"])
+    end
+  end
+
+  describe 'proposee email uniqueness' do
+    let(:pending_proposal) { create(:proposal) }
+
+    it 'does not allow duplicate pending proposals from the same proposer' do
+      duplicate_proposal =
+        build(
+          :proposal,
+          proposer: pending_proposal.proposer,
+          proposee_email: pending_proposal.proposee_email,
+        )
+
+      expect(duplicate_proposal).not_to be_valid
+      expect(duplicate_proposal.errors[:proposee_email]).to include('has already been taken')
+    end
+
+    it 'allows another proposal after the earlier proposal has been accepted' do
+      pending_proposal.update!(accepted_at: 1.minute.ago)
+
+      expect(
+        build(
+          :proposal,
+          proposer: pending_proposal.proposer,
+          proposee_email: pending_proposal.proposee_email,
+        ),
+      ).to be_valid
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,6 +5,22 @@ RSpec.describe User do
   it { is_expected.to have_many(:logs) }
   it { is_expected.to have_many(:log_shares) }
 
+  describe 'email format' do
+    it 'rejects an invalid email address' do
+      user.email = 'not-an-email-address'
+
+      expect(user).not_to be_valid
+      expect(user.errors.full_messages_for(:email)).to eq(['Email is invalid'])
+    end
+
+    it 'leaves blank email addresses to presence validation' do
+      user.email = ''
+
+      expect(user).not_to be_valid
+      expect(user.errors.full_messages_for(:email)).to eq(["Email can't be blank"])
+    end
+  end
+
   describe '#emoji_boosts' do
     subject(:emoji_boosts) { user.emoji_boosts }
 

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe ProposalPolicy do
+  subject(:policy) { described_class.new(user, proposal) }
+
+  let(:proposal) { create(:proposal, proposee_email: intended_user.email) }
+  let(:intended_user) { create(:user) }
+
+  describe '#create?' do
+    subject(:create?) { described_class.new(user, Proposal).create? }
+
+    let(:user) { create(:user) }
+
+    context 'when the user does not have a marriage' do
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the user has a solo marriage' do
+      before { create(:marriage, partners: [user]) }
+
+      it { is_expected.to eq(true) }
+    end
+
+    context 'when the user has a spouse' do
+      before { create(:marriage, partners: [user, create(:user)]) }
+
+      it { is_expected.to eq(false) }
+    end
+  end
+
+  context 'when the user is the intended recipient' do
+    let(:user) { intended_user }
+
+    it 'allows viewing the confirmation and accepting the proposal' do
+      expect(policy.confirm?).to eq(true)
+      expect(policy.accept?).to eq(true)
+    end
+  end
+
+  context 'when the user is not the intended recipient' do
+    let(:user) { create(:user) }
+
+    it 'forbids viewing the confirmation or accepting the proposal' do
+      expect(policy.confirm?).to eq(false)
+      expect(policy.accept?).to eq(false)
+    end
+  end
+end

--- a/spec/routing/proposals_routing_spec.rb
+++ b/spec/routing/proposals_routing_spec.rb
@@ -1,0 +1,15 @@
+RSpec.describe 'proposal routes' do
+  it 'routes confirmation viewing through GET' do
+    expect(get: '/proposals/public-id/confirm').
+      to route_to(controller: 'proposals', action: 'confirm', public_id: 'public-id')
+  end
+
+  it 'routes acceptance through POST' do
+    expect(post: '/proposals/public-id/accept').
+      to route_to(controller: 'proposals', action: 'accept', public_id: 'public-id')
+  end
+
+  it 'does not route acceptance through GET' do
+    expect(get: '/proposals/public-id/accept').not_to be_routable
+  end
+end

--- a/spec/validators/email_format_validator_spec.rb
+++ b/spec/validators/email_format_validator_spec.rb
@@ -1,0 +1,37 @@
+RSpec.describe EmailFormatValidator do
+  subject(:validate) do
+    described_class.new(attributes: [:email]).validate_each(user, :email, value)
+  end
+
+  let(:user) { User.new }
+
+  context 'when the value is blank' do
+    let(:value) { '' }
+
+    it 'leaves blank-value errors to presence validation' do
+      validate
+
+      expect(user.errors.full_messages).to eq([])
+    end
+  end
+
+  context 'when the value has an invalid format' do
+    let(:value) { 'not-an-email-address' }
+
+    it 'adds a full error message' do
+      validate
+
+      expect(user.errors.full_messages).to eq(['Email is invalid'])
+    end
+  end
+
+  context 'when the value has a valid format' do
+    let(:value) { 'spouse@example.com' }
+
+    it 'does not add an error' do
+      validate
+
+      expect(user.errors.full_messages).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
Persist proposals with a normalized recipient email, shared model-level email-format validation, random public locator, acceptance timestamp, and a partial unique index that reuses duplicate pending invitations. The public locator identifies a record but is not authorization, so proposal URLs no longer contain a bearer JWT or query string secret.

Replace the state-changing GET endpoint with a recipient-authorized confirmation page and a CSRF-protected POST. Require the signed-in account email to match the intended recipient, allow proposal creation only for users without a spouse, and warn before a different partnered marriage and its check-in data would be deleted without alarming users whose Check-ins visit only created a solo marriage container.

Accept proposals inside a transaction that locks the proposal, users, marriages, and memberships. Recheck recipient binding and single-use state under lock, reject self-proposals and full target marriages before destructive work, then mark the proposal accepted only after relationship changes succeed so failures roll back completely.

Update the mailer and end-to-end flow and add model, policy, routing, mailer, controller, action, rollback, replay, and feature coverage. Proposals intentionally do not expire, request logging is unchanged, and legacy JWT proposal links are intentionally unsupported.