### PR TITLE
[logs] Neutralize unsafe CSV cell prefixes

### DIFF
--- a/app/poros/log_to_csv.rb
+++ b/app/poros/log_to_csv.rb
@@ -1,4 +1,6 @@
 class LogToCsv
+  UNSAFE_SPREADSHEET_CELL_PREFIX_REGEX = /\A[=+@\-[:space:]]/
+
   def initialize(log, neutralize_formulas: true)
     @log = log
     @neutralize_formulas = neutralize_formulas
@@ -26,7 +28,8 @@ class LogToCsv
   private
 
   def exported_cell_value(value)
-    if @neutralize_formulas && value.is_a?(String) && value.match?(/\A[=+\-@]/)
+    if @neutralize_formulas && value.is_a?(String) &&
+        value.match?(UNSAFE_SPREADSHEET_CELL_PREFIX_REGEX)
       "'#{value}"
     else
       value

--- a/spec/poros/log_to_csv_spec.rb
+++ b/spec/poros/log_to_csv_spec.rb
@@ -1,7 +1,5 @@
 RSpec.describe LogToCsv do
-  subject(:csv_rows) do
-    CSV.parse(described_class.new(log, neutralize_formulas:).csv_data)
-  end
+  subject(:log_to_csv) { described_class.new(log, neutralize_formulas:) }
 
   let(:log) { logs(:text_log) }
   let(:data_label) { '=Label' }
@@ -11,41 +9,67 @@ RSpec.describe LogToCsv do
     log.log_entries.includes(:log_entry_datum).map(&:data)
   end
 
-  before do
-    log.update!(data_label:)
+  describe '#csv_data' do
+    subject(:csv_data) do
+      CSV.parse(log_to_csv.csv_data)
+    end
 
-    entry_data.each_with_index do |data, index|
-      log.build_log_entry_with_datum(data:, created_at: index.minutes.ago).save!
+    before do
+      log.update!(data_label:)
+
+      entry_data.each_with_index do |data, index|
+        log.build_log_entry_with_datum(data:, created_at: index.minutes.ago).save!
+      end
+    end
+
+    it 'neutralizes user-controlled string cells with unsafe spreadsheet prefixes' do
+      expect(csv_data.first).to eq(['Time', "'=Label"])
+      expect(csv_data.drop(1).pluck(1)).to contain_exactly(
+        *entry_data.map { "'#{it}" },
+        *original_entry_data,
+      )
+    end
+
+    context 'when formula neutralization is disabled' do
+      let(:neutralize_formulas) { false }
+
+      it 'preserves the original strings' do
+        expect(csv_data.first).to eq(['Time', '=Label'])
+        expect(csv_data.drop(1).pluck(1)).to match_array(original_entry_data + entry_data)
+      end
+    end
+
+    context 'when an entry contains a negative number' do
+      let(:log) { logs(:number_log) }
+      let(:data_label) { 'Value' }
+      let(:entry_data) { [-1.5] }
+
+      it 'preserves the numeric value' do
+        expect(csv_data.drop(1).pluck(1)).to include('-1.5')
+      end
     end
   end
 
-  it 'neutralizes formulas in user-controlled string cells' do
-    expect(csv_rows.first).to eq(['Time', "'=Label"])
-    expect(csv_rows.drop(1).pluck(1)).to contain_exactly(
-      "'=SUM(A1:A2)",
-      "'+cmd",
-      "'-cmd",
-      "'@cmd",
-      *original_entry_data,
-    )
-  end
+  describe '#exported_cell_value' do
+    subject(:exported_cell_value) { log_to_csv.send(:exported_cell_value, value) }
 
-  context 'when formula neutralization is disabled' do
-    let(:neutralize_formulas) { false }
+    context 'when neutralize_formulas is true' do
+      let(:neutralize_formulas) { true }
 
-    it 'preserves the original strings' do
-      expect(csv_rows.first).to eq(['Time', '=Label'])
-      expect(csv_rows.drop(1).pluck(1)).to match_array(original_entry_data + entry_data)
-    end
-  end
+      [
+        "\t=SUM(A1:A2)",
+        "\r=SUM(A1:A2)",
+        "\n=SUM(A1:A2)",
+        ' =SUM(A1:A2)',
+      ].each do |leading_whitespace_value|
+        context "when a value has leading whitespace (#{leading_whitespace_value.inspect})" do
+          let(:value) { leading_whitespace_value }
 
-  context 'when an entry contains a negative number' do
-    let(:log) { logs(:number_log) }
-    let(:data_label) { 'Value' }
-    let(:entry_data) { [-1.5] }
-
-    it 'preserves the numeric value' do
-      expect(csv_rows.drop(1).pluck(1)).to include('-1.5')
+          it 'neutralizes cells with leading whitespace by prefixing them with an apostrophe' do
+            expect(exported_cell_value).to eq("'#{leading_whitespace_value}")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Ensure `LogToCsv` neutralizes string cells beginning with whitespace in addition to formula operators. Some spreadsheet applications normalize whitespace before formula evaluation, which could otherwise bypass the safe default export.

Retain the explicit preserve export mode for users who need exact values.