### PR TITLE
[quizzes] Enforce answer and participation integrity

### DIFF
--- a/app/actions/quiz_participations/create.rb
+++ b/app/actions/quiz_participations/create.rb
@@ -6,13 +6,20 @@ class QuizParticipations::Create < ApplicationAction
   fails_with :invalid_participation
 
   def execute
-    participation = user.quiz_participations.build(quiz_id: quiz.id, display_name:)
+    participation = nil
 
-    if participation.valid?
-      participation.save!
+    quiz.with_lock do
+      participation = user.quiz_participations.build(quiz:, display_name:)
+
+      if participation.valid?
+        participation.save!
+      else
+        result.invalid_participation!(participation.errors.full_messages.to_sentence)
+      end
+    end
+
+    if participation.persisted?
       QuizzesChannel.broadcast_to(quiz, new_participant_name: participation.display_name)
-    else
-      result.invalid_participation!(participation.errors.full_messages.to_sentence)
     end
   end
 end

--- a/app/actions/quiz_question_answer_selections/create.rb
+++ b/app/actions/quiz_question_answer_selections/create.rb
@@ -1,11 +1,13 @@
 class QuizQuestionAnswerSelections::Create < ApplicationAction
   requires :quiz_participation, QuizParticipation
-  requires :params, ActionController::Parameters
+  requires :answer, QuizQuestionAnswer
 
   returns :selection, QuizQuestionAnswerSelection, presence: true
 
   def execute
