### PR TITLE
[release-tasks] Retry migrations and fail after exhaustion

### DIFF
--- a/bin/server/release-tasks
+++ b/bin/server/release-tasks
@@ -5,44 +5,11 @@ if !defined?(Rails)
   exec('bin/rails', 'runner', __FILE__, *ARGV)
 end
 
-class Runner
-  def run_task(task_description)
-    print("#{task_description}... ")
-    start_time = Time.current
-    yield
-    puts("done. (Took #{(Time.current - start_time).round(2)} seconds.)")
-  end
-
-  def with_modified_env(env_modifications)
-    original_env_values = {}
-
-    env_modifications.each do |env_var, new_value|
-      original_env_values[env_var] = ENV.fetch(env_var, nil)
-      ENV[env_var] = new_value
-    end
-
-    yield
-  ensure
-    original_env_values.each do |env_var, original_value|
-      ENV[env_var] = original_value
-    end
-  end
-end
-
-runner = Runner.new
+runner = ReleaseTasks::Runner.new
 
 runner.run_task('Running db:migrate') do
   Rails.application.load_tasks
-
-  (1..10).each do |attempt_number|
-    print("attempt ##{attempt_number}... ")
-    Rake::Task['db:migrate'].invoke
-  rescue => error
-    pp(error)
-    sleep(attempt_number)
-  else
-    break
-  end
+  runner.run_rake_task_with_retries('db:migrate')
 end
 
 runner.run_task('Recording asset sizes') do

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -51,6 +51,9 @@ Rails.application.configure do
   # Raise an error on page load if there are pending migrations.
   config.active_record.migration_error = :page_load
 
+  # Application files in the built Docker image are intentionally not writable.
+  config.active_record.dump_schema_after_migration = false if IS_DOCKER_BUILT
+
   # Highlight code that triggered database queries in logs.
   config.active_record.verbose_query_logs = true
 

--- a/lib/release_tasks/runner.rb
+++ b/lib/release_tasks/runner.rb
@@ -1,0 +1,39 @@
+class ReleaseTasks::Runner
+  def run_task(task_description)
+    print("#{task_description}... ")
+    start_time = Time.current
+    yield
+    puts("done. (Took #{(Time.current - start_time).round(2)} seconds.)")
+  end
+
+  def run_rake_task_with_retries(task_name, attempts: 10)
+    rake_task = Rake::Task[task_name]
+
+    (1..attempts).each do |attempt_number|
+      print("attempt ##{attempt_number}... ")
+      rake_task.invoke
+      break
+    rescue => error
+      pp(error)
+      raise if attempt_number == attempts
+
+      rake_task.reenable
+      sleep(attempt_number)
+    end
+  end
+
+  def with_modified_env(env_modifications)
+    original_env_values = {}
+
+    env_modifications.each do |env_var, new_value|
+      original_env_values[env_var] = ENV.fetch(env_var, nil)
+      ENV[env_var] = new_value # rubocop:disable Rails/EnvironmentVariableAccess
+    end
+
+    yield
+  ensure
+    original_env_values.each do |env_var, original_value|
+      ENV[env_var] = original_value # rubocop:disable Rails/EnvironmentVariableAccess
+    end
+  end
+end

