### PR TITLE
[ruby.yml] Poll service health checks faster [DEV-279]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,9 +27,9 @@ jobs:
         # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
-          --health-interval 10s
+          --health-interval 1s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 30
         ports:
           - 5432:5432
       redis:
@@ -37,9 +37,9 @@ jobs:
         # Set health checks to wait until redis has started
         options: >-
           --health-cmd "redis-cli ping"
-          --health-interval 10s
+          --health-interval 1s
           --health-timeout 5s
-          --health-retries 5
+          --health-retries 30
         ports:
           - 6379:6379
     steps:


### PR DESCRIPTION
Run the PostgreSQL and Redis health checks every second so Docker can mark each service healthy promptly. GitHub Actions polls the Docker health status with its own backoff, so the previous 10-second health interval could leave the runner observing a stale "starting" status.

Increase `--health-retries` from 5 to 30 to retain a generous startup allowance despite the shorter interval.