### PR TITLE
[assets] Sign Vite artifacts

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -123,6 +123,7 @@ jobs:
           REDIS_PORT: 6379
           AWS_ACCESS_KEY_ID: '${{secrets.AWS_ACCESS_KEY_ID}}'
           AWS_SECRET_ACCESS_KEY: '${{secrets.AWS_SECRET_ACCESS_KEY}}'
+          CONTENT_SIGNING_PRIVATE_KEY: '${{secrets.CONTENT_SIGNING_PRIVATE_KEY}}'
           CI_STEP_RESULTS_HOST: '${{secrets.CI_STEP_RESULTS_HOST}}'
           CI_STEP_RESULTS_AUTH_TOKEN: '${{secrets.CI_STEP_RESULTS_AUTH_TOKEN}}'
           PERCY_TOKEN: '${{secrets.PERCY_TOKEN}}'
@@ -198,4 +199,4 @@ jobs:
           CI: true
           AWS_ACCESS_KEY_ID: '${{secrets.AWS_ACCESS_KEY_ID}}'
           AWS_SECRET_ACCESS_KEY: '${{secrets.AWS_SECRET_ACCESS_KEY}}'
-          PRERENDER_SIGNING_PRIVATE_KEY: '${{secrets.PRERENDER_SIGNING_PRIVATE_KEY}}'
+          CONTENT_SIGNING_PRIVATE_KEY: '${{secrets.CONTENT_SIGNING_PRIVATE_KEY}}'

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,11 +72,13 @@ RUN bundle exec $(bundle info --path bootsnap)/exe/bootsnap precompile --gemfile
 COPY . .
 
 ARG GIT_REV
+ARG CONTENT_SIGNING_PUBLIC_KEY
 
 # Build public/assets/, download public/vite/ and public/vite-admin/.
 RUN DOCKER_BUILD=true \
   GIT_REV=${GIT_REV} \
   SECRET_KEY_BASE_DUMMY=1 \
+  CONTENT_SIGNING_PUBLIC_KEY=${CONTENT_SIGNING_PUBLIC_KEY} \
   VITE_RUBY_SKIP_ASSETS_PRECOMPILE_EXTENSION=true \
   bin/rails assets:precompile > /dev/null
 

--- a/app/poros/prerender_utils.rb
+++ b/app/poros/prerender_utils.rb
@@ -17,7 +17,7 @@ module PrerenderUtils
         content: html,
         object_key:,
         signature: get_response.metadata.fetch('prerender-signature'),
-        public_key: prerender_signing_public_key,
+        public_key: content_signing_public_key,
       )
 
       html_with_absolutized_asset_paths(html)
@@ -37,8 +37,8 @@ module PrerenderUtils
 
     private
 
-    def prerender_signing_public_key
-      ContentSignature.key_from_base64(ENV.fetch('PRERENDER_SIGNING_PUBLIC_KEY'))
+    def content_signing_public_key
+      ContentSignature.key_from_base64(ENV.fetch('CONTENT_SIGNING_PUBLIC_KEY'))
     end
 
     def html_with_absolutized_asset_paths(html)

--- a/bin/build-docker
+++ b/bin/build-docker
@@ -14,6 +14,16 @@ set -euo pipefail # exit on any error, don't allow undefined variables, pipes do
 
 export COMPOSE_BAKE=true
 
+# Compose's service-level `env_file` values are not available to `build.args`.
+# Load only the public signing key needed to verify precompiled Vite archives.
+CONTENT_SIGNING_PUBLIC_KEY="$(
+  # shellcheck disable=SC1091
+  source .env.production.local
+  : "${CONTENT_SIGNING_PUBLIC_KEY:?Set CONTENT_SIGNING_PUBLIC_KEY in .env.production.local.}"
+  printf '%s' "$CONTENT_SIGNING_PUBLIC_KEY"
+)"
+export CONTENT_SIGNING_PUBLIC_KEY
+
 if [ ! -v GIT_REV ] ; then
   GIT_REV="$(git rev-parse origin/main)"
   export GIT_REV

--- a/bin/prerender
+++ b/bin/prerender
@@ -77,15 +77,15 @@ class Prerenderer
             ContentSignature.signature(
               content: body,
               object_key:,
-              private_key: prerender_signing_private_key,
+              private_key: content_signing_private_key,
             ),
         },
       )
   end
 
