### PR TITLE
[vite] Use native ESM directory path [DEV-259]

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -1,4 +1,4 @@
-/* global __dirname, process */
+/* global process */
 
 import path from 'path';
 import tailwindcss from '@tailwindcss/vite';
@@ -42,9 +42,9 @@ export default defineConfig(({ mode }) => ({
   ],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './app/javascript'),
-      img: path.resolve(__dirname, './app/assets/images'),
-      css: path.resolve(__dirname, './app/assets/stylesheets'),
+      '@': path.resolve(import.meta.dirname, './app/javascript'),
+      img: path.resolve(import.meta.dirname, './app/assets/images'),
+      css: path.resolve(import.meta.dirname, './app/assets/stylesheets'),
       ...(mode === 'production' && {
         'vue-types': 'vue-types/shim',
       }),


### PR DESCRIPTION
Vite warns that `__dirname` is unsupported by the native config loader, which is planned to become the default in a future major release.

Resolve each application asset alias relative to `import.meta.dirname` instead. This preserves the existing paths while allowing the config to load natively without the deprecation warning seen in GitHub Actions job https://github.com/davidrunger/david_runger/actions/runs/31145579524/job/92764197273?pr=9037 and during local Vite startup.