### PR TITLE
[bulk ingestion] Bound records accepted per request

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@
 - Use non-ASCII characters only when there is a specific reason, such as rendering that character to a user.
 - Keep code generally hard-wrapped in accordance with repository formatters, linters, and surrounding style.
 - Do not hard-wrap prose or template text solely to enforce a fixed line width. Let editors and viewers visually wrap long lines. In particular, keep long text paragraphs in `.vue` and Haml templates on a single source line unless line breaks are semantically or structurally useful. This avoids reflow-only diffs when the text changes.
+- When a Ruby method's computed result is reused, prefer the repository's `Memoization` pattern over assigning a same-named local variable from `self`, such as `value = self.value`, solely to avoid recomputation. Add `prepend Memoization` to the class and decorate the method with `memoize \`.
 
 ## Git workflow
 

--- a/app/actions/log_entries/enqueue_from_csv.rb
+++ b/app/actions/log_entries/enqueue_from_csv.rb
@@ -1,0 +1,74 @@
+class LogEntries::EnqueueFromCsv < ApplicationAction
+  prepend Memoization
+
+  JOB_ENQUEUE_BATCH_SIZE = 1_000
+  MAX_LOG_ENTRIES = 10_000
+
+  requires :csv_path, String
+  requires :log, Log
+
+  fails_with :invalid_upload
+
+  def execute
+    if csv_rows.size > MAX_LOG_ENTRIES
+      result.invalid_upload!("Uploads may contain no more than #{MAX_LOG_ENTRIES} log entries.")
+    else
+      job_arguments = job_arguments_for(csv_rows)
+
+      if job_arguments
+        CreateLogEntry.perform_bulk(job_arguments, batch_size: JOB_ENQUEUE_BATCH_SIZE)
+      else
+        result.invalid_upload!(
+          'The uploaded data is invalid. We have not entered it in the database.',
+        )
+      end
+    end
+  end
+
+  private
+
+  memoize \
+  def csv_rows
+    File.open(csv_path) do |csv_file|
+      CSV.new(csv_file, headers: true).take(MAX_LOG_ENTRIES + 1)
+    end
+  end
+
+  def job_arguments_for(csv_rows)
+    all_log_entries_valid = true
+    job_arguments = []
+
+    csv_rows.each do |row|
+      log_entry = build_log_entry(row)
+      if !log_entry.valid?
+        all_log_entries_valid = false
+        break
+      end
+
+      job_arguments << [serialized_attributes(log_entry)]
+    ensure
+      # `build_log_entry_with_datum` adds each unsaved entry to the association target. Clear it so
+      # that validating an upload does not retain thousands of Active Record objects in memory.
+      log.log_entries.reset
+    end
+
+    job_arguments if all_log_entries_valid
+  end
+
+  def build_log_entry(row)
+    attributes = row.to_h
+    created_at_string = attributes['created_at']
+    created_at = (Time.iso8601(created_at_string) rescue Date.iso8601(created_at_string))
+    attributes['created_at'] = created_at
+    attributes['updated_at'] = created_at
+    log.build_log_entry_with_datum(attributes)
+  end
+
+  def serialized_attributes(log_entry)
+    log_entry.
+      attributes.
+      merge(log_entry.log_entry_datum.attributes.slice('data')).
+      compact.
+      to_json
+  end
+end

--- a/app/actions/quiz_questions/create_from_list.rb
+++ b/app/actions/quiz_questions/create_from_list.rb
@@ -1,7 +1,11 @@
 class QuizQuestions::CreateFromList < ApplicationAction
+  prepend Memoization
+
   class InvalidAnswers < StandardError ; end
 
   CORRECT_ANSWER_PREFIX = /\A\s*-\s*/
+  MAX_QUESTIONS = 500
+  MAX_ANSWERS = MAX_QUESTIONS * 10
 
   requires :quiz, Quiz
   requires :questions_list, String
@@ -9,6 +13,8 @@ class QuizQuestions::CreateFromList < ApplicationAction
   fails_with :invalid_answers
 
   def execute
+    validate_upload_size!(question_and_answer_text_chunks)
+
     Quiz.transaction do
       question_and_answer_text_chunks.each do |question_and_answer_text_chunk|
         create_models_from_text!(question_and_answer_text_chunk)
@@ -22,8 +28,20 @@ class QuizQuestions::CreateFromList < ApplicationAction
 
   private
 
+  memoize \
   def question_and_answer_text_chunks
-    questions_list.delete("\r").strip.split(/\n{2,}/)
+    questions_list.delete("\r").strip.split(/\n{2,}/, MAX_QUESTIONS + 1)
+  end
+
+  def validate_upload_size!(question_and_answer_text_chunks)
+    if question_and_answer_text_chunks.size > MAX_QUESTIONS
+      raise(InvalidAnswers, "Uploads may contain no more than #{MAX_QUESTIONS} questions.")
+    end
+
+    answer_count = question_and_answer_text_chunks.sum { |chunk| chunk.count("\n") }
+    if answer_count > MAX_ANSWERS
+      raise(InvalidAnswers, "Uploads may contain no more than #{MAX_ANSWERS} answers.")
+    end
   end
 
   def create_models_from_text!(question_and_answer_text_chunk)

--- a/app/controllers/logs/uploads_controller.rb
+++ b/app/controllers/logs/uploads_controller.rb
@@ -7,36 +7,16 @@ class Logs::UploadsController < ApplicationController
   def create
     authorize(LogEntry)
     log = current_user.logs.find(params.expect('log_id'))
-    log_entries =
-      CSV.parse(params.expect('csv').read, headers: true).map do |row|
-        attributes = row.to_h
-        created_at_string = attributes['created_at']
-        created_at = (Time.iso8601(created_at_string) rescue Date.iso8601(created_at_string))
-        attributes['created_at'] = created_at
-        attributes['updated_at'] = created_at
-        log.build_log_entry_with_datum(attributes)
-      end
+    result = LogEntries::EnqueueFromCsv.new!(
+      csv_path: params.expect('csv').tempfile.path,
+      log:,
+    ).run
 
-    if log_entries.all?(&:valid?)
-      log_entries.each do |log_entry|
-        CreateLogEntry.
-          perform_async(
-            log_entry.
-              attributes.
-              merge(
-                log_entry.
-                  log_entry_datum.
-                  attributes.
-                  slice('data'),
-              ).
-              compact.
-              to_json,
-          )
-      end
+    if result.success?
       flash[:notice] = 'Data uploaded successfully! Give it a moment to enter the database.'
       redirect_to(log_path(slug: log.slug))
     else
-      flash[:alert] = 'The uploaded data is invalid. We have not entered it in the database.'
+      flash[:alert] = result.error_message
       redirect_to(logs_uploads_path)
     end
   end

--- a/app/poros/ci_step_results/bulk_create.rb
+++ b/app/poros/ci_step_results/bulk_create.rb
@@ -1,4 +1,6 @@
 class CiStepResults::BulkCreate
+  MAX_CI_STEP_RESULTS = 200
+
   def initialize(user:, ci_step_results_data:)
     @user = user
     @ci_step_results_data = ci_step_results_data
@@ -6,6 +8,21 @@ class CiStepResults::BulkCreate
   end
 
   def perform
+    if @ci_step_results_data.size > MAX_CI_STEP_RESULTS
+      return [
+        :error,
+        [
+          {
+            success: false,
+            errors: {
+              base: ["Requests may contain no more than #{MAX_CI_STEP_RESULTS} CI step results."],
+            },
+            data: {},
+          },
+        ],
+      ]
+    end
+
     at_least_one_invalid_record = false
 
     ApplicationRecord.transaction do

--- a/spec/actions/log_entries/enqueue_from_csv_spec.rb
+++ b/spec/actions/log_entries/enqueue_from_csv_spec.rb
@@ -1,0 +1,91 @@
+RSpec.describe LogEntries::EnqueueFromCsv do
+  subject(:run) { described_class.new!(csv_path: tempfile.path, log:).run }
+
+  after { tempfile.close }
+
+  let(:log) { users(:user).logs.number.first! }
+  let(:csv_rows) { [] }
+  let(:tempfile) do
+    Tempfile.new('log_data.csv').tap do |file|
+      file.write(<<~CSV)
+        created_at,data,note
+        #{csv_rows.join("\n")}
+      CSV
+      file.flush
+    end
+  end
+
+  specify 'an upload can contain at most 10,000 log entries' do
+    expect(described_class::MAX_LOG_ENTRIES).to eq(10_000)
+  end
+
+  context 'when the data is valid' do
+    let(:csv_rows) do
+      [
+        "#{3.days.ago.iso8601},201,",
+        "#{18.hours.ago.iso8601},200,good!",
+        "#{1.hour.ago.iso8601},199,not bad",
+      ]
+    end
+
+    it 'bulk-enqueues one job per row' do
+      expect(CreateLogEntry).
+        to receive(:perform_bulk).
+        with(
+          satisfy do |arguments|
+            arguments.size == csv_rows.size && arguments.all?(&:one?)
+          end,
+          batch_size: 1_000,
+        ).
+        and_call_original
+
+      expect { run }.to change { CreateLogEntry.jobs.size }.by(csv_rows.size)
+    end
+
+    it 'creates every log entry when the jobs run' do
+      expect do
+        with_inline_sidekiq { run }
+      end.to change { log.reload.log_entries.size }.by(csv_rows.size)
+    end
+  end
+
+  context 'when the data is invalid' do
+    let(:csv_rows) do
+      [
+        "#{3.days.ago.iso8601},201,",
+        "#{18.hours.ago.iso8601},,missing data",
+        "#{1.hour.ago.iso8601},199,not bad",
+      ]
+    end
+
+    it 'fails without enqueueing any jobs' do
+      result = nil
+
+      expect { result = run }.not_to change { CreateLogEntry.jobs.size }
+
+      expect(result.error_message).
+        to eq('The uploaded data is invalid. We have not entered it in the database.')
+    end
+  end
+
+  context 'when the upload contains too many log entries' do
+    before { stub_const("#{described_class}::MAX_LOG_ENTRIES", 2) }
+
+    let(:csv_rows) do
+      [
+        "#{3.days.ago.iso8601},201,",
+        "#{18.hours.ago.iso8601},200,good!",
+        "#{1.hour.ago.iso8601},199,not bad",
+      ]
+    end
+
+    it 'fails before constructing log entries or enqueueing jobs' do
+      expect(log).not_to receive(:build_log_entry_with_datum)
+      result = nil
+
+      expect { result = run }.not_to change { CreateLogEntry.jobs.size }
+
+      expect(result.error_message).to eq('Uploads may contain no more than 2 log entries.')
+    end
+  end
+end

--- a/spec/actions/quiz_questions/create_from_list_spec.rb
+++ b/spec/actions/quiz_questions/create_from_list_spec.rb
@@ -166,5 +166,47 @@ RSpec.describe QuizQuestions::CreateFromList do
         }
       end
     end
+
+    context 'when the upload contains too many questions' do
+      before { stub_const("#{described_class}::MAX_QUESTIONS", 2) }
+
+      let(:questions_list) do
+        <<~QUESTIONS_LIST
+          Question one?
+          - Yes
+          No
+
+          Question two?
+          - Yes
+          No
+
+          Question three?
+          - Yes
+          No
+        QUESTIONS_LIST
+      end
+
+      it 'fails without creating any questions' do
+        expect(Quiz).not_to receive(:transaction)
+        result = nil
+
+        expect { result = run }.not_to change { quiz.questions.count }
+
+        expect(result.error_message).to eq('Uploads may contain no more than 2 questions.')
+      end
+    end
+
+    context 'when the upload contains too many answers' do
+      before { stub_const("#{described_class}::MAX_ANSWERS", 5) }
+
+      it 'fails without creating any questions' do
+        expect(Quiz).not_to receive(:transaction)
+        result = nil
+
+        expect { result = run }.not_to change { quiz.questions.count }
+
+        expect(result.error_message).to eq('Uploads may contain no more than 5 answers.')
+      end
+    end
   end
 end

--- a/spec/controllers/api/ci_step_results/bulk_creations_controller_spec.rb
+++ b/spec/controllers/api/ci_step_results/bulk_creations_controller_spec.rb
@@ -22,6 +22,14 @@ RSpec.describe(Api::CiStepResults::BulkCreationsController) do
         stopped_at: 20.seconds.ago,
       })
     end
+    let(:valid_ci_step_result_3) do
+      common_ci_step_result_data.merge({
+        name: 'RunLinters',
+        seconds: 5.432,
+        started_at: 3.minutes.ago,
+        stopped_at: 30.seconds.ago,
+      })
+    end
     let(:common_ci_step_result_data) do
       attributes_for(:ci_step_result).slice(*%i[
         passed
@@ -30,6 +38,10 @@ RSpec.describe(Api::CiStepResults::BulkCreationsController) do
         branch
         sha
       ])
+    end
+
+    specify 'a request can contain at most 200 CI step results' do
+      expect(CiStepResults::BulkCreate::MAX_CI_STEP_RESULTS).to eq(200)
     end
 
     context 'when no user is signed in' do
@@ -65,7 +77,9 @@ RSpec.describe(Api::CiStepResults::BulkCreationsController) do
         end
 
         context 'when the CiStepResult params are invalid' do
-          let(:ci_step_results_data) { [valid_ci_step_result_1, invalid_ci_step_result] }
+          let(:ci_step_results_data) do
+            [valid_ci_step_result_1, invalid_ci_step_result, valid_ci_step_result_3]
+          end
           let(:invalid_ci_step_result) do
             valid_ci_step_result_2.merge({
               branch: '',
@@ -87,7 +101,36 @@ RSpec.describe(Api::CiStepResults::BulkCreationsController) do
                 errors: { branch: ["can't be blank"] },
                 data: invalid_ci_step_result,
               },
+              {
+                success: true,
+                errors: {},
+                data: valid_ci_step_result_3,
+              },
             ].to_json))
+          end
+        end
+
+        context 'when the request contains too many CiStepResults' do
+          before { stub_const('CiStepResults::BulkCreate::MAX_CI_STEP_RESULTS', 2) }
+
+          let(:ci_step_results_data) do
+            [valid_ci_step_result_1, valid_ci_step_result_2, valid_ci_step_result_3]
+          end
+
+          it 'does not create any CiStepResults and returns a 422 status code' do
+            expect(ApplicationRecord).not_to receive(:transaction)
+            expect { post_create }.not_to change { CiStepResult.count }
+
+            expect(response).to have_http_status(422)
+            expect(response.parsed_body).to eq([
+              {
+                'success' => false,
+                'errors' => {
+                  'base' => ['Requests may contain no more than 2 CI step results.'],
+                },
+                'data' => {},
+              },
+            ])
           end
         end
       end

--- a/spec/controllers/logs/uploads_controller_spec.rb
+++ b/spec/controllers/logs/uploads_controller_spec.rb
@@ -77,5 +77,24 @@ RSpec.describe Logs::UploadsController do
         expect(flash[:alert]).to include('The uploaded data is invalid')
       end
     end
+
+    context 'when the upload contains too many log entries' do
+      before { stub_const('LogEntries::EnqueueFromCsv::MAX_LOG_ENTRIES', 2) }
+
+      let(:csv_rows) do
+        [
+          "#{3.days.ago.iso8601},201,",
+          "#{18.hours.ago.iso8601},200,good!",
+          "#{1.hour.ago.iso8601},199,not bad",
+        ]
+      end
+
+      it 'does not enqueue jobs and redirects with an error' do
+        expect { post_create }.not_to change { CreateLogEntry.jobs.size }
+
+        expect(response).to redirect_to(logs_uploads_path)
+        expect(flash[:alert]).to eq('Uploads may contain no more than 2 log entries.')
+      end
+    end
   end
 end

--- a/spec/controllers/question_uploads_controller_spec.rb
+++ b/spec/controllers/question_uploads_controller_spec.rb
@@ -37,7 +37,15 @@ RSpec.describe QuestionUploadsController do
       QUESTIONS_LIST
     end
 
-    it 'creates log entries' do
+    specify 'an upload can contain at most 500 questions' do
+      expect(QuizQuestions::CreateFromList::MAX_QUESTIONS).to eq(500)
+    end
+
+    specify 'an upload can contain at most 5,000 answers' do
+      expect(QuizQuestions::CreateFromList::MAX_ANSWERS).to eq(5_000)
+    end
+
+    it 'creates questions and answers' do
       expect {
         post_create
       }.to change {
@@ -69,6 +77,59 @@ RSpec.describe QuestionUploadsController do
           Wrong number of correct answers for question 'Do you think that smarter people are usually
           capable of deeper love?'!
         TEXT
+      end
+    end
+
+    context 'when the upload contains too many questions' do
+      before { stub_const('QuizQuestions::CreateFromList::MAX_QUESTIONS', 2) }
+
+      let(:questions_list) do
+        <<~QUESTIONS_LIST
+          Question one?
+          - Yes
+          No
+
+          Question two?
+          - Yes
+          No
+
+          Question three?
+          - Yes
+          No
+        QUESTIONS_LIST
+      end
+
+      it 'does not create questions and renders the form with an error' do
+        expect { post_create }.not_to change { QuizQuestion.count }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to have_flash_message(
+          'Uploads may contain no more than 2 questions.',
+          type: :alert,
+        )
+      end
+    end
+
+    context 'when the upload contains too many answers' do
+      before { stub_const('QuizQuestions::CreateFromList::MAX_ANSWERS', 2) }
+
+      let(:questions_list) do
+        <<~QUESTIONS_LIST
+          Which is biggest?
+          The Earth
+          - The Sun
+          The Moon
+        QUESTIONS_LIST
+      end
+
+      it 'does not create questions and renders the form with an error' do
+        expect { post_create }.not_to change { QuizQuestion.count }
+
+        expect(response).to have_http_status(:unprocessable_content)
+        expect(response.body).to have_flash_message(
+          'Uploads may contain no more than 2 answers.',
+          type: :alert,
+        )
       end
     end
   end


### PR DESCRIPTION
Cap log CSV uploads at 10,000 entries and stop parsing after the first excessive row, before constructing Active Record objects. Encapsulate bounded parsing, validation, serialization, and Sidekiq bulk enqueue calls of 1,000 in LogEntries::EnqueueFromCsv while preserving one independently retried job per entry.

Cap quiz uploads at 500 questions and 5,000 total answers so that a single question cannot bypass the record bound. Cap CI step result batches at 200 items before opening the transaction or building records. Return explicit validation errors for each excessive request.

Use the repository Memoization pattern for reused parsed input, and document that convention to avoid ad hoc same-named local-variable caching.