### PR TITLE
[prerendering] Sign S3 prerender artifacts

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -204,3 +204,4 @@ jobs:
           CI: true
           AWS_ACCESS_KEY_ID: '${{secrets.AWS_ACCESS_KEY_ID}}'
           AWS_SECRET_ACCESS_KEY: '${{secrets.AWS_SECRET_ACCESS_KEY}}'
+          PRERENDER_SIGNING_PRIVATE_KEY: '${{secrets.PRERENDER_SIGNING_PRIVATE_KEY}}'

--- a/app/poros/prerender_utils.rb
+++ b/app/poros/prerender_utils.rb
@@ -5,11 +5,22 @@ module PrerenderUtils
     end
 
     def transformed_s3_content(git_rev:, filename:)
-      Aws::S3::Resource.new(region: 'us-east-1').
-        bucket('david-runger-test-uploads').
-        object("prerenders/#{git_rev}/#{filename}").
-        get.body.read.
-        then { html_with_absolutized_asset_paths(it) }
+      object_key = "prerenders/#{git_rev}/#{filename}"
+      get_response =
+        Aws::S3::Resource.new(region: 'us-east-1').
+          bucket('david-runger-test-uploads').
+          object(object_key).
+          get
+      html = get_response.body.read
+
+      ContentSignature.verify!(
+        content: html,
+        object_key:,
+        signature: get_response.metadata.fetch('prerender-signature'),
+        public_key: prerender_signing_public_key,
+      )
+
+      html_with_absolutized_asset_paths(html)
     rescue Aws::S3::Errors::NoSuchKey => error
       log_warning(error)
 
@@ -25,6 +36,10 @@ module PrerenderUtils
     end
 
     private
+
+    def prerender_signing_public_key
+      ContentSignature.key_from_base64(ENV.fetch('PRERENDER_SIGNING_PUBLIC_KEY'))
+    end
 
     def html_with_absolutized_asset_paths(html)
       if Rails.env.development?

--- a/bin/prerender
+++ b/bin/prerender
@@ -9,6 +9,7 @@ require 'dotenv/load' if ENV.fetch('CI', nil) != 'true'
 require 'ferrum'
 require 'nokogiri'
 
+require_relative '../lib/content_signature.rb'
 require_relative '../lib/retry.rb'
 
 class Prerenderer
@@ -64,10 +65,27 @@ class Prerenderer
     git_sha = `git rev-parse HEAD`.strip
     raise('Could not determine git SHA!') if git_sha.empty?
 
+    object_key = "prerenders/#{git_sha}/#{filename}"
+
     Aws::S3::Resource.new(region: 'us-east-1').
       bucket('david-runger-test-uploads').
-      object("prerenders/#{git_sha}/#{filename}").
-      put(body:)
+      object(object_key).
+      put(
+        body:,
+        metadata: {
+          'prerender-signature' =>
+            ContentSignature.signature(
+              content: body,
+              object_key:,
+              private_key: prerender_signing_private_key,
+            ),
+        },
+      )
+  end
+
+  def prerender_signing_private_key
+    @prerender_signing_private_key ||=
+      ContentSignature.key_from_base64(ENV.fetch('PRERENDER_SIGNING_PRIVATE_KEY'))
   end
 
   def html_for_prerendering(html)

--- a/lib/content_signature.rb
+++ b/lib/content_signature.rb
@@ -1,0 +1,37 @@
+require 'base64'
+require 'openssl'
+
+class ContentSignature
+  class InvalidSignatureError < StandardError; end
+
+  class << self
+    def signature(content:, object_key:, private_key:)
+      Base64.strict_encode64(private_key.sign(nil, signing_payload(content:, object_key:)))
+    end
+
+    def verify!(content:, object_key:, signature:, public_key:)
+      valid_signature =
+        public_key.verify(
+          nil,
+          Base64.strict_decode64(signature),
+          signing_payload(content:, object_key:),
+        )
+
+      raise(InvalidSignatureError, "Invalid signature for #{object_key}.") unless valid_signature
+    rescue ArgumentError
+      raise(InvalidSignatureError, "Invalid signature encoding for #{object_key}.")
+    end
+
+    def key_from_base64(encoded_key)
+      OpenSSL::PKey.read(Base64.strict_decode64(encoded_key))
+    rescue ArgumentError, OpenSSL::PKey::PKeyError => error
+      raise(InvalidSignatureError, "Invalid signing key: #{error.message}")
+    end
+
+    private
+
+    def signing_payload(content:, object_key:)
+      "#{object_key}\0#{content}"
+    end
+  end
+end

--- a/spec/controllers/concerns/prerenderable_spec.rb
+++ b/spec/controllers/concerns/prerenderable_spec.rb
@@ -20,10 +20,18 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
     subject(:get_index) { get(:index, params:) }
 
     let(:params) { {} }
+    let(:prerender_signing_private_key) { OpenSSL::PKey.generate_key('ED25519') }
+
+    let(:prerender_signing_public_key_base64) do
+      Base64.strict_encode64(prerender_signing_private_key.public_to_pem)
+    end
 
     context 'when ENV["GIT_REV"] is set' do
       around do |spec|
-        ClimateControl.modify(GIT_REV: commit_sha) do
+        ClimateControl.modify(
+          GIT_REV: commit_sha,
+          PRERENDER_SIGNING_PUBLIC_KEY: prerender_signing_public_key_base64,
+        ) do
           spec.run
         end
       end
@@ -32,13 +40,8 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
 
       context 'when S3 responds with prerendered page content including the expected text' do
         let(:page_text) { "Some text. #{EXPECTED_CONTENT} More text!" }
