### PR TITLE
[ruby.yml] Parallelize Percy cleanup [DEV-279]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -165,6 +165,12 @@ jobs:
             with:
               token: ${{ secrets.CODECOV_TOKEN }}
 
+          - name: Stop Percy
+            if: ${{ !cancelled() }}
+            run: ./node_modules/.bin/percy exec:stop
+            env:
+              PERCY_TOKEN: '${{secrets.PERCY_TOKEN}}'
+
           - name: Prune pnpm store
             if: ${{ !cancelled() && steps.pnpm-cache.outputs.cache-hit != 'true' }}
             run: pnpm store prune

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -99,7 +99,9 @@ class Test::RequirementsResolver
           Test::Tasks::FeatureTestsCanStart,
         ],
 
-        # Necessary processes.
+        # Stop Percy runs outside Pallets in CI.
+        #
+        # Keep its dependencies for `run_all` and explicitly targeted runs.
         Test::Tasks::StopPercy => [
           Test::Tasks::RunFeatureTestsA,
           Test::Tasks::RunFeatureTestsB,
@@ -137,7 +139,6 @@ class Test::RequirementsResolver
           Test::Tasks::RunTypelizer,
           Test::Tasks::RunUnitTests,
           Test::Tasks::RunVitest,
-          Test::Tasks::StopPercy,
           Test::Tasks::UploadViteAssets,
         ],
       }


### PR DESCRIPTION
Remove `StopPercy` from the Pallets exit barrier so `bin/run-tests` completes once its checks have finished.

Run `percy exec:stop` in the existing post-test `parallel` group. `UploadViteAssets` remains in Pallets, where it can overlap with feature specs.

Percy shutdown no longer produces a Pallets `CiStepResult`; its duration is instead visible as a named GitHub Actions step.