### PR TITLE
[docker-compose/grafana] Pin Logs Drilldown plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,6 +140,9 @@ services:
       - prometheus
     env_file:
       - .env.grafana.local
+    environment:
+      GF_INSTALL_PLUGINS: ''
+      GF_PLUGINS_PREINSTALL_SYNC: grafana-lokiexplore-app@2.4.0
     expose:
       - '3000'
     image: grafana/grafana:13.1.3@sha256:ab5cb380e3ff3172d6c8bd2e7cfd31cce977d2881b260e1f5bc089bf0b759b43


### PR DESCRIPTION
Grafana 13 uses React 19, but the persisted Logs Drilldown 1.0.14 plugin predates the plugin's React 19 compatibility work and fails to load when viewing logs.

Preinstall exact Logs Drilldown 2.4.0 synchronously so Grafana upgrades the plugin before accepting requests. Version 2.4.0 supports the deployed Grafana and Loki versions.

Override the legacy GF_INSTALL_PLUGINS value from the server-local environment file. That value downloads an unversioned latest.zip artifact and Grafana 13 deprecates its installation mechanism.