### PR TITLE
[authenticated-sessions] Add revocable PostgreSQL registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@
 
 ## Tests and coverage
 
+- When adding a new model class, consider adding realistic baseline records for the primary fixtures to the FixtureBuilder setup when the domain naturally calls for them. This lets specs reuse those records for faster setup and gives feature specs a more representative database state, increasing the chance that relevant data-shape bugs surface.
 - Before running feature specs that exercise changed frontend assets, start the live Vite server with `./node_modules/.bin/vite --force` in a separate terminal and leave it running while iterating. This ensures that each feature-spec run uses the current source without rebuilding assets after every edit. When a task runner starts Vite as a managed background process instead, confirm that the server is ready before running specs and stop it when testing is complete.
 - When running a live Vite server is impractical, run `RAILS_ENV=test bin/vite build` immediately before the relevant feature specs. Repeat the build after every frontend change; otherwise feature specs can silently exercise stale compiled assets.
 - Run targeted specs with `bin/rspec path/to/spec.rb` while developing.
@@ -44,6 +45,7 @@
 ## Test design
 
 - Specs under `spec/controllers/api/` automatically receive `request_format: :json` through derived metadata in `spec/spec_helper.rb`. Do not repeat that metadata on individual API controller spec groups unless the spec intentionally needs different format behavior.
+- When a spec needs a fixture record related to another fixture, obtain it through the relevant association rather than looking up a separately named fixture. This keeps the relationship explicit and avoids relying on incidental fixture identities.
 
 ## Database migrations
 

--- a/app/admin/my_sessions.rb
+++ b/app/admin/my_sessions.rb
@@ -1,0 +1,45 @@
+ActiveAdmin.register_page('My Sessions') do
+  page_action :revoke, method: :patch do
+    authenticated_session = current_admin_user.authenticated_sessions.
+      active.
+      find(params.expect(:id))
+    current_session = authenticated_session.current_for?(session, :admin_user)
+
+    authenticated_session.revoke!
+    sign_out(:admin_user) if current_session
+
+    flash[:notice] = 'Session logged out.'
+    redirect_to(current_session ? new_admin_user_session_path : admin_my_sessions_path)
+  end
+
+  content do
+    current_session = AuthenticatedSessions::Registry.current(session, :admin_user)
+    sessions = current_admin_user.authenticated_sessions.
+      active.
+      order(last_active_at: :desc).
+      decorate
+
+    para <<~TEXT.squish
+      These are the known active sessions for your administrator account. A browser may have
+      cleared or expired its cookie without notifying the server.
+    TEXT
+    table_for sessions do
+      column('Current') do |authenticated_session|
+        authenticated_session == current_session ? 'Yes' : ''
+      end
+      column('First seen', &:first_seen)
+      column('Last active', &:last_active)
+      column('Initial IP', &:initial_ip)
+      column('Latest IP', &:latest_ip)
+      column('Initial client', &:initial_client)
+      column('Latest client', &:latest_client)
+      column do |authenticated_session|
+        button_to(
+          'Log out',
+          admin_my_sessions_revoke_path(id: authenticated_session),
+          method: :patch,
+        )
+      end
+    end
+  end
+end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -47,7 +47,14 @@ ActiveAdmin.register(User) do
     column :created_at
     column :updated_at
     actions
-    column { |user| link_to('Become', become_admin_user_path(user)) }
+    column do |user|
+      button_to(
+        'Become',
+        become_admin_user_path(user),
+        method: :post,
+        class: 'index-button',
+      )
+    end
   end
 
   form do |f1|
@@ -59,15 +66,27 @@ ActiveAdmin.register(User) do
   end
 
   action_item :become, only: :show do
-    link_to('Become', become_admin_user_path(resource))
+    button_to(
+      'Become',
+      become_admin_user_path(resource),
+      method: :post,
+      class: 'action-item-button',
+    )
   end
 
-  member_action :become do
+  member_action :become, method: :post do
+    authenticated_session = AuthenticatedSessions::Registry.create_impersonation!(
+      user: resource,
+      warden: request.env.fetch('warden'),
+    )
+    request.env['authenticated_session.authentication_kind.user'] = 'admin_impersonation'
+    request.env['authenticated_session.impersonation.user'] = authenticated_session
     sign_in(resource)
+    session[AuthenticatedSessions::Registry.session_key(:user)] = authenticated_session.identifier
     redirect_to(groceries_path)
   end
 
-  member_action :unbecome do
+  member_action :unbecome, method: :delete do
     sign_out(:user)
     redirect_to(admin_user_path(params[:id]))
   end

--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,8 +1,13 @@
 class ApplicationCable::Connection < ActionCable::Connection::Base
-  identified_by :current_user
+  identified_by :current_user, :authenticated_session_identifier
 
   def connect
     self.current_user = find_verified_user
+    authenticated_session = AuthenticatedSessions::Registry.current(request.session, :user)
+    reject_unauthorized_connection unless authenticated_session&.authenticatable == current_user
+    reject_unauthorized_connection unless valid_impersonation_parent?(authenticated_session)
+    self.authenticated_session_identifier = authenticated_session.identifier
+    authenticated_session.record_activity!(request)
     @ip = request.remote_ip
   end
 
@@ -10,5 +15,14 @@ class ApplicationCable::Connection < ActionCable::Connection::Base
 
   def find_verified_user
     env['warden'].user || reject_unauthorized_connection
+  end
+
+  def valid_impersonation_parent?(authenticated_session)
+    return true unless authenticated_session.authentication_kind == 'admin_impersonation'
+
+    parent = authenticated_session.initiated_by_authenticated_session
+    parent&.active? && parent.identifier == request.session[
+      AuthenticatedSessions::Registry.session_key(:admin_user),
+    ] && parent.authenticatable == env['warden'].user(:admin_user)
   end
 end

--- a/app/controllers/admin/omniauth_callbacks_controller.rb
+++ b/app/controllers/admin/omniauth_callbacks_controller.rb
@@ -32,6 +32,7 @@ class Admin::OmniauthCallbacksController < Devise::OmniauthCallbacksController
         admin_user.update!(google_sub: sub)
       end
 
+      request.env['authenticated_session.authentication_kind.admin_user'] = 'google_oauth'
       sign_in(admin_user)
       redirect_to(session.delete('admin_user_return_to') || admin_root_path)
     else

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,10 @@ class ApplicationController < ActionController::Base
 
   def current_user
     if Rails.env.development? && Flipper.enabled?(:automatic_user_login)
-      super || User.find_by!(email: 'davidjrunger@gmail.com').tap { |user| sign_in(user) }
+      super || User.find_by!(email: 'davidjrunger@gmail.com').tap do |user|
+        request.env['authenticated_session.authentication_kind.user'] = 'legacy'
+        sign_in(user)
+      end
     else
       super
     end
@@ -58,7 +61,10 @@ class ApplicationController < ActionController::Base
       super ||
         AdminUser.
           find_by!(email: 'davidjrunger@gmail.com').
-          tap { |admin_user| sign_in(admin_user) }
+          tap do |admin_user|
+            request.env['authenticated_session.authentication_kind.admin_user'] = 'legacy'
+            sign_in(admin_user)
+          end
     else
       super
     end

--- a/app/controllers/authenticated_sessions_controller.rb
+++ b/app/controllers/authenticated_sessions_controller.rb
@@ -1,0 +1,16 @@
+class AuthenticatedSessionsController < ApplicationController
+  def revoke
+    authenticated_session = current_user.authenticated_sessions.
+      visible_to_user.
+      active.
+      find(params.expect(:id))
+    authorize(authenticated_session)
+    current_session = authenticated_session.current_for?(session, :user)
+
+    authenticated_session.revoke!
+    sign_out(:user) if current_session
+
+    flash[:notice] = 'Session logged out.'
+    redirect_to(current_session ? root_path : my_account_path)
+  end
+end

--- a/app/controllers/my_account_controller.rb
+++ b/app/controllers/my_account_controller.rb
@@ -20,6 +20,12 @@ class MyAccountController < ApplicationController
 
   def show
     @user = current_user
+    @authenticated_sessions = @user.authenticated_sessions.
+      visible_to_user.
+      active.
+      order(last_active_at: :desc).
+      decorate
+    @current_authenticated_session = AuthenticatedSessions::Registry.current(session, :user)
     authorize(@user)
     render :show
   end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -35,6 +35,7 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
       user = Users::Create.run!(email:, google_sub: sub).user
     end
 
+    request.env['authenticated_session.authentication_kind.user'] = 'google_oauth'
     sign_in(user)
     redirect_to(redirect_location || root_path)
   end

--- a/app/decorators/authenticated_session_decorator.rb
+++ b/app/decorators/authenticated_session_decorator.rb
@@ -1,0 +1,21 @@
+class AuthenticatedSessionDecorator < Draper::Decorator
+  include UserAgentDecoratable
+
+  delegate_all
+
+  def initial_client
+    user_agent_description(initial_user_agent)
+  end
+
+  def latest_client
+    user_agent_description(latest_user_agent)
+  end
+
+  def first_seen
+    h.l(created_at, format: :minute)
+  end
+
+  def last_active
+    h.l(last_active_at, format: :minute)
+  end
+end

--- a/app/decorators/concerns/user_agent_decoratable.rb
+++ b/app/decorators/concerns/user_agent_decoratable.rb
@@ -1,35 +1,26 @@
 module UserAgentDecoratable
   prepend Memoization
 
+  memoize \
   def pretty_user_agent
