### PR TITLE
[check-links] Protect scheduled link checks from SSRF

### DIFF
--- a/app/poros/safe_external_http_fetcher.rb
+++ b/app/poros/safe_external_http_fetcher.rb
@@ -1,0 +1,100 @@
+require 'ipaddr'
+require 'resolv'
+require 'uri'
+
+class SafeExternalHttpFetcher
+  class UnsafeUrlError < StandardError; end
+
+  # IANA special-purpose ranges that are not ordinary global-unicast
+  # destinations. Keep redirect handling disabled: if it is enabled later,
+  # each redirect target must be resolved, validated, and pinned separately.
+  PROHIBITED_IPV4_RANGES = %w[
+    0.0.0.0/8
+    10.0.0.0/8
+    100.64.0.0/10
+    127.0.0.0/8
+    169.254.0.0/16
+    172.16.0.0/12
+    192.0.0.0/24
+    192.0.2.0/24
+    192.31.196.0/24
+    192.52.193.0/24
+    192.88.99.0/24
+    192.168.0.0/16
+    192.175.48.0/24
+    198.18.0.0/15
+    198.51.100.0/24
+    203.0.113.0/24
+    224.0.0.0/4
+    240.0.0.0/4
+  ].map { IPAddr.new(it) }.freeze
+  PROHIBITED_IPV6_RANGES = %w[
+    ::/96
+    64:ff9b:1::/48
+    100::/64
+    2001::/23
+    2001:2::/48
+    2001:10::/28
+    2002::/16
+    3fff::/20
+    5f00::/16
+    fc00::/7
+    fe80::/10
+    ff00::/8
+  ].map { IPAddr.new(it) }.freeze
+
+  def get(url, timeout:)
+    uri = http_uri(url)
+    pinned_address = resolved_address(uri.hostname)
+
+    Faraday.new do |connection|
+      connection.adapter(:net_http) do |http|
+        # Net::HTTP retains its original address for Host, SNI, and TLS
+        # certificate validation, while ipaddr= pins the TCP connection.
+        http.ipaddr = pinned_address.to_s
+      end
+    end.get do |request|
+      request.url(uri)
+      request.options.timeout = timeout
+    end
+  end
+
+  private
+
+  def http_uri(url)
+    uri = URI.parse(url)
+
+    unless uri.is_a?(URI::HTTP) && !uri.hostname.to_s.empty? && uri.userinfo.nil?
+      raise(UnsafeUrlError, "Unsafe external URL: #{url.inspect}")
+    end
+
+    uri
+  rescue URI::InvalidURIError
+    raise(UnsafeUrlError, "Unsafe external URL: #{url.inspect}")
+  end
+
+  def resolved_address(hostname)
+    addresses = Resolv.getaddresses(hostname).map { IPAddr.new(it) }
+    raise(UnsafeUrlError, "Could not resolve external hostname: #{hostname}") if addresses.empty?
+
+    if addresses.any? { prohibited_address?(it) }
+      raise(UnsafeUrlError, "Prohibited external address for #{hostname}")
+    end
+
+    addresses.first
+  rescue IPAddr::InvalidAddressError, Resolv::ResolvError, SocketError
+    raise(UnsafeUrlError, "Could not resolve external hostname: #{hostname}")
+  end
+
+  def prohibited_address?(address)
+    if address.ipv4_mapped?
+      prohibited_address?(address.native)
+    elsif address.ipv4?
+      PROHIBITED_IPV4_RANGES.any? { it.include?(address) }
+    elsif address.ipv6?
+      PROHIBITED_IPV6_RANGES.any? { it.include?(address) }
+    else
+      raise(UnsafeUrlError, "Unsupported resolved address: #{address}")
+    end
+  end
+end

--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -80,10 +80,7 @@ class CheckLinks::Checker
   def response(url)
     Rails.cache.fetch(cache_key(url), expires_in: 6.hours, skip_nil: true) do
       Rails.error.handle(severity: :info, context: { url: }) do
-        Faraday.new.get do |request|
-          request.url(url)
-          request.options.timeout = 5
-        end
+        SafeExternalHttpFetcher.new.get(url, timeout: 5)
       end
     end
   end

