### PR TITLE
[authenticated-sessions] Avoid redundant session queries [DEV-273]

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -4,8 +4,14 @@ class ApplicationCable::Connection < ActionCable::Connection::Base
   def connect
     self.current_user = find_verified_user
     authenticated_session = AuthenticatedSessions::Registry.current(request.session, :user)
-    reject_unauthorized_connection unless authenticated_session&.authenticatable == current_user
-    reject_unauthorized_connection unless valid_impersonation_parent?(authenticated_session)
+
+    unless (
+      authenticated_session&.belongs_to_authenticatable?(current_user) &&
+      valid_impersonation_parent?(authenticated_session)
+    )
+      reject_unauthorized_connection
+    end
+
     self.authenticated_session_identifier = authenticated_session.identifier
     authenticated_session.record_activity!(request)
     @ip = request.remote_ip
@@ -23,6 +29,6 @@ class ApplicationCable::Connection < ActionCable::Connection::Base
     parent = authenticated_session.initiated_by_authenticated_session
     parent&.active? && parent.identifier == request.session[
       AuthenticatedSessions::Registry.session_key(:admin_user),
-    ] && parent.authenticatable == env['warden'].user(:admin_user)
+    ] && parent.belongs_to_authenticatable?(env['warden'].user(:admin_user))
   end
 end

--- a/app/models/authenticated_session.rb
+++ b/app/models/authenticated_session.rb
@@ -69,8 +69,16 @@ class AuthenticatedSession < ApplicationRecord
     identifier == rack_session[AuthenticatedSessions::Registry.session_key(scope)]
   end
 
+  def belongs_to_authenticatable?(candidate)
+    return false unless candidate
+
+    authenticatable_type == candidate.class.polymorphic_name && authenticatable_id == candidate.id
+  end
+
   def record_activity!(request)
     current_minute = Time.current.change(sec: 0, usec: 0)
+    return if last_active_at >= current_minute
+
     self.class.
       where(id:).
       where(last_active_at: ...current_minute).

--- a/app/poros/authenticated_sessions/registry.rb
+++ b/app/poros/authenticated_sessions/registry.rb
@@ -76,7 +76,7 @@ module AuthenticatedSessions::Registry
     def create_impersonation!(user:, warden:)
       rack_session = warden.request.session
       parent = find_identified_session(rack_session, :admin_user)
-      valid_parent = parent&.active? && parent.authenticatable == warden.user(:admin_user)
+      valid_parent = parent&.active? && parent.belongs_to_authenticatable?(warden.user(:admin_user))
       raise(ActiveRecord::RecordNotFound) unless valid_parent
 
       find_identified_session(rack_session, :user)&.revoke!
@@ -169,12 +169,12 @@ module AuthenticatedSessions::Registry
 
     def valid_for?(authenticated_session, authenticatable, warden)
       return false unless authenticated_session.active? &&
-        authenticated_session.authenticatable == authenticatable
+        authenticated_session.belongs_to_authenticatable?(authenticatable)
       return true unless authenticated_session.authentication_kind == 'admin_impersonation'
 
       parent = authenticated_session.initiated_by_authenticated_session
       rack_session = warden.request.session
-      parent&.active? && parent.authenticatable == warden.user(:admin_user) &&
+      parent&.active? && parent.belongs_to_authenticatable?(warden.user(:admin_user)) &&
         parent.identifier == rack_session[session_key(:admin_user)]
     end
 

--- a/spec/models/authenticated_session_spec.rb
+++ b/spec/models/authenticated_session_spec.rb
@@ -29,6 +29,19 @@ RSpec.describe AuthenticatedSession do
     end
   end
 
+  describe '#belongs_to_authenticatable?' do
+    it 'matches the owning account without loading the association' do
+      other_user = User.excluding(user).first!
+      admin_user = admin_users(:admin_user)
+      authenticated_session.association(:authenticatable).reset
+
+      expect(authenticated_session.belongs_to_authenticatable?(user)).to be(true)
+      expect(authenticated_session.belongs_to_authenticatable?(other_user)).to be(false)
+      expect(authenticated_session.belongs_to_authenticatable?(admin_user)).to be(false)
+      expect(authenticated_session.association(:authenticatable)).not_to be_loaded
+    end
+  end
+
   it 'rejects missing and empty User-Agent values' do
     authenticated_session = build(:authenticated_session, initial_user_agent: nil)
     expect(authenticated_session).not_to be_valid


### PR DESCRIPTION
Compare session ownership through the polymorphic `authenticatable_type` and `authenticatable_id` fields instead of loading associated `User` or `AdminUser` records. Apply the comparison to Warden validation, impersonation checks, and Action Cable connections.

Skip the `AuthenticatedSession#record_activity!` update when the loaded session was already active in the current minute. The existing conditional `UPDATE` remains in place for requests that began with a stale session record, preserving concurrent-request safety.

Local profiling predicts a small but non-negligible performance improvement for feature specs and the application. It does not indicate that `AuthenticatedSession` changes account for a significant fraction of the feature-spec slowdown observed in CI over recent weeks. Despite this, because we do expect some improvement, we are linking this change to DEV-273.

These small request-path optimizations follow the DEV-273 feature-spec investigation and reduce ordinary application database work without changing authentication semantics.