-    if good_browser_data?
-      "#{browser_name} #{browser_version} on #{browser_platform}"
-    else
-      user_agent
-    end
+    user_agent_description(user_agent)
   end
 
   private
 
-  def good_browser_data?
-    [browser_name, browser_version, browser_platform].all?(&:present?) &&
-      browser_name != 'Unknown Browser'
-  end
+  def user_agent_description(user_agent)
+    browser = Browser.new(user_agent)
+    browser_name = browser.name
+    browser_version = browser.version
+    browser_platform = browser.platform.name
 
-  memoize \
-  def browser
-    Browser.new(user_agent)
-  end
-
-  def browser_name
-    browser.name
-  end
-
-  def browser_version
-    browser.version
-  end
-
-  def browser_platform
-    browser.platform.name
+    if [browser_name, browser_version, browser_platform].all?(&:present?) &&
+        browser_name != 'Unknown Browser'
+      "#{browser_name} #{browser_version} on #{browser_platform}"
+    else
+      user_agent
+    end
+  rescue StandardError
+    user_agent
   end
 end

--- a/app/models/admin_user.rb
+++ b/app/models/admin_user.rb
@@ -16,6 +16,7 @@ class AdminUser < ApplicationRecord
   validates :email, presence: true, uniqueness: true
 
   has_many :events, dependent: :destroy
+  has_many :authenticated_sessions, as: :authenticatable, dependent: :destroy
   has_many :requests, dependent: :restrict_with_exception
 
   devise

--- a/app/models/authenticated_session.rb
+++ b/app/models/authenticated_session.rb
@@ -1,0 +1,130 @@
+# == Schema Information
+#
+# Table name: authenticated_sessions
+#
+#  authenticatable_id                    :bigint           not null
+#  authenticatable_type                  :string           not null
+#  authentication_kind                   :string           not null
+#  created_at                            :datetime         not null
+#  id                                    :bigint           not null, primary key
+#  identifier                            :string           not null
+#  initial_ip                            :string           not null
+#  initial_user_agent                    :text             not null
+#  initiated_by_authenticated_session_id :bigint
+#  last_active_at                        :datetime         not null
+#  latest_ip                             :string           not null
+#  latest_user_agent                     :text             not null
+#  revoked_at                            :datetime
+#  updated_at                            :datetime         not null
+#
+# Indexes
+#
+#  idx_on_initiated_by_authenticated_session_id_b250d18242  (initiated_by_authenticated_session_id)
+#  index_authenticated_sessions_for_account_listing         (authenticatable_type,authenticatable_id,revoked_at)
+#  index_authenticated_sessions_on_identifier               (identifier) UNIQUE
+#
+class AuthenticatedSession < ApplicationRecord
+  AUTHENTICATION_KINDS = %w[admin_impersonation google_oauth legacy].freeze
+
+  belongs_to :authenticatable, polymorphic: true
+  belongs_to(
+    :initiated_by_authenticated_session,
+    class_name: 'AuthenticatedSession',
+    optional: true,
+    inverse_of: :initiated_authenticated_sessions,
+  )
+  has_many(
+    :initiated_authenticated_sessions,
+    class_name: 'AuthenticatedSession',
+    dependent: :destroy,
+    foreign_key: :initiated_by_authenticated_session_id,
+    inverse_of: :initiated_by_authenticated_session,
+  )
+
+  has_paper_trail on: [:destroy]
+
+  has_secure_token :identifier
+
+  scope :active, -> { where(revoked_at: nil) }
+  scope :visible_to_user, -> { where.not(authentication_kind: 'admin_impersonation') }
+
+  validates :identifier, presence: true, uniqueness: true
+  validates :authentication_kind, inclusion: { in: AUTHENTICATION_KINDS }
+  validates :initiated_by_authenticated_session_id,
+    presence: true,
+    if: -> { authentication_kind == 'admin_impersonation' }
+  validates :initial_ip,
+    :latest_ip,
+    :initial_user_agent,
+    :latest_user_agent,
+    :last_active_at,
+    presence: true
+  validate :valid_impersonation_parent
+
+  def active?
+    revoked_at.nil?
+  end
+
+  def current_for?(rack_session, scope)
+    identifier == rack_session[AuthenticatedSessions::Registry.session_key(scope)]
+  end
+
+  def record_activity!(request)
+    current_minute = Time.current.change(sec: 0, usec: 0)
+    self.class.
+      where(id:).
+      where(last_active_at: ...current_minute).
+      # A conditional bulk update makes concurrent requests race-safe and intentionally skips
+      # callbacks, including PaperTrail's update versioning.
+      # rubocop:disable Rails/SkipsModelValidations
+      update_all(
+        last_active_at: current_minute,
+        latest_ip: request.remote_ip,
+        latest_user_agent: request.user_agent.to_s,
+        updated_at: Time.current,
+      )
+    # rubocop:enable Rails/SkipsModelValidations
+  end
+
+  def revoke!
+    newly_revoked = false
+    transaction do
+      if active?
+        update!(revoked_at: Time.current)
+        newly_revoked = true
+      end
+      initiated_authenticated_sessions.active.find_each(&:revoke!)
+    end
+    disconnect_action_cable! if newly_revoked
+  end
+
+  private
+
+  def disconnect_action_cable!
+    return unless authenticatable_type == 'User'
+
+    ActionCable.server.remote_connections.
+      where(
+        authenticated_session_identifier: identifier,
+        current_user: authenticatable,
+      ).
+      disconnect
+  end
+
+  def valid_impersonation_parent
+    if authentication_kind == 'admin_impersonation'
+      unless authenticatable_type == 'User'
+        errors.add(:authenticatable, 'must be a User for impersonation')
+      end
+      if initiated_by_authenticated_session.present? &&
+          initiated_by_authenticated_session.authenticatable_type != 'AdminUser'
+        errors.add(:initiated_by_authenticated_session, 'must belong to an AdminUser')
+      end
+      if initiated_by_authenticated_session&.authentication_kind == 'admin_impersonation'
+        errors.add(:initiated_by_authenticated_session, 'cannot be an impersonation')
+      end
+    elsif initiated_by_authenticated_session.present?
+      errors.add(:initiated_by_authenticated_session, 'is only valid for impersonation')
+    end
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,6 +19,7 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true, email_format: true
 
   has_many :auth_tokens, dependent: :destroy
+  has_many :authenticated_sessions, as: :authenticatable, dependent: :destroy
   has_many :logs, dependent: :destroy
   has_many :log_shares, through: :logs
   has_many :quizzes, dependent: :destroy, foreign_key: 'owner_id', inverse_of: :owner