-  def prerender_signing_private_key
-    @prerender_signing_private_key ||=
-      ContentSignature.key_from_base64(ENV.fetch('PRERENDER_SIGNING_PRIVATE_KEY'))
+  def content_signing_private_key
+    @content_signing_private_key ||=
+      ContentSignature.key_from_base64(ENV.fetch('CONTENT_SIGNING_PRIVATE_KEY'))
   end
 
   def html_for_prerendering(html)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ x-rails-config: &default-rails-config
       - GIT_REV=${GIT_REV:-}
       - RAILS_ENV=${RAILS_ENV:-}
       - RUBY_VERSION=${RUBY_VERSION:-}
+      - CONTENT_SIGNING_PUBLIC_KEY=${CONTENT_SIGNING_PUBLIC_KEY:-}
     context: .
   depends_on:
     initialize_database:

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -16,12 +16,25 @@ namespace :assets do
     FileUtils.mkdir_p('tmp')
     system("cd public && zip -r ../#{file_output_path} #{directory_name} > /dev/null")
 
-    Aws::S3::Resource.new(region: 'us-east-1').
-      bucket('david-runger-test-uploads').
-      object("compiled-assets/#{git_sha}/#{directory_name}.zip").
-      put(body: File.read(file_output_path))
+    ViteAssetArchive.upload(
+      bucket: upload_s3_bucket,
+      git_sha:,
+      directory_name:,
+      content: File.binread(file_output_path),
+      private_key: content_signing_private_key,
+    )
 
     system("rm #{file_output_path}")
+  end
+
+  def upload_s3_bucket
+    @upload_s3_bucket ||=
+      Aws::S3::Resource.new(region: 'us-east-1').bucket('david-runger-test-uploads')
+  end
+
+  def content_signing_private_key
+    @content_signing_private_key ||=
+      ContentSignature.key_from_base64(ENV.fetch('CONTENT_SIGNING_PRIVATE_KEY'))
   end
 
   desc 'Boot a server in development that serves assets in a production-like manner'
@@ -66,9 +79,13 @@ end
 
 Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
   def download_s3_zip(git_sha, directory_name)
-    s3_bucket.
-      object("compiled-assets/#{git_sha}/#{directory_name}.zip").
-      get(response_target: "tmp/#{directory_name}.zip")
+    ViteAssetArchive.download(
+      bucket: s3_bucket,
+      git_sha:,
+      directory_name:,
+      response_target: "tmp/#{directory_name}.zip",
+      public_key: content_signing_public_key,
+    )
   end
 
   git_sha = ENV.fetch('GIT_REV')
@@ -90,6 +107,11 @@ Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
         # 1149#issuecomment-2007175332
         unsigned_operations: [:get_object],
       ).bucket('david-runger-test-uploads')
+  end
+
+  def content_signing_public_key
+    @content_signing_public_key ||=
+      ContentSignature.key_from_base64(ENV.fetch('CONTENT_SIGNING_PUBLIC_KEY'))
   end
 
   begin

--- a/lib/vite_asset_archive.rb
+++ b/lib/vite_asset_archive.rb
@@ -1,0 +1,37 @@
+module ViteAssetArchive
+  SIGNATURE_METADATA_KEY = 'vite-asset-signature'
+
+  class << self
+    def object_key(git_sha:, directory_name:)
+      "compiled-assets/#{git_sha}/#{directory_name}.zip"
+    end
+
+    def upload(bucket:, git_sha:, directory_name:, content:, private_key:)
+      object_key = object_key(git_sha:, directory_name:)
+
+      bucket.object(object_key).put(
+        body: content,
+        metadata: {
+          SIGNATURE_METADATA_KEY =>
+            ContentSignature.signature(
+              content:,
+              object_key:,
+              private_key:,
+            ),
+        },
+      )
+    end
+
+    def download(bucket:, git_sha:, directory_name:, response_target:, public_key:)
+      object_key = object_key(git_sha:, directory_name:)
+      get_response = bucket.object(object_key).get(response_target:)
+
+      ContentSignature.verify!(
+        content: File.binread(response_target),
+        object_key:,
+        signature: get_response.metadata.fetch(SIGNATURE_METADATA_KEY),
+        public_key:,
+      )
+    end
+  end
+end

--- a/spec/controllers/concerns/prerenderable_spec.rb
+++ b/spec/controllers/concerns/prerenderable_spec.rb
@@ -20,17 +20,17 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
     subject(:get_index) { get(:index, params:) }
 
     let(:params) { {} }
-    let(:prerender_signing_private_key) { OpenSSL::PKey.generate_key('ED25519') }
+    let(:content_signing_private_key) { OpenSSL::PKey.generate_key('ED25519') }
 
