### PR TITLE
[admin] Bind OAuth logins to Google subjects

### DIFF
--- a/app/controllers/admin/omniauth_callbacks_controller.rb
+++ b/app/controllers/admin/omniauth_callbacks_controller.rb
@@ -1,4 +1,6 @@
 class Admin::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  class SubMismatch < StandardError ; end
+
   skip_before_action :authenticate_user!, only: [:google_oauth2]
 
   def google_oauth2
@@ -6,9 +8,30 @@ class Admin::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
     access_token = request.env['omniauth.auth']
     email = access_token.info['email']
+    sub = access_token.dig('extra', 'id_info', 'sub').presence!
     admin_user = AdminUser.find_by(email:)
 
     if admin_user
+      # https://cyberinsider.com/unfixed-google-oauth-flaw-exposes-millions-to-account-takeovers/
+      if admin_user.google_sub
+        if sub != admin_user.google_sub
+          Rails.error.report(
+            Error.new(SubMismatch),
+            context: {
+              email:,
+              admin_user_sub_in_db: admin_user.google_sub,
+              sub_in_google_response: sub,
+            },
+          )
+
+          flash[:alert] = 'You are attempting a domain identity takeover attack. Blocked!'
+          redirect_to(new_admin_user_session_path)
+          return
+        end
+      else
+        admin_user.update!(google_sub: sub)
+      end
+
       sign_in(admin_user)
       redirect_to(session.delete('admin_user_return_to') || admin_root_path)
     else

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -18,6 +18,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
           Rails.error.report(
             Error.new(SubMismatch),
             context: {
+              email:,
               user_sub_in_db: user.google_sub,
               sub_in_google_response: sub,
             },

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -4,6 +4,7 @@
 #
 #  created_at :datetime         not null
 #  email      :string           not null
+#  google_sub :string
 #  id         :bigint           not null, primary key
 #  updated_at :datetime         not null
 #

--- a/db/migrate/20260810164357_add_google_sub_to_admin_users.rb
+++ b/db/migrate/20260810164357_add_google_sub_to_admin_users.rb
@@ -1,0 +1,5 @@
+class AddGoogleSubToAdminUsers < ActiveRecord::Migration[8.1]
+  def change
+    add_column :admin_users, :google_sub, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_152610) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_10_164357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -69,6 +69,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_152610) do
   create_table "admin_users", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "email", null: false
+    t.string "google_sub"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_admin_users_on_email", unique: true
   end

--- a/spec/factories/admin_users.rb
+++ b/spec/factories/admin_users.rb
@@ -4,6 +4,7 @@
 #
 #  created_at :datetime         not null
 #  email      :string           not null
+#  google_sub :string
 #  id         :bigint           not null, primary key
 #  updated_at :datetime         not null
 #

--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -1,22 +1,83 @@
 RSpec.describe 'Logging in as an AdminUser via Google auth' do
-  before { MockOmniAuth.google_oauth2(email: stubbed_admin_user_email, sub: rand(100_000_000_000)) }
+  before do
+    MockOmniAuth.google_oauth2(email: stubbed_admin_user_email, sub: mocked_google_response_sub)
+  end
+
+  let(:mocked_google_response_sub) { "1#{rand(100_000_000_000_000_000)}" }
 
   context 'when an AdminUser with the email exists in the database' do
     let(:stubbed_admin_user_email) { admin_user.email }
     let(:admin_user) { admin_users(:admin_user) }
 
-    it 'allows the AdminUser to log in via Google' do
-      visit(new_admin_user_session_path)
+    context 'when the AdminUser does not have a google_sub in the database' do
+      before { expect(admin_user.google_sub).to eq(nil) }
 
-      expect(page).to have_css('google-sign-in-button')
+      it "allows the AdminUser to log in and saves the AdminUser's Google 'sub' value" do
+        visit(new_admin_user_session_path)
 
-      expect {
-        click_sign_in_with_google
-        expect(page).to have_current_path(admin_root_path)
-      }.not_to change { AdminUser.count }
+        expect(page).to have_css('google-sign-in-button')
 
-      expect(page).to have_text('David Runger Admin Dashboard')
-      expect(page).to have_text('Admin Tools')
+        expect {
+          click_sign_in_with_google
+          expect(page).to have_current_path(admin_root_path)
+        }.not_to change { AdminUser.count }
+
+        expect(page).to have_text('David Runger Admin Dashboard')
+        expect(page).to have_text('Admin Tools')
+        expect(admin_user.reload.google_sub).to eq(mocked_google_response_sub)
+      end
+    end
+
+    context 'when the AdminUser has a google_sub in the database' do
+      before { admin_user.update!(google_sub: admin_user_google_sub.presence!) }
+
+      let(:admin_user_google_sub) { "1#{rand(100_000_000_000_000_000)}" }
+
+      context 'when the sub returned from Google matches the google_sub in our database' do
+        let(:mocked_google_response_sub) { admin_user_google_sub }
+
+        it 'allows the AdminUser to log in via Google' do
+          visit(new_admin_user_session_path)
+          expect(page).to have_css('google-sign-in-button')
+
+          expect { click_sign_in_with_google }.not_to change { AdminUser.count }
+
+          expect(page).to have_current_path(admin_root_path)
+          expect(page).to have_text('David Runger Admin Dashboard')
+          expect(page).to have_text('Admin Tools')
+        end
+      end
+
+      context 'when the sub returned from Google does not match the google_sub in our database' do
+        let(:mocked_google_response_sub) { (Integer(admin_user_google_sub) + 1).to_s }
+
+        it 'redirects with an error message, does not sign in the AdminUser, and reports the error' do
+          allow(Rails.error).to receive(:report).and_call_original
+
+          visit(new_admin_user_session_path)
+          expect(page).to have_css('google-sign-in-button')
+
+          expect { click_sign_in_with_google }.not_to change { AdminUser.count }
+
+          expect(page).to have_current_path(new_admin_user_session_path)
+          expect(page).to have_flash_message(<<~FLASH.squish, type: :alert)
+            You are attempting a domain identity takeover attack. Blocked!
+          FLASH
+
+          expect(Rails.error).to have_received(:report).
+            with(
+              Admin::OmniauthCallbacksController::SubMismatch,
+              context: {
+                email: admin_user.email,
+                admin_user_sub_in_db: admin_user.google_sub,
+                sub_in_google_response: mocked_google_response_sub,
+              },
+            )
+
+          visit(admin_root_path)
+          expect(page).to have_current_path(new_admin_user_session_path)
+        end
+      end
     end
   end
 

--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -103,6 +103,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
               with(
                 Users::OmniauthCallbacksController::SubMismatch,
                 context: {
+                  email: user.email,
                   user_sub_in_db: user.google_sub,
                   sub_in_google_response: mocked_google_response_sub,
                 },


### PR DESCRIPTION
Persist the immutable Google `sub` claim when an existing administrator first signs in through Google OAuth. Require subsequent responses for that email address to carry the same subject before calling `sign_in`.

This preserves access for existing administrators without requiring a backfill while preventing a reassigned email identity from inheriting administrator access. Report subject mismatches through `Rails.error` and return the administrator to the login page with the same takeover warning used by the user flow.

Include the attempted email in subject-mismatch error context so reports identify the affected account. As a tangential consistency improvement, add the same field to the pre-existing User mismatch report even though that flow is otherwise outside this administrator fix.

Add feature coverage for initial binding, matching-sub login, and mismatch rejection. This addresses the Google OAuth identity-reassignment risk described at https://cyberinsider.com/unfixed-google-oauth-flaw-exposes-millions-to-account-takeovers/.