### PR TITLE
[test] Eager-load only unit specs in CI [DEV-279]

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -11,11 +11,9 @@ Rails.application.configure do
   # While tests run files are not watched, reloading is not necessary.
   config.enable_reloading = ENV['CI'].blank?
 
-  # Eager loading loads your entire application. When running a single test locally,
-  # this is usually not necessary, and can slow down your test suite. However, it's
-  # recommended that you enable it in continuous integration systems to ensure eager
-  # loading is working properly before deploying your code.
-  config.eager_load = ENV['CI'].present?
+  # The unit-spec process sets `EAGER_LOAD=true` in CI to verify eager loading. The other test
+  # subprocesses leave it unset, avoiding repeated eager loading during their startup.
+  config.eager_load = ENV['CI'].present? && ENV['EAGER_LOAD'] == 'true'
 
   # Configure public file server for tests with cache-control for performance.
   config.public_file_server.headers = {

--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -10,6 +10,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
     execute_rspec_command(<<~COMMAND)
       DB_SUFFIX=_unit
       COVERAGE_RESULTSET_NAME=unit
+      EAGER_LOAD=true
       bin/rspec
       $(ls -d spec/*/ |
         grep --extended-regex -v 'spec/(controllers|features|helpers|requests|tools)(/|$)')


### PR DESCRIPTION
Require both `CI` and `EAGER_LOAD=true` before eager loading the test environment instead of eager loading every Rails process in CI.

Set `EAGER_LOAD=true` only for `RunUnitTests`. The unit shard retains eager-loading validation, while API, HTML, feature, and other test subprocesses skip repeated eager loading during startup.