### PR TITLE
[save request] Restrict UptimeRobot request skipping [DEV-258]

### DIFF
--- a/app/poros/save_request/skip_checker.rb
+++ b/app/poros/save_request/skip_checker.rb
@@ -14,7 +14,7 @@ class SaveRequest::SkipChecker
       ['blog', 'assets', _] |
       ['api/csp_reports', 'create', _] |
       ['api/events', 'create', _] |
-      [_, _, { uptime_robot: _ }]
+      ['home', 'index', { uptime_robot: _ }]
     )
       true
     else

--- a/spec/poros/save_request/skip_checker_spec.rb
+++ b/spec/poros/save_request/skip_checker_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe SaveRequest::SkipChecker do
       end
     end
 
-    context 'when uptime_robot is among the params keys' do
+    context 'when the controller is home, the action is index, and uptime_robot is among the params keys' do
       let(:params) { { 'controller' => 'home', 'action' => 'index', 'uptime_robot' => '1' } }
 
       it 'returns true' do
@@ -88,10 +88,18 @@ RSpec.describe SaveRequest::SkipChecker do
       end
     end
 
-    context 'when controller is home, action is index, and params does not include uptime_robot' do
+    context 'when uptime_robot is among the params keys but the endpoint is not home#index' do
+      let(:params) { { 'controller' => 'users', 'action' => 'show', 'uptime_robot' => '1' } }
+
+      it 'returns false' do
+        expect(skip?).to eq(false)
+      end
+    end
+
+    context 'when the controller is home, the action is index, and params does not include uptime_robot' do
       let(:params) { { 'controller' => 'home', 'action' => 'index', 'a_query_param' => 'true' } }
 
-      it 'returns true' do
+      it 'returns false' do
         expect(skip?).to eq(false)
       end
     end


### PR DESCRIPTION
Only treat an `uptime_robot` parameter as skippable on the root `home#index` endpoint.

The parameter is client-controlled, so accepting it at every endpoint would let a user suppress request logging for arbitrary requests. Limiting the exception to the expected uptime-monitoring endpoint preserves useful security and operational visibility while avoiding records for the intended probe.