-    result.selection = quiz_participation.quiz_question_answer_selections.create!(params)
+    selection = quiz_participation.quiz_question_answer_selections.build
+    selection.select_answer!(answer)
+    result.selection = selection
 
     QuizzesChannel.broadcast_to(
       quiz_participation.quiz,

--- a/app/controllers/quiz_question_answer_selections_controller.rb
+++ b/app/controllers/quiz_question_answer_selections_controller.rb
@@ -2,30 +2,43 @@ class QuizQuestionAnswerSelectionsController < ApplicationController
   def create
     authorize(QuizQuestionAnswerSelection, :create?)
 
+    quiz = Quiz.find_by_hashid!(params.expect(:quiz_id))
     quiz_participation =
       current_user.
         quiz_participations.
-        find_by!(quiz_id: Quiz.find_by_hashid!(params.expect(:quiz_id)).id)
+        find_by!(quiz:)
+    answer = current_question_answer(quiz)
+
+    return head(:unprocessable_content) if answer.nil?
 
     begin
       selection =
         QuizQuestionAnswerSelections::Create.run!(
-          params: quiz_question_answer_selection_params,
+          answer:,
           quiz_participation:,
         ).selection
 
       redirect_to(selection.quiz)
-    rescue ActiveRecord::RecordInvalid
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
       head :unprocessable_content
     end
   end
 
   def update
+    quiz = Quiz.find_by_hashid!(params.expect(:quiz_id))
+    quiz_participation = current_user.quiz_participations.find_by!(quiz:)
     @quiz_question_answer_selection =
-      policy_scope(QuizQuestionAnswerSelection).find(params.expect(:id))
+      policy_scope(quiz_participation.quiz_question_answer_selections).find(params.expect(:id))
     authorize(@quiz_question_answer_selection, :update?)
+    answer = current_question_answer(quiz)
 
-    @quiz_question_answer_selection.update!(quiz_question_answer_selection_params)
+    return head(:unprocessable_content) if answer.nil?
+
+    begin
+      @quiz_question_answer_selection.select_answer!(answer)
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+      return head(:unprocessable_content)
+    end
 
     flash[:notice] = 'Answer updated!'
     redirect_to(@quiz_question_answer_selection.quiz)
@@ -35,5 +48,11 @@ class QuizQuestionAnswerSelectionsController < ApplicationController
 
   def quiz_question_answer_selection_params
     params.expect(quiz_question_answer_selection: [:answer_id])
+  end
+
+  def current_question_answer(quiz)
+    quiz.current_question&.answers&.find_by(
+      id: quiz_question_answer_selection_params[:answer_id],
+    )
   end
 end

--- a/app/models/quiz_participation.rb
+++ b/app/models/quiz_participation.rb
@@ -42,4 +42,13 @@ class QuizParticipation < ApplicationRecord
 
   validates :display_name, presence: true, uniqueness: { scope: :quiz_id }
   validates :participant_id, uniqueness: { scope: :quiz_id }
+  validate :quiz_must_be_unstarted, on: :create
+
+  private
+
+  def quiz_must_be_unstarted
+    if quiz.present? && !quiz.unstarted?
+      errors.add(:quiz, 'has already started')
+    end
+  end
 end

--- a/app/models/quiz_question_answer_selection.rb
+++ b/app/models/quiz_question_answer_selection.rb
@@ -6,28 +6,72 @@
 #  created_at       :datetime         not null
 #  id               :bigint           not null, primary key
 #  participation_id :bigint           not null
+#  question_id      :bigint           not null
 #  updated_at       :datetime         not null
 #
 # Indexes
 #
 #  index_quiz_question_answer_selections_on_answer_id         (answer_id)
-#  index_quiz_question_answer_selections_on_participation_id  (participation_id)
+#  index_quiz_question_answer_selections_on_question_id       (question_id)
+#  uniq_quiz_answer_selections_on_participation_and_question  (participation_id,question_id) UNIQUE
 #
 class QuizQuestionAnswerSelection < ApplicationRecord
   belongs_to :answer, class_name: 'QuizQuestionAnswer'
   belongs_to :participation, class_name: 'QuizParticipation'
+  belongs_to :question, class_name: 'QuizQuestion'
 
   has_one :participant, through: :participation
-  has_one :question, through: :answer
   has_one :quiz, through: :question
 
-  validate :only_one_selection_per_question
+  validates :participation_id, uniqueness: { scope: :question_id }
+  validate :answer_must_belong_to_question
+  validate :answer_must_belong_to_participation_quiz
+
+  def select_answer!(new_answer)
+    participation.quiz.with_lock do
+      current_question = participation.quiz.current_question
+
+      unless answer_is_available?(current_question, new_answer)
+        answer_not_available!
+      end
+
+      current_question.with_lock do
+        answer_not_available! unless current_question.open?
+
+        self.answer = new_answer
+        self.question = new_answer.question
+        save!
+      end
+    end
+  end
 
   private
 
-  def only_one_selection_per_question
-    if question.answer_selections.where.not(id:).exists?(participation:)
-      errors.add(:base, 'Question has already been answered')
+  def answer_is_available?(current_question, new_answer)
+    participation.quiz.active? &&
+      current_question.present? &&
+      new_answer.question_id == current_question.id &&
+      (new_record? || question_id == current_question.id)
+  end
+
+  def answer_not_available!
+    errors.add(:answer, 'is not available for selection')
+    raise(ActiveRecord::RecordInvalid, self)
+  end
+
+  def answer_must_belong_to_question
+    return if answer.blank? || question.blank?
+
+    if answer.question_id != question_id
+      errors.add(:answer, 'must belong to the selected question')
+    end
+  end
+
+  def answer_must_belong_to_participation_quiz
+    return if participation.blank? || question.blank?
+
+    if participation.quiz_id != question.quiz_id
+      errors.add(:answer, "must belong to the participation's quiz")
     end
   end
 end

--- a/db/migrate/20260807061215_add_question_to_quiz_question_answer_selections.rb
+++ b/db/migrate/20260807061215_add_question_to_quiz_question_answer_selections.rb
@@ -1,0 +1,53 @@
+class AddQuestionToQuizQuestionAnswerSelections < ActiveRecord::Migration[8.1]
+  INDEX_NAME = 'uniq_quiz_answer_selections_on_participation_and_question'
+
+  def up
+    add_reference(
+      :quiz_question_answer_selections,
+      :question,
+      foreign_key: { on_delete: :cascade, to_table: :quiz_questions },
+      null: true,
+    )
+
+    execute(<<~SQL.squish)
+      UPDATE quiz_question_answer_selections
+      SET question_id = quiz_question_answers.question_id
+      FROM quiz_question_answers
+      WHERE quiz_question_answer_selections.answer_id = quiz_question_answers.id
+    SQL
+
+    execute(<<~SQL.squish)
+      DELETE FROM quiz_question_answer_selections
+      USING quiz_participations, quiz_questions
+      WHERE quiz_question_answer_selections.participation_id = quiz_participations.id
+        AND quiz_question_answer_selections.question_id = quiz_questions.id
+        AND quiz_participations.quiz_id <> quiz_questions.quiz_id
+    SQL
+
+    execute(<<~SQL.squish)
+      DELETE FROM quiz_question_answer_selections AS duplicate_selection
+      USING quiz_question_answer_selections AS original_selection
+      WHERE duplicate_selection.participation_id = original_selection.participation_id
+        AND duplicate_selection.question_id = original_selection.question_id
+        AND duplicate_selection.id > original_selection.id
+    SQL
+
+    change_column_null :quiz_question_answer_selections, :question_id, false
+    add_index(
+      :quiz_question_answer_selections,
+      %i[participation_id question_id],
+      name: INDEX_NAME,
+      unique: true,
+    )
+    remove_index :quiz_question_answer_selections, :participation_id
+  end
+
+  def down
+    remove_reference(
+      :quiz_question_answer_selections,
+      :question,
+      foreign_key: { to_table: :quiz_questions },
+    )
+    add_index :quiz_question_answer_selections, :participation_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_06_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_07_061215) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -394,9 +394,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_120000) do
     t.bigint "answer_id", null: false
     t.datetime "created_at", null: false
     t.bigint "participation_id", null: false
