### PR TITLE
[spec/features/logs] Wait for CSV downloads to finish [LOG-57]

### DIFF
--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -210,13 +210,10 @@ RSpec.describe 'Logs app' do
         it 'allows the user to download a CSV with the log data' do
           visit(log_path(slug: log.slug))
 
-          # Make sure download button has time to set up before clicking.
           wait_for { page }.to have_button('Download CSV')
-          sleep(0.5)
 
-          click_on('Download CSV')
-
-          csv = CSV.read(downloaded_file_path('*.csv'), headers: true)
+          csv_path = downloaded_file_path('*.csv') { click_on('Download CSV') }
+          csv = CSV.read(csv_path, headers: true)
 
           expect(csv.headers).to eq(['Time', log.data_label])
 
@@ -246,10 +243,13 @@ RSpec.describe 'Logs app' do
 
           within('.el-message-box') do
             expect(page).to have_text('might be evaluated as formulas')
-            click_on('Download exact CSV')
           end
 
-          csv = CSV.read(downloaded_file_path('*.csv'), headers: true)
+          csv_path =
+            downloaded_file_path('*.csv') do
+              within('.el-message-box') { click_on('Download exact CSV') }
+            end
+          csv = CSV.read(csv_path, headers: true)
 
           expect(csv.to_a.flatten).to include(formula)
         end

--- a/spec/support/features/download_helpers.rb
+++ b/spec/support/features/download_helpers.rb
@@ -15,7 +15,9 @@ end
 module Features::DownloadHelpers
   private
 
-  def downloaded_file_path(relative_glob_pattern, max_attempts: 100, sleep_seconds: 0.05)
+  def downloaded_file_path(relative_glob_pattern, max_attempts: 100, sleep_seconds: 0.05, &download)
+    page.driver.browser.downloads.wait(RSpec.configuration.wait_timeout, &download) if download
+
     absolute_glob_pattern = File.join(Capybara.save_path, relative_glob_pattern)
 
     max_attempts.times do |index|


### PR DESCRIPTION
The failed CI artifacts show both download requests reaching `LogsController#download` and completing with HTTP 200, while neither CSV appeared in `Capybara.save_path` within the helper's five-second polling window. This shared failure mode is downstream of the button and menu timing addressed by LOG-52 and LOG-56.

Initiate each download inside `Ferrum::Downloads#wait`, using the suite wait timeout so Chrome can report that the transfer has finished before `downloaded_file_path` checks the filesystem. Keep the file-state comparison from LOG-54 and LOG-55 so earlier and overwritten downloads remain handled correctly, and remove the fixed sleep that is no longer needed.