### PR TITLE
[AGENTS.md] Match branch prefixes to commit subjects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@
   git switch -c <branch-name> origin/main
   ```
 
-- When it makes the branch clearer, prefix the branch name with a short, lowercase form of the anticipated commit subject area and a slash. For example, `[AGENTS.md] Keep approval requests narrow` could use `agents-md/keep-approval-requests-narrow`. This is a preference rather than a strict mapping; use a different clear name when the subject area is not known up front or would not make a useful branch prefix.
+- When it makes the branch clearer, prefix the branch name with a short, lowercase form of the anticipated commit subject area and a slash. Prefer matching the subject area after normalizing it for a branch name instead of shortening it to a broader category; for example, `[docker-compose]` should use `docker-compose/...`, not `docker/...`. Accordingly, `[AGENTS.md] Keep approval requests narrow` could use `agents-md/keep-approval-requests-narrow`. This is a preference rather than a strict mapping; use a different clear name when the subject area is not known up front or would not make a useful branch prefix.
 - After creating the branch, configure it to track `origin/main`:
 
   ```sh


### PR DESCRIPTION
Clarify that a branch prefix should preserve the specificity of the anticipated commit subject area after normalizing it for a branch name. This avoids broad prefixes that are less useful for identifying a branch's scope.

Use docker-compose versus docker as a concrete example while retaining the existing flexibility for changes whose subject area is not known up front or would not make a useful prefix.