### PR TITLE
[coverage] Collate parallel coverage results [DEV-268]

### DIFF
--- a/bin/collate-code-coverage
+++ b/bin/collate-code-coverage
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require 'simplecov'
+require 'simplecov-cobertura'
+require File.expand_path('../lib/test/simple_cov_configuration', __dir__)
+
+SimpleCov.coverage_dir('tmp/simple_cov') # must match codecov-action directory option
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+SimpleCov.collate(Dir['tmp/simple_cov/*/.resultset.json']) do
+  Test::SimpleCovConfiguration.configure
+end

--- a/bin/collate-code-coverage
+++ b/bin/collate-code-coverage
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
+require 'bundler/setup'
 require 'simplecov'
 require 'simplecov-cobertura'
 require File.expand_path('../lib/test/simple_cov_configuration', __dir__)

--- a/bin/run-tests
+++ b/bin/run-tests
@@ -1,3 +1,10 @@
 #!/usr/bin/env bash
 
+rm -rf tmp/simple_cov
+
 bin/pallets --verbose -r ./lib/test/run_pallets_tests.rb
+pallets_exit_code=$?
+bin/collate-code-coverage
+collate_exit_code=$?
+
+exit $((pallets_exit_code || collate_exit_code))

--- a/lib/test/simple_cov_configuration.rb
+++ b/lib/test/simple_cov_configuration.rb
@@ -1,0 +1,7 @@
+module Test ; end unless defined?(Test)
+
+module Test::SimpleCovConfiguration
+  def self.configure
+    SimpleCov.skip(%r{^tools/(?!custom_cops/)})
+  end
+end

--- a/lib/test/tasks/run_api_controller_tests.rb
+++ b/lib/test/tasks/run_api_controller_tests.rb
@@ -4,6 +4,7 @@ class Test::Tasks::RunApiControllerTests < Pallets::Task
   def run
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_api
+      COVERAGE_RESULTSET_NAME=api_controller
       bin/rspec
       spec/controllers/api/
       #{rspec_output_options}

--- a/lib/test/tasks/run_feature_tests_a.rb
+++ b/lib/test/tasks/run_feature_tests_a.rb
@@ -4,6 +4,7 @@ class Test::Tasks::RunFeatureTestsA < Pallets::Task
   def run
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_feature_a CAPYBARA_SERVER_PORT=3001
+      COVERAGE_RESULTSET_NAME=feature_a
       bin/rspec $(cat tmp/feature_specs_a.txt)
       #{rspec_output_options}
     COMMAND

--- a/lib/test/tasks/run_feature_tests_b.rb
+++ b/lib/test/tasks/run_feature_tests_b.rb
@@ -4,6 +4,7 @@ class Test::Tasks::RunFeatureTestsB < Pallets::Task
   def run
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_api CAPYBARA_SERVER_PORT=3002
+      COVERAGE_RESULTSET_NAME=feature_b
       bin/rspec $(cat tmp/feature_specs_b.txt)
       #{rspec_output_options}
     COMMAND

--- a/lib/test/tasks/run_feature_tests_c.rb
+++ b/lib/test/tasks/run_feature_tests_c.rb
@@ -4,6 +4,7 @@ class Test::Tasks::RunFeatureTestsC < Pallets::Task
   def run
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_feature_c CAPYBARA_SERVER_PORT=3003
+      COVERAGE_RESULTSET_NAME=feature_c
       bin/rspec $(cat tmp/feature_specs_c.txt)
       #{rspec_output_options}
     COMMAND

--- a/lib/test/tasks/run_html_controller_tests.rb
+++ b/lib/test/tasks/run_html_controller_tests.rb
@@ -5,6 +5,7 @@ class Test::Tasks::RunHtmlControllerTests < Pallets::Task
     # run all tests in `spec/controllers/` _except_ those in `spec/controllers/api/`
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_html
+      COVERAGE_RESULTSET_NAME=html_controller
       bin/rspec
       $(ls -d spec/controllers/*/ | grep -v 'spec/controllers/api/')
       $(ls spec/controllers/*.rb)

--- a/lib/test/tasks/run_tools_tests.rb
+++ b/lib/test/tasks/run_tools_tests.rb
@@ -4,7 +4,7 @@ class Test::Tasks::RunToolsTests < Pallets::Task
   def run
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_unit
-      SPEC_GROUP=tools
+      COVERAGE_RESULTSET_NAME=tools
       bin/rspec
       spec/tools/
       #{rspec_output_options}

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -9,6 +9,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
     # RunFeatureTests).
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_unit
+      COVERAGE_RESULTSET_NAME=unit
       bin/rspec
       $(ls -d spec/*/ |
         grep --extended-regex -v 'spec/(controllers|features|helpers|requests|tools)(/|$)')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,22 +10,15 @@ module SpecHelper
 end
 
 require 'simplecov'
-SimpleCov.coverage_dir('tmp/simple_cov') # must match codecov-action directory option
+require_relative '../lib/test/simple_cov_configuration'
+coverage_resultset_name = ENV.fetch('COVERAGE_RESULTSET_NAME', nil)
+if coverage_resultset_name
+  SimpleCov.coverage_dir("tmp/simple_cov/#{coverage_resultset_name}")
+  # Pallets does not provide SimpleCov's parallel-runner coordination protocol.
+  SimpleCov.finalize_merge(false)
+end
 SimpleCov.start do
-  db_suffix = ENV.fetch('DB_SUFFIX', nil)
-  spec_group = ENV.fetch('SPEC_GROUP', nil)
-  capybara_server_port = ENV.fetch('CAPYBARA_SERVER_PORT', nil)
-  # rubocop:disable Rails/Present -- At this point, we have not yet loaded Rails.
-  if !db_suffix.nil? && !db_suffix.empty?
-    command_name(
-      "Tests on DB #{db_suffix} w/ Capybara port #{capybara_server_port.inspect} " \
-      "(spec group: #{spec_group.inspect})",
-    )
-  end
-  # rubocop:enable Rails/Present
-  # rubocop:disable RSpec/Pending
-  skip(%r{^tools/(?!custom_cops/)})
-  # rubocop:enable RSpec/Pending
+  Test::SimpleCovConfiguration.configure
   enable_coverage(:branch) if !SpecHelper.is_ci? # Codecov doesn't respect `nocov-else` etc comments
 end
 


### PR DESCRIPTION
Pallets runs the RSpec groups in separate processes, but SimpleCov does not recognize its coordination protocol. Each process therefore treated itself as the report finalizer and could overwrite tmp/simple_cov/coverage.xml with a partial snapshot.

Give every RSpec group an isolated SimpleCov resultset directory and prevent workers from finalizing their reports. After Pallets finishes, collate all resultsets into the single Cobertura XML consumed by Codecov and bin/check-code-coverage. Clear previous resultsets before the suite so only the current run contributes.

This follows the external-collation workflow introduced by the SimpleCov 1.0 migration in e8f28db73.