### PR TITLE
[action-mailbox] Authenticate and throttle Mailgun ingress

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@
 - Prefer repository binstubs, such as `bin/rails` and `bin/rspec`, over commands that bypass them.
 - Keep Spring enabled for local Rails commands because it substantially speeds up tests and other work. Disable Spring only for a concrete reason, not as a routine workaround.
 
+## Routes
+
+- Keep `root` at the top of `config/routes.rb`. All else being equal, group similar routes together. For example, keep relatively niche integration and infrastructure routes lower in the file, near related health-check, operational, or other specialized routes.
+
 ## Rollbar commit messages
 
 - When the user provides a Rollbar item link that a commit is expected to fix, include both the Rollbar resolution marker and the item's full URL in the commit message body. Put each on its own line with a blank line between them, typically at the top or bottom of the body:
@@ -20,6 +24,10 @@
   ```
 
   Use the item number in the `fixes rb#<number>` marker so Rollbar automatically resolves the item when the commit is deployed. Include the full URL so reviewers and future readers can navigate to the item.
+
+## Error reporting
+
+- Report handled application conditions through `Rails.error.report` with an exception created by `Error.new`, rather than sending a bare string to Rollbar. `Error.new` supplies a backtrace so Rollbar identifies the source of the report. Do not also log the error at the call site: `ErrorSubscriber` logs every `Rails.error` report before sending it to Rollbar.
 
 ## Tests and coverage
 

--- a/app/controllers/mailgun_inbound_emails_controller.rb
+++ b/app/controllers/mailgun_inbound_emails_controller.rb
@@ -1,0 +1,27 @@
+class MailgunInboundEmailsController < ActionMailbox::Ingresses::Mailgun::InboundEmailsController
+  class IngressRateLimitReached < StandardError ; end
+
+  REQUEST_LIMIT = 100
+  RATE_LIMIT_REACHED_MESSAGE = 'Mailgun inbound email rate limit reached.'
+
+  rate_limit(
+    to: REQUEST_LIMIT,
+    within: 1.day,
+    by: -> { 'all' },
+    with: :mailgun_ingress_rate_limit_reached,
+    only: :create,
+  )
+
+  private
+
+  def ingress_name = :mailgun
+
+  def mailgun_ingress_rate_limit_reached
+    Rails.error.report(
+      Error.new(IngressRateLimitReached, RATE_LIMIT_REACHED_MESSAGE),
+      severity: :warning,
+      context: { request_limit: REQUEST_LIMIT },
+    )
+    head :too_many_requests
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -119,6 +119,10 @@ Rails.application.routes.draw do
   get 'models', to: 'model_graph#index'
   get 'sha', to: ->(_env) { plain_text_response(ENV.fetch('GIT_REV')) }
   get 'up', to: 'health_checks#index'
+  post(
+    '/rails/action_mailbox/mailgun/inbound_emails/mime',
+    to: 'mailgun_inbound_emails#create',
+  )
 
   def plain_text_response(text)
     [200, { 'Content-Disposition' => 'inline', 'Content-Type' => 'text/plain' }, [text]]

--- a/spec/controllers/mailgun_inbound_emails_controller_spec.rb
+++ b/spec/controllers/mailgun_inbound_emails_controller_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe MailgunInboundEmailsController do
+  let(:rate_limit_cache_key) { 'rate-limit:mailgun_inbound_emails:all' }
+
+  around do |example|
+    MailgunInboundEmailsController.cache_store.delete(rate_limit_cache_key)
+    ActionMailbox.with(ingress: :mailgun) do
+      example.run
+    end
+  ensure
+    MailgunInboundEmailsController.cache_store.delete(rate_limit_cache_key)
+  end
+
+  describe '#create' do
+    subject(:post_create) { post(:create, params:) }
+
+    let(:params) { { 'body-mime' => mail.to_s } }
+    let(:mail) do
+      Mail.new(
+        to: 'reply@mg.davidrunger.com',
+        from: 'sender@example.com',
+        subject: 'Hello',
+        body: 'Hello from Mailgun',
+      )
+    end
+
+    context 'when the request is not authenticated by Mailgun' do
+      before { allow(controller).to receive(:authenticated?).and_return(false) }
+
+      it 'rejects the request before consuming an ingress rate-limit token' do
+        expect(controller).not_to receive(:rate_limiting)
+
+        post_create
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'when the request is authenticated by Mailgun' do
+      before { allow(controller).to receive(:authenticated?).and_return(true) }
+
+      context 'when the ingress rate limit has not been reached' do
+        before do
+          expect(MailgunInboundEmailsController.cache_store.read(rate_limit_cache_key)).to be_nil
+        end
+
+        it 'consumes an ingress rate-limit token before storing the email' do
+          expect(controller).to receive(:rate_limiting).and_call_original
+          expect { post_create }.to change { ActionMailbox::InboundEmail.count }.by(1)
+
+          expect(response).to have_http_status(:no_content)
+        end
+      end
+
+      context 'when the ingress rate limit has been reached' do
+        before do
+          MailgunInboundEmailsController.cache_store.increment(
+            rate_limit_cache_key,
+            MailgunInboundEmailsController::REQUEST_LIMIT,
+            expires_in: 1.day,
+          )
+        end
+
+        it 'rejects the request without storing the email' do
+          expect(Rails.error).
+            to receive(:report).
+            with(
+              an_object_having_attributes(
+                backtrace: an_instance_of(Array),
+                class: MailgunInboundEmailsController::IngressRateLimitReached,
+                message: 'Mailgun inbound email rate limit reached.',
+              ),
+              severity: :warning,
+              context: { request_limit: 100 },
+            ).
+            and_call_original
+
+          expect { post_create }.not_to change { ActionMailbox::InboundEmail.count }
+
+          expect(response).to have_http_status(:too_many_requests)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Override the Action Mailbox Mailgun ingress route with a small subclass that continues to use Rails HMAC authentication and inbound-email persistence.

Apply the global 100-request daily limit only after the valid Mailgun signature check. Unauthenticated callers cannot consume the quota, while requests over the limit receive a logged 429 response before an `InboundEmail` record or raw-email blob is created.

Report each authenticated request that exceeds the quota through `Rails.error.report`, using an `Error`-created exception so Rollbar includes the source backtrace for the report. `ErrorSubscriber` logs the report before it is sent to Rollbar, so avoid duplicate call-site logging. The alert contains no inbound-email content. Group the custom route with similar operational routes and document the repository conventions in `AGENTS.md`.