### PR TITLE
[ruby.yml] Set CI PostgreSQL to 18.6 [DEV-281]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     timeout-minutes: 10
     services:
       postgres:
-        image: postgres:18.4-alpine
+        image: postgres:18.6-alpine
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Align the GitHub Actions PostgreSQL service with the PostgreSQL 18.6 version used by the production-oriented Compose configuration. This keeps CI coverage on the same major and minor database release as production.

PR #9125 bumped the production-oriented Compose PostgreSQL service from 18.4 to 18.6. Update the CI service to match that version.