### PR TITLE
[logs] Limit CSV upload requests

### DIFF
--- a/app/controllers/logs/uploads_controller.rb
+++ b/app/controllers/logs/uploads_controller.rb
@@ -1,4 +1,14 @@
 class Logs::UploadsController < ApplicationController
+  CSV_UPLOAD_LIMIT = 6
+
+  rate_limit(
+    to: CSV_UPLOAD_LIMIT,
+    within: 1.hour,
+    by: -> { current_user.id },
+    with: :csv_upload_rate_limit_reached,
+    only: :create,
+  )
+
   def new
     authorize(LogEntry, :new?)
     render :new
@@ -19,5 +29,14 @@ class Logs::UploadsController < ApplicationController
       flash[:alert] = result.error_message
       redirect_to(logs_uploads_path)
     end
+  end
+
+  private
+
+  def csv_upload_rate_limit_reached
+    redirect_to(
+      logs_uploads_path,
+      alert: "CSV uploads are limited to #{CSV_UPLOAD_LIMIT} per hour. Please try again later.",
+    )
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -23,6 +23,7 @@ Rails.application.configure do
   # Show full error reports.
   config.consider_all_requests_local = true
   config.cache_store = :null_store
+  config.action_controller.cache_store = :memory_store
 
   # Render exceptions via ErrorsController
   config.exceptions_app = routes

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -3,6 +3,7 @@ class Rack::Attack
   PENTESTERS_PREFIX = 'pentesters-'
   PENTESTING_FINDTIME = 1.day.freeze
   PUBLIC_TELEMETRY_REQUEST_LIMIT = 10
+  LOG_CSV_UPLOAD_REQUEST_LIMIT = 30
   PUBLIC_TELEMETRY_ENDPOINTS = {
     csp_reports: %r{\A/api/csp_reports(?:\.[^/]+)?/?\z},
     events: %r{\A/api/events(?:\.[^/]+)?/?\z},
@@ -29,6 +30,10 @@ class Rack::Attack
     throttle("#{endpoint}/ip", limit: PUBLIC_TELEMETRY_REQUEST_LIMIT, period: 1.minute) do |request|
       request.ip if request.post? && request.path.match?(path_regex)
     end
+  end
+
+  throttle('logs/uploads/global', limit: LOG_CSV_UPLOAD_REQUEST_LIMIT, period: 1.hour) do |request|
+    'all' if request.post? && request.path == '/logs/uploads'
   end
 
   class << self

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -28,6 +28,33 @@ RSpec.describe('Rack::Attack') do
     end
   end
 
+  describe 'log CSV upload throttle' do
+    subject(:throttle) { Rack::Attack.throttles.fetch('logs/uploads/global') }
+
+    it 'allows at most 30 uploads in an hour across all users' do
+      expect(throttle.limit).to eq(Rack::Attack::LOG_CSV_UPLOAD_REQUEST_LIMIT)
+      expect(throttle.period).to eq(1.hour)
+    end
+
+    it 'discriminates POST requests to the upload endpoint together' do
+      request = Rack::Attack::Request.new(
+        Rack::MockRequest.env_for('/logs/uploads', method: 'POST'),
+      )
+
+      expect(throttle.block.call(request)).to eq('all')
+    end
+
+    it 'does not match other request methods or paths' do
+      get_request = Rack::Attack::Request.new(Rack::MockRequest.env_for('/logs/uploads'))
+      other_path_request = Rack::Attack::Request.new(
+        Rack::MockRequest.env_for('/logs/anything', method: 'POST'),
+      )
+
+      expect(throttle.block.call(get_request)).to be_nil
+      expect(throttle.block.call(other_path_request)).to be_nil
+    end
+  end
+
   describe 'notification logging' do
     it 'includes the matched rule and throttle usage' do
       request = Rack::Attack::Request.new(Rack::MockRequest.env_for('/api/events'))

--- a/spec/controllers/logs/uploads_controller_spec.rb
+++ b/spec/controllers/logs/uploads_controller_spec.rb
@@ -89,11 +89,32 @@ RSpec.describe Logs::UploadsController do
         ]
       end
 
-      it 'does not enqueue jobs and redirects with an error' do
+      it 'does not enqueue CreateLogEntry jobs and redirects to the upload page with an error' do
         expect { post_create }.not_to change { CreateLogEntry.jobs.size }
 
         expect(response).to redirect_to(logs_uploads_path)
         expect(flash[:alert]).to eq('Uploads may contain no more than 2 log entries.')
+      end
+    end
+
+    context 'when the user has already uploaded six CSVs this hour' do
+      before do
+        Prosopite.pause do
+          Logs::UploadsController::CSV_UPLOAD_LIMIT.times do
+            post(:create, params: { log_id: log.id, csv: csv_file })
+          end
+        end
+      end
+
+      let(:csv_rows) { ["#{3.days.ago.iso8601},201,"] }
+
+      it 'does not enqueue CreateLogEntry jobs and redirects to the upload page with an error' do
+        expect { post_create }.not_to change { CreateLogEntry.jobs.size }
+
+        expect(response).to redirect_to(logs_uploads_path)
+        expect(flash[:alert]).to eq(
+          'CSV uploads are limited to 6 per hour. Please try again later.',
+        )
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -312,6 +312,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
+    ActionController::Base.cache_store.clear
     Rack::Attack.reset!
     $redis_pool.with { |conn| conn.call('flushdb', 'sync') }
     Sidekiq.redis { |conn| conn.call('flushdb', 'sync') }


### PR DESCRIPTION
CSV imports can enqueue up to 10,000 independently retried `CreateLogEntry` jobs per accepted request. Add a Rails controller rate limit of six `POST /logs/uploads` requests per authenticated user per hour, including invalid attempts. When the per-user limit is exceeded, redirect to the upload page with an explanatory alert.

Add a `Rack::Attack` global limit of 30 `POST /logs/uploads` requests per hour as an early cross-account backstop. `Rack::Attack` runs before Devise/Warden in this application, so the authenticated per-user discriminator belongs in the controller-level Rails limiter while the global control remains at the middleware layer.

Configure `config.action_controller.cache_store` as an in-memory store in test and clear `ActionController::Base.cache_store` before every example. The controller spec therefore makes six actual upload requests and verifies that the seventh is rejected, without mocking the rate counter or inspecting Rails callback internals.

Cover the endpoint discriminator, global limit configuration, per-user cache key, and rejection behavior in focused request/controller specs.