### PR TITLE
[comments] Limit administrator notifications

### DIFF
--- a/app/actions/comments/create.rb
+++ b/app/actions/comments/create.rb
@@ -9,7 +9,12 @@ class Comments::Create < ApplicationAction
 
     result.comment = comment
 
-    AdminMailer.comment_created(comment.id).deliver_later
+    administrator_notification_limit =
+      Email::UserGeneratedDeliveryLimiter.reserve_global(category: :comment_created)
+
+    if administrator_notification_limit.permitted?
+      AdminMailer.comment_created(comment.id).deliver_later
+    end
 
     parent_user = comment.parent&.user
 

--- a/spec/actions/comments/create_spec.rb
+++ b/spec/actions/comments/create_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe Comments::Create, queue_adapter: :test do
     end
   end
 
+  context 'when the global email delivery limit is reached' do
+    before do
+      Email::UserGeneratedDeliveryLimiter::GLOBAL_LIMIT.maximum.times do
+        Email::UserGeneratedDeliveryLimiter.reserve_global(category: :proposal)
+      end
+    end
+
+    it 'retains the comment without sending notifications' do
+      expect { run_action }.
+        to have_enqueued_mail(AdminMailer, :comment_created).exactly(0).times.
+        and have_enqueued_mail(CommentMailer, :reply_created).exactly(0).times
+
+      expect(run_action.comment).to be_persisted
+    end
+  end
+
   context 'when the author replies to their own comment' do
     let(:parent_user) { user }
 


### PR DESCRIPTION
Reserve the existing global user-generated-email quota before enqueuing a comment-created administrator notification.

Comments remain persisted when the circuit breaker is open, while ordinary comment notifications remain immediate until the shared hourly limit is reached. Cover the denied path alongside the existing reply-notification behavior.