### PR TITLE
[blazer] Preserve saved SQL operators [DEV-264]

### DIFF
--- a/config/initializers/loofah.rb
+++ b/config/initializers/loofah.rb
@@ -1,1 +1,5 @@
 Loofah::XssFoliate.xss_foliate_all_models
+
+Rails.application.config.to_prepare do
+  Blazer::Query.xss_foliate(except: :statement, encode_special_chars: false)
+end

--- a/db/datamigrate/20260814183740_restore_blazer_query_comparison_operators.rb
+++ b/db/datamigrate/20260814183740_restore_blazer_query_comparison_operators.rb
@@ -1,0 +1,27 @@
+class RestoreBlazerQueryComparisonOperators < Datamigration::Base
+  def run
+    within_transaction do
+      queries_with_escaped_comparison_operators.find_each do |query|
+        query.update!(statement: restored_statement(query.statement))
+
+        log("Restored comparison operators in Blazer::Query:#{query.id}.")
+      end
+    end
+  end
+
+  private
+
+  def queries_with_escaped_comparison_operators
+    Blazer::Query.where(
+      'statement LIKE ? OR statement LIKE ?',
+      '%&gt;%',
+      '%&lt;%',
+    )
+  end
+
+  def restored_statement(statement)
+    statement.gsub('&gt;', '>').gsub('&lt;', '<')
+  end
+end
+
+Datamigration::Runner.new(RestoreBlazerQueryComparisonOperators).run

--- a/spec/features/blazer_spec.rb
+++ b/spec/features/blazer_spec.rb
@@ -1,6 +1,18 @@
 RSpec.describe 'Blazer', :rack_test_driver do
   subject(:visit_blazer) { visit('/blazer') }
 
+  describe 'saved queries' do
+    it 'preserves SQL comparison operators in statements' do
+      statement = <<~SQL.squish
+        SELECT * FROM ci_step_results WHERE started_at > now() - interval '4 weeks' HAVING SUM(seconds) < 200
+      SQL
+
+      query = Blazer::Query.create!(statement:)
+
+      expect(query.reload.statement).to eq(statement)
+    end
+  end
+
   context 'when logged in as an AdminUser' do
     before { sign_in(admin_users(:admin_user), scope: :admin_user) }
 


### PR DESCRIPTION
Loofah foliation is configured for every Active Record model, including `Blazer::Query`, which inherits directly from `ActiveRecord::Base`. Its default text scrubber converted SQL comparison operators into HTML entities before the query was saved.

Exclude `Blazer::Query#statement` while retaining the existing unescaped-text configuration for Blazer’s other text attributes. Add a data migration to restore escaped comparison operators in affected saved statements, plus a regression spec for new saves.