### PR TITLE
[docker-compose] Bump PostgreSQL from 18.4 to 18.6

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -254,7 +254,7 @@ services:
       interval: 5m
       timeout: 1s
       retries: 1
-    image: postgres:18.4-alpine
+    image: postgres:18.6-alpine
     logging: *default-logging
     memswap_limit: 99G
     networks:


### PR DESCRIPTION
Update the PostgreSQL Compose image from `18.4-alpine` to the current `18.6-alpine` minor release.

PostgreSQL minor releases provide cumulative bug and security fixes within a major version. Digest pinning remains a separate follow-up so upgrades retain a clear review history.