### PR TITLE
[LogEntriesMailbox] Clarify absent-log guard

### DIFF
--- a/app/mailboxes/log_entries_mailbox.rb
+++ b/app/mailboxes/log_entries_mailbox.rb
@@ -7,7 +7,7 @@ class LogEntriesMailbox < ApplicationMailbox
     user = User.find_by(email: mail.from&.first)
     log = user&.logs&.find_by(email_submission_token:)
 
-    return if log.nil?
+    return unless log
 
     LogEntries::Save.new(log_entry: log.build_log_entry_with_datum(data: mail.parsed_body)).run
   end


### PR DESCRIPTION
Express the mailbox’s successful no-op path directly with `return unless log` when the sender and submission token do not identify an authorized log.

This preserves the existing behavior while making the guard condition easier to read.

The real purpose of this change is to test #9161.