### PR TITLE
[proposals] Add cancellation UX

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -682,7 +682,7 @@ GEM
     runger_email_reply_trimmer (0.3.0)
     runger_rails_model_explorer (0.2.2)
       activerecord (>= 8.0.2)
-    runger_style (5.13.2)
+    runger_style (5.14.0)
       prism (>= 0.24.0)
       rubocop (>= 1.72.0)
     safely_block (1.0.0)
@@ -1130,7 +1130,7 @@ CHECKSUMS
   runger_config (5.2.0) sha256=9b76d767a2daa63f6f8f2c52a8183f3f09a877cd35bcaee692d25377f4dd4558
   runger_email_reply_trimmer (0.3.0) sha256=068aa90311da474065f604cf29704785bb36d511a5d5e4031fc87fef8bbd9ac7
   runger_rails_model_explorer (0.2.2) sha256=99adf4e287951996d7a2bc308271abe92065836437719eae0a444894c08e683b
-  runger_style (5.13.2) sha256=7f01c78726399bed399dc7b9d520c747c021ea4e2b2dfa0dabf622a84d47a576
+  runger_style (5.14.0) sha256=4fbed1be49c06a3f3358e47cedfce7d1d0e20d8aeaef22e751d0742f1b8c5755
   safely_block (1.0.0) sha256=bea80e084e620adeada62fd98cf461bbb9888d40dc0f06d337df9d01e1a658e5
   sanitize (7.0.0) sha256=269d1b9d7326e69307723af5643ec032ff86ad616e72a3b36d301ac75a273984
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/app/actions/proposals/accept.rb
+++ b/app/actions/proposals/accept.rb
@@ -70,6 +70,7 @@ class Proposals::Accept < ApplicationAction
     proposee_marriage:
   )
     return 'This proposal has already been accepted.' if proposal.accepted_at.present?
+    return 'This proposal has been canceled.' if proposal.canceled_at.present?
 
     if !proposal.proposee_email.casecmp?(locked_proposee.email)
       return 'This proposal was sent to a different email address.'

--- a/app/actions/proposals/cancel.rb
+++ b/app/actions/proposals/cancel.rb
@@ -1,0 +1,17 @@
+class Proposals::Cancel < ApplicationAction
+  requires :proposal, Proposal
+
+  fails_with :unavailable
+
+  def execute
+    ApplicationRecord.transaction do
+      proposal.lock!
+
+      if proposal.accepted_at.present?
+        result.unavailable!('This proposal has already been accepted.')
+      elsif proposal.canceled_at.nil?
+        proposal.update!(canceled_at: Time.current)
+      end
+    end
+  end
+end

--- a/app/controllers/check_ins_controller.rb
+++ b/app/controllers/check_ins_controller.rb
@@ -8,6 +8,7 @@ class CheckInsController < ApplicationController
     authorize(CheckIn)
     @title = 'Check-ins'
     @marriage = current_user.marriage.decorate
+    @pending_proposals = current_user.sent_proposals.pending.order(created_at: :desc)
     render :index
   end
 

--- a/app/controllers/marriages_controller.rb
+++ b/app/controllers/marriages_controller.rb
@@ -10,6 +10,7 @@ class MarriagesController < ApplicationController
 
   def new
     authorize(Marriage)
+    @pending_proposals = current_user.sent_proposals.pending.order(created_at: :desc)
     render :new
   end
 

--- a/app/controllers/proposals_controller.rb
+++ b/app/controllers/proposals_controller.rb
@@ -1,7 +1,7 @@
 class ProposalsController < ApplicationController
   self.container_classes = %w[p-8]
 
-  before_action :set_proposal, only: %i[accept confirm]
+  before_action :set_proposal, only: %i[accept cancel confirm]
 
   def create
     authorize(Proposal)
@@ -48,6 +48,19 @@ class ProposalsController < ApplicationController
 
     if result.success?
       flash[:notice] = 'Marriage created.'
