### PR TITLE
[coverage] Check full coverage independently [DEV-261]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -128,6 +128,11 @@ jobs:
           PERCY_TOKEN: '${{secrets.PERCY_TOKEN}}'
           CODECOV_TOKEN: '${{secrets.CODECOV_TOKEN}}'
 
+      - name: Check code coverage
+        id: check_code_coverage
+        continue-on-error: true
+        run: bin/check-code-coverage
+
       - name: Save failed feature spec logs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
@@ -151,6 +156,10 @@ jobs:
 
       - name: Prune pnpm store
         run: pnpm store prune
+
+      - name: Propagate code coverage failure
+        if: ${{ !cancelled() && steps.check_code_coverage.outcome == 'failure' }}
+        run: exit 1
 
   deploy-and-prerender:
     concurrency:

--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -1,4 +1,4 @@
-expected-num-github-checks: 4
+expected-num-github-checks: 2
 javascript-watch-command: ./node_modules/.bin/vite --force
 spec-commands: |
   export RAILS_ENV=test PALLETS_CONCURRENCY=${PALLETS_CONCURRENCY:-6} DISABLE_SPRING=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@
 - Do not routinely run Vitest or TypeScript checks locally. Run them when the task particularly benefits from them; otherwise rely on CI.
 - Do not run `bin/run-tests` locally by default. It is primarily a CI command, and CI may catch issues through checks that are intentionally not run during local development.
 - Maintain 100% line coverage for Ruby code included in coverage, apart from lines that are explicitly ignored. Coverage may come from any combination of spec types; it does not need to come entirely from unit specs.
-- Do not run the entire test suite locally solely to confirm total coverage. CI and Codecov perform the authoritative full-suite coverage check.
+- Do not run the entire test suite locally solely to confirm total coverage. CI performs the authoritative full-suite coverage check; Codecov also reports full-suite coverage.
 
 ## Test design
 

--- a/app/poros/null_byte_finder.rb
+++ b/app/poros/null_byte_finder.rb
@@ -3,10 +3,6 @@ class NullByteFinder
     @object = object
   end
 
-  def dev_261_uncovered_method
-    nil
-  end
-
   def has_null_byte?
     case @object
     when String

--- a/app/poros/null_byte_finder.rb
+++ b/app/poros/null_byte_finder.rb
@@ -3,6 +3,10 @@ class NullByteFinder
     @object = object
   end
 
+  def dev_261_uncovered_method
+    nil
+  end
+
   def has_null_byte?
     case @object
     when String

--- a/bin/check-code-coverage
+++ b/bin/check-code-coverage
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require 'rexml/document'
+
+coverage_report_path = ARGV.fetch(0, 'tmp/simple_cov/coverage.xml')
+abort("Coverage report not found at #{coverage_report_path}.") if !File.file?(coverage_report_path)
+
+coverage = REXML::Document.new(File.read(coverage_report_path)).root
+covered_lines = Integer(coverage.attributes.fetch('lines-covered').to_s)
+valid_lines = Integer(coverage.attributes.fetch('lines-valid').to_s)
+
+if covered_lines != valid_lines
+  abort("Line coverage is not 100% (#{covered_lines}/#{valid_lines} lines covered).")
+end
+
+puts("Line coverage is 100% (#{covered_lines}/#{valid_lines} lines covered).")


### PR DESCRIPTION
Fail the test workflow when the existing Cobertura report contains any uncovered lines. Compare the integer covered and valid line totals instead of the rounded line rate.

Let the coverage check continue initially so later steps, including the existing Codecov upload and cleanup, still run. At the end of the job, propagate the original failure outcome so incomplete coverage remains merge-blocking.

Reduce `expected-num-github-checks` from four to two so the Codecov project and patch statuses no longer delay merges. Keep Codecov as a reporting tool and document CI as the authoritative coverage gate.

Temporarily add an unused method body to `NullByteFinder`. This deliberately leaves one executable line uncovered so the initial commit can confirm that both the new check and Codecov detect it; a follow-up commit will remove the method.