### PR TITLE
[marriages] Add divorce UX [DEV-266]

### DIFF
--- a/app/controllers/marriages_controller.rb
+++ b/app/controllers/marriages_controller.rb
@@ -14,6 +14,14 @@ class MarriagesController < ApplicationController
     render :new
   end
 
+  def destroy
+    marriage = Marriage.with_eager_loading_for_destroy.find(current_user.marriage.id)
+    authorize(marriage)
+    marriage.destroy!
+    flash[:notice] = 'Your marriage has been ended.'
+    redirect_to(check_ins_path)
+  end
+
   private
 
   def ensure_no_spouse

--- a/app/policies/marriage_policy.rb
+++ b/app/policies/marriage_policy.rb
@@ -8,4 +8,8 @@ class MarriagePolicy < ApplicationPolicy
   def show_groceries?
     [@user.id, @user.spouse.id].sort == @record.partners.ids.sort
   end
+
+  def destroy?
+    show? && record.partners.size == 2
+  end
 end

--- a/app/views/marriages/show.html.haml
+++ b/app/views/marriages/show.html.haml
@@ -38,3 +38,12 @@
   .mb-4
     %div
       = form.submit(class: 'btn-primary')
+
+- if @marriage.other_partner
+  .mt-12
+    %h2 End marriage
+    %p Permanently delete this marriage and all of its check-in and emotional-needs data for both partners.
+    = button_to('End marriage', marriage_path,
+      method: :delete,
+      class: 'btn-danger',
+      data: { confirm: "Are you sure that you want to end your marriage to #{@marriage.other_partner.email}? This will permanently delete all check-in and emotional-needs data for both of you." })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,7 @@ Rails.application.routes.draw do
       post :cancel
     end
   end
-  resource :marriage, only: %i[new show]
+  resource :marriage, only: %i[destroy new show]
   resources :emotional_needs, only: %i[create destroy edit update] do
     member do
       get :history

--- a/spec/controllers/marriages_controller_spec.rb
+++ b/spec/controllers/marriages_controller_spec.rb
@@ -16,4 +16,29 @@ RSpec.describe MarriagesController do
       expect(assigns[:pending_proposals]).not_to include(canceled_proposal)
     end
   end
+
+  describe '#destroy' do
+    subject(:delete_marriage) { delete(:destroy) }
+
+    let(:user) { users(:user) }
+    let(:spouse) { users(:married_user) }
+    let(:marriage) { user.marriage.presence! }
+    let!(:check_in) { marriage.check_ins.first! }
+    let!(:emotional_need) { marriage.emotional_needs.first! }
+
+    before { sign_in(user) }
+
+    it 'ends the marriage for both partners' do
+      expect { delete_marriage }.
+        to change { Marriage.exists?(marriage.id) }.
+        from(true).to(false)
+
+      expect(user.reload.marriage).to be_nil
+      expect(spouse.reload.marriage).to be_nil
+      expect(CheckIn.exists?(check_in.id)).to eq(false)
+      expect(EmotionalNeed.exists?(emotional_need.id)).to eq(false)
+      expect(response).to redirect_to(check_ins_path)
+      expect(flash[:notice]).to eq('Your marriage has been ended.')
+    end
+  end
 end

--- a/spec/features/divorce_spec.rb
+++ b/spec/features/divorce_spec.rb
@@ -1,0 +1,20 @@
+RSpec.describe 'Ending a marriage' do
+  let(:user) { users(:user) }
+  let!(:spouse) { user.spouse }
+  let(:marriage) { user.marriage }
+
+  before { sign_in(user) }
+
+  it 'allows the user to end the marriage after confirmation' do
+    visit marriage_path
+
+    expect(page).to have_button('End marriage')
+
+    accept_confirm { click_on('End marriage') }
+
+    expect(page).to have_flash_message('Your marriage has been ended.')
+    expect(Marriage.exists?(marriage.id)).to eq(false)
+    expect(user.reload.marriage.partners).to contain_exactly(user)
+    expect(spouse.reload.marriage).to be_nil
+  end
+end

--- a/spec/policies/marriage_policy_spec.rb
+++ b/spec/policies/marriage_policy_spec.rb
@@ -1,0 +1,33 @@
+RSpec.describe MarriagePolicy do
+  subject(:policy) { described_class.new(user, marriage) }
+
+  let(:partner) { create(:user) }
+  let(:marriage) { create(:marriage, partners: [partner, create(:user)]) }
+
+  describe '#destroy?' do
+    context 'when the user is a partner in the marriage' do
+      let(:user) { partner }
+
+      it 'allows ending the marriage' do
+        expect(policy.destroy?).to eq(true)
+      end
+    end
+
+    context 'when the user is not a partner in the marriage' do
+      let(:user) { create(:user) }
+
+      it 'forbids ending the marriage' do
+        expect(policy.destroy?).to eq(false)
+      end
+    end
+
+    context 'when the marriage has only one partner' do
+      let(:user) { partner }
+      let(:marriage) { create(:marriage, partners: [partner]) }
+
+      it 'forbids ending the marriage' do
+        expect(policy.destroy?).to eq(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow either partner in a two-person marriage to end it through a confirmed `DELETE /marriage` action.

Reuse the marriage destruction path so shared check-ins and emotional needs are permanently deleted along with both memberships. The check-ins redirect continues to create a new solo marriage for the acting user, preserving the existing invitation flow.

Keep the control at the bottom of the marriage-management page and cover authorization, dependent-data deletion, and browser confirmation behavior.