-
-        before do
-          stub_request(
-            :get,
-            'https://david-runger-test-uploads.s3.amazonaws.com/' \
-            "prerenders/#{commit_sha}/home.html",
-          ).to_return(status: 200, headers: {}, body: <<~HTML)
+        let(:prerendered_html) do
+          <<~HTML
             <!doctype html>
             <html>
               <head>
@@ -52,6 +55,26 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
           HTML
         end
 
+        let(:prerender_signature) do
+          ContentSignature.signature(
+            content: prerendered_html,
+            object_key: "prerenders/#{commit_sha}/home.html",
+            private_key: prerender_signing_private_key,
+          )
+        end
+
+        before do
+          stub_request(
+            :get,
+            'https://david-runger-test-uploads.s3.amazonaws.com/' \
+            "prerenders/#{commit_sha}/home.html",
+          ).to_return(
+            status: 200,
+            headers: { 'x-amz-meta-prerender-signature' => prerender_signature },
+            body: prerendered_html,
+          )
+        end
+
         context 'when no user is signed in' do
           before { sign_out(:user) }
 
@@ -59,6 +82,34 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
             get_index
 
             expect(response.body).to have_text(page_text)
+          end
+        end
+
+        context 'when the S3 response has an invalid signature' do
+          let(:prerender_signature) { Base64.strict_encode64('invalid') }
+
+          context 'when Rails.env is "test"' do
+            before { expect(Rails.env).to eq('test') }
+
+            it 'raises an error' do
+              expect { get_index }.to raise_error(ContentSignature::InvalidSignatureError)
+            end
+          end
+
+          context 'when Rails.env is "production"', rails_env: :production do
+            it 'reports the error and live-renders the page' do
+              expect(Rails.error).
+                to receive(:report).
+                with(
+                  an_instance_of(ContentSignature::InvalidSignatureError),
+                  severity: :error,
+                  context: { filename: 'home.html' },
+                ).and_call_original
+
+              get_index
+
+              expect(response.body).to eq(LIVE_RENDERED_PAGE_TEXT)
+            end
           end
         end
 

--- a/spec/lib/content_signature_spec.rb
+++ b/spec/lib/content_signature_spec.rb
@@ -45,5 +45,36 @@ RSpec.describe ContentSignature do
           to raise_error(described_class::InvalidSignatureError, /Invalid signature/)
       end
     end
+
+    context 'when the signature is not valid Base64' do
+      let(:signature) { 'not valid Base64' }
+
+      it 'raises an error about the signature encoding' do
+        expect { verify_signature }.
+          to raise_error(described_class::InvalidSignatureError, /Invalid signature encoding/)
+      end
+    end
+  end
+
+  describe '.key_from_base64' do
+    subject(:key_from_base64) { described_class.key_from_base64(encoded_key) }
+
+    context 'when the value is not valid Base64' do
+      let(:encoded_key) { 'not valid Base64' }
+
+      it 'raises an error about the signing key' do
+        expect { key_from_base64 }.
+          to raise_error(described_class::InvalidSignatureError, /Invalid signing key/)
+      end
+    end
+
+    context 'when the decoded value is not a PEM key' do
+      let(:encoded_key) { Base64.strict_encode64('not a PEM key') }
+
+      it 'raises an error about the signing key' do
+        expect { key_from_base64 }.
+          to raise_error(described_class::InvalidSignatureError, /Invalid signing key/)
+      end
+    end
   end
 end

--- a/spec/lib/content_signature_spec.rb
+++ b/spec/lib/content_signature_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe ContentSignature do
+  let(:private_key) { OpenSSL::PKey.generate_key('ED25519') }
+  let(:signed_object_key) { 'prerenders/a-git-revision/home.html' }
+  let(:signed_content) { '<html>Home</html>' }
+  let(:object_key) { signed_object_key }
+  let(:content) { signed_content }
+  let(:public_key) { OpenSSL::PKey.read(private_key.public_to_pem) }
+
+  describe '.verify!' do
+    subject(:verify_signature) do
+      described_class.verify!(
+        content:,
+        object_key:,
+        signature:,
+        public_key:,
+      )
+    end
+
+    let(:signature) do
+      described_class.signature(
+        content: signed_content,
+        object_key: signed_object_key,
+        private_key:,
+      )
+    end
+
+    it 'accepts a signature for the artifact content and object key' do
+      expect { verify_signature }.not_to raise_error
+    end
+
+    context 'when the artifact content has changed' do
+      let(:content) { '<html>Changed</html>' }
+
+      it 'rejects the signature' do
+        expect { verify_signature }.
+          to raise_error(described_class::InvalidSignatureError, /Invalid signature/)
+      end
+    end
+
+    context 'when the artifact object key has changed' do
+      let(:object_key) { 'prerenders/a-different-git-revision/home.html' }
+
+      it 'rejects the signature' do
+        expect { verify_signature }.
+          to raise_error(described_class::InvalidSignatureError, /Invalid signature/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Treat prerendered HTML fetched from S3 as trusted only after its signature verifies. CI signs the exact HTML bytes and S3 object key with an Ed25519 private key, then writes the signature as object metadata.

The Rails app verifies that metadata using a base64-encoded public key from `PRERENDER_SIGNING_PUBLIC_KEY`. An absent or invalid signature follows the existing fetch-error behavior rather than rendering unverified HTML. Keeping the signature in S3 metadata preserves the existing single-object fetch before the verified artifact is cached.