### PR TITLE
Disallow grocery item store reassignment

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -37,7 +37,7 @@ class Api::ItemsController < Api::BaseController
   private
 
   def item_params
-    params.expect(item: %i[name needed store_id])
+    params.expect(item: %i[name needed])
   end
 
   def set_item

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -87,6 +87,19 @@ RSpec.describe Api::ItemsController do
       end
     end
 
+    context "when attempting to reassign the item to another user's store" do
+      let(:destination_store) { Store.joins(:user).merge(User.excluding(user)).first! }
+      let(:params) do
+        base_params.merge(
+          item: { name: "#{item.name} Changed", store_id: destination_store.id },
+        )
+      end
+
+      it 'does not reassign the item' do
+        expect { patch_update }.not_to change { item.reload.store_id }
+      end
+    end
+
     context 'when the item is being updated with valid params' do
       let(:valid_params) { { item: { name: "#{item.name} Changed" } } }
       let(:params) { base_params.merge(valid_params) }

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -14,13 +14,14 @@ FixtureBuilder.configure do |fbuilder|
     # users
     user = name(:user, create(:user)).first
     married_user = name(:married_user, create(:user)).first
-    name(:single_user, create(:user))
+    single_user = name(:single_user, create(:user)).first
 
     # AdminUsers
     admin_user = name(:admin_user, create(:admin_user, email: 'davidjrunger@gmail.com')).first
 
     # groceries
     other_store = create(:store, user:, name: 'Another Store')
+    create(:store, user: single_user, name: 'Hardware Store')
     store = name(
       :store,
       create(


### PR DESCRIPTION
Item updates permitted store_id to support moving grocery items between stores with drag and drop.

The drag-and-drop UI was removed during the Vue 3 upgrade in 6e91087b because its supporting library did not appear compatible, but the backend permission remained. Since item authorization is based on the current store, that leftover permission lets an authenticated user move an authorized item into another user's store by supplying its ID.

Limit ordinary item updates to name and needed, and cover attempts to reassign an item to another user's store.

(Also, add a new fixture store not belonging to the `user` fixture (nor his spouse) so that such a store exists in the test database (maybe incidentally surfacing bugs) and so that the spec being added covering this change doesn't have to create a store on the fly.)