### PR TITLE
Authorize emailed log entries with capability tokens

### DIFF
--- a/app/mailboxes/application_mailbox.rb
+++ b/app/mailboxes/application_mailbox.rb
@@ -1,5 +1,6 @@
 class ApplicationMailbox < ActionMailbox::Base
-  LOG_ENTRIES_ROUTING_REGEX = %r{log-entries\|log/(?<log_id>\d+)@mg\.davidrunger\.com}i
+  LOG_ENTRIES_ROUTING_REGEX =
+    %r{\Alog-entries\|log/(?<email_submission_token>[A-Za-z0-9]{#{Log::EMAIL_SUBMISSION_TOKEN_LENGTH}})@mg\.davidrunger\.com\z}i
 
   routing(LOG_ENTRIES_ROUTING_REGEX => :log_entries, /\Areply@/ => :replies)
 end

--- a/app/mailboxes/log_entries_mailbox.rb
+++ b/app/mailboxes/log_entries_mailbox.rb
@@ -2,10 +2,12 @@ class LogEntriesMailbox < ApplicationMailbox
   using Refinements::ParsedMailBody
 
   def process
-    log_id = mail.to.first.presence!.match(ApplicationMailbox::LOG_ENTRIES_ROUTING_REGEX)[:log_id]
-    user_email = mail.from.first.presence!
-    user = User.find_by!(email: user_email)
-    log = user.logs.find(log_id)
+    email_submission_token =
+      mail.to.first.presence!.match(ApplicationMailbox::LOG_ENTRIES_ROUTING_REGEX)[:email_submission_token]
+    user = User.find_by(email: mail.from&.first)
+    log = user&.logs&.find_by(email_submission_token:)
+
+    return if log.nil?
 
     LogEntries::Save.new(log_entry: log.build_log_entry_with_datum(data: mail.parsed_body)).run
   end

--- a/app/mailers/log_reminder_mailer.rb
+++ b/app/mailers/log_reminder_mailer.rb
@@ -8,7 +8,7 @@ class LogReminderMailer < ApplicationMailer
       from: email_address_with_name('log-reminders@davidrunger.com', 'DavidRunger.com'),
       # ApplicationMailbox::LOG_ENTRIES_ROUTING_REGEX depends on the format of this `reply_to`
       reply_to: email_address_with_name(
-        "log-entries|log/#{@log.id}@mg.davidrunger.com",
+        "log-entries|log/#{@log.email_submission_token}@mg.davidrunger.com",
         "#{log_name} Log Entries",
       ),
     )

--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -6,6 +6,7 @@
 #  data_label               :string           not null
 #  data_type                :string           not null
 #  description              :string
+#  email_submission_token   :string           not null
 #  id                       :bigint           not null, primary key
 #  name                     :string           not null
 #  publicly_viewable        :boolean          default(FALSE), not null
@@ -17,10 +18,13 @@
 #
 # Indexes
 #
-#  index_logs_on_user_id_and_name  (user_id,name) UNIQUE
-#  index_logs_on_user_id_and_slug  (user_id,slug) UNIQUE
+#  index_logs_on_email_submission_token  (email_submission_token) UNIQUE
+#  index_logs_on_user_id_and_name        (user_id,name) UNIQUE
+#  index_logs_on_user_id_and_slug        (user_id,slug) UNIQUE
 #
 class Log < ApplicationRecord
+  EMAIL_SUBMISSION_TOKEN_LENGTH = 24
+
   DATA_TYPES = {
     'counter' => {
       datum_class: NumberLogEntryDatum,
@@ -38,8 +42,11 @@ class Log < ApplicationRecord
 
   validates :data_label, presence: true
   validates :data_type, presence: true, inclusion: DATA_TYPES.keys
+  validates :email_submission_token, presence: true, uniqueness: true
   validates :name, presence: true, uniqueness: { scope: :user_id }
   validates :slug, presence: true, uniqueness: { scope: :user_id }
+
+  has_secure_token :email_submission_token, length: EMAIL_SUBMISSION_TOKEN_LENGTH
 
   belongs_to :user
 

--- a/app/serializers/log_serializer.rb
+++ b/app/serializers/log_serializer.rb
@@ -6,6 +6,7 @@
 #  data_label               :string           not null
 #  data_type                :string           not null
 #  description              :string
+#  email_submission_token   :string           not null
 #  id                       :bigint           not null, primary key
 #  name                     :string           not null
 #  publicly_viewable        :boolean          default(FALSE), not null
@@ -17,8 +18,9 @@
 #
 # Indexes
 #
-#  index_logs_on_user_id_and_name  (user_id,name) UNIQUE
-#  index_logs_on_user_id_and_slug  (user_id,slug) UNIQUE
+#  index_logs_on_email_submission_token  (email_submission_token) UNIQUE
+#  index_logs_on_user_id_and_name        (user_id,name) UNIQUE
+#  index_logs_on_user_id_and_slug        (user_id,slug) UNIQUE
 #
 class LogSerializer < ApplicationSerializer
   attributes(*%i[

--- a/db/migrate/20260806120000_add_email_submission_token_to_logs.rb
+++ b/db/migrate/20260806120000_add_email_submission_token_to_logs.rb
@@ -1,0 +1,24 @@
+class AddEmailSubmissionTokenToLogs < ActiveRecord::Migration[8.1]
+  EMAIL_SUBMISSION_TOKEN_LENGTH = 24
+
+  class MigrationLog < ActiveRecord::Base
+    self.table_name = 'logs'
+    self.record_timestamps = false
+  end
+
+  def up
+    add_column :logs, :email_submission_token, :string
+    add_index :logs, :email_submission_token, unique: true
+
+    MigrationLog.reset_column_information
+    MigrationLog.find_each do |log|
+      log.update!(email_submission_token: SecureRandom.base58(EMAIL_SUBMISSION_TOKEN_LENGTH))
+    end
+
+    change_column_null :logs, :email_submission_token, false
+  end
+
+  def down
+    remove_column :logs, :email_submission_token
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_06_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -301,6 +301,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
     t.string "data_label", null: false
     t.string "data_type", null: false
     t.string "description"
+    t.string "email_submission_token", null: false
     t.string "name", null: false
     t.boolean "publicly_viewable", default: false, null: false
     t.datetime "reminder_last_sent_at", precision: nil
@@ -308,6 +309,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_120000) do
     t.string "slug", null: false
     t.datetime "updated_at", precision: nil, null: false
     t.bigint "user_id", null: false
+    t.index ["email_submission_token"], name: "index_logs_on_email_submission_token", unique: true
     t.index ["user_id", "name"], name: "index_logs_on_user_id_and_name", unique: true
     t.index ["user_id", "slug"], name: "index_logs_on_user_id_and_slug", unique: true
   end

--- a/spec/factories/logs.rb
+++ b/spec/factories/logs.rb
@@ -6,6 +6,7 @@
 #  data_label               :string           not null
 #  data_type                :string           not null
 #  description              :string
+#  email_submission_token   :string           not null
 #  id                       :bigint           not null, primary key
 #  name                     :string           not null
 #  publicly_viewable        :boolean          default(FALSE), not null
@@ -17,8 +18,9 @@
 #
 # Indexes
 #
-#  index_logs_on_user_id_and_name  (user_id,name) UNIQUE
-#  index_logs_on_user_id_and_slug  (user_id,slug) UNIQUE
+#  index_logs_on_email_submission_token  (email_submission_token) UNIQUE
+#  index_logs_on_user_id_and_name        (user_id,name) UNIQUE
+#  index_logs_on_user_id_and_slug        (user_id,slug) UNIQUE
 #
 FactoryBot.define do
   factory :log do

--- a/spec/mailboxes/log_entries_mailbox_spec.rb
+++ b/spec/mailboxes/log_entries_mailbox_spec.rb
@@ -1,11 +1,17 @@
 RSpec.describe LogEntriesMailbox do
-  let(:to_email) { "log-entries|log/#{log.id}@mg.davidrunger.com" }
+  let(:to_email) { "log-entries|log/#{log.email_submission_token}@mg.davidrunger.com" }
   let(:user) { users(:user) }
   let(:log) { user.logs.number.first! }
 
   describe 'routing' do
     it 'routes email to the mailbox' do
       expect(LogEntriesMailbox).to receive_email(to: to_email)
+    end
+
+    it 'does not route email addressed with an enumerable log ID' do
+      expect(LogEntriesMailbox).not_to receive_email(
+        to: "log-entries|log/#{log.id}@mg.davidrunger.com",
+      )
     end
   end
 
@@ -15,12 +21,13 @@ RSpec.describe LogEntriesMailbox do
     let(:mail) do
       Mail.new(
         to: to_email,
-        from: user.email,
+        from: from_email,
         subject: %(Re: Submit a log entry for your "#{log.name}" log),
         body:,
       )
     end
     let(:body) { '148.8' }
+    let(:from_email) { user.email }
 
     it 'marks email as delivered' do
       expect(processed_mail).to have_been_delivered
@@ -33,10 +40,36 @@ RSpec.describe LogEntriesMailbox do
       expect(last_log_entry.data).to eq(Float(body))
     end
 
+    it 'authorizes the log by the recipient token and From address' do
+      expect { processed_mail }.to change { log.log_entries.count }.by(1)
+    end
+
     it 'broadcasts the creation of the new log entry', :action_cable_test_adapter do
       expect { processed_mail }.
         to broadcast_to(LogEntriesChannel.broadcasting_for(log)).
         with(hash_including(model: hash_including(data: Float(body))))
+    end
+
+    context 'when the From address does not belong to the log owner' do
+      let(:from_email) { User.excluding(user).first!.email }
+
+      it 'delivers the email without creating a log entry' do
+        expect { processed_mail }.not_to(change { LogEntry.count })
+        expect(processed_mail).to have_been_delivered
+      end
+    end
+
+    context 'when the email submission token is not recognized' do
+      let(:to_email) do
+        unknown_token = '0' * Log::EMAIL_SUBMISSION_TOKEN_LENGTH
+
+        "log-entries|log/#{unknown_token}@mg.davidrunger.com"
+      end
+
+      it 'delivers the email without creating a log entry' do
+        expect { processed_mail }.not_to(change { LogEntry.count })
+        expect(processed_mail).to have_been_delivered
+      end
     end
   end
 end

--- a/spec/mailers/log_reminder_mailer_spec.rb
+++ b/spec/mailers/log_reminder_mailer_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe LogReminderMailer do
     end
 
     it 'has a reply-to that will create a new log entry' do
-      expect(mail.reply_to).to eq(["log-entries|log/#{log.id}@mg.davidrunger.com"])
+      expect(mail.reply_to).
+        to eq(["log-entries|log/#{log.email_submission_token}@mg.davidrunger.com"])
     end
 
     describe 'the email body' do

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -3,6 +3,16 @@ RSpec.describe Log do
 
   it { is_expected.to have_many(:log_shares) }
 
+  describe 'creation' do
+    it 'generates a unique email submission token' do
+      logs = create_list(:log, 2)
+
+      expect(logs.map(&:email_submission_token)).
+        to all(have_attributes(length: described_class::EMAIL_SUBMISSION_TOKEN_LENGTH))
+      expect(logs.map(&:email_submission_token).uniq.size).to eq(2)
+    end
+  end
+
   describe '::needing_reminder' do
     subject(:needing_reminder) { Log.needing_reminder }
 

--- a/spec/serializers/log_serializer_spec.rb
+++ b/spec/serializers/log_serializer_spec.rb
@@ -6,6 +6,7 @@
 #  data_label               :string           not null
 #  data_type                :string           not null
 #  description              :string
+#  email_submission_token   :string           not null
 #  id                       :bigint           not null, primary key
 #  name                     :string           not null
 #  publicly_viewable        :boolean          default(FALSE), not null
@@ -17,8 +18,9 @@
 #
 # Indexes
 #
-#  index_logs_on_user_id_and_name  (user_id,name) UNIQUE
-#  index_logs_on_user_id_and_slug  (user_id,slug) UNIQUE
+#  index_logs_on_email_submission_token  (email_submission_token) UNIQUE
+#  index_logs_on_user_id_and_name        (user_id,name) UNIQUE
+#  index_logs_on_user_id_and_slug        (user_id,slug) UNIQUE
 #
 RSpec.describe(LogSerializer) do
   subject(:log_serializer) do
@@ -31,11 +33,18 @@ RSpec.describe(LogSerializer) do
     context 'when only one log is serialized' do
       subject(:log_as_json) { log_serializer.as_json.first }
 
+      let(:current_user) { nil }
       let(:log) { Log.first! }
       let(:logs) { Log.where(id: log) }
 
       describe 'private fields' do
-        let(:private_fields) do
+        it 'does not expose the email submission token' do
+          expect(log_as_json).not_to have_key('email_submission_token')
+        end
+      end
+
+      describe 'semi-private fields' do
+        let(:semi_private_fields) do
           %w[
             publicly_viewable
             reminder_time_in_seconds
@@ -46,8 +55,8 @@ RSpec.describe(LogSerializer) do
         context 'when the log belongs to the current user' do
           let(:current_user) { log.user }
 
-          it 'includes private fields' do
-            private_fields.each do |field|
+          it 'includes semi-private fields' do
+            semi_private_fields.each do |field|
               expect(log_as_json).to have_key(field)
             end
           end
@@ -56,8 +65,8 @@ RSpec.describe(LogSerializer) do
         context 'when the log does not belong to the current user' do
           let(:current_user) { User.where.not(id: log.user).first! }
 
-          it 'does not include private fields' do
-            private_fields.each do |field|
+          it 'does not include semi-private fields' do
+            semi_private_fields.each do |field|
               expect(log_as_json).not_to have_key(field.to_s)
             end
           end


### PR DESCRIPTION
SMTP From headers are spoofable, so using mail.from by itself does not authenticate an inbound log submission. Generate a unique 24-character secure token for each log, backfill existing logs, and enforce database uniqueness and presence.

Put the per-log capability in reminder Reply-To addresses and require it to identify a log owned by the user in the From header. The capability prevents sender spoofing alone from granting access, while retaining the sender check prevents forwarded recipients and casual misuse from creating entries.

Reject the old enumerable numeric address format, safely ignore unknown or mismatched credentials, keep the capability out of serialized log data, and cover token generation, reminder addressing, sender ownership, legacy routing, and invalid-token behavior.