### PR TITLE
[sidekiq] Harden job argument logging

### DIFF
--- a/app/actions/log_entries/enqueue_from_csv.rb
+++ b/app/actions/log_entries/enqueue_from_csv.rb
@@ -45,7 +45,7 @@ class LogEntries::EnqueueFromCsv < ApplicationAction
         break
       end
 
-      job_arguments << [serialized_attributes(log_entry)]
+      job_arguments << [attributes_for_job(log_entry)]
     ensure
       # `build_log_entry_with_datum` adds each unsaved entry to the association target. Clear it so
       # that validating an upload does not retain thousands of Active Record objects in memory.
@@ -64,11 +64,11 @@ class LogEntries::EnqueueFromCsv < ApplicationAction
     log.build_log_entry_with_datum(attributes)
   end
 
-  def serialized_attributes(log_entry)
+  def attributes_for_job(log_entry)
     log_entry.
       attributes.
       merge(log_entry.log_entry_datum.attributes.slice('data')).
       compact.
-      to_json
+      as_json
   end
 end

--- a/app/workers/create_log_entry.rb
+++ b/app/workers/create_log_entry.rb
@@ -1,8 +1,7 @@
 class CreateLogEntry
   prepend ApplicationWorker
 
-  def perform(log_entry_attributes_json)
-    log_entry_attributes = JSON(log_entry_attributes_json)
+  def perform(log_entry_attributes)
     log_id = log_entry_attributes['log_id']
     log_entry = Log.find(log_id).build_log_entry_with_datum(log_entry_attributes)
     log_entry.save!

--- a/lib/sidekiq_ext/job_arguments_formatter.rb
+++ b/lib/sidekiq_ext/job_arguments_formatter.rb
@@ -1,0 +1,25 @@
+module SidekiqExt ; end
+
+class SidekiqExt::JobArgumentsFormatter
+  MAX_LOG_LENGTH = 140
+
+  def call(arguments)
+    json = JSON.dump(filtered(arguments))
+    json.size <= MAX_LOG_LENGTH ? json : "#{json[0...MAX_LOG_LENGTH]}...]"
+  end
+
+  private
+
+  def filtered(value)
+    case value
+    when String
+      value.match?(/[[:space:]]/) ? "[FILTERED: #{value.bytesize} bytes]" : value
+    when Array
+      value.map { filtered(it) }
+    when Hash
+      value.transform_values { filtered(it) }
+    else
+      value
+    end
+  end
+end

--- a/lib/sidekiq_ext/job_logger.rb
+++ b/lib/sidekiq_ext/job_logger.rb
@@ -1,5 +1,6 @@
 require 'sidekiq/component'
 require 'sidekiq/job_logger'
+require 'sidekiq_ext/job_arguments_formatter'
 
 module SidekiqExt ; end
 
@@ -9,8 +10,7 @@ class SidekiqExt::JobLogger < Sidekiq::JobLogger
   def call(item, queue)
     start = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
     Sidekiq::Context.add(:queue, queue)
-    json = JSON.dump(item['args'])
-    Sidekiq::Context.add(:args, json.size <= 140 ? json : "#{json[0...140]}...]")
+    Sidekiq::Context.add(:args, SidekiqExt::JobArgumentsFormatter.new.call(item['args']))
     @logger.info('start')
 
     yield

--- a/spec/actions/log_entries/enqueue_from_csv_spec.rb
+++ b/spec/actions/log_entries/enqueue_from_csv_spec.rb
@@ -33,13 +33,24 @@ RSpec.describe LogEntries::EnqueueFromCsv do
         to receive(:perform_bulk).
         with(
           satisfy do |arguments|
-            arguments.size == csv_rows.size && arguments.all?(&:one?)
+            arguments.size == csv_rows.size &&
+              arguments.all? do |arguments_for_job|
+                arguments_for_job.one? && arguments_for_job.first.is_a?(Hash)
+              end
           end,
           batch_size: 1_000,
         ).
         and_call_original
 
       expect { run }.to change { CreateLogEntry.jobs.size }.by(csv_rows.size)
+    end
+
+    it 'enqueues JSON-compatible log entry attributes' do
+      run
+
+      attributes = CreateLogEntry.jobs.first.fetch('args').first
+      expect(attributes).to include('log_id' => log.id, 'data' => 201)
+      expect(JSON.parse(JSON.dump(attributes))).to eq(attributes)
     end
 
     it 'creates every log entry when the jobs run' do