@@ -82,6 +83,7 @@ class User < ApplicationRecord
       includes(
         :auth_tokens,
         :need_satisfaction_ratings,
+        authenticated_sessions: :initiated_authenticated_sessions,
         logs: [:log_shares, { log_entries: :log_entry_datum }],
         marriage: {
           check_ins: %i[check_in_submissions need_satisfaction_ratings],

--- a/app/policies/authenticated_session_policy.rb
+++ b/app/policies/authenticated_session_policy.rb
@@ -1,0 +1,5 @@
+class AuthenticatedSessionPolicy < ApplicationPolicy
+  def revoke?
+    record.authenticatable == user && record.authentication_kind != 'admin_impersonation'
+  end
+end

--- a/app/poros/authenticated_sessions/registry.rb
+++ b/app/poros/authenticated_sessions/registry.rb
@@ -1,0 +1,209 @@
+module AuthenticatedSessions::Registry
+  SCOPES = { admin_user: AdminUser, user: User }.freeze
+
+  class << self
+    def session_key(scope)
+      "authenticated_session_identifier.#{scope}"
+    end
+
+    def enforce!(authenticatable, warden, options)
+      scope = options.fetch(:scope).to_sym
+      scope_class = scope_class_for!(scope)
+      unless authenticatable.is_a?(scope_class)
+        raise(
+          ArgumentError,
+          "Expected #{scope_class} for Warden scope #{scope.inspect}, " \
+          "got #{authenticatable.class}",
+        )
+      end
+
+      rack_session = warden.request.session
+      request = ActionDispatch::Request.new(warden.request.env)
+      identifier_present = rack_session[session_key(scope)].present?
+      identified_session = find_identified_session(rack_session, scope)
+      is_fresh_authentication = options[:event] != :fetch
+
+      if is_fresh_authentication
+        identified_session&.revoke!
+        authenticated_session = create_for_authentication!(
+          authenticatable,
+          warden,
+          scope,
+          request,
+        )
+        rack_session[session_key(scope)] = authenticated_session.identifier
+      elsif identifier_present
+        unless identified_session
+          reject!(warden, rack_session, scope)
+          return
+        end
+        unless valid_for?(
+          identified_session,
+          authenticatable,
+          warden,
+        )
+          reject!(
+            warden,
+            rack_session,
+            scope,
+          )
+          return
+        end
+        identified_session.record_activity!(request)
+      else
+        authenticated_session = enroll_legacy!(authenticatable, warden, scope, request)
+        rack_session[session_key(scope)] = authenticated_session.identifier
+      end
+    end
+
+    def revoke_for_logout(authenticatable, warden, options)
+      scope = options.fetch(:scope).to_sym
+      scope_class = scope_class_for!(scope)
+      return unless authenticatable
+      unless authenticatable.is_a?(scope_class)
+        raise(
+          ArgumentError,
+          "Expected #{scope_class} for Warden scope #{scope.inspect}, " \
+          "got #{authenticatable.class}",
+        )
+      end
+
+      rack_session = warden.request.session
+      find_identified_session(rack_session, scope)&.revoke!
+      rack_session.delete(session_key(scope))
+    end
+
+    def create_impersonation!(user:, warden:)
+      rack_session = warden.request.session
+      parent = find_identified_session(rack_session, :admin_user)
+      valid_parent = parent&.active? && parent.authenticatable == warden.user(:admin_user)
+      raise(ActiveRecord::RecordNotFound) unless valid_parent
+
+      find_identified_session(rack_session, :user)&.revoke!
+      request = ActionDispatch::Request.new(warden.request.env)
+      create_session!(
+        authenticatable: user,
+        authentication_kind: 'admin_impersonation',
+        request:,
+        initiated_by_authenticated_session: parent,
+      )
+    end
+
+    def current(rack_session, scope)
+      find_identified_session(rack_session, scope)&.then { |record| record if record.active? }
+    end
+
+    private
+
+    def scope_class_for!(scope)
+      SCOPES.fetch(scope) do
+        raise(ArgumentError, "Unsupported Warden scope: #{scope.inspect}")
+      end
+    end
+
+    def create_for_authentication!(authenticatable, warden, scope, request)
+      authentication_kind = warden.request.env.delete(
+        "authenticated_session.authentication_kind.#{scope}",
+      )
+      if (impersonation = warden.request.env.delete("authenticated_session.impersonation.#{scope}"))
+        return impersonation
+      end
+
+      unless authentication_kind
+        raise(
+          ArgumentError,
+          'No authentication kind registered for fresh Warden authentication ' \
+          "in scope #{scope.inspect}",
+        )
+      end
+
+      create_session!(
+        authenticatable:,
+        authentication_kind:,
+        request:,
+      )
+    end
+
+    def create_session!(
+      authenticatable:,
+      authentication_kind:,
+      request:,
+      initiated_by_authenticated_session: nil
+    )
+      current_minute = Time.current.change(sec: 0, usec: 0)
+      authenticatable.authenticated_sessions.create!(
+        authentication_kind:,
+        initial_ip: request.remote_ip,
+        latest_ip: request.remote_ip,
+        initial_user_agent: request.user_agent.to_s,
+        latest_user_agent: request.user_agent.to_s,
+        last_active_at: current_minute,
+        initiated_by_authenticated_session:,
+      )
+    end
+
+    def enroll_legacy!(authenticatable, warden, scope, request)
+      parent = legacy_impersonation_parent(authenticatable, warden, scope, request)
+      create_session!(
+        authenticatable:,
+        authentication_kind: parent ? 'admin_impersonation' : 'legacy',
+        request:,
+        initiated_by_authenticated_session: parent,
+      )
+    end
+
+    def legacy_impersonation_parent(authenticatable, warden, scope, request)
+      return unless scope == :user
+
+      admin_user = warden.user(:admin_user)
+      # Matching emails are ambiguous here: the cookies may represent ordinary simultaneous
+      # sign-ins rather than legacy Become. The explicit Become flow does not use this heuristic.
+      return unless admin_user && admin_user.email != authenticatable.email
+
+      rack_session = warden.request.session
+      find_identified_session(rack_session, :admin_user) ||
+        enroll_legacy!(admin_user, warden, :admin_user, request).tap do |parent|
+          rack_session[session_key(:admin_user)] = parent.identifier
+        end
+    end
+
+    def valid_for?(authenticated_session, authenticatable, warden)
+      return false unless authenticated_session.active? &&
+        authenticated_session.authenticatable == authenticatable
+      return true unless authenticated_session.authentication_kind == 'admin_impersonation'
+
+      parent = authenticated_session.initiated_by_authenticated_session
+      rack_session = warden.request.session
+      parent&.active? && parent.authenticatable == warden.user(:admin_user) &&
+        parent.identifier == rack_session[session_key(:admin_user)]
+    end
+
+    def find_identified_session(rack_session, scope)
+      identifier = rack_session[session_key(scope)]
+      AuthenticatedSession.find_by(identifier:) if identifier.present?
+    end
+
+    def reject!(warden, rack_session, scope)
+      rack_session.delete(session_key(scope))
+      warden.logout(scope)
+      # User and AdminUser authentication are independent. A revoked optional scope should not
+      # abort a request that remains authenticated through the other scope.
+      return if another_scope_authenticated?(warden, rack_session, scope)
+
+      throw(:warden, scope:, action: :unauthenticated)
+    end
+
+    def another_scope_authenticated?(warden, rack_session, rejected_scope)
+      SCOPES.keys.excluding(rejected_scope).any? do |scope|
+        authenticatable = warden.user(scope:, run_callbacks: false)
+        next false unless authenticatable
+
+        identifier = rack_session[session_key(scope)]
+        next true if identifier.blank?
+
+        identified_session = find_identified_session(rack_session, scope)
+        identified_session && valid_for?(identified_session, authenticatable, warden)
+      end
+    end
+  end
+end

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -44,9 +44,9 @@
 
   %body{class: class_names('sans-serif', body_classes, user_signed_in? ? 'logged-in' : 'logged-out')}
     - if user_signed_in?
-      - if admin_user_signed_in? && (current_user.email != current_admin_user.email)
+      - if admin_user_signed_in? && AuthenticatedSessions::Registry.current(session, :user)&.authentication_kind == 'admin_impersonation'
         .text-center.p-2.bg-sky-200
-          = link_to('Unbecome', unbecome_admin_user_path(current_user))
+          = button_to('Unbecome', unbecome_admin_user_path(current_user), method: :delete)
           = current_user.email
       = render(partial: 'layouts/logged_in_header')
     - unless render_flash_messages_via_js?

--- a/app/views/my_account/show.html.haml
+++ b/app/views/my_account/show.html.haml
@@ -15,6 +15,35 @@
   .my-2
     = form.submit('Update', class: 'btn-primary')
 
+.mt-8
+  %h2 Sessions
+  %p.mt-2 These are the known active sessions for your account. A browser may have cleared or expired its cookie without notifying this server.
+
+  - @authenticated_sessions.each do |authenticated_session|
+    .mt-4.p-4.border.border-neutral-600.rounded-md
+      - if authenticated_session == @current_authenticated_session
+        %strong Current session
+      .mt-2
+        %b First seen:
+        = authenticated_session.first_seen
+      %div
+        %b Last active:
+        = authenticated_session.last_active
+      %div
+        %b Initial IP:
+        = authenticated_session.initial_ip
+      %div
+        %b Latest IP:
+        = authenticated_session.latest_ip
+      %div
+        %b Initial client:
+        = authenticated_session.initial_client
+      %div
+        %b Latest client:
+        = authenticated_session.latest_client
+      .mt-3
+        = button_to('Log out', revoke_authenticated_session_path(authenticated_session), method: :patch, class: 'btn-danger')
+
 .mt-4
   = link_to('Manage Auth Tokens', edit_my_account_path)
 

--- a/config/initializers/authenticated_sessions.rb
+++ b/config/initializers/authenticated_sessions.rb
@@ -1,0 +1,7 @@
+Warden::Manager.after_set_user do |authenticatable, warden, options|
+  AuthenticatedSessions::Registry.enforce!(authenticatable, warden, options)
+end
+
+Warden::Manager.before_logout do |authenticatable, warden, options|
+  AuthenticatedSessions::Registry.revoke_for_logout(authenticatable, warden, options)
+end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -30,4 +30,7 @@
 # available at https://guides.rubyonrails.org/i18n.html.
 
 en:
+  time:
+    formats:
+      minute: "%B %-d, %Y at %-I:%M %p"
   hello: 'Hello world'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,5 +32,5 @@
 en:
   time:
     formats:
-      minute: "%B %-d, %Y at %-I:%M %p"
+      minute: '%B %-d, %Y at %-I:%M %p'
   hello: 'Hello world'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,11 @@ Rails.application.routes.draw do
   end
   get 'login', to: 'sessions#new', as: :new_user_session
   resource :my_account, controller: :my_account, only: %i[destroy edit show update]
+  resources :authenticated_sessions, only: [] do
+    member do
+      patch :revoke
+    end
+  end
 
   get 'blog', to: 'blog#index'
   get 'blog/:slug', to: 'blog#show'

--- a/db/migrate/20260813061819_create_authenticated_sessions.rb
+++ b/db/migrate/20260813061819_create_authenticated_sessions.rb
@@ -1,0 +1,25 @@
+class CreateAuthenticatedSessions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :authenticated_sessions do |t|
+      t.string :identifier, null: false
+      t.references :authenticatable, polymorphic: true, null: false, index: false
+      t.string :authentication_kind, null: false
+      t.string :initial_ip, null: false
+      t.string :latest_ip, null: false
+      t.text :initial_user_agent, null: false
+      t.text :latest_user_agent, null: false
+      t.datetime :last_active_at, null: false
+      t.datetime :revoked_at
+      t.references :initiated_by_authenticated_session,
+                   foreign_key: {
+                     to_table: :authenticated_sessions,
+                   }
+
+      t.timestamps
+    end
+    add_index :authenticated_sessions, :identifier, unique: true
+    add_index :authenticated_sessions,
+              %i[authenticatable_type authenticatable_id revoked_at],
+              name: :index_authenticated_sessions_for_account_listing
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_11_164750) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_13_061819) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -84,6 +84,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_164750) do
     t.bigint "user_id", null: false
     t.index ["secret"], name: "index_auth_tokens_on_secret"
     t.index ["user_id", "secret"], name: "index_auth_tokens_on_user_id_and_secret", unique: true
