### PR TITLE
[runger-config] Require at least (not exactly) two passed checks

### DIFF
--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -1,4 +1,5 @@
-expected-num-github-checks: 2
+expected-num-github-checks:
+  at-least: 2
 javascript-watch-command: ./node_modules/.bin/vite --force
 spec-commands: |
   export RAILS_ENV=test PALLETS_CONCURRENCY=${PALLETS_CONCURRENCY:-6} DISABLE_SPRING=1


### PR DESCRIPTION
In #9074, we started checking code coverage within GitHub Actions, rather than waiting for the Codecov report. However, sometimes the Codecov checks will have completed by the time we merge. Changing from expecting exactly 2 passed checks to expecting at least 2 passed checks will prevent `wait-for-gh-checks` (used by `wm`/`wait-merge`) from printing a warning when more than 2 checks have passed.