### PR TITLE
[email] Apply the global circuit breaker broadly

### DIFF
--- a/app/controllers/api/webhook_email_forwards_controller.rb
+++ b/app/controllers/api/webhook_email_forwards_controller.rb
@@ -6,11 +6,18 @@ class Api::WebhookEmailForwardsController < Api::BaseController
 
     subject = params[:title]
     html_body = params[:message]
-    GenericMailer.generic_html(
-      current_or_auth_token_user.email,
-      subject,
-      html_body,
-    ).deliver_later
+    delivery_limit =
+      Email::UserGeneratedDeliveryLimiter.reserve_global(
+        category: :webhook_email_forward,
+      )
+
+    if delivery_limit.permitted?
+      GenericMailer.generic_html(
+        current_or_auth_token_user.email,
+        subject,
+        html_body,
+      ).deliver_later
+    end
 
     head :created
   end

--- a/app/mailboxes/replies_mailbox.rb
+++ b/app/mailboxes/replies_mailbox.rb
@@ -15,13 +15,18 @@ class RepliesMailbox < ApplicationMailbox
         mail.parsed_body || '[no body]'
       end
 
-    ReplyForwardingMailer.reply_received(
-      mail.message_id,
-      from_email,
-      subject,
-      body,
-      is_attachment,
-      has_attachments,
-    ).deliver_later
+    delivery_limit =
+      Email::UserGeneratedDeliveryLimiter.reserve_global(category: :reply_forwarding)
+
+    if delivery_limit.permitted?
+      ReplyForwardingMailer.reply_received(
+        mail.message_id,
+        from_email,
+        subject,
+        body,
+        is_attachment,
+        has_attachments,
+      ).deliver_later
+    end
   end
 end

--- a/app/poros/email/user_generated_delivery_limiter.rb
+++ b/app/poros/email/user_generated_delivery_limiter.rb
@@ -80,12 +80,17 @@ class Email::UserGeneratedDeliveryLimiter
     def reserve(actor:, recipient_email:, category:)
       new(actor:, recipient_email:, category:).reserve
     end
+
+    def reserve_global(category:)
+      new(category:, global_only: true).reserve
+    end
   end
 
-  def initialize(actor:, recipient_email:, category:)
-    @actor_id = actor.id
-    @recipient_email = recipient_email.strip.downcase
+  def initialize(category:, actor: nil, recipient_email: nil, global_only: false)
+    @actor_id = actor&.id
+    @recipient_email = recipient_email&.strip&.downcase
     @category = category
+    @global_only = global_only
   end
 
   def reserve
@@ -107,10 +112,12 @@ class Email::UserGeneratedDeliveryLimiter
 
   private
 
-  attr_reader :actor_id, :category, :recipient_email
+  attr_reader :actor_id, :category, :global_only, :recipient_email
 
   memoize \
   def applicable_quotas
+    return [build_quota(GLOBAL_LIMIT)] if global_only
+
     [
       build_quota(GLOBAL_LIMIT),
       *ACTOR_LIMITS.map { build_quota(it, actor_id) },
@@ -201,6 +208,6 @@ class Email::UserGeneratedDeliveryLimiter
       category:,
       actor_id:,
       recipient_email:,
-    }
+    }.compact
   end
 end

--- a/app/workers/send_log_reminder_emails.rb
+++ b/app/workers/send_log_reminder_emails.rb
@@ -5,6 +5,11 @@ class SendLogReminderEmails
 
   def perform
     Log.needing_reminder.find_each do |log|
+      delivery_limit =
+        Email::UserGeneratedDeliveryLimiter.reserve_global(category: :log_reminder)
+
+      next unless delivery_limit.permitted?
+
       log.update!(reminder_last_sent_at: Time.current)
       LogReminderMailer.reminder(log.id).deliver_later
     end

--- a/spec/controllers/api/webhook_email_forwards_controller_spec.rb
+++ b/spec/controllers/api/webhook_email_forwards_controller_spec.rb
@@ -36,6 +36,22 @@ RSpec.describe Api::WebhookEmailForwardsController do
           expect(mail.subject).to eq(alert_title)
           expect(mail.body.to_s).to eq(alert_body)
         end