+  end
+
+  create_table "authenticated_sessions", force: :cascade do |t|
+    t.bigint "authenticatable_id", null: false
+    t.string "authenticatable_type", null: false
+    t.string "authentication_kind", null: false
+    t.datetime "created_at", null: false
+    t.string "identifier", null: false
+    t.string "initial_ip", null: false
+    t.text "initial_user_agent", null: false
+    t.bigint "initiated_by_authenticated_session_id"
+    t.datetime "last_active_at", null: false
+    t.string "latest_ip", null: false
+    t.text "latest_user_agent", null: false
+    t.datetime "revoked_at"
+    t.datetime "updated_at", null: false
+    t.index ["authenticatable_type", "authenticatable_id", "revoked_at"], name: "index_authenticated_sessions_for_account_listing"
+    t.index ["identifier"], name: "index_authenticated_sessions_on_identifier", unique: true
+    t.index ["initiated_by_authenticated_session_id"], name: "idx_on_initiated_by_authenticated_session_id_b250d18242"
   end
 
   create_table "banned_path_fragments", force: :cascade do |t|
@@ -524,6 +543,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_11_164750) do
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "auth_tokens", "users"
+  add_foreign_key "authenticated_sessions", "authenticated_sessions", column: "initiated_by_authenticated_session_id"
   add_foreign_key "blazer_audits", "admin_users", column: "user_id"
   add_foreign_key "blazer_audits", "blazer_queries", column: "query_id"
   add_foreign_key "blazer_checks", "admin_users", column: "creator_id"

--- a/spec/channels/application_cable/channel_spec.rb
+++ b/spec/channels/application_cable/channel_spec.rb
@@ -4,12 +4,47 @@ RSpec.describe(ApplicationCable::Channel) do
   let(:connection) do
     ApplicationCable::Connection.new(
       ActionCable::Server::Base.new,
-      { 'warden' => warden },
+      {
+        'rack.session' => {
+          AuthenticatedSessions::Registry.session_key(:user) => authenticated_session.identifier,
+        },
+        'warden' => warden,
+      },
     )
   end
   let(:warden) { instance_double(Warden::Proxy, user:) }
+  let(:user) { User.first! }
+  let(:authenticated_session) do
+    user.authenticated_sessions.create!(
+      authentication_kind: 'legacy',
+      initial_ip: '127.0.0.1',
+      latest_ip: '127.0.0.1',
+      initial_user_agent: 'Test client',
+      latest_user_agent: 'Test client',
+      last_active_at: Time.current,
+      revoked_at:,
+    )
+  end
+  let(:revoked_at) { nil }
 
-  before { connection.connect }
+  describe '#connect' do
+    context 'with an active AuthenticatedSession' do
+      it 'identifies the connection with the specific session' do
+        connection.connect
+
+        expect(connection.authenticated_session_identifier).to eq(authenticated_session.identifier)
+      end
+    end
+
+    context 'with a revoked AuthenticatedSession' do
+      let(:revoked_at) { Time.current }
+
+      it 'rejects the new connection' do
+        expect { connection.connect }.
+          to raise_error(ActionCable::Connection::Authorization::UnauthorizedError)
+      end
+    end
+  end
 
   describe '#authorize!' do
     subject(:authorize!) { channel.authorize!(record, policy_query) }
@@ -17,6 +52,8 @@ RSpec.describe(ApplicationCable::Channel) do
     let(:record) { log }
     let(:log) { Log.first! }
     let(:policy_query) { :show? }
+
+    before { connection.connect }
 
     context 'when there is a current_user' do
       let(:user) { User.where.not(id: record.user_id).first! }

--- a/spec/channels/application_cable/channel_spec.rb
+++ b/spec/channels/application_cable/channel_spec.rb
@@ -1,13 +1,16 @@
 RSpec.describe(ApplicationCable::Channel) do
   subject(:channel) { ApplicationCable::Channel.new(connection, :current_user) }
 
+  let(:rack_session) do
+    {
+      AuthenticatedSessions::Registry.session_key(:user) => authenticated_session.identifier,
+    }
+  end
   let(:connection) do
     ApplicationCable::Connection.new(
       ActionCable::Server::Base.new,
       {
-        'rack.session' => {
-          AuthenticatedSessions::Registry.session_key(:user) => authenticated_session.identifier,
-        },
+        'rack.session' => rack_session,
         'warden' => warden,
       },
     )
@@ -42,6 +45,36 @@ RSpec.describe(ApplicationCable::Channel) do
       it 'rejects the new connection' do
         expect { connection.connect }.
           to raise_error(ActionCable::Connection::Authorization::UnauthorizedError)
+      end
+    end
+
+    context 'with an impersonation AuthenticatedSession and its active parent' do
+      let(:admin_user) { admin_users(:admin_user) }
+      let(:parent) { admin_user.authenticated_sessions.first! }
+      let(:authenticated_session) do
+        user.authenticated_sessions.create!(
+          authentication_kind: 'admin_impersonation',
+          initial_ip: '127.0.0.1',
+          latest_ip: '127.0.0.1',
+          initial_user_agent: 'Test client',
+          latest_user_agent: 'Test client',
+          last_active_at: Time.current,
+          initiated_by_authenticated_session: parent,
+        )
+      end
+      let(:warden) do
+        instance_double(Warden::Proxy).tap do |proxy|
+          allow(proxy).to receive(:user).with(no_args).and_return(user)
+          allow(proxy).to receive(:user).with(:admin_user).and_return(admin_user)
+        end
+      end
+
+      before do
+        rack_session[AuthenticatedSessions::Registry.session_key(:admin_user)] = parent.identifier
+      end
+
+      it 'accepts the connection' do
+        expect { connection.connect }.not_to raise_error
       end
     end
   end

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,8 +1,14 @@
 RSpec.describe Admin::UsersController do
   let(:user) { users(:user) }
+  let(:admin_user) { admin_users(:admin_user) }
+  let(:admin_authenticated_session) { admin_user.authenticated_sessions.first! }
 
   context 'when logged in as an AdminUser' do
-    before { sign_in(admin_users(:admin_user)) }
+    before do
+      sign_in(admin_user)
+      session[AuthenticatedSessions::Registry.session_key(:admin_user)] =
+        admin_authenticated_session.identifier
+    end
 
     describe '#index' do
       subject(:get_index) { get(:index) }
@@ -32,13 +38,25 @@ RSpec.describe Admin::UsersController do
     end
 
     describe '#unbecome' do
-      subject(:get_unbecome) { get(:unbecome, params: { id: user.id }) }
+      subject(:delete_unbecome) { delete(:unbecome, params: { id: user.id }) }
 
       context 'when a user is signed in' do
-        before { sign_in(user) }
+        before do
+          impersonation = create(
+            :authenticated_session,
+            authenticatable: user,
+            authentication_kind: 'admin_impersonation',
+            initiated_by_authenticated_session: admin_authenticated_session,
+          )
+          sign_in(user)
+          session[AuthenticatedSessions::Registry.session_key(:user)] = impersonation.identifier
+        end
 
-        it 'redirects to the admin user show page' do
-          get_unbecome
+        it 'revokes the impersonation and redirects to the admin user show page' do
+          delete_unbecome
+
+          expect(user.authenticated_sessions.last!.reload).not_to be_active
+          expect(admin_authenticated_session.reload).to be_active
           expect(response).to redirect_to(admin_user_path(user))
         end
       end
@@ -48,7 +66,7 @@ RSpec.describe Admin::UsersController do
         before { sign_out(:user) }
 
         it 'redirects to the admin user show page' do
-          get_unbecome
+          delete_unbecome
           expect(response).to redirect_to(admin_user_path(user))
         end
       end
@@ -66,13 +84,45 @@ RSpec.describe Admin::UsersController do
   end
 
   describe '#become' do
-    subject(:get_become) { get(:become, params: { id: user.id }) }
+    subject(:post_become) { post(:become, params: { id: user.id }) }
 
     context 'when logged in as an AdminUser' do
-      before { sign_in(admin_users(:admin_user)) }
+      before do
+        sign_in(admin_user)
+        session[AuthenticatedSessions::Registry.session_key(:admin_user)] =
+          admin_authenticated_session.identifier
+      end
 
-      it 'redirects to the groceries app' do
-        get_become
+      it 'creates a linked impersonation and redirects to the groceries app' do
+        post_become
+
+        impersonation = user.authenticated_sessions.last!
+        expect(impersonation.authentication_kind).to eq('admin_impersonation')
+        expect(impersonation.initiated_by_authenticated_session).to eq(admin_authenticated_session)
+        expect(response).to redirect_to(groceries_path)
+      end
+    end
+
+    context 'when already signed in as the selected User' do
+      let(:user_authenticated_session) { user.authenticated_sessions.first! }
+
+      before do
+        sign_in(admin_user)
+        session[AuthenticatedSessions::Registry.session_key(:admin_user)] =
+          admin_authenticated_session.identifier
+        sign_in(user)
+        session[AuthenticatedSessions::Registry.session_key(:user)] =
+          user_authenticated_session.identifier
+      end
+
+      it 'replaces the User session with the new impersonation session' do
+        post_become
+
+        impersonation = user.authenticated_sessions.last!
+        expect(impersonation.authentication_kind).to eq('admin_impersonation')
+        expect(impersonation).to be_active
+        expect(session[AuthenticatedSessions::Registry.session_key(:user)]).
+          to eq(impersonation.identifier)
         expect(response).to redirect_to(groceries_path)
       end
     end
@@ -84,7 +134,7 @@ RSpec.describe Admin::UsersController do
       end
 
       it 'redirects to the admin login page' do
