### PR TITLE
[docker-compose] Upgrade and pin cAdvisor

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,7 +60,7 @@ services:
     cpu_shares: 512
     expose:
       - '8080'
-    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    image: ghcr.io/google/cadvisor:v0.60.5@sha256:763aecf1c32c2be8a1a75f9abfc2fc461005c9dbbaa39cb356b354aac1296dbe
     networks:
       - internal
     volumes:


### PR DESCRIPTION
Upgrade cAdvisor from v0.52.1 to v0.60.5 and use GHCR, the upstream registry for cAdvisor releases beginning with v0.53.0.

Pin the multi-platform OCI image index by digest so deployments use the reviewed artifact instead of whatever a mutable tag resolves to. This is especially important because cAdvisor receives the Docker socket and host filesystem mounts: a malicious or unexpectedly replaced image could inspect sensitive Docker state and potentially obtain host-level control.

Digest pinning does not reduce the authority granted to cAdvisor; the planned read-only Docker socket proxy will address that separately. It does make image changes explicit and reviewable while retaining the version tag for readability.

Release: https://github.com/google/cadvisor/releases/tag/v0.60.5