+    else
+      flash[:alert] = result.error_message
+    end
+
+    redirect_to(check_ins_path)
+  end
+
+  def cancel
+    authorize(@proposal)
+    result = Proposals::Cancel.new(proposal: @proposal).run
+
+    if result.success?
+      flash[:notice] = 'Invitation canceled.'
     else
       flash[:alert] = result.error_message
     end

--- a/app/javascript/comments/components/GravatarAndPublicName.vue
+++ b/app/javascript/comments/components/GravatarAndPublicName.vue
@@ -28,7 +28,7 @@ import { computed } from 'vue';
 import { bool, nullable, object, oneOfType } from 'vue-types';
 
 import { useCommentsStore } from '@/comments/stores/commentsStore';
-import { useCancellableInput } from '@/lib/composables/useCancellableInput';
+import { useCancelableInput } from '@/lib/composables/useCancelableInput';
 import { type UserSerializerPublic } from '@/types';
 
 const store = useCommentsStore();
@@ -38,7 +38,7 @@ const {
   isEditing: isEditingPublicName,
   startEditing: startEditingPublicName,
   inputEventHandlers: publicNameInputEventHandlers,
-} = useCancellableInput({
+} = useCancelableInput({
   onUpdate(newPublicName) {
     store.updateCurrentUser({ public_name: newPublicName });
   },

--- a/app/javascript/groceries/components/Item.vue
+++ b/app/javascript/groceries/components/Item.vue
@@ -49,7 +49,7 @@ import { bool, object } from 'vue-types';
 
 import { useGroceriesStore } from '@/groceries/store';
 import type { Item } from '@/groceries/types';
-import { useCancellableInput } from '@/lib/composables/useCancellableInput';
+import { useCancelableInput } from '@/lib/composables/useCancelableInput';
 import { linkifiedAndSanitizedHtml } from '@/lib/linkifiedAndSanitizedHtml';
 
 const ICON_SIZE = 17;
@@ -66,7 +66,7 @@ const {
   isEditing,
   startEditing,
   inputEventHandlers,
-} = useCancellableInput({
+} = useCancelableInput({
   onUpdate: (newValue: string) => {
     groceriesStore.updateItem({
       item: props.item,

--- a/app/javascript/groceries/components/StoreHeader.vue
+++ b/app/javascript/groceries/components/StoreHeader.vue
@@ -35,7 +35,7 @@ import { EditIcon } from 'vue-tabler-icons';
 import { object } from 'vue-types';
 
 import { useGroceriesStore } from '@/groceries/store';
-import { useCancellableInput } from '@/lib/composables/useCancellableInput';
+import { useCancelableInput } from '@/lib/composables/useCancelableInput';
 import type { Store } from '@/types';
 
 const props = defineProps({
@@ -49,7 +49,7 @@ const {
   isEditing: isEditingName,
   startEditing: startEditingName,
   inputEventHandlers: nameInputEventHandlers,
-} = useCancellableInput({
+} = useCancelableInput({
   onUpdate(newName) {
     groceriesStore.updateStore({
       store: props.store,

--- a/app/javascript/groceries/components/StoreNotes.vue
+++ b/app/javascript/groceries/components/StoreNotes.vue
@@ -28,7 +28,7 @@ import { EditIcon } from 'vue-tabler-icons';
 import { object } from 'vue-types';
 
 import { useGroceriesStore } from '@/groceries/store';
-import { useCancellableInput } from '@/lib/composables/useCancellableInput';
+import { useCancelableInput } from '@/lib/composables/useCancelableInput';
 import type { Store } from '@/types';
 
 const props = defineProps({
@@ -42,7 +42,7 @@ const {
   isEditing: isEditingNotes,
   startEditing: startEditingNotes,
   inputEventHandlers: notesInputEventHandlers,
-} = useCancellableInput({
+} = useCancelableInput({
   onUpdate(newNotes) {
     groceriesStore.updateStore({
       store: props.store,

--- a/app/javascript/lib/composables/useCancelableInput.ts
+++ b/app/javascript/lib/composables/useCancelableInput.ts
@@ -1,11 +1,11 @@
 import { nextTick, ref, Ref, useTemplateRef } from 'vue';
 
-interface UseCancellableInputOptions {
+interface UseCancelableInputOptions {
   onUpdate: (newValue: string) => void;
   refName: string;
 }
 
-interface UseCancellableInputReturn {
+interface UseCancelableInputReturn {
   editableRef: Ref<string>;
   isEditing: Ref<boolean>;
   startEditing: (initialValue: string) => void;
@@ -16,9 +16,9 @@ interface UseCancellableInputReturn {
   };
 }
 
-export function useCancellableInput(
-  options: UseCancellableInputOptions,
-): UseCancellableInputReturn {
+export function useCancelableInput(
+  options: UseCancelableInputOptions,
+): UseCancelableInputReturn {
   const { onUpdate, refName } = options;
 
   const isEditing = ref<boolean>(false);

--- a/app/javascript/logs/components/EditLogRemindersModal.vue
+++ b/app/javascript/logs/components/EditLogRemindersModal.vue
@@ -99,7 +99,7 @@ async function cancelReminders() {
     updatedLogParams: { reminder_time_in_seconds: null },
   });
 
-  toast('Reminders cancelled!');
+  toast('Reminders canceled!');
 }
 
 function hideReminderSchedulingModal() {

--- a/app/models/proposal.rb
+++ b/app/models/proposal.rb
@@ -3,6 +3,7 @@
 # Table name: proposals
 #
 #  accepted_at    :datetime
+#  canceled_at    :datetime
 #  created_at     :datetime         not null
 #  id             :bigint           not null, primary key
 #  proposee_email :string           not null
@@ -14,7 +15,7 @@
 #
 #  index_proposals_on_proposer_id  (proposer_id)
 #  index_proposals_on_public_id    (public_id) UNIQUE
-#  uniq_pending_proposals          (proposer_id,proposee_email) UNIQUE WHERE (accepted_at IS NULL)
+#  uniq_pending_proposals          (proposer_id,proposee_email) UNIQUE WHERE ((accepted_at IS NULL) AND (canceled_at IS NULL))
 #
 class Proposal < ApplicationRecord
   belongs_to :proposer, class_name: 'User', inverse_of: :sent_proposals
@@ -28,13 +29,17 @@ class Proposal < ApplicationRecord
     :proposee_email,
     uniqueness: {
       scope: :proposer_id,
-      conditions: -> { where(accepted_at: nil) },
+      conditions: -> { pending },
     },
-    if: -> { accepted_at.nil? },
+    if: -> { pending? },
   )
   validates :public_id, presence: true, uniqueness: true
 
-  scope :pending, -> { where(accepted_at: nil) }
+  scope :pending, -> { where(accepted_at: nil, canceled_at: nil) }
+
+  def pending?
+    accepted_at.nil? && canceled_at.nil?
+  end
 
   def to_param
     public_id

--- a/app/policies/proposal_policy.rb
+++ b/app/policies/proposal_policy.rb
@@ -11,6 +11,10 @@ class ProposalPolicy < ApplicationPolicy
     intended_recipient?
   end
 
+  def cancel?
+    record.proposer == user
+  end
+
   private
 
   def intended_recipient?

--- a/app/views/marriages/_proposal_form.html.haml
+++ b/app/views/marriages/_proposal_form.html.haml
@@ -1,4 +1,13 @@
 %h1 Enter the email of your spouse
+
+- if @pending_proposals.any?
+  %h2 Pending invitations
+  %ul
+    - @pending_proposals.each do |proposal|
+      %li
+        = proposal.proposee_email
+        = button_to('Cancel invitation', cancel_proposal_path(proposal), method: :post)
+
 %form{action: proposals_path, method: 'post'}
   = hidden_field_tag :authenticity_token, form_authenticity_token
   %input{type: 'text', name: 'spouse_email', placeholder: 'Spouse email'}

--- a/app/views/marriages/_proposal_form.html.haml
+++ b/app/views/marriages/_proposal_form.html.haml
@@ -6,7 +6,8 @@
     - @pending_proposals.each do |proposal|
       %li
         = proposal.proposee_email
-        = button_to('Cancel invitation', cancel_proposal_path(proposal), method: :post)
+        = button_to('Cancel invitation', cancel_proposal_path(proposal),
+          method: :post, class: 'btn-danger')
 
 %form{action: proposals_path, method: 'post'}
   = hidden_field_tag :authenticity_token, form_authenticity_token

--- a/app/views/proposals/confirm.html.haml
+++ b/app/views/proposals/confirm.html.haml
@@ -6,6 +6,8 @@
 
 - if @proposal.accepted_at.present?
   %p This proposal has already been accepted.
+- elsif @proposal.canceled_at.present?
+  %p This proposal has been canceled.
 - else
   - if current_user.spouse.present? && current_user.marriage != @proposal.proposer.marriage
     %p

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -37,7 +37,7 @@ en:
       updated: 'Your password has been changed successfully. You are now signed in.'
       updated_not_active: 'Your password has been changed successfully.'
     registrations:
-      destroyed: 'Bye! Your account has been successfully cancelled. We hope to see you again soon.'
+      destroyed: 'Bye! Your account has been successfully canceled. We hope to see you again soon.'
       signed_up: 'Welcome! You have signed up successfully.'
       signed_up_but_inactive: 'You have signed up successfully. However, we could not sign you in because your account is not yet activated.'
       signed_up_but_locked: 'You have signed up successfully. However, we could not sign you in because your account is locked.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,6 +44,7 @@ Rails.application.routes.draw do
     member do
       get :confirm
       post :accept
+      post :cancel
     end
   end
   resource :marriage, only: %i[new show]

--- a/db/migrate/20260811022209_add_canceled_at_to_proposals.rb
+++ b/db/migrate/20260811022209_add_canceled_at_to_proposals.rb
@@ -1,0 +1,26 @@
+class AddCanceledAtToProposals < ActiveRecord::Migration[8.1]
+  def up
+    add_column :proposals, :canceled_at, :datetime
+
+    remove_index :proposals, name: 'uniq_pending_proposals'
+    add_index(
+      :proposals,
+      %i[proposer_id proposee_email],
+      unique: true,
+      where: 'accepted_at IS NULL AND canceled_at IS NULL',
+      name: 'uniq_pending_proposals',
+    )
+  end
+
+  def down
+    remove_index :proposals, name: 'uniq_pending_proposals'
+    remove_column :proposals, :canceled_at
+    add_index(
+      :proposals,
+      %i[proposer_id proposee_email],
+      unique: true,
+      where: 'accepted_at IS NULL',
+      name: 'uniq_pending_proposals',
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_10_164357) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_022209) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -369,12 +369,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_10_164357) do
 
   create_table "proposals", force: :cascade do |t|
     t.datetime "accepted_at"
+    t.datetime "canceled_at"
     t.datetime "created_at", null: false
     t.string "proposee_email", null: false
     t.bigint "proposer_id", null: false
     t.string "public_id", null: false
     t.datetime "updated_at", null: false
-    t.index ["proposer_id", "proposee_email"], name: "uniq_pending_proposals", unique: true, where: "(accepted_at IS NULL)"
+    t.index ["proposer_id", "proposee_email"], name: "uniq_pending_proposals", unique: true, where: "((accepted_at IS NULL) AND (canceled_at IS NULL))"
     t.index ["proposer_id"], name: "index_proposals_on_proposer_id"
     t.index ["public_id"], name: "index_proposals_on_public_id", unique: true
   end

--- a/spec/actions/proposals/accept_spec.rb
+++ b/spec/actions/proposals/accept_spec.rb
@@ -104,6 +104,23 @@ RSpec.describe Proposals::Accept do
     end
   end
 
+  context 'when the proposal has been canceled' do
+    before { proposal.update!(canceled_at: 1.minute.ago) }
+
+    let!(:proposee_marriage) { create(:marriage, partners: [proposee]) }
+
+    it 'rejects the proposal without changing the proposee marriage' do
+      expect {
+        expect(run).not_to be_success
+      }.not_to change {
+        proposee.reload.marriage.id
+      }.from(proposee_marriage.id)
+
+      expect(run.error_message).to eq('This proposal has been canceled.')
+      expect(proposal.reload.accepted_at).to be_nil
+    end
+  end
+
   context 'when the proposal was sent to a different user' do
     let(:proposee) { create(:user) }
 

--- a/spec/actions/proposals/cancel_spec.rb
+++ b/spec/actions/proposals/cancel_spec.rb
@@ -1,0 +1,35 @@
+RSpec.describe Proposals::Cancel do
+  subject(:run) { described_class.new(proposal:).run }
+
+  let!(:proposal) { create(:proposal) }
+
+  it 'marks the proposal as canceled', :frozen_time do
+    expect {
+      expect(run).to be_success
+    }.to change {
+      proposal.reload.canceled_at
+    }.from(nil).to(Time.current)
+  end
+
+  context 'when the proposal has already been canceled' do
+    before { proposal.update!(canceled_at: 1.minute.ago) }
+
+    it 'succeeds without changing the cancellation time' do
+      expect {
+        expect(run).to be_success
+      }.not_to change {
+        proposal.reload.canceled_at
+      }
+    end
+  end
+
+  context 'when the proposal has already been accepted' do
+    before { proposal.update!(accepted_at: 1.minute.ago) }
+
+    it 'does not cancel the proposal' do
+      expect(run).not_to be_success
+      expect(run.error_message).to eq('This proposal has already been accepted.')
+      expect(proposal.reload.canceled_at).to be_nil
+    end
+  end
+end

--- a/spec/controllers/marriages_controller_spec.rb
+++ b/spec/controllers/marriages_controller_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe MarriagesController do
+  describe '#new' do
+    subject(:get_new) { get(:new) }
+
+    let(:user) { users(:single_user) }
+
+    before { sign_in(user) }
+
+    it "assigns the current user's pending proposals" do
+      pending_proposal = create(:proposal, proposer: user)
+      canceled_proposal = create(:proposal, proposer: user, canceled_at: 1.minute.ago)
+
+      get_new
+
+      expect(assigns[:pending_proposals]).to contain_exactly(pending_proposal)
+      expect(assigns[:pending_proposals]).not_to include(canceled_proposal)
+    end
+  end
+end

--- a/spec/controllers/proposals_controller_spec.rb
+++ b/spec/controllers/proposals_controller_spec.rb
@@ -97,6 +97,7 @@ RSpec.describe(ProposalsController, queue_adapter: :test) do
     end
 
     let!(:proposal) { create(:proposal, proposer:, proposee_email: proposee.email) }
+    let(:accept_proposal_button_text) { 'Accept proposal' }
     let(:existing_marriage_warning) do
       'Warning: Accepting this proposal will delete your existing marriage and its associated ' \
         'check-in data.'
@@ -114,7 +115,7 @@ RSpec.describe(ProposalsController, queue_adapter: :test) do
 
         expect(response).to have_http_status(:ok)
         expect(response.body).to have_text(proposer.email)
-        expect(response.body).to have_button('Accept proposal')
+        expect(response.body).to have_button(accept_proposal_button_text)
       end
 
       context 'when the proposee does not have an existing marriage' do
@@ -154,7 +155,18 @@ RSpec.describe(ProposalsController, queue_adapter: :test) do
           get_confirm
 
           expect(response.body).to have_text('This proposal has already been accepted.')
-          expect(response.body).not_to have_button('Accept proposal')
+          expect(response.body).not_to have_button(accept_proposal_button_text)
+        end
+      end
+
+      context 'when the proposal has been canceled' do
+        before { proposal.update!(canceled_at: 1.minute.ago) }
+
+        it 'shows that the proposal was canceled without an acceptance button' do
+          get_confirm
+
+          expect(response.body).to have_text('This proposal has been canceled.')
+          expect(response.body).not_to have_button(accept_proposal_button_text)
         end
       end
     end
@@ -225,6 +237,69 @@ RSpec.describe(ProposalsController, queue_adapter: :test) do
           post_accept
         }.not_to change {
           proposal.reload.accepted_at
+        }
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('You are not authorized to perform this action.')
+      end
+    end
+  end
+
+  describe '#cancel' do
+    subject(:post_cancel) do
+      post(:cancel, params: { public_id: proposal.public_id })
+    end
+
+    let!(:proposal) { create(:proposal, proposer:, proposee_email: proposee.email) }
+
+    context 'when the proposer is signed in' do
+      before { sign_in(proposer) }
+
+      it 'cancels the proposal via POST', :frozen_time do
+        expect {
+          post_cancel
+        }.to change {
+          proposal.reload.canceled_at
+        }.from(nil).to(Time.current)
+
+        expect(flash[:notice]).to eq('Invitation canceled.')
+        expect(response).to redirect_to(check_ins_path)
+      end
+
+      context 'when the proposal has already been canceled' do
+        before { proposal.update!(canceled_at: 1.minute.ago) }
+
+        it 'succeeds without changing the cancellation time' do
+          expect {
+            post_cancel
+          }.not_to change {
+            proposal.reload.canceled_at
+          }
+
+          expect(flash[:notice]).to eq('Invitation canceled.')
+        end
+      end
+
+      context 'when the proposal has already been accepted' do
+        before { proposal.update!(accepted_at: 1.minute.ago) }
+
+        it 'reports that the proposal cannot be canceled' do
+          post_cancel
+
+          expect(proposal.reload.canceled_at).to be_nil
+          expect(flash[:alert]).to eq('This proposal has already been accepted.')
+        end
+      end
+    end
+
+    context 'when the intended proposee is signed in' do
+      before { sign_in(proposee) }
+
+      it 'does not cancel the proposal' do
+        expect {
+          post_cancel
+        }.not_to change {
+          proposal.reload.canceled_at
         }
 
         expect(response).to redirect_to(root_path)

--- a/spec/factories/proposals.rb
+++ b/spec/factories/proposals.rb
@@ -3,6 +3,7 @@
 # Table name: proposals
 #
 #  accepted_at    :datetime
+#  canceled_at    :datetime
 #  created_at     :datetime         not null
 #  id             :bigint           not null, primary key
 #  proposee_email :string           not null
@@ -14,7 +15,7 @@
 #
 #  index_proposals_on_proposer_id  (proposer_id)
 #  index_proposals_on_public_id    (public_id) UNIQUE
-#  uniq_pending_proposals          (proposer_id,proposee_email) UNIQUE WHERE (accepted_at IS NULL)
+#  uniq_pending_proposals          (proposer_id,proposee_email) UNIQUE WHERE ((accepted_at IS NULL) AND (canceled_at IS NULL))
 #
 FactoryBot.define do
   factory :proposal do

--- a/spec/features/proposal_spec.rb
+++ b/spec/features/proposal_spec.rb
@@ -19,5 +19,24 @@ RSpec.describe 'proposing marriage to another user' do
         expect(page).to have_current_path(check_ins_path)
       end
     end
+
+    context 'when the user has a pending invitation', :rack_test_driver do
+      let!(:proposal) { create(:proposal, proposer: user) }
+
+      before { marriage.destroy! }
+
+      it 'shows and cancels the invitation' do
+        visit check_ins_path
+
+        expect(page).to have_text(proposal.proposee_email)
+        expect(page).to have_button('Cancel invitation')
+
+        click_on('Cancel invitation')
+
+        expect(page).to have_flash_message('Invitation canceled.')
+        expect(proposal.reload.canceled_at).to be_present
+        expect(page).not_to have_text('Pending invitations')
+      end
+    end
   end
 end

--- a/spec/models/proposal_spec.rb
+++ b/spec/models/proposal_spec.rb
@@ -22,6 +22,12 @@ RSpec.describe Proposal do
     it 'returns only proposals that have not been accepted' do
       expect(described_class.pending).to contain_exactly(pending_proposal)
     end
+
+    it 'excludes canceled proposals' do
+      pending_proposal.update!(canceled_at: 1.minute.ago)
+
+      expect(described_class.pending).to be_empty
+    end
   end
 
   describe 'proposee email format' do
@@ -59,6 +65,18 @@ RSpec.describe Proposal do
 
     it 'allows another proposal after the earlier proposal has been accepted' do
       pending_proposal.update!(accepted_at: 1.minute.ago)
+
+      expect(
+        build(
+          :proposal,
+          proposer: pending_proposal.proposer,
+          proposee_email: pending_proposal.proposee_email,
+        ),
+      ).to be_valid
+    end
+
+    it 'allows another proposal after the earlier proposal has been canceled' do
+      pending_proposal.update!(canceled_at: 1.minute.ago)
 
       expect(
         build(

--- a/spec/policies/proposal_policy_spec.rb
+++ b/spec/policies/proposal_policy_spec.rb
@@ -33,14 +33,27 @@ RSpec.describe ProposalPolicy do
       expect(policy.confirm?).to eq(true)
       expect(policy.accept?).to eq(true)
     end
+
+    it 'does not allow canceling the proposal' do
+      expect(policy.cancel?).to eq(false)
+    end
   end
 
   context 'when the user is not the intended recipient' do
     let(:user) { create(:user) }
 
-    it 'forbids viewing the confirmation or accepting the proposal' do
+    it 'forbids viewing the confirmation, accepting, or canceling the proposal' do
       expect(policy.confirm?).to eq(false)
       expect(policy.accept?).to eq(false)
+      expect(policy.cancel?).to eq(false)
+    end
+  end
+
+  context 'when the user is the proposer' do
+    let(:user) { proposal.proposer }
+
+    it 'allows canceling the proposal' do
+      expect(policy.cancel?).to eq(true)
     end
   end
 end

--- a/spec/routing/proposals_routing_spec.rb
+++ b/spec/routing/proposals_routing_spec.rb
@@ -12,4 +12,13 @@ RSpec.describe 'proposal routes' do
   it 'does not route acceptance through GET' do
     expect(get: '/proposals/public-id/accept').not_to be_routable
   end
+
+  it 'routes cancellation through POST' do
+    expect(post: '/proposals/public-id/cancel').
+      to route_to(controller: 'proposals', action: 'cancel', public_id: 'public-id')
+  end
+
+  it 'does not route cancellation through GET' do
+    expect(get: '/proposals/public-id/cancel').not_to be_routable
+  end
 end


### PR DESCRIPTION
Add a canceled_at state and proposer-only cancellation action for invitations. Cancellation locks the proposal and is idempotent, while acceptance checks the canceled state within its existing transaction to prevent canceled invitations from being accepted.

Expose pending invitations on the marriage and check-in pages with cancellation controls, update confirmation messaging, and permit new invitations after cancellation. Add migration, schema updates, and focused model, action, policy, controller, routing, and feature coverage.

Update unrelated existing spelling in user-facing copy and shared frontend identifiers for consistency with the project's American English convention. These changes keep the repository's terminology consistent rather than leaving mixed regional spellings.