-        get_become
+        post_become
         expect(response).to redirect_to(new_admin_user_session_path)
       end
     end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe ApplicationController, :without_verifying_authorization do
 
             it 'returns the User with email "davidjrunger@gmail.com"' do
               expect(current_user.email).to eq(david_runger_email)
+              expect(current_user.authenticated_sessions.last!.authentication_kind).to eq('legacy')
             end
           end
         end
@@ -41,6 +42,8 @@ RSpec.describe ApplicationController, :without_verifying_authorization do
 
           it 'returns the AdminUser with email "davidjrunger@gmail.com"' do
             expect(current_admin_user.email).to eq('davidjrunger@gmail.com')
+            expect(current_admin_user.authenticated_sessions.last!.authentication_kind).
+              to eq('legacy')
           end
         end
       end
@@ -82,6 +85,20 @@ RSpec.describe ApplicationController, :without_verifying_authorization do
             to eq('error' => 'Your token is not permitted for anonymous#index.')
         end
       end
+    end
+  end
+
+  describe 'bearer token authentication' do
+    let(:auth_token) { AuthToken.first! }
+
+    before do
+      auth_token.update!(permitted_actions_list: 'anonymous#index')
+      request.headers['Authorization'] = "Bearer #{auth_token.secret}"
+    end
+
+    it 'does not create an AuthenticatedSession' do
+      expect { post(:index, format: :json) }.
+        not_to change { AuthenticatedSession.count }
     end
   end
 end

--- a/spec/controllers/authenticated_sessions_controller_spec.rb
+++ b/spec/controllers/authenticated_sessions_controller_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe AuthenticatedSessionsController do
+  let(:user) { users(:user) }
+  let(:other_user) { User.excluding(user).first! }
+  let(:admin_user) { admin_users(:admin_user) }
+  let(:current_authenticated_session) { user.authenticated_sessions.first! }
+
+  before do
+    sign_in(user)
+    session[AuthenticatedSessions::Registry.session_key(:user)] =
+      current_authenticated_session.identifier
+  end
+
+  describe '#revoke' do
+    subject(:patch_revoke) { patch(:revoke, params: { id: authenticated_session.id }) }
+
+    context 'with another session belonging to the current user' do
+      let(:authenticated_session) { create(:authenticated_session, authenticatable: user) }
+
+      it 'revokes only that session and leaves the current session signed in' do
+        patch_revoke
+
+        expect(authenticated_session.reload).not_to be_active
+        expect(current_authenticated_session.reload).to be_active
+        expect(controller.current_user).to eq(user)
+        expect(response).to redirect_to(my_account_path)
+      end
+    end
+
+    context 'with the current session' do
+      let(:authenticated_session) { current_authenticated_session }
+
+      it 'revokes the session and signs the User scope out' do
+        patch_revoke
+
+        expect(authenticated_session.reload).not_to be_active
+        expect(controller.current_user).to eq(nil)
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "with another user's session" do
+      let(:authenticated_session) { create(:authenticated_session, authenticatable: other_user) }
+
+      it 'prevents cross-account revocation' do
+        expect { patch_revoke }.to raise_error(ActiveRecord::RecordNotFound)
+        expect(authenticated_session.reload).to be_active
+      end
+    end
+
+    context 'with an impersonation session' do
+      let(:parent) { admin_user.authenticated_sessions.first! }
+      let(:authenticated_session) do
+        create(
+          :authenticated_session,
+          authenticatable: user,
+          authentication_kind: 'admin_impersonation',
+          initiated_by_authenticated_session: parent,
+        )
+      end
+
+      it 'does not let a User revoke the hidden session' do
+        expect { patch_revoke }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+end

--- a/spec/controllers/concerns/request_recordable_spec.rb
+++ b/spec/controllers/concerns/request_recordable_spec.rb
@@ -19,6 +19,36 @@ RSpec.describe RequestRecordable, :without_verifying_authorization do
     let(:params) { {} }
     let(:user_agent) { 'RequestRecordable spec user agent' }
 
+    context 'when both User and AdminUser scopes are signed in' do
+      let(:user) { users(:user) }
+      let(:admin_user) { admin_users(:admin_user) }
+      let(:user_session) { user.authenticated_sessions.first! }
+      let(:admin_session) { admin_user.authenticated_sessions.first! }
+
+      before do
+        sign_in(user)
+        sign_in(admin_user, scope: :admin_user)
+        session[AuthenticatedSessions::Registry.session_key(:user)] = user_session.identifier
+        session[AuthenticatedSessions::Registry.session_key(:admin_user)] = admin_session.identifier
+      end
+
+      context 'when the AdminUser session is revoked' do
+        before { admin_session.revoke! }
+
+        it 'still records a request authenticated as the User' do
+          expect(data_stashed_in_redis_after_request).to include('user_id' => user.id)
+        end
+      end
+
+      context 'when the User session is revoked' do
+        before { user_session.revoke! }
+
+        it 'still records a request authenticated as the AdminUser' do
+          expect(data_stashed_in_redis_after_request).to include('admin_user_id' => admin_user.id)
+        end
+      end
+    end
+
     context 'when a user is not logged in' do
       before { controller.sign_out_all_scopes }
 

--- a/spec/controllers/my_account_controller_spec.rb
+++ b/spec/controllers/my_account_controller_spec.rb
@@ -1,5 +1,6 @@
 RSpec.describe MyAccountController do
   let(:user) { users(:user) }
+  let(:admin_user) { admin_users(:admin_user) }
 
   describe '#destroy' do
     subject(:delete_destroy) { delete(:destroy) }
@@ -54,6 +55,35 @@ RSpec.describe MyAccountController do
 
         expect(response.body).to have_button('Create New Auth Token')
       end
+    end
+  end
+
+  describe '#show' do
+    subject(:get_show) { get(:show) }
+
+    before { sign_in(user) }
+
+    it "lists only the current account's unrevoked, non-impersonation sessions" do
+      visible_session = user.authenticated_sessions.first!
+      create(:authenticated_session, authenticatable: User.excluding(user).first!)
+      create(:authenticated_session, authenticatable: user, revoked_at: Time.current)
+      impersonation = create(
+        :authenticated_session,
+        authenticatable: user,
+        authentication_kind: 'admin_impersonation',
+        initiated_by_authenticated_session: admin_user.authenticated_sessions.first!,
+      )
+
+      get_show
+
+      expect(assigns(:authenticated_sessions).map(&:object)).to include(visible_session)
+      expect(assigns(:authenticated_sessions).map(&:object)).to all(
+        satisfy { |record| record.authenticatable == user && record.active? },
+      )
+      expect(response.body).to have_text(visible_session.initial_ip)
+      expect(response.body).not_to have_text(visible_session.identifier)
+      expect(response.body).not_to have_text(impersonation.initial_ip)
+      expect(response.body).to match(/Last active:.*\d{1,2}:\d{2} [AP]M/m)
     end
   end
 end

--- a/spec/decorators/concerns/user_agent_decoratable_spec.rb
+++ b/spec/decorators/concerns/user_agent_decoratable_spec.rb
@@ -1,0 +1,42 @@
+RSpec.describe UserAgentDecoratable do
+  let(:decorated_class) do
+    Class.new do
+      include UserAgentDecoratable
+
+      attr_reader :user_agent
+
+      def initialize(user_agent)
+        @user_agent = user_agent
+      end
+    end
+  end
+  let(:decorated_object) { decorated_class.new(user_agent) }
+
+  context 'when the browser is recognized' do
+    let(:user_agent) do
+      'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36'
+    end
+
+    it 'returns a readable description' do
+      expect(decorated_object.pretty_user_agent).to include('Chrome')
+    end
+  end
+
+  context 'when browser details are not recognized' do
+    let(:user_agent) { 'Test browser' }
+
+    it 'returns the original user agent' do
+      expect(decorated_object.pretty_user_agent).to eq(user_agent)
+    end
+  end
+
+  context 'when browser parsing raises an error' do
+    let(:user_agent) { 'Test browser' }
+
+    before { allow(Browser).to receive(:new).and_raise(StandardError) }
+
+    it 'returns the original user agent' do
+      expect(decorated_object.pretty_user_agent).to eq(user_agent)
+    end
+  end
+end

--- a/spec/factories/authenticated_sessions.rb
+++ b/spec/factories/authenticated_sessions.rb
@@ -1,0 +1,40 @@
+# == Schema Information
+#
+# Table name: authenticated_sessions
+#
+#  authenticatable_id                    :bigint           not null
+#  authenticatable_type                  :string           not null
+#  authentication_kind                   :string           not null
+#  created_at                            :datetime         not null
+#  id                                    :bigint           not null, primary key
+#  identifier                            :string           not null
+#  initial_ip                            :string           not null
+#  initial_user_agent                    :text             not null
+#  initiated_by_authenticated_session_id :bigint
+#  last_active_at                        :datetime         not null
+#  latest_ip                             :string           not null
+#  latest_user_agent                     :text             not null
+#  revoked_at                            :datetime
+#  updated_at                            :datetime         not null
+#
+# Indexes
+#
+#  idx_on_initiated_by_authenticated_session_id_b250d18242  (initiated_by_authenticated_session_id)
+#  index_authenticated_sessions_for_account_listing         (authenticatable_type,authenticatable_id,revoked_at)
+#  index_authenticated_sessions_on_identifier               (identifier) UNIQUE
+#
+FactoryBot.define do
+  factory :authenticated_session do
+    association :authenticatable, factory: :user
+    authentication_kind { 'legacy' }
+    initial_ip { Faker::Internet.ip_v4_address }
+    latest_ip { initial_ip }
+    initial_user_agent { 'Mozilla/5.0 Test Browser' }
+    latest_user_agent { initial_user_agent }
+    last_active_at { Time.current.change(sec: 0, usec: 0) }
+
+    trait :admin do
+      association :authenticatable, factory: :admin_user
+    end
+  end
+end

