### PR TITLE
[std_lib.rb] Centralize standard library requires [DEV-269]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,9 @@
 ## Ruby conventions
 
 - When a Ruby method's computed result is reused, prefer the repository's `Memoization` pattern over assigning a same-named local variable from `self`, such as `value = self.value`, solely to avoid recomputation. Add `prepend Memoization` to the class and decorate the method with `memoize \`.
+- This repository intentionally loads standard-library dependencies used by Rails application code in `config/initializers/std_lib.rb` instead of requiring them in each consumer. This provides a Gemfile-like application contract: after the Rails environment initializes, the listed standard-library APIs are available throughout the application. It also prevents deleting one consumer, which happened to load a shared dependency, from breaking another consumer that relied on the same API.
+- Add standard-library requires used by Rails-initialized code to `config/initializers/std_lib.rb` and remove redundant requires from individual consumers. Code that runs before or without Rails environment initialization must continue to require its dependencies locally.
+- Do not use comments on individual entries in `config/initializers/std_lib.rb` as a consumer index. Such comments become incomplete or stale as usages change. Audit current usage by searching the repository, and reserve an entry-specific comment for non-obvious loading or compatibility requirements.
 
 ## Local tooling
 

--- a/app/poros/safe_external_http_fetcher.rb
+++ b/app/poros/safe_external_http_fetcher.rb
@@ -1,7 +1,3 @@
-require 'ipaddr'
-require 'resolv'
-require 'uri'
-
 class SafeExternalHttpFetcher
   class UnsafeUrlError < StandardError; end
 

--- a/app/workers/application_worker.rb
+++ b/app/workers/application_worker.rb
@@ -1,5 +1,3 @@
-require 'digest/sha1'
-
 module ApplicationWorker
   prepend Memoization
   include Sidekiq::Worker # rubocop:disable CustomCops/DontIncludeSidekiqWorker

--- a/config/initializers/std_lib.rb
+++ b/config/initializers/std_lib.rb
@@ -1,4 +1,11 @@
-require 'csv' # for LogsController, Logs::UploadsController
-require 'digest' # for ApplicationWorker uniqueness enforcement, gravatar URL
-require 'fileutils' # assets:precompile
-require 'uri' # CSP report origin validation
+# Standard-library dependencies available throughout the Rails application.
+# Code loaded without the Rails environment must require its dependencies locally.
+require 'base64'
+require 'csv'
+require 'digest'
+require 'fileutils'
+require 'ipaddr'
+require 'openssl'
+require 'resolv'
+require 'stringio'
+require 'uri'

--- a/lib/content_signature.rb
+++ b/lib/content_signature.rb
@@ -1,6 +1,3 @@
-require 'base64'
-require 'openssl'
-
 class ContentSignature
   class InvalidSignatureError < StandardError; end
 

--- a/lib/email/mailgun_via_http.rb
+++ b/lib/email/mailgun_via_http.rb
@@ -1,5 +1,3 @@
-require 'stringio'
-
 # rubocop:disable Style/ClassAndModuleChildren
 module Email
   class MailgunViaHttp

--- a/script/create_blazer_user.rb
+++ b/script/create_blazer_user.rb
@@ -1,7 +1,5 @@
 require_relative '../config/environment'
 
-require 'uri'
-
 url = ENV.fetch('BLAZER_DATABASE_URL')
 uri = URI.parse(url)
 username = uri.user

--- a/script/create_pghero_user.rb
+++ b/script/create_pghero_user.rb
@@ -4,8 +4,6 @@
 
 require_relative '../config/environment'
 
-require 'uri'
-
 url = ENV.fetch('PGHERO_DATABASE_URL')
 uri = URI.parse(url)
 pghero_password = uri.password


### PR DESCRIPTION
Treat `config/initializers/std_lib.rb` as the manifest of standard-library APIs available after Rails initialization, analogous to Bundler loading the application's Gemfile dependencies.

Move `base64`, `openssl`, `stringio`, `ipaddr`, and `resolv` into that manifest and remove redundant local requires from Rails-boot consumers. Keep dependencies local for code that runs before or without the Rails environment.

Document the convention and its load-order motivation in `AGENTS.md`. Replace the incomplete per-entry consumer comments with guidance to audit current repository usage.