### PR TITLE
[spec/support/features] Recognize overwritten downloads [LOG-55]

### DIFF
--- a/spec/features/download_helpers_spec.rb
+++ b/spec/features/download_helpers_spec.rb
@@ -1,0 +1,38 @@
+RSpec.describe Features::DownloadHelpers do
+  include described_class
+
+  around do |example|
+    original_save_path = Capybara.save_path
+
+    Dir.mktmpdir do |tmp_dir|
+      Capybara.save_path = tmp_dir
+      example.run
+    ensure
+      Capybara.save_path = original_save_path
+    end
+  end
+
+  it 'recognizes a download that overwrites a file from an earlier example' do
+    csv_path = File.join(Capybara.save_path, 'log.csv')
+    File.write(csv_path, 'old CSV')
+    @capybara_saved_file_states_before_example = {
+      csv_path => capybara_saved_file_state(csv_path),
+    }
+
+    File.write(csv_path, 'new,larger CSV')
+
+    expect(downloaded_file_path('*.csv', max_attempts: 1)).to eq(csv_path)
+  end
+
+  it 'ignores an unchanged download from an earlier example' do
+    csv_path = File.join(Capybara.save_path, 'log.csv')
+    File.write(csv_path, 'old CSV')
+    @capybara_saved_file_states_before_example = {
+      csv_path => capybara_saved_file_state(csv_path),
+    }
+
+    expect {
+      downloaded_file_path('*.csv', max_attempts: 1)
+    }.to raise_error(RuntimeError, /Could not find a file matching '\*\.csv'/)
+  end
+end

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -5,9 +5,10 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :feature) do
-    @preexisting_capybara_save_paths = Dir.glob(
-      File.join(Capybara.save_path, '**', '*'),
-    )
+    @capybara_saved_file_states_before_example =
+      Dir.glob(File.join(Capybara.save_path, '**', '*')).
+        select { |path| File.file?(path) }.
+        index_with { |path| capybara_saved_file_state(path) }
   end
 end
 
@@ -18,9 +19,12 @@ module Features::DownloadHelpers
     absolute_glob_pattern = File.join(Capybara.save_path, relative_glob_pattern)
 
     max_attempts.times do |index|
-      matching_paths = Dir.glob(absolute_glob_pattern) - @preexisting_capybara_save_paths
+      matching_path =
+        Dir.glob(absolute_glob_pattern).find do |path|
+          @capybara_saved_file_states_before_example[path] != capybara_saved_file_state(path)
+        end
 
-      if (matching_path = matching_paths.first)
+      if matching_path
         break matching_path
       elsif index == max_attempts - 1
         raise(<<~ERROR.squish)
@@ -31,5 +35,10 @@ module Features::DownloadHelpers
         sleep(sleep_seconds)
       end
     end
+  end
+
+  def capybara_saved_file_state(path)
+    stat = File.stat(path)
+    [stat.ino, stat.size, stat.mtime, stat.ctime]
   end
 end


### PR DESCRIPTION
The LOG-54 change in #9077 excluded downloads based only on their paths. Log CSV filenames have one-second timestamp precision, so randomized adjacent standard and exact download examples can receive the same path. Chrome overwrites that path, but `downloaded_file_path` continued treating it as stale even though Rails successfully served the second request.

Snapshot the inode, size, modification time, and change time for each file at the start of an example. A path is now fresh when it is new or its file state changed, while a genuinely unchanged file remains excluded.

Cover both same-path overwrites and unchanged stale downloads with focused regression examples.