+
+        context 'when the global email circuit breaker is open' do
+          before do
+            Email::UserGeneratedDeliveryLimiter::GLOBAL_LIMIT.maximum.times do
+              Email::UserGeneratedDeliveryLimiter.reserve_global(
+                category: :webhook_email_forward,
+              )
+            end
+          end
+
+          it 'responds with :created without sending the forwarded email', queue_adapter: :test do
+            expect { post_create }.not_to enqueue_mail(GenericMailer, :generic_html)
+
+            expect(response).to have_http_status(:created)
+          end
+        end
       end
     end
   end

--- a/spec/mailboxes/replies_mailbox_spec.rb
+++ b/spec/mailboxes/replies_mailbox_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe RepliesMailbox do
         }
     end
 
+    context 'when the global email circuit breaker is open' do
+      before do
+        Email::UserGeneratedDeliveryLimiter::GLOBAL_LIMIT.maximum.times do
+          Email::UserGeneratedDeliveryLimiter.reserve_global(category: :reply_forwarding)
+        end
+      end
+
+      it 'does not forward the email', queue_adapter: :test do
+        expect { processed_mail }.not_to enqueue_mail(ReplyForwardingMailer, :reply_received)
+      end
+    end
+
     context 'when an error is raised while parsing the email body' do
       before do
         expect(RungerEmailReplyTrimmer).

--- a/spec/poros/email/user_generated_delivery_limiter_spec.rb
+++ b/spec/poros/email/user_generated_delivery_limiter_spec.rb
@@ -238,4 +238,22 @@ RSpec.describe Email::UserGeneratedDeliveryLimiter, queue_adapter: :test do
       end
     end
   end
+
+  describe '::reserve_global' do
+    it 'limits global-only deliveries across categories' do
+      described_class::GLOBAL_LIMIT.maximum.times do |index|
+        result =
+          described_class.reserve_global(
+            category: %i[log_reminder reply_forwarding webhook_email_forward].fetch(index % 3),
+          )
+
+        expect(result).to be_permitted
+      end
+
+      denied_result = described_class.reserve_global(category: :log_reminder)
+
+      expect(denied_result).not_to be_permitted
+      expect(denied_result.limit_name).to eq(:global_hour)
+    end
+  end
 end

--- a/spec/workers/send_log_reminder_emails_spec.rb
+++ b/spec/workers/send_log_reminder_emails_spec.rb
@@ -31,6 +31,20 @@ RSpec.describe SendLogReminderEmails do
         expect { perform }.to enqueue_mail(LogReminderMailer, :reminder).
           with(log_needing_reminder.id)
       end
+
+      context 'when the global email circuit breaker is open' do
+        before do
+          Email::UserGeneratedDeliveryLimiter::GLOBAL_LIMIT.maximum.times do
+            Email::UserGeneratedDeliveryLimiter.reserve_global(category: :log_reminder)
+          end
+        end
+
+        it 'does not update the reminder timestamp or send an email', queue_adapter: :test do
+          expect { perform }.not_to enqueue_mail(LogReminderMailer, :reminder)
+
+          expect(log_needing_reminder.reload.reminder_last_sent_at).to be_nil
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
PR #9058 added the shared user-generated email limiter for proposals, log shares, and comment replies. Extend only its global hourly circuit breaker to the remaining user-controlled delivery paths: webhook forwarding, log reminders, and replies mailbox forwarding.

Add `reserve_global(category:)` so these paths do not need fabricated actor or recipient identities and are not subject to the per-actor or per-recipient quotas. The global counter remains shared with the existing limiter, and Redis failures retain the fail-open behavior established by PR #9058.

When the global limit is open, webhook requests still return `201 Created` without enqueuing the forwarded email, inbound replies are accepted without forwarding, and log reminders remain eligible for a later run because their `reminder_last_sent_at` timestamp advances only after a permitted enqueue.

Cover the global-only limiter path and each integration with real enqueue assertions. The administrator circuit-breaker alert remains the one-per-window notification handled by the existing `SET ... NX` alert key.