### PR TITLE
[ruby.yml] Collapse early setup groups [DEV-279]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -71,14 +71,6 @@ jobs:
           - name: Verify Ruby base image digest
             run: bin/check-ruby-image-digest
 
-      - name: Print context info
-        run: |
-          echo "Branch: ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
-          pr=${GITHUB_REF#refs/pull/}
-          echo "PR: #${pr%/merge}"
-          echo "SHA: $GIT_REV"
-
-      - parallel:
           - name: Set up Ruby
             uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
             with:
@@ -88,6 +80,13 @@ jobs:
             uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
             with:
               node-version-file: .node-version
+
+      - name: Print context info
+        run: |
+          echo "Branch: ${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          pr=${GITHUB_REF#refs/pull/}
+          echo "PR: #${pr%/merge}"
+          echo "SHA: $GIT_REV"
 
       - name: Install pnpm
         run: npm install -g pnpm@11.21.0


### PR DESCRIPTION
Run `ruby/setup-ruby` and `actions/setup-node` in the first post-checkout `parallel` group alongside the independent PostgreSQL, Git revision, Percy, and Ruby image-digest setup.

Keep “Print context info” after the combined group so it still receives `GIT_REV`, while runtime setup no longer waits for the first group to complete.