### PR TITLE
[marriages] Initialize marriages during proposal acceptance

### DIFF
--- a/app/actions/marriages/create.rb
+++ b/app/actions/marriages/create.rb
@@ -16,6 +16,8 @@ class Marriages::Create < ApplicationAction
 
   requires :proposer, User
 
+  returns :marriage, Marriage
+
   def execute
     ApplicationRecord.transaction do
       marriage = Marriage.create!(partners: [proposer])
@@ -23,6 +25,8 @@ class Marriages::Create < ApplicationAction
       DEFAULT_EMOTIONAL_NEEDS.each do |name, description|
         marriage.emotional_needs.create!(name:, description:)
       end
+
+      result.marriage = marriage
     end
   end
 end

--- a/app/actions/proposals/accept.rb
+++ b/app/actions/proposals/accept.rb
@@ -93,7 +93,8 @@ class Proposals::Accept < ApplicationAction
   end
 
   def accept_proposal!(locked_proposer:, locked_proposee:, proposer_marriage:, proposee_marriage:)
-    target_marriage = proposer_marriage || Marriage.create!(partners: [locked_proposer])
+    target_marriage =
+      proposer_marriage || Marriages::Create.run!(proposer: locked_proposer).marriage
 
     if proposee_marriage != target_marriage
       destroy_marriage!(proposee_marriage) if proposee_marriage

--- a/spec/actions/proposals/accept_spec.rb
+++ b/spec/actions/proposals/accept_spec.rb
@@ -44,6 +44,8 @@ RSpec.describe Proposals::Accept do
       }.from(nil).to(Marriage)
 
       expect(proposer.marriage.partners.order(:id)).to eq([proposer, proposee].sort_by(&:id))
+      expect(proposer.marriage.emotional_needs.pluck(:name, :description)).
+        to match_array(Marriages::Create::DEFAULT_EMOTIONAL_NEEDS.to_a)
       expect(Marriage.exists?(proposee_marriage.id)).to eq(false)
     end
   end


### PR DESCRIPTION
Proposal acceptance created a marriage directly when the proposer had not already visited Check-ins. That bypassed `Marriages::Create`, leaving the resulting marriage without the default emotional needs.

Return the created record from `Marriages::Create` and use that action during proposal acceptance. The acceptance transaction now creates the memberships, default emotional needs, and accepted proposal atomically. Add regression coverage for the acceptance-only creation path.