### PR TITLE
[rubocop] Store cache in workspace

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,7 @@ require:
   - ./tools/custom_cops/require_all_custom_cops.rb
 
 AllCops:
+  CacheRootDirectory: tmp
   Exclude:
     - !ruby/regexp /db\/migrate\/(201|202[0-4])/
   StringLiteralsFrozenByDefault: true


### PR DESCRIPTION
Configure RuboCop to write its result cache beneath the repository’s ignored `tmp/` directory. RuboCop creates its own `rubocop_cache` subdirectory there, allowing normal workspace-sandboxed lint runs to use caching without requesting access to the shared user cache directory.