### PR TITLE
[public telemetry] Freeze ingestion rate-limit time [DEV-282]

### DIFF
--- a/spec/features/public_telemetry_ingestion_spec.rb
+++ b/spec/features/public_telemetry_ingestion_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Public telemetry ingestion', :cache, :rack_test_driver do
     end
   end
 
-  context 'when an IP posts more than ten Events in one minute' do
+  context 'when an IP posts more than ten Events in one minute', :frozen_time do
     let(:event_body) { { data: { page_url: DavidRunger::CANONICAL_URL }, type: 'scroll' }.to_json }
 
     it 'returns 429 for the eleventh request without creating another Event' do


### PR DESCRIPTION
Rack::Attack counts requests in fixed clock-minute windows. The feature spec could begin during the final milliseconds of a minute, allowing the counter to reset before its eleventh request.

Mark the rate-limit context with `:frozen_time` so every request is evaluated in the same window and the assertion reliably verifies the configured limit.