### PR TITLE
[spec/features/logs] Ignore prior CSV downloads [LOG-54]

### DIFF
--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -234,8 +234,6 @@ RSpec.describe 'Logs app' do
         it 'allows the user to confirm an exact CSV download' do
           formula = '=SUM(A1:A2)'
           log.build_log_entry_with_datum(data: formula).save!
-          csv_glob = File.join(Capybara.save_path, '*.csv')
-          existing_csv_paths = Dir.glob(csv_glob)
 
           visit(log_path(slug: log.slug))
 
@@ -247,11 +245,7 @@ RSpec.describe 'Logs app' do
             click_on('Download exact CSV')
           end
 
-          new_csv_path = nil
-          wait_for do
-            new_csv_path = (Dir.glob(csv_glob) - existing_csv_paths).first
-          end.not_to be_nil
-          csv = CSV.read(new_csv_path, headers: true)
+          csv = CSV.read(downloaded_file_path('*.csv'), headers: true)
 
           expect(csv.to_a.flatten).to include(formula)
         end

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -3,6 +3,12 @@ RSpec.configure do |config|
     tmp_dir = Dir.mktmpdir
     Capybara.save_path = tmp_dir
   end
+
+  config.before(:each, type: :feature) do
+    @preexisting_capybara_save_paths = Dir.glob(
+      File.join(Capybara.save_path, '**', '*'),
+    )
+  end
 end
 
 module Features::DownloadHelpers
@@ -12,7 +18,7 @@ module Features::DownloadHelpers
     absolute_glob_pattern = File.join(Capybara.save_path, relative_glob_pattern)
 
     max_attempts.times do |index|
-      matching_paths = Dir.glob(absolute_glob_pattern)
+      matching_paths = Dir.glob(absolute_glob_pattern) - @preexisting_capybara_save_paths
 
       if (matching_path = matching_paths.first)
         break matching_path


### PR DESCRIPTION
Feature downloads share one Capybara save directory for the full suite. When the exact CSV example runs first, its file remains available and the standard CSV example can mistakenly parse that stale download.

Record paths already present at the start of each feature example, and have `downloaded_file_path` automatically ignore them. Download assertions stay concise and cannot accidentally inspect a file from an earlier example.