### PR TITLE
[rack-attack] Cover CSV upload route variants

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -4,6 +4,7 @@ class Rack::Attack
   PENTESTING_FINDTIME = 1.day.freeze
   PUBLIC_TELEMETRY_REQUEST_LIMIT = 10
   LOG_CSV_UPLOAD_REQUEST_LIMIT = 30
+  LOG_CSV_UPLOAD_ENDPOINT = %r{\A/logs/uploads(?:\.[^/]+)?/?\z}
   PUBLIC_TELEMETRY_ENDPOINTS = {
     csp_reports: %r{\A/api/csp_reports(?:\.[^/]+)?/?\z},
     events: %r{\A/api/events(?:\.[^/]+)?/?\z},
@@ -33,7 +34,7 @@ class Rack::Attack
   end
 
   throttle('logs/uploads/global', limit: LOG_CSV_UPLOAD_REQUEST_LIMIT, period: 1.hour) do |request|
-    'all' if request.post? && request.path == '/logs/uploads'
+    'all' if request.post? && request.path.match?(LOG_CSV_UPLOAD_ENDPOINT)
   end
 
   class << self

--- a/spec/config/initializers/rack_attack_spec.rb
+++ b/spec/config/initializers/rack_attack_spec.rb
@@ -36,12 +36,14 @@ RSpec.describe('Rack::Attack') do
       expect(throttle.period).to eq(1.hour)
     end
 
-    it 'discriminates POST requests to the upload endpoint together' do
-      request = Rack::Attack::Request.new(
-        Rack::MockRequest.env_for('/logs/uploads', method: 'POST'),
-      )
+    it 'discriminates POST requests to all upload route variants together' do
+      %w[/logs/uploads /logs/uploads.json /logs/uploads/].each do |path|
+        request = Rack::Attack::Request.new(
+          Rack::MockRequest.env_for(path, method: 'POST'),
+        )
 
-      expect(throttle.block.call(request)).to eq('all')
+        expect(throttle.block.call(request)).to eq('all')
+      end
     end
 
     it 'does not match other request methods or paths' do
@@ -49,9 +51,13 @@ RSpec.describe('Rack::Attack') do
       other_path_request = Rack::Attack::Request.new(
         Rack::MockRequest.env_for('/logs/anything', method: 'POST'),
       )
+      nested_path_request = Rack::Attack::Request.new(
+        Rack::MockRequest.env_for('/logs/uploads/archive', method: 'POST'),
+      )
 
       expect(throttle.block.call(get_request)).to be_nil
       expect(throttle.block.call(other_path_request)).to be_nil
+      expect(throttle.block.call(nested_path_request)).to be_nil
     end
   end
 


### PR DESCRIPTION
The global `logs/uploads/global` throttle previously matched only the exact `POST /logs/uploads` path, allowing Rails route variants to bypass the shared 30-per-hour counter.

Match the optional format suffix and trailing slash used by the routed upload endpoint. Add focused coverage for the canonical, JSON, and trailing-slash paths while preserving rejection of other methods and nested paths.