### PR TITLE
[Dockerfile] Pin Ruby image digest

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -74,6 +74,9 @@ jobs:
           echo "PR: #${pr%/merge}"
           echo "SHA: $GIT_REV"
 
+      - name: Verify Ruby base image digest
+        run: bin/check-ruby-image-digest
+
       - name: Set up Ruby
         uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ARG RUBY_VERSION
-FROM ruby:$RUBY_VERSION-slim-bookworm AS base
+# Update this digest when `.ruby-version` changes.
+FROM ruby:$RUBY_VERSION-slim-bookworm@sha256:c5650da02325ecb3e7dd96e7074772c3ae2ecd093a9acf2cdbcf1a2fdc680726 AS base
 
 RUN test -n "$RUBY_VERSION"
 

--- a/bin/check-ruby-image-digest
+++ b/bin/check-ruby-image-digest
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail # exit on any error, don't allow undefined variables, pipes don't swallow errors
+
+ruby_version="$(<.ruby-version)"
+ruby_image="ruby:$ruby_version-slim-bookworm"
+expected_digest="$(docker buildx imagetools inspect "$ruby_image" --format '{{.Manifest.Digest}}')"
+# shellcheck disable=SC2016 # Match the literal build-argument name in the Dockerfile.
+actual_digest="$(sed -nE 's|^FROM ruby:\$RUBY_VERSION-slim-bookworm@(sha256:[0-9a-f]{64}) AS base$|\1|p' Dockerfile)"
+
+if [[ ! "$actual_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ; then
+  echo 'Dockerfile must pin the Ruby base image to exactly one SHA-256 digest.' >&2
+  exit 1
+fi
+
+if [ "$actual_digest" != "$expected_digest" ] ; then
+  echo "Dockerfile pins $ruby_image to $actual_digest, but Docker Hub currently resolves it to $expected_digest." >&2
+  exit 1
+fi


### PR DESCRIPTION
Pin `ruby:4.0.6-slim-bookworm` to its Docker Hub manifest-list digest, making the Ruby build input immutable.

Add `bin/check-ruby-image-digest` and run it in GitHub Actions. The check resolves the tag implied by `.ruby-version` with `docker buildx imagetools inspect` and compares it with the digest in `Dockerfile`, so a Ruby-version bump or a tag rebuild cannot silently leave the digest stale.