### PR TITLE
[api/telemetry] Limit public ingestion

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@
 
 ## Test design
 
+- Specs under `spec/controllers/api/` automatically receive `request_format: :json` through derived metadata in `spec/spec_helper.rb`. Do not repeat that metadata on individual API controller spec groups unless the spec intentionally needs different format behavior.
 - Keep specs focused on the behavior under test. Set up only attributes and conditions that are relevant to that behavior.
 - Express required relationships directly instead of relying on incidental fixture identities. For example, when an owner must differ from `user`, prefer `User.excluding(user).first!` over naming a fixture that merely happens to represent another user.
 - Avoid confounding conditions in regression specs. Construct the example so that the rule under test, not an unrelated validation, privacy setting, authorization rule, or fixture detail, determines the outcome.

--- a/app/controllers/api/csp_reports_controller.rb
+++ b/app/controllers/api/csp_reports_controller.rb
@@ -1,10 +1,6 @@
 class Api::CspReportsController < Api::BaseController
   prepend Memoization
 
-  IGNORED_USER_AGENTS = [
-    /DuckDuckBot/,
-  ].freeze
-
   skip_before_action :authenticate_user!, only: %i[create]
   # The browser submitting the report will not have any CSRF token
   skip_before_action :verify_authenticity_token, only: %i[create]
@@ -12,13 +8,8 @@ class Api::CspReportsController < Api::BaseController
   def create
     skip_authorization
 
-    if send_csp_violation_to_rollbar?
-      Rails.error.report(
-        Error.new(CspViolation),
-        severity: :info,
-        context: { csp_report_params: },
-      )
-    end
+    return head :bad_request unless csp_report_params.is_a?(Hash)
+    return head :unprocessable_content unless document_uri_from_request_origin?
 
     csp_report =
       CspReport.new do |report|
@@ -30,20 +21,35 @@ class Api::CspReportsController < Api::BaseController
         report.user_agent = request.user_agent
         report.violated_directive = csp_report_params['violated-directive']
       end
-    csp_report.save!
 
-    head :no_content
+    if csp_report.save
+      head :no_content
+    else
+      head :unprocessable_content
+    end
+  rescue JSON::ParserError
+    head :bad_request
   end
 
   private
 
   memoize \
   def csp_report_params
-    JSON(request.raw_post)['csp-report']
+    JSON.parse(request.raw_post)['csp-report']
   end
 
-  memoize \
-  def send_csp_violation_to_rollbar?
-    IGNORED_USER_AGENTS.none? { request.user_agent.match?(it) }
+  def document_uri_from_request_origin?
+    origin_for(csp_report_params['document-uri']).then do |document_origin|
+      document_origin.present? && document_origin == origin_for(request.base_url)
+    end
+  end
+
+  def origin_for(url)
+    uri = URI.parse(url.to_s)
+    return unless uri.is_a?(URI::HTTP) && uri.host.present?
+
+    [uri.scheme.downcase, uri.host.downcase, uri.port]
+  rescue URI::InvalidURIError
+    nil
   end
 end

--- a/app/controllers/api/events_controller.rb
+++ b/app/controllers/api/events_controller.rb
@@ -8,7 +8,7 @@ class Api::EventsController < Api::BaseController
   def create
     authorize(Event)
 
