### PR TITLE
[datamigrations] Document execution workflow [DEV-271]

### DIFF
--- a/docs/datamigrations.md
+++ b/docs/datamigrations.md
@@ -1,0 +1,35 @@
+# Datamigrations
+
+Datamigrations make one-time changes to application data. They are separate from schema migrations (which run automatically when deployed). To run a datamigration in production, you must first deploy the file, and then manually execute it.
+
+## Create a datamigration
+
+Generate a timestamped datamigration with:
+
+```sh
+bin/rails generate datamigration NAME
+```
+
+The generated file begins with the exact commands for running that datamigration locally and in production.
+
+## Run locally
+
+Use the local command shown at the top of the generated file:
+
+```sh
+bin/rails runner db/datamigrate/TIMESTAMP_name.rb
+```
+
+New datamigrations run in a transaction with `rollback: true`, so their changes are rolled back after the run. This makes the generated default suitable for checking the migration's behavior locally without persisting its changes. Change that setting only when persistent local changes are intentional.
+
+## Run in production
+
+After the datamigration file has deployed, run the production command from a developer machine:
+
+```sh
+bin/run-datamigration db/datamigrate/TIMESTAMP_name.rb
+```
+
+This command connects to the production application, sets the developer identity required by the runner, and sends output to both the terminal and production logging. The runner also records the run in `DatamigrationRun` and notifies administrators when it starts.
+
+Datamigrations are not automatically run during deployment. Run a datamigration only once unless repeating it is explicitly safe and intended.

--- a/lib/generators/datamigration/datamigration_generator.rb
+++ b/lib/generators/datamigration/datamigration_generator.rb
@@ -4,8 +4,8 @@ class DatamigrationGenerator < Rails::Generators::NamedBase
   def create_datamigration_file
     if behavior == :invoke
       timestamp = Time.now.utc.strftime('%Y%m%d%H%M%S')
-      migration_filename = "#{timestamp}_#{file_name.underscore}.rb"
-      template('datamigration_template.tt', "db/datamigrate/#{migration_filename}")
+      @migration_filename = "#{timestamp}_#{file_name.underscore}.rb"
+      template('datamigration_template.tt', "db/datamigrate/#{@migration_filename}")
     else
       # In revoke mode, find and remove the most recent matching file.
       datamigration_absolute_path =

--- a/lib/generators/datamigration/templates/datamigration_template.tt
+++ b/lib/generators/datamigration/templates/datamigration_template.tt
@@ -1,3 +1,9 @@
+# Run locally:
+#   bin/rails runner db/datamigrate/<%= @migration_filename %>
+#
+# Run in production after this datamigration deploys:
+#   bin/run-datamigration db/datamigrate/<%= @migration_filename %>
+
 class <%= class_name %> < Datamigration::Base
   def run
     within_transaction(rollback: true) do


### PR DESCRIPTION
Add `docs/datamigrations.md` with the generation, local verification, and post-deploy production workflow for datamigrations.

Generate exact `bin/rails runner` and `bin/run-datamigration` commands in each new datamigration so the path does not need to be reconstructed when the migration is run.