+    t.bigint "question_id", null: false
     t.datetime "updated_at", null: false
     t.index ["answer_id"], name: "index_quiz_question_answer_selections_on_answer_id"
-    t.index ["participation_id"], name: "index_quiz_question_answer_selections_on_participation_id"
+    t.index ["participation_id", "question_id"], name: "uniq_quiz_answer_selections_on_participation_and_question", unique: true
+    t.index ["question_id"], name: "index_quiz_question_answer_selections_on_question_id"
   end
 
   create_table "quiz_question_answers", force: :cascade do |t|
@@ -547,6 +549,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_06_120000) do
   add_foreign_key "quiz_participations", "users", column: "participant_id"
   add_foreign_key "quiz_question_answer_selections", "quiz_participations", column: "participation_id"
   add_foreign_key "quiz_question_answer_selections", "quiz_question_answers", column: "answer_id"
+  add_foreign_key "quiz_question_answer_selections", "quiz_questions", column: "question_id", on_delete: :cascade
   add_foreign_key "quiz_question_answers", "quiz_questions", column: "question_id"
   add_foreign_key "quiz_questions", "quizzes"
   add_foreign_key "quizzes", "users", column: "owner_id"

--- a/spec/controllers/quiz_participations_controller_spec.rb
+++ b/spec/controllers/quiz_participations_controller_spec.rb
@@ -35,6 +35,17 @@ RSpec.describe QuizParticipationsController do
           expect(flash[:alert]).to eq("Display name can't be blank")
         end
       end
+
+      context 'when the quiz has already started' do
+        before { quiz.update!(status: 'active') }
+
+        let(:display_name) { "#{Faker::Name.first_name}-#{SecureRandom.alphanumeric(5)}" }
+
+        it 'does not create a participation and explains that joining is closed' do
+          expect { post_create }.not_to change { user.reload.quiz_participations.size }
+          expect(flash[:alert]).to eq('Quiz has already started')
+        end
+      end
     end
   end
 end

--- a/spec/controllers/quiz_question_answer_selections_controller_spec.rb
+++ b/spec/controllers/quiz_question_answer_selections_controller_spec.rb
@@ -16,27 +16,77 @@ RSpec.describe QuizQuestionAnswerSelectionsController do
       )
     end
 
-    let(:answer) { quiz.question_answers.first! }
+    before do
+      quiz.update!(current_question_number: 1, status: 'active')
+      question.update!(status: QuizQuestion::OPEN)
+    end
+
+    let(:answer) { question.answers.first! }
+    let(:participation) { quiz.participations.find_by!(participant: user) }
+    let(:question) { quiz.ordered_questions.first! }
     let(:quiz) { Quiz.first! }
 
     context 'when the user has not yet answered that question' do
       before { answer.selections.where(participation:).find_each(&:destroy!) }
 