--- a/spec/poros/safe_external_http_fetcher_spec.rb
+++ b/spec/poros/safe_external_http_fetcher_spec.rb
@@ -1,0 +1,128 @@
+RSpec.describe SafeExternalHttpFetcher do
+  # rubocop:disable Style/IpAddresses
+  subject(:fetcher) { described_class.new }
+
+  describe '#get' do
+    subject(:get) { fetcher.get(url, timeout: 5) }
+
+    let(:url) { 'https://public.example.test/path?query=value' }
+    let(:hostname) { 'public.example.test' }
+    let(:resolved_addresses) { [] }
+
+    before do
+      allow(Resolv).to receive(:getaddresses).with(hostname).and_return(resolved_addresses)
+      stub_request(:get, url).to_return(status: 200, body: '', headers: {})
+    end
+
+    context 'when the hostname resolves to a public IPv4 address' do
+      let(:resolved_addresses) { ['8.8.8.8'] }
+
+      it 'connects to the address' do
+        expect(get.status).to eq(200)
+      end
+
+      it 'pins the connection while preserving the hostname for HTTP and TLS' do
+        expect(Net::HTTP).to receive(:new).with(hostname, 443, nil).
+          and_wrap_original do |method, *arguments|
+            method.call(*arguments).tap do |http|
+              expect(http).to receive(:ipaddr=).with('8.8.8.8').and_call_original
+              expect(http).to receive(:open_timeout=).with(5).and_call_original
+              expect(http).to receive(:read_timeout=).with(5).and_call_original
+              expect(http.address).to eq(hostname)
+            end
+          end
+
+        get
+      end
+    end
+
+    context 'when the hostname resolves to a public IPv6 address' do
+      let(:resolved_addresses) { ['2606:4700:4700::1111'] }
+
+      it 'connects to the address' do
+        expect(get.status).to eq(200)
+      end
+    end
+
+    [
+      '127.0.0.1',
+      '::1',
+      '10.0.0.1',
+      'fd00::1',
+      '169.254.169.254',
+      'fe80::1',
+      '0.0.0.0',
+      '::',
+      '224.0.0.1',
+      '100.64.0.1',
+      '192.0.2.1',
+      '::ffff:127.0.0.1',
+      '::ffff:10.0.0.1',
+    ].each do |address|
+      context "when the hostname resolves to prohibited address #{address}" do
+        let(:resolved_addresses) { [address] }
+
+        it 'raises an unsafe URL error without making a request' do
+          expect { get }.to raise_error(described_class::UnsafeUrlError)
+          expect(a_request(:get, url)).not_to have_been_made
+        end
+      end
+    end
+
+    context 'when the hostname resolves to public and prohibited addresses' do
+      let(:resolved_addresses) { ['8.8.8.8', '127.0.0.1'] }
+
+      it 'rejects the hostname without making a request' do
+        expect { get }.to raise_error(described_class::UnsafeUrlError)
+        expect(a_request(:get, url)).not_to have_been_made
+      end
+    end
+
+    context 'when hostname resolution fails' do
+      before do
+        allow(Resolv).to receive(:getaddresses).with(hostname).
+          and_raise(Resolv::ResolvError, 'DNS failure')
+      end
+
+      it 'raises an unsafe URL error without making a request' do
+        expect { get }.to raise_error(described_class::UnsafeUrlError)
+        expect(a_request(:get, url)).not_to have_been_made
+      end
+    end
+
+    context 'when resolution returns an unsupported address family' do
+      let(:resolved_addresses) { ['8.8.8.8'] }
+      let(:unsupported_address) do
+        instance_double(IPAddr, ipv4_mapped?: false, ipv4?: false, ipv6?: false)
+      end
+
+      before do
+        allow(IPAddr).to receive(:new).with('8.8.8.8').and_return(unsupported_address)
+      end
+
+      it 'raises an unsafe URL error without making a request' do
+        expect { get }.
+          to raise_error(described_class::UnsafeUrlError, /Unsupported resolved address/)
+        expect(a_request(:get, url)).not_to have_been_made
+      end
+    end
+
+    [
+      'not a URL',
+      'ftp://public.example.test/',
+      'https:///path',
+      'https://user:password@public.example.test/',
+    ].each do |unsafe_url|
+      context "when the URL is #{unsafe_url.inspect}" do
+        let(:url) { unsafe_url }
+
+        it 'rejects it without resolving or making a request' do
+          expect { get }.to raise_error(described_class::UnsafeUrlError)
+          expect(Resolv).not_to have_received(:getaddresses)
+          expect(a_request(:get, url)).not_to have_been_made
+        end
+      end
+    end
+  end
+  # rubocop:enable Style/IpAddresses
+end

--- a/spec/workers/check_links/checker_spec.rb
+++ b/spec/workers/check_links/checker_spec.rb
@@ -9,10 +9,15 @@ RSpec.describe CheckLinks::Checker do
 
     let(:status) { 200 }
     let(:redis_failure_key) { worker.send(:redis_failure_key, url) }
-
     let!(:stubbed_request) do
       stub_request(:get, url).
         to_return(status:, body: '', headers: {})
+    end
+
+    before do
+      # rubocop:disable Style/IpAddresses
+      allow(Resolv).to receive(:getaddresses).and_return(['8.8.8.8'])
+      # rubocop:enable Style/IpAddresses
     end
 
     context 'when a previous failure is marked in Redis' do
@@ -77,6 +82,32 @@ RSpec.describe CheckLinks::Checker do
         end
 
         it 'sends an AdminMailer#broken_link email', queue_adapter: :test do
+          expect { perform }.
+            to enqueue_mail(AdminMailer, :broken_link).
+            with(url, page_source_url, nil, [200])
+        end
+      end
+
+      context 'when the URL resolves to a prohibited address' do
+        let(:url) { 'https://unsafe.example.test/' }
+
+        before do
+          allow(Resolv).to receive(:getaddresses).with('unsafe.example.test').
+            and_return(['127.0.0.1'])
+        end
+
+        it 'reports the validation failure and sends a broken-link email', queue_adapter: :test do
+          expect(Rails.error).
+            to receive(:report).
+            with(
+              SafeExternalHttpFetcher::UnsafeUrlError,
+              severity: :info,
+              handled: true,
+              context: { url: },
+              source: 'application',
+            ).
+            and_call_original
+
           expect { perform }.
             to enqueue_mail(AdminMailer, :broken_link).
             with(url, page_source_url, nil, [200])


### PR DESCRIPTION
Introduce `SafeExternalHttpFetcher` for scheduled external link checks. It accepts only `http` and `https` URLs with hostnames, rejects URL userinfo, resolves each hostname immediately before use, and rejects a hostname when any result is non-global or special-purpose.

Pin the selected validated address through `Net::HTTP#ipaddr=` while retaining the original hostname for the HTTP `Host` header, HTTPS SNI, and certificate verification. The checker retains its five-second timeout, cache behavior, status expectations, and existing handled-error flow. Redirect following remains disabled; any future redirect support must validate and pin every target independently.

Add resolver-stubbed coverage for permitted IPv4 and IPv6 addresses, prohibited IPv4/IPv6 ranges, mapped IPv6 values, mixed DNS results, malformed URLs, pinning, timeout configuration, checker email handling, caching, and fail-closed handling of an unsupported address family.