### PR TITLE
[docker-compose] Pin Vector image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -321,7 +321,7 @@ services:
       - 'true'
       - '--watch-config'
     cpu_shares: 512
-    image: timberio/vector:latest-alpine
+    image: timberio/vector:0.57.0-alpine@sha256:19e3526faf4d4b1ed0c28a0d68d4cc3a1e13e437099986a5b7a768707907497c
     networks:
       - internal
     volumes:

--- a/vector/vector.yaml
+++ b/vector/vector.yaml
@@ -17,6 +17,9 @@ sinks:
     type: loki
     inputs:
       - docker_with_grafana_nginx_separated
+    # This template sets a Loki label value from Docker's Compose metadata; it
+    # does not select a path, URL, or object key that confinement could protect.
+    dangerously_allow_unconfined_template_resolution: true
     endpoint: http://loki:3100
     encoding:
       codec: text


### PR DESCRIPTION
Replace the moving latest-alpine tag with the current Vector 0.57.0 Alpine release and its multi-platform OCI image-index digest. This makes deployments reproducible across supported architectures and prevents the tag from silently changing the executable image.

Vector has direct access to the host Docker control socket, so a compromised or unexpectedly replaced Vector image could obtain host-level control. Pin the reviewed artifact to reduce this supply-chain risk rather than trusting a mutable tag. Continue making deliberate version and digest updates so pinning does not leave known vulnerabilities in place.

Vector 0.57 applies template confinement to Loki label values and rejects the existing Compose service label template because it has no literal prefix. Preserve the established label values with the documented per-sink opt-out; the value comes from Docker Compose metadata and cannot select a filesystem path, URL, or object key.

Release notes: https://vector.dev/releases/0.57.0/