### PR TITLE
[supply chain] Pin external build inputs

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -85,7 +85,7 @@ jobs:
           node-version-file: .node-version
 
       - name: Install pnpm
-        run: npm install -g pnpm@11
+        run: npm install -g pnpm@11.21.0
 
       - name: Set pnpm store directory
         run: echo "PNPM_STORE_PATH=$(pnpm store path)" >> $GITHUB_ENV

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,10 @@ RUN --mount=type=cache,sharing=private,target=/var/lib/apt/lists \
 
 # Download skedjewel binary.
 ARG SKEDJEWEL_VERSION=v2.1.1
-RUN curl --fail -L "https://github.com/davidrunger/skedjewel/releases/download/$SKEDJEWEL_VERSION/skedjewel-$SKEDJEWEL_VERSION-linux" > skedjewel && \
+ARG SKEDJEWEL_SHA256=893b22fe45c795fd0875567c11fe06290debe1f082d5e89a02c70d211041cd81
+RUN curl --fail --location --output skedjewel \
+  "https://github.com/davidrunger/skedjewel/releases/download/$SKEDJEWEL_VERSION/skedjewel-$SKEDJEWEL_VERSION-linux" && \
+  echo "$SKEDJEWEL_SHA256  skedjewel" | sha256sum --check --strict && \
   mkdir -p /app/bin && \
   mv skedjewel /app/bin/ && \
   chmod a+x /app/bin/skedjewel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
       - .env.grafana.local
     expose:
       - '3000'
-    image: grafana/grafana:latest
+    image: grafana/grafana:13.1.3@sha256:ab5cb380e3ff3172d6c8bd2e7cfd31cce977d2881b260e1f5bc089bf0b759b43
     networks:
       - external # Allows Grafana to download plugins.
       - internal
@@ -162,7 +162,7 @@ services:
         condition: service_started
   loki:
     cpu_shares: 512
-    image: grafana/loki:latest
+    image: grafana/loki:3.7.6@sha256:efd47c67f9bac88ca29bcf8cb997d9ab29d1848bd0aff579282295542a745952
     command:
       - -config.file=/etc/loki/local-config.yaml
       - -log.level=warn
@@ -215,7 +215,7 @@ services:
     cpu_shares: 512
     expose:
       - '9100'
-    image: prom/node-exporter:latest
+    image: prom/node-exporter:v1.12.1@sha256:1b4e4438faca4dd7e001dd445d161a4a2091b0fededa84093b3a8dfeae1f1be0
     networks:
       - internal
   postgres:
@@ -262,7 +262,7 @@ services:
     cpu_shares: 512
     expose:
       - '9090'
-    image: prom/prometheus:latest
+    image: prom/prometheus:v3.13.2@sha256:508729e0e2d18e11fd742a5a5ca70e557b940a93948c3c95fd0123a6fd538b69
     networks:
       - internal
     volumes:


### PR DESCRIPTION
Replace the remaining Compose latest tags with explicit Grafana, Loki, node_exporter, and Prometheus release tags plus their multi-platform image-index digests. The selected release tags resolve to the same indexes as latest at the time of this change, so deployments become reproducible without changing the artifacts currently in use.

Verify the downloaded Skedjewel v2.1.1 Linux binary against its pinned SHA-256 digest before installing it. A changed, truncated, or substituted release asset now fails the image build.

Install exact pnpm 11.21.0 in CI instead of allowing npm to select any future pnpm 11 release. Version and digest upgrades remain deliberate reviewable changes.