### PR TITLE
[groceries] Ignore expected duplicate store error [GROC-42]

### DIFF
--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -149,6 +149,12 @@ RSpec.describe 'Groceries app' do
 
       context 'when the user attempts to recreate a store' do
         it 'displays a toast message and allows (re)submitting with a unique store name' do
+          Cuprite::BrowserLogger.ignore_browser_log_entries_matching(
+            'source' => 'network',
+            'text' => /status.*422/i,
+            'url' => %r{/api/stores\z},
+          )
+
           visit(groceries_path)
 
           fill_in('Add a store', with: existing_store.name)

--- a/spec/lib/cuprite/browser_logger_spec.rb
+++ b/spec/lib/cuprite/browser_logger_spec.rb
@@ -3,10 +3,13 @@ RSpec.describe Cuprite::BrowserLogger do
 
   before do
     described_class.browser_log_entries.clear
+    described_class.browser_log_entries_to_ignore.clear
     allow($stdout).to receive(:puts)
   end
 
   describe '#log_entry' do
+    let(:url) { 'https://example.com/portfolio.png' }
+
     let(:entry) do
       {
         'level' => 'error',
@@ -40,6 +43,36 @@ RSpec.describe Cuprite::BrowserLogger do
       let(:url) { "#{Rails.configuration.public_uploads_origin}/portfolio.png" }
 
       before { entry['text'] = 'A different network error' }
+
+      it 'records the browser log entry' do
+        logger.log_entry(entry)
+
+        expect(described_class.browser_log_entries).to eq([entry])
+      end
+    end
+
+    context 'when the log entry matches an entry configured to be ignored' do
+      before do
+        described_class.ignore_browser_log_entries_matching(
+          'source' => 'network',
+          'text' => /BLOCKED_BY_CLIENT/,
+        )
+      end
+
+      it 'ignores the log entry' do
+        logger.log_entry(entry)
+
+        expect(described_class.browser_log_entries).to be_empty
+      end
+    end
+
+    context 'when the log entry does not match an entry configured to be ignored' do
+      before do
+        described_class.ignore_browser_log_entries_matching(
+          'source' => 'network',
+          'text' => /different network error/,
+        )
+      end
 
       it 'records the browser log entry' do
         logger.log_entry(entry)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -336,6 +336,7 @@ RSpec.configure do |config|
     Cuprite::BrowserLogger.javascript_errors.clear
     Cuprite::BrowserLogger.javascript_logs.clear
     Cuprite::BrowserLogger.browser_log_entries.clear
+    Cuprite::BrowserLogger.browser_log_entries_to_ignore.clear
 
     example.run
 

--- a/spec/support/cuprite/browser_logger.rb
+++ b/spec/support/cuprite/browser_logger.rb
@@ -20,6 +20,14 @@ class Cuprite::BrowserLogger
     @browser_log_entries ||= []
   end
 
+  def self.browser_log_entries_to_ignore
+    @browser_log_entries_to_ignore ||= []
+  end
+
+  def self.ignore_browser_log_entries_matching(entry)
+    browser_log_entries_to_ignore << entry
+  end
+
   def puts(message)
     # The message can be an Integer if an integer is logged in JavaScript.
     if !message.is_a?(String)
@@ -79,7 +87,7 @@ class Cuprite::BrowserLogger
   end
 
   def log_entry(entry)
-    return if blocked_public_upload_request?(entry)
+    return if blocked_public_upload_request?(entry) || ignored_browser_log_entry?(entry)
 
     message = entry.fetch('text')
 
@@ -88,6 +96,14 @@ class Cuprite::BrowserLogger
   end
 
   private
+
+  def ignored_browser_log_entry?(entry)
+    self.class.browser_log_entries_to_ignore.any? do |entry_to_ignore|
+      entry_to_ignore.all? do |key, value|
+        value.is_a?(Regexp) ? value.match?(entry[key]) : value == entry[key]
+      end
+    end
+  end
 
   def blocked_public_upload_request?(entry)
     entry.values_at('source', 'text') == ['network', BLOCKED_BY_CLIENT_MESSAGE] &&


### PR DESCRIPTION
PR #9153 made feature specs fail when Chrome records any browser-level log entry. The duplicate-store scenario intentionally receives a `422 Unprocessable Content` response, so Chrome can report the expected rejection as a network error after the feature behavior has already passed.

Add per-example partial matching for browser log entries and configure this scenario to ignore only the network `422` from `/api/stores`. Keeping the matcher active until teardown avoids depending on when Chrome delivers `Log.entryAdded`, while all other browser entries continue to fail the example.

This is now the third exception to this rule we've had to accommodate (gravatar, S3-hosted images, this 4xx response). I might go back to just CSP checks if we have any/many more such issues in the near future.