### PR TITLE
[AGENTS.md] Prefer subject-area branch prefixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,7 @@
   git switch -c <branch-name> origin/main
   ```
 
+- When it makes the branch clearer, prefix the branch name with a short, lowercase form of the anticipated commit subject area and a slash. For example, `[AGENTS.md] Keep approval requests narrow` could use `agents-md/keep-approval-requests-narrow`. This is a preference rather than a strict mapping; use a different clear name when the subject area is not known up front or would not make a useful branch prefix.
 - After creating the branch, configure it to track `origin/main`:
 
   ```sh


### PR DESCRIPTION
Make branch names easier to associate with their eventual commits by generally deriving a short lowercase prefix from the anticipated commit subject area.

Keep the guidance flexible for work whose subject area is not known when the branch is created or would not produce a useful prefix.