### PR TITLE
[docker-compose/grafana] Remove legacy plugin override

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -141,7 +141,6 @@ services:
     env_file:
       - .env.grafana.local
     environment:
-      GF_INSTALL_PLUGINS: ''
       GF_PLUGINS_PREINSTALL_SYNC: grafana-lokiexplore-app@2.4.0
     expose:
       - '3000'


### PR DESCRIPTION
Remove the empty `GF_INSTALL_PLUGINS` override now that the deprecated variable has been removed from the server-local environment file.

Keep `GF_PLUGINS_PREINSTALL_SYNC` as the source-controlled configuration that installs exact Logs Drilldown 2.4.0 before Grafana starts.