### PR TITLE
[active_storage] Disable unused image variants [DEV-260]

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -56,6 +56,9 @@ class DavidRunger::Application < Rails::Application
   # These settings can be overridden in specific environments using the files
   # in config/environments, which are processed later.
 
+  # The application does not generate Active Storage image variants.
+  config.active_storage.variant_processor = :disabled
+
   config.time_zone = ENV.fetch('TIME_ZONE', 'America/Chicago')
   config.active_record.default_timezone = :utc
 


### PR DESCRIPTION
The `config.load_defaults(8.0)` call transitively applies the Rails 7.0 default that selects the `vips` variant processor. Rails warns at boot because the application does not include the `image_processing` gem.

Explicitly disable variant processing because the application has no variant consumers. This removes the release-task warning without adding an unused dependency or native image-processing runtime.