### PR TITLE
[prune-docker-and-rebuild] Expect socket proxy

### DIFF
--- a/bin/server/prune-docker-and-rebuild.sh
+++ b/bin/server/prune-docker-and-rebuild.sh
@@ -4,7 +4,7 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 # To minimize risk of accidental DB deletion, continue only if all expected
 # services are running.
-expected_num_services=15
+expected_num_services=16
 actual_num_services=$(docker ps --filter status=running --quiet | wc -l)
 
 if [[ "$actual_num_services" -ne "$expected_num_services" ]] ; then


### PR DESCRIPTION
The shared Docker socket proxy adds a sixteenth persistent production container. Keeping the expected count at 15 causes the scheduled maintenance script to exit before pruning or rebuilding even when every intended service is running.

Increase the count to preserve the fail-closed guard while allowing maintenance to proceed with the new production topology.

Related change: [docker-compose] Proxy monitoring socket access (#9041), main commit a1070eb15.