### PR TITLE
Revert "Bump pghero from 3.8.0 to 4.0.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,7 +485,7 @@ GEM
     pg (1.6.3-x86_64-linux-musl)
     pg_query (6.2.2)
       google-protobuf (>= 3.25.3)
-    pghero (4.0.0)
+    pghero (3.8.0)
       activerecord (>= 7.2)
     pp (0.6.4)
       prettyprint
@@ -1061,7 +1061,7 @@ CHECKSUMS
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
   pg_query (6.2.2) sha256=316c194160ccfac8af9a7aff55cdc5b2d13bdd8bd8734976c6bddc477e779b6f
-  pghero (4.0.0) sha256=b3fb400ec89a0d2cf35d2524567e55a68d70aaae64b626a0c5a6be5727c024d7
+  pghero (3.8.0) sha256=f6fda87a095c2bd153954cb895366a3ffc4c8f7785b2b9234a5dbd1cbcabb360
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85


### PR DESCRIPTION
Reverts davidrunger/david_runger#9087

We're seeing an error occur repeatedly in production: https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/782 (ActiveRecord::StatementInvalid: PG::UndefinedTable: ERROR:  relation "pghero_queries" does not exist LINE 10:  WHERE a.attrelid = '"pghero_queries"'::regclass). I'm going to revert to 3.8.0 for now, to hopefully stop the errors.