-      let(:participation) { QuizParticipation.where(participant: user) }
-
       it 'creates a QuizQuestionAnswerSelection' do
         expect { post_create }.to change { QuizQuestionAnswerSelection.count }.by(1)
+      end
+
+      it 'stores the current question with the selected answer' do
+        post_create
+
+        selection = participation.quiz_question_answer_selections.find_by!(answer:)
+        expect(selection.question).to eq(question)
       end
     end
 
     context 'when the user has already answered the question' do
       before { expect(answer.selections.where(participation:)).to exist }
 
-      let(:participation) { QuizParticipation.where(participant: user) }
-
       it 'responds with 422' do
         post_create
 
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the answer belongs to a different quiz' do
+      let(:answer) do
+        other_quiz = create(:quiz, owner: user)
+        other_question = create(:quiz_question, quiz: other_quiz)
+        create(:quiz_question_answer, question: other_question)
+      end
+
+      it 'does not create a selection and responds with 422' do
+        expect { post_create }.not_to change { QuizQuestionAnswerSelection.count }
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the answer belongs to a future question' do
+      let(:answer) { quiz.ordered_questions.second.answers.first! }
+
+      it 'does not create a selection and responds with 422' do
+        expect { post_create }.not_to change { QuizQuestionAnswerSelection.count }
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the current question is closed' do
+      before { question.update!(status: QuizQuestion::CLOSED) }
+
+      it 'does not create a selection and responds with 422' do
+        expect { post_create }.not_to change { QuizQuestionAnswerSelection.count }
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the quiz has not started' do
+      before { quiz.update!(status: 'unstarted') }
+
+      it 'does not create a selection and responds with 422' do
+        expect { post_create }.not_to change { QuizQuestionAnswerSelection.count }
         expect(response).to have_http_status(422)
       end
     end
@@ -56,16 +106,61 @@ RSpec.describe QuizQuestionAnswerSelectionsController do
       )
     end
 
-    let(:answer_selection) do
-      QuizQuestionAnswerSelection.where(participation_id: user.quiz_participations).first!
+    before do
+      quiz.update!(current_question_number: 1, status: 'active')
+      question.update!(status: QuizQuestion::OPEN)
     end
-    let(:quiz) { answer_selection.quiz }
-    let(:new_answer) do
-      answer_selection.quiz.question_answers.where.not(id: answer_selection.answer_id).first!
-    end
+
+    let(:answer_selection) { question.answer_selections.find_by!(participation:) }
+    let(:new_answer) { question.answers.where.not(id: answer_selection.answer_id).first! }
+    let(:participation) { quiz.participations.find_by!(participant: user) }
+    let(:question) { quiz.ordered_questions.first! }
+    let(:quiz) { Quiz.first! }
 
     it 'changes the `answer_id` of the QuizQuestionAnswerSelection' do
       expect { patch_update }.to change { answer_selection.reload.answer_id }.to(new_answer.id)
+    end
+
+    context 'when the new answer belongs to a different quiz' do
+      let(:new_answer) do
+        other_quiz = create(:quiz, owner: user)
+        other_question = create(:quiz_question, quiz: other_quiz)
+        create(:quiz_question_answer, question: other_question)
+      end
+
+      it 'does not update the selection and responds with 422' do
+        expect { patch_update }.not_to change { answer_selection.reload.answer_id }
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the new answer belongs to a future question' do
+      let(:new_answer) { quiz.ordered_questions.second.answers.first! }
+
+      it 'does not update the selection and responds with 422' do
+        expect { patch_update }.not_to change { answer_selection.reload.answer_id }
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the current question is closed' do
+      before { question.update!(status: QuizQuestion::CLOSED) }
+
+      it 'does not update the selection and responds with 422' do
+        expect { patch_update }.not_to change { answer_selection.reload.answer_id }
+        expect(response).to have_http_status(422)
+      end
+    end
+
+    context 'when the selection belongs to an earlier question' do
+      before { quiz.update!(current_question_number: 2) }
+
+      let(:new_answer) { quiz.current_question.answers.first! }
+
+      it 'does not replay the selection for the current question and responds with 422' do
+        expect { patch_update }.not_to change { answer_selection.reload.answer_id }
+        expect(response).to have_http_status(422)
+      end
     end
   end
 end