-    let(:prerender_signing_public_key_base64) do
-      Base64.strict_encode64(prerender_signing_private_key.public_to_pem)
+    let(:content_signing_public_key_base64) do
+      Base64.strict_encode64(content_signing_private_key.public_to_pem)
     end
 
     context 'when ENV["GIT_REV"] is set' do
       around do |spec|
         ClimateControl.modify(
           GIT_REV: commit_sha,
-          PRERENDER_SIGNING_PUBLIC_KEY: prerender_signing_public_key_base64,
+          CONTENT_SIGNING_PUBLIC_KEY: content_signing_public_key_base64,
         ) do
           spec.run
         end
@@ -59,7 +59,7 @@ RSpec.describe Prerenderable, :without_verifying_authorization do
           ContentSignature.signature(
             content: prerendered_html,
             object_key: "prerenders/#{commit_sha}/home.html",
-            private_key: prerender_signing_private_key,
+            private_key: content_signing_private_key,
           )
         end
 

--- a/spec/lib/vite_asset_archive_spec.rb
+++ b/spec/lib/vite_asset_archive_spec.rb
@@ -1,0 +1,74 @@
+RSpec.describe ViteAssetArchive do
+  let(:private_key) { OpenSSL::PKey.generate_key('ED25519') }
+  let(:public_key) { OpenSSL::PKey.read(private_key.public_to_pem) }
+  let(:git_sha) { 'a-git-revision' }
+  let(:directory_name) { 'vite' }
+  let(:object_key) { "compiled-assets/#{git_sha}/#{directory_name}.zip" }
+  let(:signed_content) { "PK\x03\x04archive content".b }
+  let(:content) { signed_content }
+  let(:object) { instance_double(Aws::S3::Object) }
+  let(:bucket) { instance_double(Aws::S3::Bucket) }
+
+  before do
+    allow(bucket).to receive(:object).with(object_key).and_return(object)
+  end
+
+  describe '.upload' do
+    it 'uploads a signature for the archive content and object key' do
+      expect(object).to receive(:put) do |body:, metadata:|
+        expect(body).to eq(content)
+        expect(metadata).to include(described_class::SIGNATURE_METADATA_KEY)
+
+        expect do
+          ContentSignature.verify!(
+            content: body,
+            object_key:,
+            signature: metadata.fetch(described_class::SIGNATURE_METADATA_KEY),
+            public_key:,
+          )
+        end.not_to raise_error
+      end
+
+      described_class.upload(bucket:, git_sha:, directory_name:, content:, private_key:)
+    end
+  end
+
+  describe '.download' do
+    let(:response_target) { Rails.root.join('tmp/vite-asset-archive-spec.zip') }
+    let(:signature) do
+      ContentSignature.signature(content: signed_content, object_key:, private_key:)
+    end
+    let(:get_response) { instance_double(Aws::S3::Types::GetObjectOutput, metadata: { described_class::SIGNATURE_METADATA_KEY => signature }) }
+
+    before do
+      allow(object).to receive(:get).with(response_target:) do
+        File.binwrite(response_target, content)
+        get_response
+      end
+    end
+
+    after { FileUtils.rm_f(response_target) }
+
+    it 'accepts a signed archive' do
+      expect do
+        described_class.download(bucket:, git_sha:, directory_name:, response_target:, public_key:)
+      end.not_to raise_error
+    end
+
+    context 'when the archive content has changed' do
+      let(:content) { "PK\x03\x04modified archive content".b }
+
+      it 'rejects the archive' do
+        expect do
+          described_class.download(
+            bucket:,
+            git_sha:,
+            directory_name:,
+            response_target:,
+            public_key:,
+          )
+        end.to raise_error(ContentSignature::InvalidSignatureError, /Invalid signature/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sign each uploaded Vite archive with the shared content-signing key and store the signature in S3 metadata. Verify the downloaded archive before extracting it during the production image build, binding verification to both its bytes and its object key.

Use `CONTENT_SIGNING_PRIVATE_KEY` and `CONTENT_SIGNING_PUBLIC_KEY` for both Vite archives and prerendered HTML. The public key is passed only to the Docker build for asset verification; CI receives the private key when it uploads artifacts.

Load the public key from `.env.production.local` into the Compose build environment without exposing the file's other values as build variables.

This extends the artifact-integrity approach introduced by 9cd544ca4 ([prerendering] Sign S3 prerender artifacts (#9092)) to JavaScript bundles.