### PR TITLE
[spec/support/cuprite] Capture CSP violation logs

### DIFF
--- a/spec/lib/cuprite/browser_logger_spec.rb
+++ b/spec/lib/cuprite/browser_logger_spec.rb
@@ -1,0 +1,24 @@
+RSpec.describe Cuprite::BrowserLogger do
+  subject(:logger) { described_class.new }
+
+  before do
+    described_class.csp_violations.clear
+    allow($stdout).to receive(:puts)
+  end
+
+  describe '#log_entry' do
+    it 'records Content Security Policy violations' do
+      message = 'Refused to execute inline script because it violates Content Security Policy.'
+
+      logger.log_entry('text' => message)
+
+      expect(described_class.csp_violations).to eq([message])
+    end
+
+    it 'ignores log entries that are not Content Security Policy violations' do
+      logger.log_entry('text' => 'A normal browser log entry.')
+
+      expect(described_class.csp_violations).to be_empty
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -334,11 +334,13 @@ RSpec.configure do |config|
   config.around(:each, type: :feature) do |example|
     Cuprite::BrowserLogger.javascript_errors.clear
     Cuprite::BrowserLogger.javascript_logs.clear
+    Cuprite::BrowserLogger.csp_violations.clear
 
     example.run
 
     expect(Cuprite::BrowserLogger.javascript_errors).to be_empty
     expect(Cuprite::BrowserLogger.javascript_logs).to be_empty
+    expect(Cuprite::BrowserLogger.csp_violations).to be_empty
   end
 
   # NOTE: This `around` block should be registered after the block that checks

--- a/spec/support/cuprite/browser_logger.rb
+++ b/spec/support/cuprite/browser_logger.rb
@@ -1,5 +1,6 @@
 class Cuprite::BrowserLogger
   JSON_EXTRACTION_REGEX = /\A\s*[▶◀]\s+\d+\.\d+ ({.*})\n?\z/
+  CSP_VIOLATION_REGEX = /content security policy/i
   LOG_MESSAGES_TO_IGNORE = [
     /\A\[vite\] connecting\.\.\.\z/,
     /\A\[vite\] connected\.\z/,
@@ -13,6 +14,10 @@ class Cuprite::BrowserLogger
 
   def self.javascript_logs
     @javascript_logs ||= []
+  end
+
+  def self.csp_violations
+    @csp_violations ||= []
   end
 
   def puts(message)
@@ -70,6 +75,15 @@ class Cuprite::BrowserLogger
 
         self.class.javascript_logs << args_values
       end
+    end
+  end
+
+  def log_entry(entry)
+    message = entry.fetch('text')
+
+    if message.match?(CSP_VIOLATION_REGEX)
+      $stdout.puts(Rainbow("Content Security Policy violation: #{message}").red)
+      self.class.csp_violations << message
     end
   end
 

--- a/spec/support/cuprite/custom_drivers.rb
+++ b/spec/support/cuprite/custom_drivers.rb
@@ -16,10 +16,13 @@ module Cuprite::CustomDrivers
 
     def register_driver(driver_name, custom_options_proc = nil)
       Capybara.register_driver(driver_name) do |app|
-        Capybara::Cuprite::Driver.new(
+        logger = Cuprite::BrowserLogger.new
+        driver = Capybara::Cuprite::Driver.new(
           app,
-          base_options.merge(custom_options_proc&.call || {}),
+          base_options.merge(custom_options_proc&.call || {}).merge(logger:),
         )
+        driver.browser.on('Log.entryAdded') { |params| logger.log_entry(params.fetch('entry')) }
+        driver
       end
     end
 
@@ -30,7 +33,6 @@ module Cuprite::CustomDrivers
         headless: !SpecHelper.use_headful_chrome?,
         timeout:,
         process_timeout: 30,
-        logger: Cuprite::BrowserLogger.new,
         window_size: [1200, 800],
         browser_options: {
           # Most of these are lifted from:


### PR DESCRIPTION
Subscribe each Cuprite driver to Chrome DevTools `Log.entryAdded` events so Content Security Policy violations are captured alongside Runtime console messages and exceptions.

Fail feature examples after execution when a CSP violation was captured. This makes browser-enforced CSP regressions visible to the existing feature-spec feedback loop.

Add focused coverage for recognizing CSP log entries without requiring an intentionally CSP-broken application page. The spec lives under `spec/lib`, rather than the matching `spec/support/cuprite` path, because `spec/support/**/*.rb` files are eager-loaded through Zeitwerk and would be expected to define a `Cuprite::BrowserLoggerSpec` constant.