--- a/spec/factories/quiz_question_answer_selections.rb
+++ b/spec/factories/quiz_question_answer_selections.rb
@@ -6,16 +6,19 @@
 #  created_at       :datetime         not null
 #  id               :bigint           not null, primary key
 #  participation_id :bigint           not null
+#  question_id      :bigint           not null
 #  updated_at       :datetime         not null
 #
 # Indexes
 #
 #  index_quiz_question_answer_selections_on_answer_id         (answer_id)
-#  index_quiz_question_answer_selections_on_participation_id  (participation_id)
+#  index_quiz_question_answer_selections_on_question_id       (question_id)
+#  uniq_quiz_answer_selections_on_participation_and_question  (participation_id,question_id) UNIQUE
 #
 FactoryBot.define do
   factory :quiz_question_answer_selection do
     association :answer
     association :participation, factory: :quiz_participation
+    question { answer.question }
   end
 end

--- a/spec/models/quiz_participation_spec.rb
+++ b/spec/models/quiz_participation_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe QuizParticipation do
+  subject(:participation) do
+    build(
+      :quiz_participation,
+      display_name: "Participant-#{SecureRandom.alphanumeric(5)}",
+      participant: create(:user),
+      quiz:,
+    )
+  end
+
+  let(:quiz) { create(:quiz, owner: create(:user), status:) }
+
+  context 'when the quiz has not started' do
+    let(:status) { 'unstarted' }
+
+    it { is_expected.to be_valid }
+  end
+
+  context 'when the quiz is active' do
+    let(:status) { 'active' }
+
+    it 'does not allow a new participation' do
+      expect(participation).not_to be_valid
+      expect(participation.errors[:quiz]).to include('has already started')
+    end
+  end
+
+  context 'when the quiz is closed' do
+    let(:status) { 'closed' }
+
+    it 'does not allow a new participation' do
+      expect(participation).not_to be_valid
+    end
+  end
+end

--- a/spec/models/quiz_question_answer_selection_spec.rb
+++ b/spec/models/quiz_question_answer_selection_spec.rb
@@ -36,6 +36,38 @@ RSpec.describe QuizQuestionAnswerSelection do
       it 'considers the new selection not to be valid' do
         expect(new_selection).not_to be_valid
       end
+
+      it 'is rejected by the database uniqueness constraint without model validation' do
+        expect { new_selection.save!(validate: false) }.
+          to raise_error(ActiveRecord::RecordNotUnique)
+      end
+    end
+  end
+
+  context 'when the answer belongs to a different quiz than the participation' do
+    let(:answer) { create(:quiz_question_answer, question:) }
+    let(:other_quiz) { create(:quiz, owner: participation.participant) }
+    let(:participation) { QuizParticipation.first! }
+    let(:question) { create(:quiz_question, quiz: other_quiz) }
+    let(:selection) { build(:quiz_question_answer_selection, answer:, participation:) }
+
+    it 'considers the selection invalid' do
+      expect(selection).not_to be_valid
+      expect(selection.errors[:answer]).to include("must belong to the participation's quiz")
+    end
+  end
+
+  context 'when the answer and selected question do not match' do
+    let(:answer) { participation.quiz.questions.first!.answers.first! }
+    let(:participation) { QuizParticipation.first! }
+    let(:question) { participation.quiz.questions.where.not(id: answer.question_id).first! }
+    let(:selection) do
+      build(:quiz_question_answer_selection, answer:, participation:, question:)
+    end
+
+    it 'considers the selection invalid' do
+      expect(selection).not_to be_valid
+      expect(selection.errors[:answer]).to include('must belong to the selected question')
     end
   end
 end


### PR DESCRIPTION
Resolve submitted answer IDs only through the current quiz question and recheck quiz and question state under row locks before creating or updating a selection. This prevents cross-quiz answers, future-question answers, closed-question changes, and replaying an earlier selection.

Reject new participations after a quiz starts, both through a model invariant and while holding the quiz lock so starting and joining cannot race.

Persist each selection's question, remove existing cross-quiz and duplicate invalid selections during backfill, and enforce one selection per participation and question with a unique database index. Add regression coverage for each rejected path and for the database constraint.