### PR TITLE
[pghero] Upgrade to 4.0.0 [DEV-265]

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -485,7 +485,7 @@ GEM
     pg (1.6.3-x86_64-linux-musl)
     pg_query (6.2.2)
       google-protobuf (>= 3.25.3)
-    pghero (3.8.0)
+    pghero (4.0.0)
       activerecord (>= 7.2)
     pp (0.6.4)
       prettyprint
@@ -1061,7 +1061,7 @@ CHECKSUMS
   pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pg (1.6.3-x86_64-linux-musl) sha256=9c9c90d98c72f78eb04c0f55e9618fe55d1512128e411035fe229ff427864009
   pg_query (6.2.2) sha256=316c194160ccfac8af9a7aff55cdc5b2d13bdd8bd8734976c6bddc477e779b6f
-  pghero (3.8.0) sha256=f6fda87a095c2bd153954cb895366a3ffc4c8f7785b2b9234a5dbd1cbcabb360
+  pghero (4.0.0) sha256=b3fb400ec89a0d2cf35d2524567e55a68d70aaae64b626a0c5a6be5727c024d7
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85

--- a/db/migrate/20260811153309_upgrade_pghero_query_stats.rb
+++ b/db/migrate/20260811153309_upgrade_pghero_query_stats.rb
@@ -1,0 +1,27 @@
+class UpgradePgheroQueryStats < ActiveRecord::Migration[8.1]
+  def change
+    # rubocop:disable Rails/CreateTableWithTimestamps
+    create_table :pghero_queries do |t|
+      t.text :query
+    end
+    # rubocop:enable Rails/CreateTableWithTimestamps
+
+    add_index :pghero_queries, :query, using: :hash
+
+    add_reference :pghero_query_stats, :query, index: false
+
+    # rubocop:disable Rails/ReversibleMigration
+    execute(<<~SQL.squish)
+      INSERT INTO pghero_queries (query)
+        SELECT DISTINCT query FROM pghero_query_stats WHERE query IS NOT NULL
+    SQL
+
+    execute(<<~SQL.squish)
+      UPDATE pghero_query_stats SET query_id = pghero_queries.id, query = NULL
+        FROM pghero_queries WHERE pghero_queries.query = pghero_query_stats.query
+    SQL
+
+    remove_column :pghero_query_stats, :query
+    # rubocop:enable Rails/ReversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_11_022209) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_11_153309) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -347,12 +347,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_022209) do
     t.datetime "updated_at", precision: nil, null: false
   end
 
+  create_table "pghero_queries", force: :cascade do |t|
+    t.text "query"
+    t.index ["query"], name: "index_pghero_queries_on_query", using: :hash
+  end
+
   create_table "pghero_query_stats", force: :cascade do |t|
     t.bigint "calls"
     t.datetime "captured_at", precision: nil
     t.text "database"
-    t.text "query"
     t.bigint "query_hash"
+    t.bigint "query_id"
     t.float "total_time"
     t.text "user"
     t.index ["database", "captured_at"], name: "index_pghero_query_stats_on_database_and_captured_at"


### PR DESCRIPTION
fixes rb#782

https://app.rollbar.com/a/davidjrunger/fix/item/davidrunger/782

PgHero 4.0 reduces the space used for historical query statistics by storing query text in the new `pghero_queries` table and referencing it from `pghero_query_stats`.

The previous lockfile-only upgrade caused production errors because the required schema upgrade was omitted. Generate the upstream `pghero:upgrade_query_stats` migration to backfill the lookup table, set each existing `query_id`, and remove the duplicated `query` column.

The migration is intentionally irreversible because PgHero’s generated data transformation discards the original duplicated column after the backfill.