### PR TITLE
[proposals] Prevent repeated invitation emails

### DIFF
--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -10,11 +10,13 @@ class ProposalsController < ApplicationController
       proposee_email: params[:spouse_email],
     )
 
-    if proposal.persisted?
+    if !proposal.persisted?
+      flash[:alert] = proposal.errors.full_messages.to_sentence
+    elsif proposal.previously_new_record?
       ProposalMailer.proposal_created(proposal.id).deliver_later
       flash[:notice] = 'Invitation sent.'
     else
-      flash[:alert] = proposal.errors.full_messages.to_sentence
+      flash[:notice] = 'Invitation already pending.'
     end
 
     redirect_to(redirect_location || check_ins_path)

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -30,19 +30,17 @@ RSpec.describe(ProposalsController) do
     end
 
     context 'when the same proposal is already pending' do
-      let!(:existing_proposal) do
-        create(:proposal, proposer:, proposee_email: proposee.email)
-      end
+      before { create(:proposal, proposer:, proposee_email: proposee.email) }
 
-      it 'resends the existing proposal instead of creating another one' do
+      it 'does not create or resend the proposal' do
         expect {
           post_create
         }.not_to change {
           proposer.sent_proposals.count
         }
 
-        expect(ProposalMailer).to have_received(:proposal_created).with(existing_proposal.id)
-        expect(flash[:notice]).to eq('Invitation sent.')
+        expect(ProposalMailer).not_to have_received(:proposal_created)
+        expect(flash[:notice]).to eq('Invitation already pending.')
       end
     end
 


### PR DESCRIPTION
`ProposalsController#create` used `find_or_create_by` but sent an email whenever the returned proposal was persisted. Repeating a request for an existing pending proposal therefore enqueued another invitation without creating a new record.

Use `previously_new_record?` to send only after creating the proposal. Preserve the pending proposal and its acceptance link on repeated requests, but report `Invitation already pending.` and enqueue no email.