-    event = Event.create_with_stack_trace!(
+    event = Event.build_with_stack_trace(
       admin_user: current_admin_user,
       data: params[:data],
       ip: request.remote_ip,
@@ -17,8 +17,11 @@ class Api::EventsController < Api::BaseController
       user_agent: request.user_agent,
     )
 
-    FetchIpInfoForRecord.perform_async(event.class.name, event.id)
-
-    head :created
+    if event.save
+      FetchIpInfoForRecord.perform_async(event.class.name, event.id)
+      head :created
+    else
+      head :unprocessable_content
+    end
   end
 end

--- a/app/models/csp_report.rb
+++ b/app/models/csp_report.rb
@@ -14,11 +14,26 @@
 #  violated_directive :string           not null
 #
 class CspReport < ApplicationRecord
+  MAX_ORIGINAL_POLICY_LENGTH = 8.kilobytes
+  MAX_URI_LENGTH = 2.kilobytes
+  MAX_USER_AGENT_LENGTH = 1.kilobyte
+  MAX_VIOLATED_DIRECTIVE_LENGTH = 1.kilobyte
+
   validates :document_uri, presence: true
   validates :violated_directive, presence: true
   validates :original_policy, presence: true
   validates :ip, presence: true
   validates :user_agent, presence: true
+  validates(
+    :blocked_uri,
+    :document_uri,
+    :referrer,
+    length: { maximum: MAX_URI_LENGTH },
+    allow_nil: true,
+  )
+  validates :original_policy, length: { maximum: MAX_ORIGINAL_POLICY_LENGTH }
+  validates :user_agent, length: { maximum: MAX_USER_AGENT_LENGTH }
+  validates :violated_directive, length: { maximum: MAX_VIOLATED_DIRECTIVE_LENGTH }
 
   def self.ransackable_attributes(_auth_object = nil)
     %w[

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -23,19 +23,26 @@
 #  index_events_on_user_id        (user_id)
 #
 class Event < ApplicationRecord
+  MAX_DATA_BYTES = 8.kilobytes
+  MAX_TYPE_LENGTH = 100
+  MAX_USER_AGENT_LENGTH = 1.kilobyte
+
   # Tell ActiveRecord not to use 'type' column for Single Table Inheritance.
   self.inheritance_column = nil
 
   validates :ip, presence: true
   validates :stack_trace, presence: true
   validates :type, presence: true
+  validates :type, length: { maximum: MAX_TYPE_LENGTH }
+  validates :user_agent, length: { maximum: MAX_USER_AGENT_LENGTH }, allow_nil: true
+  validate :data_fits_size_limit
 
   belongs_to :admin_user, optional: true
   belongs_to :user, optional: true
 
   class << self
-    def create_with_stack_trace!(attributes)
-      create!(attributes.merge(
+    def build_with_stack_trace(attributes)
+      new(attributes.merge(
         stack_trace:
           StackTraceFilter.new.
             application_stack_trace(ignore: [__FILE__]),
@@ -61,6 +68,14 @@ class Event < ApplicationRecord
         user_agent
         user_id
       ]
+    end
+  end
+
+  private
+
+  def data_fits_size_limit
+    if data.to_json.bytesize > MAX_DATA_BYTES
+      errors.add(:data, "must serialize to at most #{MAX_DATA_BYTES} bytes")
     end
   end
 end

--- a/app/poros/save_request/skip_checker.rb
+++ b/app/poros/save_request/skip_checker.rb
@@ -12,6 +12,7 @@ class SaveRequest::SkipChecker
       [%r{\Ablazer/}, _, _] |
       ['anonymous', _, _] |
       ['blog', 'assets', _] |
+      ['api/csp_reports', 'create', _] |
       ['api/events', 'create', _] |
       [_, _, { uptime_robot: _ }]
     )

--- a/app/workers/truncate_tables.rb
+++ b/app/workers/truncate_tables.rb
@@ -1,6 +1,9 @@
 class TruncateTables
   prepend ApplicationWorker
 
+  CSP_REPORT_MAX_ROWS = 10_000
+  CSP_REPORT_RETENTION_PERIOD = 30.days
+
   ROW_COUNT_SQL = <<~SQL.squish
     SELECT relname, n_live_tup
     FROM pg_stat_user_tables
@@ -76,6 +79,13 @@ class TruncateTables
     Rails.logger.info('Approximate row counts prior to deletion:')
     self.class.print_row_counts
     Rails.logger.info
+
+    self.class.truncate(
+      table: 'csp_reports',
+      timestamp: 'created_at',
+      min_surviving_timestamp: CSP_REPORT_RETENTION_PERIOD.ago,
+      max_allowed_rows: CSP_REPORT_MAX_ROWS,
+    )
 
     self.class.truncate(
       table: 'ip_blocks',

--- a/config/application.rb
+++ b/config/application.rb
@@ -46,6 +46,8 @@ class DavidRunger::Application < Rails::Application
   # Common ones are `templates`, `generators`, or `middleware`, for example.
   config.autoload_lib(ignore: %w[generators tasks test])
 
+  require Rails.root.join('lib/middleware/public_telemetry_body_limiter')
+
   # ActiveJob/Sidekiq
   config.active_job.queue_adapter = :sidekiq
 
@@ -85,15 +87,18 @@ class DavidRunger::Application < Rails::Application
   end
 
   initializer(
+    'insert public telemetry body limiter after Rack::Attack',
+    after: 'rack-attack.middleware',
+  ) do |app|
+    app.middleware.insert_after(Rack::Attack, Middleware::PublicTelemetryBodyLimiter)
+  end
+
+  initializer(
     'move Browser middleware after Rack::Attack',
     after: 'rack-attack.middleware',
   ) do |app|
     app.middleware.move_after(Rack::Attack, Browser::Middleware)
   end
-
-  errors_file = Rails.root.join('lib/errors.rb')
-  Rails.autoloaders.main.ignore(errors_file) # must do this bc. `errors.rb` does not define `Errors`
-  require errors_file
 
   ENV['FIXTURES_PATH'] ||= 'spec/fixtures' if ENV.fetch('RAILS_ENV', nil) == 'test'
 

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -2,6 +2,11 @@ class Rack::Attack
   PATH_FRAGMENT_SEPARATOR_REGEX = %r{/|\.|\?|-|_|=|\d|%}
   PENTESTERS_PREFIX = 'pentesters-'
   PENTESTING_FINDTIME = 1.day.freeze
+  PUBLIC_TELEMETRY_REQUEST_LIMIT = 10
+  PUBLIC_TELEMETRY_ENDPOINTS = {
+    csp_reports: %r{\A/api/csp_reports(?:\.[^/]+)?/?\z},
+    events: %r{\A/api/events(?:\.[^/]+)?/?\z},
+  }.freeze
   WHITELISTED_PATH_PREFIXES = %w[
     /assets/blazer/
     /auth/failure?
@@ -19,6 +24,12 @@ class Rack::Attack
     request.ip
   end
   # rubocop:enable Style/SymbolProc
+
+  PUBLIC_TELEMETRY_ENDPOINTS.each do |endpoint, path_regex|
+    throttle("#{endpoint}/ip", limit: PUBLIC_TELEMETRY_REQUEST_LIMIT, period: 1.minute) do |request|
+      request.ip if request.post? && request.path.match?(path_regex)
+    end
+  end
 
   class << self
     prepend Memoization
@@ -97,9 +108,13 @@ ActiveSupport::Notifications.
     next if payload.keys == [:discriminator] # from InstrumentFail2BanEventMonkeypatch
 
     request = payload[:request]
+    match_data = request.env.fetch('rack.attack.match_data', {})
     Rails.logger.info(<<~LOG.squish)
       [rack-attack]
       event=#{name}
+      matched=#{request.env['rack.attack.matched']}
+      match_count=#{match_data[:count]}
+      match_limit=#{match_data[:limit]}
       ip=#{request.ip}
       fullpath=#{request.fullpath}
       request_method=#{request.request_method}

--- a/config/initializers/std_lib.rb
+++ b/config/initializers/std_lib.rb
@@ -1,3 +1,4 @@
 require 'csv' # for LogsController, Logs::UploadsController
 require 'digest' # for ApplicationWorker uniqueness enforcement, gravatar URL
 require 'fileutils' # assets:precompile
+require 'uri' # CSP report origin validation

--- a/config/nginx/sites-enabled/davidrunger.com.conf
+++ b/config/nginx/sites-enabled/davidrunger.com.conf
@@ -23,6 +23,12 @@ server {
     # Tell Google we want it to prefetch search results.
     include nginxconfig.io/traffic-advice.conf;
 
+    # Bound public telemetry bodies before NGINX buffers them and forwards them to Rails.
+    location ~ ^/api/(csp_reports|events)(\.[^/]+)?/?$ {
+        client_max_body_size 16k;
+        try_files            $uri @rails_app;
+    }
+
     # Serve static files from the public directory
     location / {
         root /var/www/david-runger-public;

--- a/lib/errors.rb
+++ b/lib/errors.rb
@@ -1,5 +1,0 @@
-class CspViolation < StandardError
-  def initialize(message = nil)
-    super(message || 'Content Security Policy violation')
-  end
-end

--- a/lib/middleware/public_telemetry_body_limiter.rb
+++ b/lib/middleware/public_telemetry_body_limiter.rb
@@ -1,0 +1,42 @@
+module Middleware ; end
+
+class Middleware::PublicTelemetryBodyLimiter
+  MAX_BODY_BYTES = 16.kilobytes
+  TELEMETRY_PATH_REGEX = %r{\A/api/(?:csp_reports|events)(?:\.[^/]+)?/?\z}
+  TOO_LARGE_BODY = 'Telemetry request body is too large.'
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    return @app.call(env) unless limited_request?(env)
+
+    declared_body_bytes = Integer(env.fetch('CONTENT_LENGTH', 0), exception: false) || 0
+    return content_too_large_response if declared_body_bytes > MAX_BODY_BYTES
+
+    request_body = env.fetch('rack.input')
+    body = request_body.read(MAX_BODY_BYTES + 1).to_s
+    return content_too_large_response if body.bytesize > MAX_BODY_BYTES
+
+    request_body.rewind
+    @app.call(env)
+  end
+
+  private
+
+  def limited_request?(env)
+    env['REQUEST_METHOD'] == 'POST' && env['PATH_INFO'].match?(TELEMETRY_PATH_REGEX)
+  end
+
+  def content_too_large_response
+    [
+      413,
+      {
+        'content-length' => TOO_LARGE_BODY.bytesize.to_s,
+        'content-type' => 'text/plain; charset=utf-8',
+      },
+      [TOO_LARGE_BODY],
+    ]
+  end
+end

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -1,4 +1,47 @@
 RSpec.describe('Rack::Attack') do
+  describe 'public telemetry throttles' do
+    Rack::Attack::PUBLIC_TELEMETRY_ENDPOINTS.each_key do |endpoint|
+      context "when checking #{endpoint}" do
+        subject(:throttle) { Rack::Attack.throttles.fetch("#{endpoint}/ip") }
+
+        it 'allows a generous burst while bounding endpoint amplification' do
+          expect(throttle.limit).to eq(Rack::Attack::PUBLIC_TELEMETRY_REQUEST_LIMIT)
+          expect(throttle.period).to eq(1.minute)
+        end
+
+        it 'discriminates POST requests to the endpoint by IP address' do
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for("/api/#{endpoint}", method: 'POST'),
+          )
+
+          expect(throttle.block.call(request)).to eq(request.ip)
+        end
+
+        it 'does not match other request methods' do
+          request = Rack::Attack::Request.new(
+            Rack::MockRequest.env_for("/api/#{endpoint}", method: 'GET'),
+          )
+
+          expect(throttle.block.call(request)).to be_nil
+        end
+      end
+    end
+  end
+
+  describe 'notification logging' do
+    it 'includes the matched rule and throttle usage' do
+      request = Rack::Attack::Request.new(Rack::MockRequest.env_for('/api/events'))
+      request.env['rack.attack.matched'] = 'events/ip'
+      request.env['rack.attack.match_data'] = { count: 11, limit: 10 }
+
+      expect(Rails.logger).
+        to receive(:info).
+        with(/matched=events\/ip match_count=11 match_limit=10/)
+
+      ActiveSupport::Notifications.instrument('throttle.rack_attack', request:)
+    end
+  end
+
   describe '::blocked_path?' do
     subject(:blocked_path?) { Rack::Attack.blocked_path?(request) }
 

--- a/spec/controllers/api/csp_reports_controller_spec.rb
+++ b/spec/controllers/api/csp_reports_controller_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Api::CspReportsController do
     let(:params) do
       {
         'csp-report' => {
-          'document-uri' => 'http://example.com/signup.html',
+          'document-uri' => 'http://test.host/signup.html',
           'referrer' => '',
           'blocked-uri' => 'http://example.com/css/style.css',
           'violated-directive' => 'style-src cdn.example.com',
@@ -15,59 +15,76 @@ RSpec.describe Api::CspReportsController do
         },
       }
     end
+    let(:user_agent) do
+      'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:105.0) Gecko/20100101 Firefox/105.0'
+    end
+
+    before { request.headers['User-Agent'] = user_agent }
 
     it 'returns a 204 status code' do
       post_create
       expect(response).to have_http_status(204)
     end
 
-    it 'creates that item for the store' do
+    it 'creates a CSP report' do
       expect { post_create }.to change { CspReport.count }.by(1)
     end
 
-    context 'when the user agent is DuckDuckBot' do
-      before { request.headers['User-Agent'] = duck_duck_bot_user_agent }
+    it 'does not send the public report to the error-reporting service' do
+      expect(Rails.error).not_to receive(:report)
+      post_create
+    end
 
-      let(:duck_duck_bot_user_agent) do
-        "'DuckDuckBot-Https/1.1; (+https://duckduckgo.com/duckduckbot)'"
-      end
+    it 'records the user agent' do
+      post_create
+      expect(CspReport.last!.user_agent).to eq(user_agent)
+    end
 
-      it 'does not send an error to Rollbar' do
-        expect(Rollbar).not_to receive(:error)
+    context 'when the document URI has a different origin' do
+      before { params['csp-report']['document-uri'] = 'https://attacker.example/path' }
 
-        post_create
-      end
-
-      it 'creates a CspReport with the DuckDuckBot user agent' do
-        post_create
-
-        expect(CspReport.last!.user_agent).to eq(duck_duck_bot_user_agent)
+      it 'returns 422 without creating a CSP report' do
+        expect { post_create }.not_to change { CspReport.count }
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
 
-    context 'when the user agent is Firefox' do
-      before { request.headers['User-Agent'] = firefox_user_agent }
+    context 'when the document URI is invalid' do
+      before { params['csp-report']['document-uri'] = 'https://not a URI' }
 
-      let(:firefox_user_agent) do
-        'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:105.0) Gecko/20100101 Firefox/105.0'
+      it 'returns 422 without creating a CSP report' do
+        expect { post_create }.not_to change { CspReport.count }
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+
+    context 'when the CSP report root object is missing' do
+      let(:params) { { 'other-report' => {} } }
+
+      it 'returns 400 without creating a CSP report' do
+        expect { post_create }.not_to change { CspReport.count }
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context 'when the body contains malformed JSON' do
+      subject(:post_create) { process(:create, method: :post, body: '{') }
+
+      it 'returns 400 without creating a CSP report' do
+        expect { post_create }.not_to change { CspReport.count }
+        expect(response).to have_http_status(:bad_request)
+      end
+    end
+
+    context 'when a CSP report field is too long' do
+      before do
+        params['csp-report']['original-policy'] =
+          'a' * (CspReport::MAX_ORIGINAL_POLICY_LENGTH + 1)
       end
 
-      it 'reports via Rails.error at info level' do
-        expect(Rails.error).
-          to receive(:report).
-          with(
-            CspViolation,
-            severity: :info,
-            context: hash_including(:csp_report_params),
-          )
-
-        post_create
-      end
-
-      it 'creates a CspReport with the Firefox user agent' do
-        post_create
-
-        expect(CspReport.last!.user_agent).to eq(firefox_user_agent)
+      it 'returns 422 without creating a CSP report' do
+        expect { post_create }.not_to change { CspReport.count }
+        expect(response).to have_http_status(:unprocessable_content)
       end
     end
   end

--- a/spec/controllers/api/events_controller_spec.rb
+++ b/spec/controllers/api/events_controller_spec.rb
@@ -1,0 +1,45 @@
+RSpec.describe Api::EventsController do
+  describe '#create' do
+    subject(:post_create) { post(:create, params:) }
+
+    let(:data) { { page_url: DavidRunger::CANONICAL_URL } }
+    let(:params) { { data:, type: } }
+    let(:type) { 'scroll' }
+    let(:user_agent) { 'Public telemetry controller spec' }
+
+    before { request.headers['User-Agent'] = user_agent }
+
+    context 'when the event is valid' do
+      it 'returns 201 and creates the event' do
+        expect { post_create }.to change { Event.count }.by(1)
+
+        expect(response).to have_http_status(:created)
+        expect(Event.last!).to have_attributes(
+          data: data.stringify_keys,
+          type:,
+          user_agent:,
+        )
+      end
+
+      it 'enqueues IP enrichment for the event' do
+        post_create
+
+        event = Event.last!
+        expect(FetchIpInfoForRecord).
+          to have_enqueued_sidekiq_job.
+          with(Event.name, event.id)
+      end
+    end
+
+    context 'when the event is invalid' do
+      let(:type) { 'a' * (Event::MAX_TYPE_LENGTH + 1) }
+
+      it 'returns 422 without creating an event or enqueuing IP enrichment' do
+        expect { post_create }.
+          not_to change { [Event.count, Sidekiq::Queues['default'].size] }
+
+        expect(response).to have_http_status(:unprocessable_content)
+      end
+    end
+  end
+end

--- a/spec/factories/csp_reports.rb
+++ b/spec/factories/csp_reports.rb
@@ -25,7 +25,7 @@ FactoryBot.define do
         'unsafe-inline'; frame-ancestors 'self'; report-uri /api/csp_reports
       POLICY
     end
-    ip { Faker::Internet.public_ip_v6_address }
+    ip { Faker::Internet.public_ip_v4_address }
     referrer { "#{DavidRunger::CANONICAL_URL}check_ins/9" }
     blocked_uri { 'inline' }
     user_agent { Faker::Internet.user_agent }

--- a/spec/features/public_telemetry_ingestion_spec.rb
+++ b/spec/features/public_telemetry_ingestion_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe 'Public telemetry ingestion', :cache, :rack_test_driver do
+  around do |spec|
+    expect(Rails.cache).to be_a(ActiveSupport::Cache::MemoryStore)
+
+    Rack::Attack.cache.with(store: Rails.cache) do
+      spec.run
+    end
+  end
+
+  {
+    '/api/csp_reports' => CspReport,
+    '/api/events' => Event,
+  }.each do |path, model|
+    context "when POST #{path} has an oversized body" do
+      it 'returns 413 without persisting telemetry' do
+        expect {
+          page.driver.post(
+            path,
+            'a' * (Middleware::PublicTelemetryBodyLimiter::MAX_BODY_BYTES + 1),
+            'CONTENT_TYPE' => 'application/json',
+          )
+        }.not_to change { model.count }
+
+        expect(page.status_code).to eq(413)
+      end
+    end
+  end
+
+  context 'when an IP posts more than ten Events in one minute' do
+    let(:event_body) { { data: { page_url: DavidRunger::CANONICAL_URL }, type: 'scroll' }.to_json }
+
+    it 'returns 429 for the eleventh request without creating another Event' do
+      expect {
+        Rack::Attack::PUBLIC_TELEMETRY_REQUEST_LIMIT.times do
+          page.driver.post(
+            '/api/events',
+            event_body,
+            'CONTENT_TYPE' => 'application/json',
+          )
+          expect(page.status_code).to eq(201)
+        end
+      }.to change { Event.count }.by(Rack::Attack::PUBLIC_TELEMETRY_REQUEST_LIMIT)
+
+      expect {
+        page.driver.post(
+          '/api/events',
+          event_body,
+          'CONTENT_TYPE' => 'application/json',
+        )
+      }.not_to change { Event.count }
+
+      expect(page.status_code).to eq(429)
+    end
+  end
+end

--- a/spec/lib/middleware/public_telemetry_body_limiter_spec.rb
+++ b/spec/lib/middleware/public_telemetry_body_limiter_spec.rb
@@ -1,0 +1,72 @@
+RSpec.describe Middleware::PublicTelemetryBodyLimiter do
+  subject(:response) { described_class.new(app).call(env) }
+
+  let(:app) do
+    lambda do |app_env|
+      [200, {}, [app_env.fetch('rack.input').read]]
+    end
+  end
+  let(:body) { 'a' * described_class::MAX_BODY_BYTES }
+  let(:env) { Rack::MockRequest.env_for(path, method:, input: body) }
+  let(:method) { 'POST' }
+  let(:path) { '/api/events' }
+
+  context 'when a telemetry POST body is exactly the maximum size' do
+    it 'rewinds the body and passes the request to the application' do
+      expect(response).to eq([200, {}, [body]])
+    end
+  end
+
+  context 'when a telemetry POST declares an oversized body' do
+    let(:body) { 'a' * (described_class::MAX_BODY_BYTES + 1) }
+
+    it 'returns 413 without calling the application' do
+      expect(app).not_to receive(:call)
+
+      expect(response).to match([
+        413,
+        hash_including('content-length', 'content-type'),
+        [described_class::TOO_LARGE_BODY],
+      ])
+    end
+  end
+
+  context 'when a telemetry POST understates its oversized body length' do
+    let(:body) { 'a' * (described_class::MAX_BODY_BYTES + 1) }
+    let(:env) do
+      super().tap { it['CONTENT_LENGTH'] = '1' }
+    end
+
+    it 'returns 413 after bounded reading without calling the application' do
+      expect(app).not_to receive(:call)
+      expect(response.first).to eq(413)
+    end
+  end
+
+  context 'when a formatted CSP report path has an oversized body' do
+    let(:body) { 'a' * (described_class::MAX_BODY_BYTES + 1) }
+    let(:path) { '/api/csp_reports.json/' }
+
+    it 'returns 413' do
+      expect(response.first).to eq(413)
+    end
+  end
+
+  context 'when another path has an oversized body' do
+    let(:body) { 'a' * (described_class::MAX_BODY_BYTES + 1) }
+    let(:path) { '/api/logs' }
+
+    it 'passes the request to the application' do
+      expect(response).to eq([200, {}, [body]])
+    end
+  end
+
+  context 'when a telemetry path receives a non-POST request with an oversized body' do
+    let(:body) { 'a' * (described_class::MAX_BODY_BYTES + 1) }
+    let(:method) { 'PUT' }
+
+    it 'passes the request to the application' do
+      expect(response).to eq([200, {}, [body]])
+    end
+  end
+end

--- a/spec/models/csp_report_spec.rb
+++ b/spec/models/csp_report_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe CspReport do
+  describe 'validations' do
+    it 'limits URI field lengths' do
+      %i[blocked_uri document_uri referrer].each do |attribute|
+        expect(build(:csp_report, attribute => 'a' * CspReport::MAX_URI_LENGTH)).to be_valid
+        expect(
+          build(:csp_report, attribute => 'a' * (CspReport::MAX_URI_LENGTH + 1)),
+        ).not_to be_valid
+      end
+    end
+
+    it 'limits other attacker-controlled field lengths' do
+      {
+        original_policy: CspReport::MAX_ORIGINAL_POLICY_LENGTH,
+        user_agent: CspReport::MAX_USER_AGENT_LENGTH,
+        violated_directive: CspReport::MAX_VIOLATED_DIRECTIVE_LENGTH,
+      }.each do |attribute, maximum|
+        expect(build(:csp_report, attribute => 'a' * maximum)).to be_valid
+        expect(build(:csp_report, attribute => 'a' * (maximum + 1))).not_to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -8,5 +8,23 @@ RSpec.describe(Event) do
     it { is_expected.to validate_presence_of(:ip) }
     it { is_expected.to validate_presence_of(:stack_trace) }
     it { is_expected.to validate_presence_of(:type) }
+
+    it 'limits attacker-controlled field lengths' do
+      {
+        type: Event::MAX_TYPE_LENGTH,
+        user_agent: Event::MAX_USER_AGENT_LENGTH,
+      }.each do |attribute, maximum|
+        expect(build(:event, attribute => 'a' * maximum)).to be_valid
+        expect(build(:event, attribute => 'a' * (maximum + 1))).not_to be_valid
+      end
+    end
+
+    it 'limits the serialized data size in bytes' do
+      data_at_limit = 'a' * (Event::MAX_DATA_BYTES - ''.to_json.bytesize)
+
+      expect(data_at_limit.to_json.bytesize).to eq(Event::MAX_DATA_BYTES)
+      expect(build(:event, data: data_at_limit)).to be_valid
+      expect(build(:event, data: "#{data_at_limit}a")).not_to be_valid
+    end
   end
 end

--- a/spec/poros/save_request/skip_checker_spec.rb
+++ b/spec/poros/save_request/skip_checker_spec.rb
@@ -64,6 +64,14 @@ RSpec.describe SaveRequest::SkipChecker do
       end
     end
 
+    context 'when the controller is api/csp_reports and the action is create' do
+      let(:params) { { 'controller' => 'api/csp_reports', 'action' => 'create' } }
+
+      it 'returns true' do
+        expect(skip?).to eq(true)
+      end
+    end
+
     context 'when the controller starts with "blazer/"' do
       let(:params) { { 'controller' => 'blazer/queries', 'action' => 'home' } }
 

--- a/spec/poros/stack_trace_filter_spec.rb
+++ b/spec/poros/stack_trace_filter_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe(StackTraceFilter) do
       let(:mocked_stack_trace) do
         # rubocop:disable Layout/LineLength
         [
-          "#{file_to_ignore}:37:in 'Event.create_with_stack_trace!'",
+          "#{file_to_ignore}:37:in 'Event.build_with_stack_trace'",
           expected_line_of_interest,
           "/app/vendor/bundle/ruby/3.4.0/gems/actionpack-8.0.1/lib/action_controller/metal/basic_implicit_render.rb:8:in 'ActionController::BasicImplicitRender#send_action'",
           "/app/lib/middleware/early.rb:11:in 'Middleware::Early#call'",

--- a/spec/workers/truncate_tables_spec.rb
+++ b/spec/workers/truncate_tables_spec.rb
@@ -12,6 +12,27 @@ RSpec.describe TruncateTables do
       end
     end
 
+    it 'applies bounded retention to CSP reports but not events or requests', :frozen_time do
+      allow(described_class).to receive(:truncate)
+
+      perform
+
+      expect(described_class).
+        to have_received(:truncate).
+        with(
+          table: 'csp_reports',
+          timestamp: 'created_at',
+          min_surviving_timestamp: described_class::CSP_REPORT_RETENTION_PERIOD.ago,
+          max_allowed_rows: described_class::CSP_REPORT_MAX_ROWS,
+        )
+      expect(described_class).
+        not_to have_received(:truncate).
+        with(hash_including(table: 'events'))
+      expect(described_class).
+        not_to have_received(:truncate).
+        with(hash_including(table: 'requests'))
+    end
+
     context 'when there is at least one row in the `ip_blocks` table' do
       before { expect(IpBlock.count).to be > 0 }
 


### PR DESCRIPTION
The public Event and CSP report endpoints accepted request bodies up to the global 16 MiB NGINX limit. Each accepted request could also cause persistence, Event IP enrichment, and, for CSP reports, duplicate Request storage and external error reporting.

Cap both routes at 16 KiB in NGINX and early Rack middleware, throttle each endpoint to 10 POSTs per IP per minute, validate attacker-controlled field sizes, and require CSP document URIs to match the receiving application origin. Log the matched Rack::Attack rule, count, and limit so legitimate throttling can be identified and tuned.

Stop forwarding CSP payloads to the error-reporting service and exclude CSP ingestion from Request recording. Retain CSP reports for at most 30 days or 10,000 rows. Preserve indefinite Event and Request history by design, and avoid random sampling because the deterministic controls already bound the immediate amplification paths.

Add controller, model, middleware, Rack::Attack, retention, and full-stack regression coverage for rejected payloads and throttled requests.