--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Logging in as an AdminUser via Google auth' do
         )
         expect(page).to have_button('Log out')
 
-        click_on('Log out')
+        within('tr', text: 'Yes') { click_on('Log out') }
         expect(page).to have_flash_message('Session logged out.')
 
         visit('/sidekiq')

--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -30,7 +30,9 @@ RSpec.describe 'Logging in as an AdminUser via Google auth' do
 
         visit(admin_my_sessions_path)
         expect(page).to have_text('My Sessions')
-        expect(page).to have_text('These are the known active sessions for your administrator account.')
+        expect(page).to have_text(
+          'These are the known active sessions for your administrator account.',
+        )
         expect(page).to have_button('Log out')
 
         click_on('Log out')

--- a/spec/features/admin_google_login_spec.rb
+++ b/spec/features/admin_google_login_spec.rb
@@ -25,6 +25,20 @@ RSpec.describe 'Logging in as an AdminUser via Google auth' do
         expect(page).to have_text('David Runger Admin Dashboard')
         expect(page).to have_text('Admin Tools')
         expect(admin_user.reload.google_sub).to eq(mocked_google_response_sub)
+        authenticated_session = admin_user.authenticated_sessions.last!
+        expect(authenticated_session.authentication_kind).to eq('google_oauth')
+
+        visit(admin_my_sessions_path)
+        expect(page).to have_text('My Sessions')
+        expect(page).to have_text('These are the known active sessions for your administrator account.')
+        expect(page).to have_button('Log out')
+
+        click_on('Log out')
+        expect(page).to have_flash_message('Session logged out.')
+
+        visit('/sidekiq')
+
+        expect(page).to have_current_path(new_admin_user_session_path)
       end
     end
 

--- a/spec/features/user_google_login_spec.rb
+++ b/spec/features/user_google_login_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe 'Logging in as a User via Google auth', :prerendering_disabled do
 
           expect(page).to have_current_path(root_path)
           expect(page).to have_text('David Runger Full stack web developer')
+          expect(user.authenticated_sessions.last!.authentication_kind).to eq('google_oauth')
 
           expect(sign_in_confirmed_via_my_account?(user)).to eq(true)
         end

--- a/spec/models/authenticated_session_spec.rb
+++ b/spec/models/authenticated_session_spec.rb
@@ -18,6 +18,17 @@ RSpec.describe AuthenticatedSession do
     expect(admin_session.authenticatable).to be_a(AdminUser)
   end
 
+  describe '#current_for?' do
+    it 'matches the session identifier for its scope' do
+      rack_session = {
+        AuthenticatedSessions::Registry.session_key(:user) => authenticated_session.identifier,
+      }
+
+      expect(authenticated_session.current_for?(rack_session, :user)).to be(true)
+      expect(authenticated_session.current_for?(rack_session, :admin_user)).to be(false)
+    end
+  end
+
   it 'rejects missing and empty User-Agent values' do
     authenticated_session = build(:authenticated_session, initial_user_agent: nil)
     expect(authenticated_session).not_to be_valid
@@ -63,6 +74,31 @@ RSpec.describe AuthenticatedSession do
       )
       impersonation.initiated_by_authenticated_session = admin_parent
       expect(impersonation).not_to be_valid
+    end
+
+    it 'requires a User authenticatable' do
+      impersonation = build(
+        :authenticated_session,
+        :admin,
+        authentication_kind: 'admin_impersonation',
+        initiated_by_authenticated_session: admin_users(:admin_user).authenticated_sessions.first!,
+      )
+
+      expect(impersonation).not_to be_valid
+      expect(impersonation.errors[:authenticatable]).to include('must be a User for impersonation')
+    end
+
+    it 'rejects a parent session for a non-impersonation session' do
+      parent = admin_users(:admin_user).authenticated_sessions.first!
+      session = build(
+        :authenticated_session,
+        authenticatable: user,
+        initiated_by_authenticated_session: parent,
+      )
+
+      expect(session).not_to be_valid
+      expect(session.errors[:initiated_by_authenticated_session]).
+        to include('is only valid for impersonation')
     end
 
     it 'revokes active impersonation children when their administrator parent is revoked' do

--- a/spec/models/authenticated_session_spec.rb
+++ b/spec/models/authenticated_session_spec.rb
@@ -1,0 +1,206 @@
+RSpec.describe AuthenticatedSession do
+  subject(:authenticated_session) { user.authenticated_sessions.first! }
+
+  let(:user) { users(:user) }
+
+  it 'generates a unique, cryptographically random identifier' do
+    identifiers = Array.new(2) { create(:authenticated_session).identifier }
+
+    expect(identifiers).to all(match(/\A[A-Za-z0-9]{24}\z/))
+    expect(identifiers.uniq.size).to eq(2)
+  end
+
+  it 'belongs polymorphically to Users and AdminUsers' do
+    user_session = authenticated_session
+    admin_session = create(:authenticated_session, :admin)
+
+    expect(user_session.authenticatable).to be_a(User)
+    expect(admin_session.authenticatable).to be_a(AdminUser)
+  end
+
+  it 'rejects missing and empty User-Agent values' do
+    authenticated_session = build(:authenticated_session, initial_user_agent: nil)
+    expect(authenticated_session).not_to be_valid
+
+    authenticated_session.initial_user_agent = ''
+    authenticated_session.latest_user_agent = ''
+
+    expect(authenticated_session).not_to be_valid
+    expect(authenticated_session.errors).to include(:initial_user_agent, :latest_user_agent)
+  end
+
+  describe 'impersonation validation' do
+    it 'requires a parent session' do
+      impersonation = build(
+        :authenticated_session,
+        authentication_kind: 'admin_impersonation',
+      )
+
+      expect(impersonation).not_to be_valid
+      expect(impersonation.errors[:initiated_by_authenticated_session_id]).
+        to include("can't be blank")
+    end
+
+    it 'requires an AdminUser parent and disallows nested impersonation' do
+      user_parent = create(:authenticated_session)
+      admin_parent = create(:authenticated_session, :admin)
+      impersonation = build(
+        :authenticated_session,
+        authentication_kind: 'admin_impersonation',
+        initiated_by_authenticated_session: user_parent,
+      )
+
+      expect(impersonation).not_to be_valid
+
+      impersonation.initiated_by_authenticated_session = admin_parent
+      expect(impersonation).to be_valid
+
+      admin_parent = create(
+        :authenticated_session,
+        authenticatable: user,
+        authentication_kind: 'admin_impersonation',
+        initiated_by_authenticated_session: admin_parent,
+      )
+      impersonation.initiated_by_authenticated_session = admin_parent
+      expect(impersonation).not_to be_valid
+    end
+
+    it 'revokes active impersonation children when their administrator parent is revoked' do
+      parent = create(:authenticated_session, :admin)
+      child = create(
+        :authenticated_session,
+        authenticatable: user,
+        authentication_kind: 'admin_impersonation',
+        initiated_by_authenticated_session: parent,
+      )
+
+      parent.revoke!
+
+      expect(parent.reload).not_to be_active
+      expect(child.reload).not_to be_active
+    end
+
+    it 'destroys impersonation children when their administrator parent is destroyed' do
+      parent = create(:authenticated_session, :admin)
+      child = create(
+        :authenticated_session,
+        authenticatable: user,
+        authentication_kind: 'admin_impersonation',
+        initiated_by_authenticated_session: parent,
+      )
+
+      expect { parent.destroy! }.
+        to change { AuthenticatedSession.where(id: [parent.id, child.id]).count }.
+        from(2).
+        to(0)
+    end
+
+    it 'destroys impersonation children when their AdminUser is destroyed' do
+      admin_user = create(:admin_user)
+      parent = create(:authenticated_session, :admin, authenticatable: admin_user)
+      child = create(
+        :authenticated_session,
+        authenticatable: user,
+        authentication_kind: 'admin_impersonation',
+        initiated_by_authenticated_session: parent,
+      )
+
+      expect { admin_user.destroy! }.
+        to change { AuthenticatedSession.where(id: [parent.id, child.id]).count }.
+        from(2).
+        to(0)
+    end
+  end
+
+  describe '#revoke!' do
+    it 'disconnects only the Action Cable connection for that User session' do
+      remote_connections = instance_double(ActionCable::RemoteConnections)
+      remote_connection = instance_double(
+        ActionCable::RemoteConnections::RemoteConnection,
+        disconnect: true,
+      )
+      allow(ActionCable.server).to receive(:remote_connections).and_return(remote_connections)
+      allow(remote_connections).to receive(:where).and_return(remote_connection)
+
+      authenticated_session.revoke!
+
+      expect(remote_connections).to have_received(:where).with(
+        authenticated_session_identifier: authenticated_session.identifier,
+        current_user: user,
+      )
+      expect(remote_connection).to have_received(:disconnect).once
+    end
+  end
+
+  describe '#record_activity!' do
+    let(:observed_ip) { Faker::Internet.ip_v4_address }
+    let(:request) do
+      instance_double(ActionDispatch::Request, remote_ip: observed_ip, user_agent: 'New client')
+    end
+
+    it 'updates activity and latest metadata at most once in the current minute' do
+      travel_to(Time.zone.parse('2026-08-13 12:34:10')) do
+        authenticated_session.update!(last_active_at: 1.minute.ago.change(sec: 0, usec: 0))
+
+        expect { authenticated_session.record_activity!(request) }.
+          to change { authenticated_session.reload.last_active_at }
+        first_updated_at = authenticated_session.updated_at
+
+        travel 30.seconds
+        authenticated_session.record_activity!(request)
+
+        expect(authenticated_session.reload.updated_at).to eq(first_updated_at)
+        expect(authenticated_session.last_active_at).to eq(Time.current.change(sec: 0, usec: 0))
+        expect(authenticated_session.attributes.values_at('latest_ip', 'latest_user_agent')).
+          to eq([observed_ip, 'New client'])
+      end
+    end
+
+    it 'updates again after the minute changes without rounding into the future' do
+      travel_to(Time.zone.parse('2026-08-13 12:34:59')) do
+        authenticated_session.update!(last_active_at: 1.minute.ago.change(sec: 0, usec: 0))
+        authenticated_session.record_activity!(request)
+        travel 2.seconds
+
+        expect { authenticated_session.record_activity!(request) }.
+          to change { authenticated_session.reload.last_active_at }.
+          to(Time.zone.parse('2026-08-13 12:35:00'))
+      end
+    end
+  end
+
+  describe 'PaperTrail retention', :versioning do
+    it 'versions destruction but not creation, activity, or revocation' do
+      request = instance_double(
+        ActionDispatch::Request,
+        remote_ip: Faker::Internet.ip_v4_address,
+        user_agent: 'New client',
+      )
+      authenticated_session.update!(last_active_at: 2.minutes.ago)
+
+      expect { authenticated_session.record_activity!(request) }.
+        not_to change { PaperTrail::Version.count }
+      expect { authenticated_session.revoke! }.
+        not_to change { PaperTrail::Version.count }
+      expect { authenticated_session.destroy! }.
+        to change { PaperTrail::Version.where(item_type: 'AuthenticatedSession').count }.by(1)
+    end
+
+    it 'destroys sessions and retains destroy versions when an account is deleted' do
+      authenticated_session
+
+      expect { User.with_eager_loading_for_destroy.find(user.id).destroy! }.
+        to change { PaperTrail::Version.where(item_type: 'AuthenticatedSession').count }.by(1)
+      expect(AuthenticatedSession.where(id: authenticated_session.id)).not_to exist
+    end
+
+    it 'destroys an AdminUser session and retains its destroy version' do
+      admin_user = create(:admin_user)
+      admin_session = create(:authenticated_session, :admin, authenticatable: admin_user)
+
+      expect { admin_user.destroy! }.
+        to change { PaperTrail::Version.where(item_type: 'AuthenticatedSession').count }.by(1)
+      expect(AuthenticatedSession.where(id: admin_session.id)).not_to exist
+    end
+  end
+end

