### PR TITLE
[supply chain] Pin Certbot and S3 backup images

### DIFF
--- a/bin/server/bootstrap-letsencrypt.sh
+++ b/bin/server/bootstrap-letsencrypt.sh
@@ -6,6 +6,7 @@
 # shellcheck disable=SC2128
 
 domains=(davidrunger.com grafana.davidrunger.com www.davidrunger.com)
+certbot_commit=a0e8b490579193dd818f68772bbd0be4d1b25fe2 # Certbot v3.2.0
 rsa_key_size=4096
 data_path="./ssl-data/certbot"
 email="davidjrunger@gmail.com" # Adding a valid address is strongly recommended
@@ -27,8 +28,8 @@ fi
 if [ ! -e "$data_path/conf/options-ssl-nginx.conf" ] || [ ! -e "$data_path/conf/ssl-dhparams.pem" ]; then
   echo "### Downloading recommended TLS parameters ..."
   mkdir -p "$data_path/conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf > "$data_path/conf/options-ssl-nginx.conf"
-  curl -s https://raw.githubusercontent.com/certbot/certbot/master/certbot/certbot/ssl-dhparams.pem > "$data_path/conf/ssl-dhparams.pem"
+  curl --fail --location --output "$data_path/conf/options-ssl-nginx.conf" "https://raw.githubusercontent.com/certbot/certbot/$certbot_commit/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf"
+  curl --fail --location --output "$data_path/conf/ssl-dhparams.pem" "https://raw.githubusercontent.com/certbot/certbot/$certbot_commit/certbot/certbot/ssl-dhparams.pem"
   echo
 fi
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,7 +84,7 @@ services:
       interval: 1h
       timeout: 10s
       retries: 1
-    image: certbot/certbot
+    image: certbot/certbot:v3.2.0@sha256:3ad1eb352f6b2ae3f359dce4b262f699cc178be0ab9d9f375210e8741404720e
     logging: *default-logging
     networks:
       - external
@@ -337,7 +337,7 @@ services:
         condition: service_started
     env_file:
       - .env.s3_db_backup.local
-    image: dokku/s3backup
+    image: dokku/s3backup:0.18.2@sha256:a781df6117de0ecfebdc2d67643a576ebea84c0bdddf9bd8686e515e05cde649
     logging: *default-logging
     networks:
       - external


### PR DESCRIPTION
Pin the Certbot service to the v3.2.0 multi-platform manifest digest currently running in production. This preserves the reviewed artifact while preventing a future pull of the mutable latest tag.

Pin dokku/s3backup to 0.18.2 and its multi-platform manifest digest. The latest tag has resolved to this release since February 2025, matching the production deployment period without introducing an upgrade.

Download Certbot TLS configuration files from the immutable commit behind v3.2.0 instead of the mutable master branch. Make failed HTTP requests explicit so bootstrap does not save an error response as a TLS file.