### PR TITLE
[sidekiq] Clarify Redis database environment variable

### DIFF
--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -3,7 +3,7 @@ unless IS_DOCKER_BUILD
 
   # We'll give Sidekiq db 1 (by default, except in tests, where this is ignored).
   # (The app uses db 0 for its direct uses.)
-  db = Integer(ENV.fetch('REDIS_DATABASE_NUMBER', 1))
+  db = Integer(ENV.fetch('SIDEKIQ_REDIS_DATABASE_NUMBER', 1))
   redis_options = RedisOptions.new(db:, sidekiq: true)
 
   Sidekiq.configure_client do |config|


### PR DESCRIPTION
REDIS_DATABASE_NUMBER configures only Sidekiq, but its broad name suggests that it selects the database for every Redis-backed application feature. That ambiguity becomes more troublesome as additional dedicated Redis databases are introduced.

Rename it to SIDEKIQ_REDIS_DATABASE_NUMBER so deployment configuration communicates its actual scope. Keep database 1 as the default, and intentionally omit a compatibility fallback for the unused old name.