--- a/spec/lib/release_tasks/runner_spec.rb
+++ b/spec/lib/release_tasks/runner_spec.rb
@@ -1,0 +1,106 @@
+RSpec.describe ReleaseTasks::Runner do
+  subject(:runner) { described_class.new }
+
+  describe '#run_task' do
+    it 'runs the block and reports its duration' do
+      allow(Time).to receive(:current).and_return(Time.zone.at(0), Time.zone.at(1.234))
+      block_ran = false
+
+      expect do
+        runner.run_task('Doing something') { block_ran = true }
+      end.to output("Doing something... done. (Took 1.23 seconds.)\n").to_stdout
+
+      expect(block_ran).to be(true)
+    end
+  end
+
+  describe '#run_rake_task_with_retries' do
+    subject(:run_rake_task_with_retries) do
+      runner.run_rake_task_with_retries(task_name, attempts:)
+    end
+
+    let(:attempts) { 3 }
+    let(:task_name) { "spec:retryable_task_#{SecureRandom.hex}" }
+    let(:task) { Rake::Task.define_task(task_name) { task_action.call } }
+    let(:task_action) { instance_double(Proc) }
+
+    before do
+      task
+      allow(runner).to receive(:pp)
+      allow(runner).to receive(:sleep)
+    end
+
+    context 'when the task succeeds on its first attempt' do
+      before do
+        allow(task_action).to receive(:call)
+      end
+
+      it 'invokes the task once without sleeping' do
+        run_rake_task_with_retries
+
+        expect(task_action).to have_received(:call).once
+        expect(runner).not_to have_received(:sleep)
+      end
+    end
+
+    context 'when the task succeeds after an initial failure' do
+      before do
+        allow(task_action).to receive(:call).and_invoke(
+          -> { raise('transient failure') },
+          -> {},
+        )
+      end
+
+      it 're-enables and invokes the task again' do
+        run_rake_task_with_retries
+
+        expect(task_action).to have_received(:call).twice
+        expect(runner).to have_received(:sleep).once.with(1)
+      end
+    end
+
+    context 'when every attempt fails' do
+      let(:final_error) { RuntimeError.new('persistent failure') }
+
+      before do
+        allow(task_action).to receive(:call).and_raise(final_error)
+      end
+
+      it 'raises the final error after invoking the task for every attempt' do
+        expect { run_rake_task_with_retries }.to raise_error(final_error)
+
+        expect(task_action).to have_received(:call).exactly(attempts).times
+      end
+
+      it 'sleeps only between attempts' do
+        expect { run_rake_task_with_retries }.to raise_error(final_error)
+
+        expect(runner).to have_received(:sleep).ordered.with(1)
+        expect(runner).to have_received(:sleep).ordered.with(2)
+      end
+    end
+  end
+
+  describe '#with_modified_env' do
+    it 'restores existing and absent environment variables when the block raises' do
+      ClimateControl.modify(
+        'EXISTING_RELEASE_TASKS_SPEC_VAR' => 'original',
+        'ABSENT_RELEASE_TASKS_SPEC_VAR' => nil,
+      ) do
+        expect do
+          runner.with_modified_env(
+            'EXISTING_RELEASE_TASKS_SPEC_VAR' => 'modified',
+            'ABSENT_RELEASE_TASKS_SPEC_VAR' => 'added',
+          ) do
+            expect(ENV.fetch('EXISTING_RELEASE_TASKS_SPEC_VAR')).to eq('modified')
+            expect(ENV.fetch('ABSENT_RELEASE_TASKS_SPEC_VAR')).to eq('added')
+            raise('block failure')
+          end
+        end.to raise_error('block failure')
+
+        expect(ENV.fetch('EXISTING_RELEASE_TASKS_SPEC_VAR')).to eq('original')
+        expect(ENV.fetch('ABSENT_RELEASE_TASKS_SPEC_VAR', nil)).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
The migration retry loop repeatedly invoked the same failed Rake task. Rake caches an invocation exception, so attempts after the first immediately re-raised it without executing the migration again. The loop also swallowed the tenth failure and allowed deployment to continue.

Extract `ReleaseTasks::Runner`, re-enable `db:migrate` between attempts, and raise the final exception without an unnecessary final sleep. Focused specs use a real in-memory `Rake::Task` to verify successful first attempts, genuine retries, exhaustion behavior, and the existing runner helpers.

The unprivileged application user introduced by main commit 2a878ee44939345f99b85ba5bbe9719306c17bb2 cannot rewrite root-owned application files. Disable `dump_schema_after_migration` only in built development Docker images so `LOCAL_TEST=1 bin/server/deploy.sh` can migrate while host development continues updating `db/schema.rb`.