### PR TITLE
[sitemap-crawler] Restrict crawled sitemap URLs

### DIFF
--- a/app/poros/sitemap_crawler.rb
+++ b/app/poros/sitemap_crawler.rb
@@ -1,32 +1,73 @@
 class SitemapCrawler
   prepend Memoization
 
+  MAX_SITEMAP_DEPTH = 5
+  MAX_SITEMAPS = 100
+
   def initialize(sitemap_url)
     @sitemap_url = sitemap_url
   end
 
   memoize \
   def urls
-    urls_from_sitemap_doc(nokogiri_sitemap_doc(@sitemap_url))
+    urls_from_sitemap_url(@sitemap_url, visited_sitemap_urls: Set.new, depth: 0).uniq.sort
   end
 
   private
+
+  def urls_from_sitemap_url(url, visited_sitemap_urls:, depth:)
+    normalized_url = normalized_sitemap_url(url)
+    return [] unless normalized_url
+    return [] if visited_sitemap_urls.include?(normalized_url)
+    return [] if depth > MAX_SITEMAP_DEPTH
+    return [] if visited_sitemap_urls.size >= MAX_SITEMAPS
+
+    visited_sitemap_urls.add(normalized_url)
+    urls_from_sitemap_doc(
+      nokogiri_sitemap_doc(normalized_url),
+      visited_sitemap_urls:,
+      depth:,
+    )
+  end
 
   def nokogiri_sitemap_doc(url)
     Nokogiri::XML(Faraday.get(url).body)
   end
 
-  def urls_from_sitemap_doc(sitemap)
+  def urls_from_sitemap_doc(sitemap, visited_sitemap_urls:, depth:)
     # Extract URLs from <url> tags
-    urls = sitemap.xpath('//*:url/*:loc').map(&:text)
+    urls = sitemap.xpath('//*:url/*:loc').filter_map { normalized_page_url(it.text) }
 
     # Extract nested sitemaps from <sitemap> tags
     sitemap.xpath('//*:sitemap/*:loc').each do |loc|
-      nested_sitemap_url = loc.text
-      nested_sitemap = nokogiri_sitemap_doc(nested_sitemap_url)
-      urls.concat(urls_from_sitemap_doc(nested_sitemap))
+      urls.concat(
+        urls_from_sitemap_url(
+          loc.text,
+          visited_sitemap_urls:,
+          depth: depth + 1,
+        ),
+      )
     end
 
-    urls.uniq.sort
+    urls
+  end
+
+  def normalized_sitemap_url(url)
+    normalized_url(url) if site_url?(url)
+  end
+
+  def normalized_page_url(url)
+    normalized_url(url) if site_url?(url)
+  end
+
+  def site_url?(url)
+    uri = URI.parse(url)
+    uri.is_a?(URI::HTTPS) && uri.host == DavidRunger::CANONICAL_DOMAIN
+  rescue URI::InvalidURIError
+    false
+  end
+
+  def normalized_url(url)
+    URI.parse(url).normalize.to_s
   end
 end

--- a/spec/poros/sitemap_crawler_spec.rb
+++ b/spec/poros/sitemap_crawler_spec.rb
@@ -1,0 +1,83 @@
+RSpec.describe SitemapCrawler do
+  describe '#urls' do
+    subject(:urls) { SitemapCrawler.new(sitemap_url).urls }
+
+    let(:sitemap_url) { 'https://davidrunger.com/sitemap.xml' }
+
+    before do
+      stub_request(:get, sitemap_url).to_return(
+        body: <<~XML,
+          <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <sitemap>
+              <loc>https://davidrunger.com/nested-sitemap.xml</loc>
+            </sitemap>
+            <sitemap>
+              <loc>https://example.com/sitemap.xml</loc>
+            </sitemap>
+            <sitemap>
+              <loc>not a URL</loc>
+            </sitemap>
+          </sitemapindex>
+        XML
+      )
+      stub_request(:get, 'https://davidrunger.com/nested-sitemap.xml').to_return(
+        body: <<~XML,
+          <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url>
+              <loc>https://davidrunger.com/blog/</loc>
+            </url>
+            <url>
+              <loc>https://david-runger-public-uploads.s3.amazonaws.com/resume.pdf</loc>
+            </url>
+            <url>
+              <loc>http://davidrunger.com/insecure</loc>
+            </url>
+            <url>
+              <loc>not a URL</loc>
+            </url>
+            <sitemap>
+              <loc>https://davidrunger.com/sitemap.xml</loc>
+            </sitemap>
+          </urlset>
+        XML
+      )
+    end
+
+    it 'returns only HTTPS URLs from the site and does not revisit sitemaps' do
+      expect(urls).to eq(['https://davidrunger.com/blog/'])
+
+      expect(a_request(:get, sitemap_url)).to have_been_made.once
+      expect(a_request(:get, 'https://davidrunger.com/nested-sitemap.xml')).to have_been_made.once
+      expect(a_request(:get, 'https://example.com/sitemap.xml')).not_to have_been_made
+    end
+
+    it 'does not fetch a sitemap beyond the nesting limit' do
+      sitemap_urls =
+        (0..SitemapCrawler::MAX_SITEMAP_DEPTH).map do |depth|
+          "https://davidrunger.com/sitemap-#{depth}.xml"
+        end
+      too_deep_sitemap_url = 'https://davidrunger.com/too-deep-sitemap.xml'
+
+      sitemap_urls.each_with_index do |url, depth|
+        nested_sitemap_url = sitemap_urls[depth + 1] || too_deep_sitemap_url
+        page_url =
+          if depth == SitemapCrawler::MAX_SITEMAP_DEPTH
+            '<url><loc>https://davidrunger.com/at-depth-limit</loc></url>'
+          end
+
+        stub_request(:get, url).to_return(
+          body: <<~XML,
+            <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+              #{page_url}
+              <sitemap><loc>#{nested_sitemap_url}</loc></sitemap>
+            </sitemapindex>
+          XML
+        )
+      end
+
+      expect(SitemapCrawler.new(sitemap_urls.first).urls).
+        to eq(['https://davidrunger.com/at-depth-limit'])
+      expect(a_request(:get, too_deep_sitemap_url)).not_to have_been_made
+    end
+  end
+end

--- a/spec/workers/check_links/launch_page_fetches_spec.rb
+++ b/spec/workers/check_links/launch_page_fetches_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe CheckLinks::LaunchPageFetches do
         expected_page_urls_to_check =
           %w[
             https://davidrunger.com/
-            https://david-runger-public-uploads.s3.amazonaws.com/David-Runger-Resume.pdf
             https://davidrunger.com/blog/using-vs-code-as-a-rails-app-update-merge-tool
             https://davidrunger.com/blog/
           ]


### PR DESCRIPTION
Only fetch HTTPS sitemaps and queue HTTPS pages hosted by `davidrunger.com`. This makes the crawler's trust boundary explicit and avoids dispatching link-check jobs for sitemap-listed external assets.

Bound recursive sitemap traversal to five levels and 100 documents, and track normalized sitemap URLs to prevent cycles. Add coverage for host and scheme filtering, cycles, and the nesting limit.