--- a/spec/poros/authenticated_sessions/registry_spec.rb
+++ b/spec/poros/authenticated_sessions/registry_spec.rb
@@ -1,0 +1,264 @@
+RSpec.describe AuthenticatedSessions::Registry do
+  let(:rack_session) { {} }
+  let(:observed_ip) { Faker::Internet.ip_v4_address }
+  let(:env) do
+    {
+      'HTTP_USER_AGENT' => 'Test Browser/1.0',
+      'REMOTE_ADDR' => observed_ip,
+      'rack.session' => rack_session,
+    }
+  end
+  let(:request) { ActionDispatch::Request.new(env) }
+  let(:warden) { instance_double(Warden::Proxy, request:, logout: true) }
+  let(:user) { users(:user) }
+  let(:admin_user) { admin_users(:admin_user) }
+
+  before { allow(warden).to receive(:user).and_return(nil) }
+
+  describe '.enforce!' do
+    it 'raises for a scope not managed by the registry' do
+      expect {
+        enforce(user, scope: :unmanaged, event: :fetch)
+      }.to raise_error(ArgumentError, 'Unsupported Warden scope: :unmanaged')
+    end
+
+    it 'raises when the authenticatable does not match the Warden scope' do
+      expect {
+        enforce(admin_user, scope: :user, event: :fetch)
+      }.to raise_error(
+        ArgumentError,
+        'Expected User for Warden scope :user, got AdminUser',
+      )
+    end
+
+    it 'registers a fresh OAuth User login with request metadata' do
+      env['authenticated_session.authentication_kind.user'] = 'google_oauth'
+
+      expect { enforce(user, scope: :user, event: :set_user) }.
+        to change { user.authenticated_sessions.count }.by(1)
+
+      authenticated_session = user.authenticated_sessions.last!
+      expect(authenticated_session.authentication_kind).to eq('google_oauth')
+      expect(authenticated_session.attributes.values_at('initial_ip', 'latest_ip')).
+        to eq([observed_ip, observed_ip])
+      expect(
+        authenticated_session.attributes.values_at('initial_user_agent', 'latest_user_agent'),
+      ).to eq(['Test Browser/1.0', 'Test Browser/1.0'])
+    end
+
+    it 'raises when a fresh authentication has no registered kind' do
+      expect {
+        enforce(user, scope: :user, event: :authentication)
+      }.to raise_error(
+        ArgumentError,
+        'No authentication kind registered for fresh Warden authentication in scope :user',
+      )
+    end
+
+    it 'uses distinct identifiers for User and AdminUser scopes' do
+      env['authenticated_session.authentication_kind.user'] = 'google_oauth'
+      env['authenticated_session.authentication_kind.admin_user'] = 'google_oauth'
+
+      enforce(user, scope: :user, event: :authentication)
+      enforce(admin_user, scope: :admin_user, event: :authentication)
+
+      expect(rack_session.values_at(session_key(:user), session_key(:admin_user)).uniq.size).
+        to eq(2)
+    end
+
+    it 'lazily enrolls an authenticated legacy cookie without signing it out' do
+      expect { enforce(user, scope: :user, event: :fetch) }.
+        to change { user.authenticated_sessions.count }.by(1)
+
+      expect(user.authenticated_sessions.last!.authentication_kind).to eq('legacy')
+      expect(rack_session[session_key(:user)]).to be_present
+      expect(warden).not_to have_received(:logout)
+    end
+
+    it 'enrolls the administrator first when a legacy cookie clearly represents Become' do
+      allow(warden).to receive(:user).with(:admin_user).and_return(admin_user)
+      allow(warden).to receive(:user).
+        with(scope: :admin_user, run_callbacks: false).
+        and_return(admin_user)
+
+      enforce(user, scope: :user, event: :fetch)
+
+      admin_session = admin_user.authenticated_sessions.last!
+      impersonation = user.authenticated_sessions.last!
+      expect(admin_session.authentication_kind).to eq('legacy')
+      expect(impersonation.authentication_kind).to eq('admin_impersonation')
+      expect(impersonation.initiated_by_authenticated_session).to eq(admin_session)
+      expect(rack_session[session_key(:admin_user)]).to eq(admin_session.identifier)
+    end
+
+    it 'classifies explicit User OAuth as OAuth when an administrator scope coexists' do
+      admin_session = admin_user.authenticated_sessions.first!
+      allow(warden).to receive(:user).with(:admin_user).and_return(admin_user)
+      allow(warden).to receive(:user).
+        with(scope: :admin_user, run_callbacks: false).
+        and_return(admin_user)
+      rack_session[session_key(:admin_user)] = admin_session.identifier
+      env['authenticated_session.authentication_kind.user'] = 'google_oauth'
+
+      enforce(user, scope: :user, event: :set_user)
+
+      expect(user.authenticated_sessions.last!.authentication_kind).to eq('google_oauth')
+      expect(user.authenticated_sessions.last!.initiated_by_authenticated_session).to eq(nil)
+    end
+
+    it 'rejects a missing identified session without reenrolling it' do
+      rack_session[session_key(:user)] = SecureRandom.urlsafe_base64(32)
+
+      expect { expect_rejection { enforce(user, scope: :user, event: :fetch) } }.
+        not_to change { AuthenticatedSession.count }
+    end
+
+    it 'rejects a revoked identified session without reenrolling it' do
+      authenticated_session = create(
+        :authenticated_session,
+        authenticatable: user,
+        revoked_at: Time.current,
+      )
+      rack_session[session_key(:user)] = authenticated_session.identifier
+
+      expect { expect_rejection { enforce(user, scope: :user, event: :fetch) } }.
+        not_to change { AuthenticatedSession.count }
+    end
+
+    it 'rejects an identifier belonging to another account' do
+      other_user_session = create(
+        :authenticated_session,
+        authenticatable: User.excluding(user).first!,
+      )
+      rack_session[session_key(:user)] = other_user_session.identifier
+
+      expect_rejection { enforce(user, scope: :user, event: :fetch) }
+    end
+
+    it 'rejects an identifier belonging to another Warden scope' do
+      admin_session = admin_user.authenticated_sessions.first!
+      rack_session[session_key(:user)] = admin_session.identifier
+
+      expect_rejection { enforce(user, scope: :user, event: :fetch) }
+    end
+
+    it 'rejects an impersonation whose administrator parent has been revoked' do
+      parent = create(
+        :authenticated_session,
+        :admin,
+        authenticatable: admin_user,
+        revoked_at: Time.current,
+      )
+      impersonation = create(
+        :authenticated_session,
+        authenticatable: user,
+        authentication_kind: 'admin_impersonation',
+        initiated_by_authenticated_session: parent,
+      )
+      allow(warden).to receive(:user).with(:admin_user).and_return(admin_user)
+      allow(warden).to receive(:user).
+        with(scope: :admin_user, run_callbacks: false).
+        and_return(admin_user)
+      rack_session[session_key(:admin_user)] = parent.identifier
+      rack_session[session_key(:user)] = impersonation.identifier
+
+      expect_rejection { enforce(user, scope: :user, event: :fetch) }
+    end
+
+    it 'does not reject a valid User request when the optional AdminUser session is revoked' do
+      user_session = user.authenticated_sessions.first!
+      admin_session = admin_user.authenticated_sessions.first!
+      admin_session.revoke!
+      rack_session[session_key(:user)] = user_session.identifier
+      rack_session[session_key(:admin_user)] = admin_session.identifier
+      allow(warden).to receive(:user).
+        with(scope: :user, run_callbacks: false).
+        and_return(user)
+
+      expect { enforce(admin_user, scope: :admin_user, event: :fetch) }.
+        not_to throw_symbol(:warden)
+      expect(warden).to have_received(:logout).with(:admin_user)
+    end
+
+    it 'does not reject a valid AdminUser request when the optional User session is revoked' do
+      user_session = user.authenticated_sessions.first!
+      admin_session = admin_user.authenticated_sessions.first!
+      user_session.revoke!
+      rack_session[session_key(:user)] = user_session.identifier
+      rack_session[session_key(:admin_user)] = admin_session.identifier
+      allow(warden).to receive(:user).
+        with(scope: :admin_user, run_callbacks: false).
+        and_return(admin_user)
+
+      expect { enforce(user, scope: :user, event: :fetch) }.
+        not_to throw_symbol(:warden)
+      expect(warden).to have_received(:logout).with(:user)
+    end
+  end
+
+  describe '.revoke_for_logout' do
+    it 'revokes the represented session and clears its identifier' do
+      authenticated_session = user.authenticated_sessions.first!
+      rack_session[session_key(:user)] = authenticated_session.identifier
+
+      described_class.revoke_for_logout(user, warden, scope: :user)
+
+      expect(authenticated_session.reload).not_to be_active
+      expect(rack_session).not_to have_key(session_key(:user))
+    end
+  end
+
+  describe '.create_impersonation!' do
+    before { allow(warden).to receive(:user).with(:admin_user).and_return(admin_user) }
+
+    it 'replaces the User scope with a child of the exact active administrator session' do
+      admin_user.update!(email: user.email)
+      parent = admin_user.authenticated_sessions.first!
+      previous_user_session = user.authenticated_sessions.first!
+      rack_session[session_key(:admin_user)] = parent.identifier
+      rack_session[session_key(:user)] = previous_user_session.identifier
+
+      impersonation = described_class.create_impersonation!(user:, warden:)
+
+      expect(previous_user_session.reload).not_to be_active
+      expect(impersonation.authentication_kind).to eq('admin_impersonation')
+      expect(impersonation.authenticatable).to eq(user)
+      expect(impersonation.initiated_by_authenticated_session).to eq(parent)
+    end
+
+    it 'rejects a revoked administrator parent' do
+      parent = create(
+        :authenticated_session,
+        :admin,
+        authenticatable: admin_user,
+        revoked_at: Time.current,
+      )
+      rack_session[session_key(:admin_user)] = parent.identifier
+
+      expect { described_class.create_impersonation!(user:, warden:) }.
+        to raise_error(ActiveRecord::RecordNotFound)
+    end
+  end
+
+  private
+
+  def enforce(authenticatable, options)
+    described_class.enforce!(authenticatable, warden, options)
+  end
+
+  def expect_rejection
+    result =
+      catch(:warden) do
+        yield
+        :not_rejected
+      end
+
+    expect(result).to include(scope: :user, action: :unauthenticated)
+    expect(warden).to have_received(:logout).with(:user)
+    expect(rack_session).not_to have_key(session_key(:user))
+  end
+
+  def session_key(scope)
+    described_class.session_key(scope)
+  end
+end

