### PR TITLE
[spec/features] Fail on browser log entries [BLOG-32]

### DIFF
--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -29,9 +29,9 @@ class UserSerializer < ApplicationSerializer
     typelize 'string | null'
     attribute(:gravatar_url) do |user|
       # If the user doesn't want to share a name, they probably don't want to share a gravatar URL.
-      if user.public_name.present?
+      if user.public_name.present? && (gravatar_origin = Rails.configuration.gravatar_origin)
         email_hash = Digest::SHA256.hexdigest(user.email.downcase)
-        "https://gravatar.com/avatar/#{email_hash}?s=32&d=robohash&r=r"
+        "#{gravatar_origin}/avatar/#{email_hash}?s=32&d=robohash&r=r"
       end
     end
   end

--- a/config/application.rb
+++ b/config/application.rb
@@ -39,6 +39,8 @@ class DavidRunger::Application < Rails::Application
   config.load_defaults(8.0)
 
   config.gravatar_origin = 'https://gravatar.com'
+  config.public_uploads_origin =
+    'https://david-runger-public-uploads.s3.us-east-1.amazonaws.com'
 
   # We enable YJIT for the web server only in config/initializers/enable_yjit.rb.
   config.yjit = false

--- a/config/application.rb
+++ b/config/application.rb
@@ -38,6 +38,8 @@ class DavidRunger::Application < Rails::Application
   # Initialize configuration defaults for originally generated Rails version.
   config.load_defaults(8.0)
 
+  config.gravatar_origin = 'https://gravatar.com'
+
   # We enable YJIT for the web server only in config/initializers/enable_yjit.rb.
   config.yjit = false
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -4,6 +4,8 @@
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.gravatar_origin = nil
+
   # Settings specified here will take precedence over those in config/application.rb.
 
   # While tests run files are not watched, reloading is not necessary.

--- a/spec/lib/cuprite/browser_logger_spec.rb
+++ b/spec/lib/cuprite/browser_logger_spec.rb
@@ -7,15 +7,45 @@ RSpec.describe Cuprite::BrowserLogger do
   end
 
   describe '#log_entry' do
