### PR TITLE
[check-links] Restrict IPv6 destinations to global unicast

### DIFF
--- a/app/poros/safe_external_http_fetcher.rb
+++ b/app/poros/safe_external_http_fetcher.rb
@@ -5,6 +5,10 @@ require 'uri'
 class SafeExternalHttpFetcher
   class UnsafeUrlError < StandardError; end
 
+  # IPv6 global-unicast allocations currently occupy 2000::/3. Review this
+  # allowlist if IANA allocates global-unicast space outside that range.
+  IPV6_GLOBAL_UNICAST_RANGE = IPAddr.new('2000::/3').freeze
+
   # IANA special-purpose ranges that are not ordinary global-unicast
   # destinations. Keep redirect handling disabled: if it is enabled later,
   # each redirect target must be resolved, validated, and pinned separately.
@@ -34,6 +38,7 @@ class SafeExternalHttpFetcher
     100::/64
     2001::/23
     2001:2::/48
+    2001:db8::/32
     2001:10::/28
     2002::/16
     3fff::/20
@@ -92,9 +97,17 @@ class SafeExternalHttpFetcher
     elsif address.ipv4?
       PROHIBITED_IPV4_RANGES.any? { it.include?(address) }
     elsif address.ipv6?
-      PROHIBITED_IPV6_RANGES.any? { it.include?(address) }
+      prohibited_ipv6_address?(address)
     else
       raise(UnsafeUrlError, "Unsupported resolved address: #{address}")
+    end
+  end
+
+  def prohibited_ipv6_address?(address)
+    if IPV6_GLOBAL_UNICAST_RANGE.include?(address)
+      PROHIBITED_IPV6_RANGES.any? { it.include?(address) }
+    else
+      true
     end
   end
 end

--- a/spec/poros/safe_external_http_fetcher_spec.rb
+++ b/spec/poros/safe_external_http_fetcher_spec.rb
@@ -36,11 +36,17 @@ RSpec.describe SafeExternalHttpFetcher do
       end
     end
 
-    context 'when the hostname resolves to a public IPv6 address' do
-      let(:resolved_addresses) { ['2606:4700:4700::1111'] }
+    [
+      '2606:4700:4700::1111',
+      '2001:4860:4860::8888',
+      '2a00:1450:2::',
+    ].each do |address|
+      context "when the hostname resolves to a public IPv6 address #{address}" do
+        let(:resolved_addresses) { [address] }
 
-      it 'connects to the address' do
-        expect(get.status).to eq(200)
+        it 'connects to the address' do
+          expect(get.status).to eq(200)
+        end
       end
     end
 
@@ -58,6 +64,11 @@ RSpec.describe SafeExternalHttpFetcher do
       '192.0.2.1',
       '::ffff:127.0.0.1',
       '::ffff:10.0.0.1',
+      'fec0::1',
+      '2001:db8::1',
+      '100:0:0:1::1',
+      '64:ff9b::7f00:1',
+      '4000::1',
     ].each do |address|
       context "when the hostname resolves to prohibited address #{address}" do
         let(:resolved_addresses) { [address] }


### PR DESCRIPTION
Use the current 2000::/3 IPv6 global-unicast space as an application allowlist before applying the existing special-purpose denylist. This closes gaps for deprecated site-local, dummy, NAT64-embedded IPv4, and future non-global IPv6 destinations while preserving mapped-IPv4 recursion, DNS-result validation, address pinning, and hostname-based TLS behavior.

Add coverage for the newly rejected IPv6 classes and multiple ordinary public IPv6 addresses. The deployment uses standard Docker bridge networks without IPv6 or DNS64/NAT64 configuration, so the conservative policy is compatible with the repository deployment assumptions.