--- a/spec/lib/sidekiq_ext/job_arguments_formatter_spec.rb
+++ b/spec/lib/sidekiq_ext/job_arguments_formatter_spec.rb
@@ -1,0 +1,52 @@
+RSpec.describe SidekiqExt::JobArgumentsFormatter do
+  subject(:formatted_arguments) { described_class.new.call(arguments) }
+
+  context 'with whitespace-free strings' do
+    let(:arguments) { ['record-123', 'https://example.com/a-long-url'] }
+
+    it 'preserves them' do
+      expect(formatted_arguments).to eq('["record-123","https://example.com/a-long-url"]')
+    end
+  end
+
+  context 'with strings containing whitespace' do
+    let(:arguments) { ['first last', "tab\tvalue", "line\nbreak", "caf\u00e9 note"] }
+    let(:expected_arguments) do
+      '["[FILTERED: 10 bytes]","[FILTERED: 9 bytes]","[FILTERED: 10 bytes]",' \
+        '"[FILTERED: 10 bytes]"]'
+    end
+
+    it 'filters each string using its original byte count' do
+      expect(formatted_arguments).to eq(expected_arguments)
+    end
+  end
+
+  context 'with nested arrays and hashes' do
+    let(:arguments) do
+      [
+        {
+          'preserved key' => ['private value', { 'nested' => "private\tnote" }],
+          'number' => 1,
+          'boolean' => true,
+          'nothing' => nil,
+        },
+      ]
+    end
+    let(:expected_arguments) do
+      '[{"preserved key":["[FILTERED: 13 bytes]",{"nested":"[FILTERED: 12 bytes]"}],' \
+        '"number":1,"boolean":true,"nothing":null}]'
+    end
+
+    it 'filters string values while preserving hash keys and non-string values' do
+      expect(formatted_arguments).to eq(expected_arguments)
+    end
+  end
+
+  context 'with lengthy arguments' do
+    let(:arguments) { [('123.' * 300).remove(/\.\z/)] }
+
+    it 'truncates the final JSON output' do
+      expect(formatted_arguments).to eq("[\"#{'123.' * 34}12...]")
+    end
+  end
+end

--- a/spec/lib/sidekiq_ext/job_logger_spec.rb
+++ b/spec/lib/sidekiq_ext/job_logger_spec.rb
@@ -56,6 +56,24 @@ RSpec.describe SidekiqExt::JobLogger do
           call
         end
       end
+
+      context 'when job arguments contain filtered content' do
+        let(:ip_address) { 'private message' }
+
+        it 'does not emit the original content in Sidekiq log lines' do
+          expect(Sidekiq.logger.instance_variable_get(:@logdev)).
+            to receive(:write).
+            with(/queue=default args=\["\[FILTERED: 15 bytes\]"\]: start\n\z/).
+            and_call_original
+          expect(Rails.logger).to receive(:debug).with('Performing the work ... !')
+          expect(Sidekiq.logger.instance_variable_get(:@logdev)).
+            to receive(:write).
+            with(/args=\["\[FILTERED: 15 bytes\]"\] elapsed=\d+\.\d{1,3}: done\n\z/).
+            and_call_original
+
+          call
+        end
+      end
     end
 
     context 'when the executed job raises an error' do

--- a/spec/workers/create_log_entry_spec.rb
+++ b/spec/workers/create_log_entry_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe CreateLogEntry do
+  subject(:perform) { described_class.new.perform(log_entry_attributes) }
+
+  let(:log) { Log.number.first! }
+  let(:created_at) { 1.hour.ago.change(usec: 0) }
+  let(:log_entry_attributes) do
+    {
+      'log_id' => log.id,
+      'created_at' => created_at.as_json,
+      'updated_at' => created_at.as_json,
+      'data' => 201,
+    }
+  end
+
+  it 'creates a log entry from structured attributes' do
+    expect { perform }.to change { log.reload.log_entries.size }.by(1)
+    expect(log.log_entries.last).to have_attributes(data: 201, created_at:)
+  end
+end


### PR DESCRIPTION
Filter whitespace-bearing string values recursively before `JSON.dump`. Whitespace makes a value more likely to contain free-form personal content, whereas whitespace-free values are more often identifiers or locators such as URLs; retain the latter while preserving the existing 140-character log-output cap.

CSV imports now enqueue `as_json` attribute hashes, and `CreateLogEntry` consumes those structured arguments directly instead of parsing a serialized JSON string. This lets the logger filter likely personal free-form values individually instead of filtering the entire serialized argument and losing useful structured context.

Focused specs cover filtering, truncation, emitted log content, JSON-compatible enqueueing, and worker persistence.