-    it 'records browser log entries' do
-      entry = {
+    let(:entry) do
+      {
         'level' => 'error',
-        'text' => 'Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector',
+        'source' => 'network',
+        'text' => described_class::BLOCKED_BY_CLIENT_MESSAGE,
+        'url' => url,
       }
+    end
 
-      logger.log_entry(entry)
+    context 'when a public uploads request was blocked by the browser' do
+      let(:url) { "#{Rails.configuration.public_uploads_origin}/portfolio.png" }
 
-      expect(described_class.browser_log_entries).to eq([entry])
+      it 'ignores the log entry' do
+        logger.log_entry(entry)
+
+        expect(described_class.browser_log_entries).to be_empty
+      end
+    end
+
+    context 'when another request was blocked by the browser' do
+      let(:url) { 'https://example.com/portfolio.png' }
+
+      it 'records the browser log entry' do
+        logger.log_entry(entry)
+
+        expect(described_class.browser_log_entries).to eq([entry])
+      end
+    end
+
+    context 'when a different public uploads error is logged' do
+      let(:url) { "#{Rails.configuration.public_uploads_origin}/portfolio.png" }
+
+      before { entry['text'] = 'A different network error' }
+
+      it 'records the browser log entry' do
+        logger.log_entry(entry)
+
+        expect(described_class.browser_log_entries).to eq([entry])
+      end
     end
   end
 end

--- a/spec/lib/cuprite/browser_logger_spec.rb
+++ b/spec/lib/cuprite/browser_logger_spec.rb
@@ -2,23 +2,20 @@ RSpec.describe Cuprite::BrowserLogger do
   subject(:logger) { described_class.new }
 
   before do
-    described_class.csp_violations.clear
+    described_class.browser_log_entries.clear
     allow($stdout).to receive(:puts)
   end
 
   describe '#log_entry' do
-    it 'records Content Security Policy violations' do
-      message = 'Refused to execute inline script because it violates Content Security Policy.'
+    it 'records browser log entries' do
+      entry = {
+        'level' => 'error',
+        'text' => 'Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector',
+      }
 
-      logger.log_entry('text' => message)
+      logger.log_entry(entry)
 
-      expect(described_class.csp_violations).to eq([message])
-    end
-
-    it 'ignores log entries that are not Content Security Policy violations' do
-      logger.log_entry('text' => 'A normal browser log entry.')
-
-      expect(described_class.csp_violations).to be_empty
+      expect(described_class.browser_log_entries).to eq([entry])
     end
   end
 end

--- a/spec/serializers/user_serializer_spec.rb
+++ b/spec/serializers/user_serializer_spec.rb
@@ -66,5 +66,34 @@ RSpec.describe UserSerializer do
         end
       end
     end
+
+    describe 'gravatar_url attribute' do
+      subject(:gravatar_url) { user_serializer_public_as_json['gravatar_url'] }
+
+      let(:object_to_serialize) { user }
+
+      before { user.update!(public_name: 'David Runger') }
+
+      context 'when a Gravatar origin is configured' do
+        before do
+          allow(Rails.configuration).
+            to receive(:gravatar_origin).
+            and_return('https://gravatar.test')
+        end
+
+        it "is the user's Gravatar URL" do
+          email_hash = Digest::SHA256.hexdigest(user.email.downcase)
+
+          expect(gravatar_url).
+            to eq("https://gravatar.test/avatar/#{email_hash}?s=32&d=robohash&r=r")
+        end
+      end
+
+      context 'when a Gravatar origin is not configured' do
+        it 'is nil' do
+          expect(gravatar_url).to eq(nil)
+        end
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -335,13 +335,13 @@ RSpec.configure do |config|
   config.around(:each, type: :feature) do |example|
     Cuprite::BrowserLogger.javascript_errors.clear
     Cuprite::BrowserLogger.javascript_logs.clear
-    Cuprite::BrowserLogger.csp_violations.clear
+    Cuprite::BrowserLogger.browser_log_entries.clear
 
     example.run
 
     expect(Cuprite::BrowserLogger.javascript_errors).to be_empty
     expect(Cuprite::BrowserLogger.javascript_logs).to be_empty
-    expect(Cuprite::BrowserLogger.csp_violations).to be_empty
+    expect(Cuprite::BrowserLogger.browser_log_entries).to be_empty
   end
 
   # NOTE: This `around` block should be registered after the block that checks

--- a/spec/support/cuprite/browser_logger.rb
+++ b/spec/support/cuprite/browser_logger.rb
@@ -1,4 +1,5 @@
 class Cuprite::BrowserLogger
+  BLOCKED_BY_CLIENT_MESSAGE = 'Failed to load resource: net::ERR_BLOCKED_BY_CLIENT.Inspector'
   JSON_EXTRACTION_REGEX = /\A\s*[▶◀]\s+\d+\.\d+ ({.*})\n?\z/
   LOG_MESSAGES_TO_IGNORE = [
     /\A\[vite\] connecting\.\.\.\z/,
@@ -78,6 +79,8 @@ class Cuprite::BrowserLogger
   end
 
   def log_entry(entry)
+    return if blocked_public_upload_request?(entry)
+
     message = entry.fetch('text')
 
     $stdout.puts(Rainbow("Browser log entry: #{message}").red)
@@ -85,6 +88,11 @@ class Cuprite::BrowserLogger
   end
 
   private
+
+  def blocked_public_upload_request?(entry)
+    entry.values_at('source', 'text') == ['network', BLOCKED_BY_CLIENT_MESSAGE] &&
+      entry.fetch('url', '').start_with?("#{Rails.configuration.public_uploads_origin}/")
+  end
 
   def extract_arg_from_data(arg_data)
     if (value = arg_data['value'])

--- a/spec/support/cuprite/browser_logger.rb
+++ b/spec/support/cuprite/browser_logger.rb
@@ -1,6 +1,5 @@
 class Cuprite::BrowserLogger
   JSON_EXTRACTION_REGEX = /\A\s*[▶◀]\s+\d+\.\d+ ({.*})\n?\z/
-  CSP_VIOLATION_REGEX = /content security policy/i
   LOG_MESSAGES_TO_IGNORE = [
     /\A\[vite\] connecting\.\.\.\z/,
     /\A\[vite\] connected\.\z/,
@@ -16,8 +15,8 @@ class Cuprite::BrowserLogger
     @javascript_logs ||= []
   end
 
-  def self.csp_violations
-    @csp_violations ||= []
+  def self.browser_log_entries
+    @browser_log_entries ||= []
   end
 
   def puts(message)
@@ -81,10 +80,8 @@ class Cuprite::BrowserLogger
   def log_entry(entry)
     message = entry.fetch('text')
 
-    if message.match?(CSP_VIOLATION_REGEX)
-      $stdout.puts(Rainbow("Content Security Policy violation: #{message}").red)
-      self.class.csp_violations << message
-    end
+    $stdout.puts(Rainbow("Browser log entry: #{message}").red)
+    self.class.browser_log_entries << entry
   end
 
   private


### PR DESCRIPTION
Record every Chrome `Log.entryAdded` payload and assert that feature examples leave no entries behind. This expands the existing CSP-only check to catch blocked resources and other browser-level problems while preserving the full entry for useful failure output.

Make the Gravatar origin configurable and disable it in the test environment. Production continues to use `https://gravatar.com`, while feature specs no longer attempt external avatar requests when comments render.