### PR TITLE
[ci-step-results] Scope run uniqueness by user

### DIFF
--- a/app/models/ci_step_result.rb
+++ b/app/models/ci_step_result.rb
@@ -18,13 +18,14 @@
 #
 # Indexes
 #
-#  idx_on_name_github_run_id_github_run_attempt_96ff2b0b91  (name,github_run_id,github_run_attempt) UNIQUE
-#  index_ci_step_results_on_user_id                         (user_id)
+#  idx_on_user_id_name_github_run_id_github_run_attemp_5e30d34615  (user_id,name,github_run_id,github_run_attempt) UNIQUE
 #
 class CiStepResult < ApplicationRecord
   belongs_to :user
 
-  validates :name, presence: true, uniqueness: { scope: %i[github_run_id github_run_attempt] }
+  validates :name,
+            presence: true,
+            uniqueness: { scope: %i[user_id github_run_id github_run_attempt] }
   validates :seconds, presence: true
   validates :started_at, presence: true
   validates :stopped_at, presence: true

--- a/db/migrate/20260810152610_scope_ci_step_result_uniqueness_to_user.rb
+++ b/db/migrate/20260810152610_scope_ci_step_result_uniqueness_to_user.rb
@@ -1,0 +1,17 @@
+class ScopeCiStepResultUniquenessToUser < ActiveRecord::Migration[8.1]
+  def up
+    add_index :ci_step_results,
+              %i[user_id name github_run_id github_run_attempt],
+              unique: true
+    remove_index :ci_step_results, %i[name github_run_id github_run_attempt]
+    remove_index :ci_step_results, :user_id
+  end
+
+  def down
+    add_index :ci_step_results,
+              %i[name github_run_id github_run_attempt],
+              unique: true
+    add_index :ci_step_results, :user_id, if_not_exists: true
+    remove_index :ci_step_results, %i[user_id name github_run_id github_run_attempt]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_07_061215) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_152610) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -177,8 +177,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_07_061215) do
     t.datetime "stopped_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
-    t.index ["name", "github_run_id", "github_run_attempt"], name: "idx_on_name_github_run_id_github_run_attempt_96ff2b0b91", unique: true
-    t.index ["user_id"], name: "index_ci_step_results_on_user_id"
+    t.index ["user_id", "name", "github_run_id", "github_run_attempt"], name: "idx_on_user_id_name_github_run_id_github_run_attemp_5e30d34615", unique: true
   end
 
   create_table "comments", force: :cascade do |t|

--- a/spec/controllers/api/ci_step_results/bulk_creations_controller_spec.rb
+++ b/spec/controllers/api/ci_step_results/bulk_creations_controller_spec.rb
@@ -74,6 +74,24 @@ RSpec.describe(Api::CiStepResults::BulkCreationsController) do
 
             expect(response).to have_http_status(201)
           end
+
+          context 'when another user has a result for the same GitHub run' do
+            before do
+              create(
+                :ci_step_result,
+                user: User.excluding(user).first!,
+                **valid_ci_step_result_1.slice(:name, :github_run_id, :github_run_attempt),
+              )
+            end
+
+            it 'creates CiStepResults for the authenticated user' do
+              expect { post_create }.to change {
+                user.reload.ci_step_results.size
+              }.by(ci_step_results_data.size)
+
+              expect(response).to have_http_status(201)
+            end
+          end
         end
 
         context 'when the CiStepResult params are invalid' do

--- a/spec/factories/ci_step_results.rb
+++ b/spec/factories/ci_step_results.rb
@@ -18,8 +18,7 @@
 #
 # Indexes
 #
-#  idx_on_name_github_run_id_github_run_attempt_96ff2b0b91  (name,github_run_id,github_run_attempt) UNIQUE
-#  index_ci_step_results_on_user_id                         (user_id)
+#  idx_on_user_id_name_github_run_id_github_run_attemp_5e30d34615  (user_id,name,github_run_id,github_run_attempt) UNIQUE
 #
 FactoryBot.define do
   factory :ci_step_result do


### PR DESCRIPTION
CI step ingestion previously enforced uniqueness across all users for the combination of step name, GitHub run ID, and run attempt. Because GitHub run metadata is public, one authenticated user could reserve another user's tuple and cause that user's bulk submission transaction to roll back.

Include user_id in both the Active Record validation and database unique index so run identities are isolated by account. The composite index also covers user-only lookups, allowing the now-redundant user_id index to be removed.

Add a controller regression example proving an authenticated user's bulk submission succeeds when another user already owns the same run tuple.