--- a/spec/poros/authenticated_sessions/registry_spec.rb
+++ b/spec/poros/authenticated_sessions/registry_spec.rb
@@ -55,6 +55,20 @@ RSpec.describe AuthenticatedSessions::Registry do
       )
     end
 
+    it 'uses an explicitly supplied impersonation session for fresh authentication' do
+      impersonation = create(
+        :authenticated_session,
+        authenticatable: user,
+        authentication_kind: 'admin_impersonation',
+        initiated_by_authenticated_session: admin_user.authenticated_sessions.first!,
+      )
+      env['authenticated_session.impersonation.user'] = impersonation
+
+      enforce(user, scope: :user, event: :authentication)
+
+      expect(rack_session[session_key(:user)]).to eq(impersonation.identifier)
+    end
+
     it 'uses distinct identifiers for User and AdminUser scopes' do
       env['authenticated_session.authentication_kind.user'] = 'google_oauth'
       env['authenticated_session.authentication_kind.admin_user'] = 'google_oauth'
@@ -72,6 +86,15 @@ RSpec.describe AuthenticatedSessions::Registry do
 
       expect(user.authenticated_sessions.last!.authentication_kind).to eq('legacy')
       expect(rack_session[session_key(:user)]).to be_present
+      expect(warden).not_to have_received(:logout)
+    end
+
+    it 'records activity for an identified active session' do
+      authenticated_session = user.authenticated_sessions.first!
+      rack_session[session_key(:user)] = authenticated_session.identifier
+
+      expect { enforce(user, scope: :user, event: :fetch) }.
+        not_to change { AuthenticatedSession.count }
       expect(warden).not_to have_received(:logout)
     end
 
@@ -111,6 +134,19 @@ RSpec.describe AuthenticatedSessions::Registry do
 
       expect { expect_rejection { enforce(user, scope: :user, event: :fetch) } }.
         not_to change { AuthenticatedSession.count }
+    end
+
+    it 'clears an unrecognized optional identifier without rejecting another scope' do
+      admin_session = admin_user.authenticated_sessions.first!
+      rack_session[session_key(:user)] = SecureRandom.urlsafe_base64(32)
+      rack_session[session_key(:admin_user)] = admin_session.identifier
+      allow(warden).to receive(:user).
+        with(scope: :admin_user, run_callbacks: false).
+        and_return(admin_user)
+
+      expect { enforce(user, scope: :user, event: :fetch) }.
+        not_to throw_symbol(:warden)
+      expect(warden).to have_received(:logout).with(:user)
     end
 
     it 'rejects a revoked identified session without reenrolling it' do
@@ -205,6 +241,15 @@ RSpec.describe AuthenticatedSessions::Registry do
 
       expect(authenticated_session.reload).not_to be_active
       expect(rack_session).not_to have_key(session_key(:user))
+    end
+
+    it 'raises when the authenticatable does not match the Warden scope' do
+      expect {
+        described_class.revoke_for_logout(admin_user, warden, scope: :user)
+      }.to raise_error(
+        ArgumentError,
+        'Expected User for Warden scope :user, got AdminUser',
+      )
     end
   end
 

--- a/spec/support/features/sign_in_helpers.rb
+++ b/spec/support/features/sign_in_helpers.rb
@@ -1,4 +1,13 @@
 module Features::SignInHelpers
+  def sign_in(resource, scope: nil)
+    scope ||= Devise::Mapping.find_scope!(resource)
+
+    Warden.on_next_request do |proxy|
+      proxy.env["authenticated_session.authentication_kind.#{scope}"] = 'legacy'
+      proxy.set_user(resource, scope:, event: :authentication)
+    end
+  end
+
   def click_sign_in_with_google
     within(find('google-sign-in-button').shadow_root) do
       find('button', text: 'Sign in with Google').trigger('click')

--- a/spec/support/features/sign_in_helpers.rb
+++ b/spec/support/features/sign_in_helpers.rb
@@ -3,6 +3,7 @@ module Features::SignInHelpers
     scope ||= Devise::Mapping.find_scope!(resource)
 
     Warden.on_next_request do |proxy|
+      proxy.env['HTTP_USER_AGENT'] = 'Feature spec browser' if proxy.env['HTTP_USER_AGENT'].blank?
       proxy.env["authenticated_session.authentication_kind.#{scope}"] = 'legacy'
       proxy.set_user(resource, scope:, event: :authentication)
     end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -19,6 +19,13 @@ FixtureBuilder.configure do |fbuilder|
     # AdminUsers
     admin_user = name(:admin_user, create(:admin_user, email: 'davidjrunger@gmail.com')).first
 
+    # authenticated sessions
+    name(:user_authenticated_session, create(:authenticated_session, authenticatable: user))
+    name(
+      :admin_authenticated_session,
+      create(:authenticated_session, :admin, authenticatable: admin_user),
+    )
+
     # groceries
     other_store = create(:store, user:, name: 'Another Store')
     create(:store, user: single_user, name: 'Hardware Store')


### PR DESCRIPTION
Keep the existing encrypted `CookieStore` payload and one-year expiration while attaching each Warden scope to an independently revocable `AuthenticatedSession` record. Enforce identified sessions through Warden so ordinary controllers, mounted administrator apps, and new Action Cable connections fail closed after revocation.

Lazily enroll legacy cookies, record client metadata with race-safe minute sampling, and retain session rows indefinitely. Configure PaperTrail for destroy events only so account deletion remains auditable without versioning routine activity or revocation writes.

Add account and administrator session-management interfaces with ownership-scoped revoke controls. Model administrator impersonation explicitly as a child of the initiating administrator session, convert Become and Unbecome to CSRF-protected mutations, hide impersonation records from users, and revoke children with their parent.

Cover OAuth and legacy enrollment, scope and account mismatches, logout and manual revocation, bearer-token exclusion, PaperTrail retention, mounted administrator protection, impersonation behavior, and session-specific Action Cable validation and disconnection.