### PR TITLE
[blog] Restrict served files to blog directory

### DIFF
--- a/app/controllers/blog_controller.rb
+++ b/app/controllers/blog_controller.rb
@@ -60,13 +60,16 @@ class BlogController < ApplicationController
       Rails.root.join(
         relative_path.to_s.sub(%r{\A/*}, ''),
       ).realpath.to_s
+    within_blog_directory =
+      absolute_path == BLOG_DIRECTORY ||
+      absolute_path.start_with?("#{BLOG_DIRECTORY}/")
 
     if (
-      (starts_with_blog_directory = absolute_path.start_with?(BLOG_DIRECTORY)) &&
+      within_blog_directory &&
         absolute_path.match?(/\.(css|jpg|js|png|xml)\z/)
     )
       send_file(absolute_path, **kwargs)
-    elsif starts_with_blog_directory && absolute_path.end_with?('.html')
+    elsif within_blog_directory && absolute_path.end_with?('.html')
       render(html: blog_html_with_additions(absolute_path))
     else
       Rails.error.report(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -385,7 +385,7 @@ services:
     profiles:
       - nondefault
     volumes:
-      - ./blog:/app/blog
+      - ./blog:/app/blog:ro
   worker:
     <<: *default-rails-config
     command: ['bin/sidekiq']

--- a/spec/controllers/blog_controller_spec.rb
+++ b/spec/controllers/blog_controller_spec.rb
@@ -106,40 +106,6 @@ RSpec.describe(BlogController) do
           get_show
         end
       end
-
-      context 'when an attacker somehow submits a path that resolves outside of the blog directory' do
-        before do
-          # I cannot think of any way to actually test the relevant code, so use
-          # allow_any_instance_of.
-          # rubocop:disable RSpec/AnyInstance
-          allow_any_instance_of(Pathname).to receive(:realpath).and_return(path_outside_of_blog)
-          # rubocop:enable RSpec/AnyInstance
-        end
-
-        let(:path_outside_of_blog) { '/etc/you-got-hacked.xml' }
-
-        it 'responds with 404 status and 404 page content' do
-          get_show
-
-          expect(response).to have_http_status(404)
-          expect(response.body).to have_text(not_found_page_content)
-        end
-
-        it 'reports via Rails.error' do
-          expect(Rails.error).
-            to receive(:report).
-            with(
-              BlogController::UnauthorizedBlogFileRequest,
-              context: hash_including(
-                absolute_path: path_outside_of_blog,
-                relative_path: "/blog/#{slug}.html",
-              ),
-            ).
-            and_call_original
-
-          get_show
-        end
-      end
     end
 
     describe '#assets' do

--- a/spec/requests/blog_spec.rb
+++ b/spec/requests/blog_spec.rb
@@ -55,4 +55,49 @@ RSpec.describe 'Blog requests' do
       end
     end
   end
+
+  describe 'GET requests containing path traversal' do
+    let(:sibling_directory_name) { "blog_#{SecureRandom.hex}" }
+    let(:sibling_directory) { Rails.root.join(sibling_directory_name) }
+    let(:sensitive_file) { sibling_directory.join('sensitive.xml') }
+    let(:sensitive_content) { '<sensitive>content</sensitive>' }
+
+    around do |example|
+      FileUtils.mkdir(sibling_directory)
+      File.write(sensitive_file, sensitive_content)
+
+      with_blog_file('404.html', 'Not found') do
+        example.run
+      end
+    ensure
+      FileUtils.rm_f(sensitive_file)
+      FileUtils.rmdir(sibling_directory) if sibling_directory.exist?
+    end
+
+    it 'rejects a canonical path in a sibling whose name starts with "blog"' do
+      link = Rails.root.join('blog', sibling_directory_name)
+      FileUtils.ln_s(sibling_directory, link)
+
+      get("/blog/#{sibling_directory_name}/sensitive.xml")
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).not_to include(sensitive_content)
+    ensure
+      FileUtils.rm_f(link)
+    end
+
+    it 'rejects percent-encoded dot segments' do
+      get("/blog/%2e%2e/#{sibling_directory_name}/sensitive.xml")
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).not_to include(sensitive_content)
+    end
+
+    it 'rejects percent-encoded dot segments and separators' do
+      get("/blog/%2E%2E%2F#{sibling_directory_name}%2Fsensitive.xml")
+
+      expect(response).to have_http_status(:not_found)
+      expect(response.body).not_to include(sensitive_content)
+    end
+  end
 end


### PR DESCRIPTION
Require a canonical path to equal the blog directory or begin at its path boundary before serving or rendering it. This prevents similarly named sibling directories from passing a string-prefix check.

Replace the stubbed controller coverage with request specs that exercise a real canonical sibling path and percent-encoded traversal variants. Mount the production blog bind as read-only for defense in depth.