### PR TITLE
[docker-compose] Update NGINX to 1.31.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -198,7 +198,7 @@ services:
       interval: 5m
       timeout: 3s
       retries: 1
-    image: nginx:1.29.4-alpine
+    image: nginx:1.31.3-alpine
     logging: *default-logging
     memswap_limit: 99G
     networks:


### PR DESCRIPTION
Update the internet-facing NGINX service from `1.29.4` to the current `1.31.3` mainline release while retaining the Alpine variant.

The existing image was already on the mainline release track. This is a version-only update; image digest pinning will be handled separately so its validation and maintenance workflow can be reviewed independently.