### PR TITLE
[LogShare] Normalize and validate recipient emails

### DIFF
--- a/app/models/log_share.rb
+++ b/app/models/log_share.rb
@@ -16,7 +16,9 @@ class LogShare < ApplicationRecord
   belongs_to :log
   has_one :user, through: :log
 
-  validates :email, presence: true, uniqueness: { scope: :log_id }
+  normalizes :email, with: ->(email) { email.strip.downcase }
+
+  validates :email, presence: true, email_format: true, uniqueness: { scope: :log_id }
 
   has_paper_trail
 end

--- a/spec/models/log_share_spec.rb
+++ b/spec/models/log_share_spec.rb
@@ -4,4 +4,38 @@ RSpec.describe LogShare do
   it { is_expected.to belong_to(:log) }
 
   it { is_expected.to validate_presence_of(:email) }
+
+  describe 'email' do
+    it 'normalizes whitespace and letter case' do
+      log_share.email = '  Shared.User@Example.COM  '
+
+      expect(log_share.email).to eq('shared.user@example.com')
+    end
+
+    it 'rejects an invalid email address' do
+      log_share.email = 'not-an-email-address'
+
+      expect(log_share).not_to be_valid
+      expect(log_share.errors.full_messages_for(:email)).to eq(['Email is invalid'])
+    end
+
+    it 'leaves blank email addresses to presence validation' do
+      log_share.email = ''
+
+      expect(log_share).not_to be_valid
+      expect(log_share.errors.full_messages_for(:email)).to eq(["Email can't be blank"])
+    end
+
+    it 'rejects a normalized duplicate for the same log' do
+      duplicate_log_share =
+        build(
+          :log_share,
+          log: log_share.log,
+          email: "  #{log_share.email.upcase}  ",
+        )
+
+      expect(duplicate_log_share).not_to be_valid
+      expect(duplicate_log_share.errors[:email]).to include('has already been taken')
+    end
+  end
 end


### PR DESCRIPTION
`LogShare` previously accepted any nonblank recipient address and stored its whitespace and letter case unchanged. That allowed malformed delivery targets and semantic duplicates that could evade the `(log_id, email)` uniqueness constraint and complicate recipient-based email quotas.

Normalize new assignments with `strip.downcase` and apply the shared `email_format` validation. The existing exact unique index then protects canonical addresses for future application writes.

Intentionally omit a data migration based on the assumption that production contains no existing `LogShare` rows and that a row appearing before deployment is extremely unlikely. Any such unexpected row remains untouched by this change.