### PR TITLE
[spec/features/download_helpers] Keep download path stable [LOG-59]

### DIFF
--- a/spec/features/download_helpers_spec.rb
+++ b/spec/features/download_helpers_spec.rb
@@ -1,19 +1,13 @@
 RSpec.describe Features::DownloadHelpers do
   include described_class
 
-  around do |example|
-    original_save_path = Capybara.save_path
+  let(:tmp_dir) { Dir.mktmpdir('download_helpers_spec', Capybara.save_path) }
+  let(:csv_path) { File.join(tmp_dir, 'log.csv') }
+  let(:relative_glob_pattern) { File.join(File.basename(tmp_dir), '*.csv') }
 
-    Dir.mktmpdir do |tmp_dir|
-      Capybara.save_path = tmp_dir
-      example.run
-    ensure
-      Capybara.save_path = original_save_path
-    end
-  end
+  after { FileUtils.remove_entry(tmp_dir) }
 
   it 'recognizes a download that overwrites a file from an earlier example' do
-    csv_path = File.join(Capybara.save_path, 'log.csv')
     File.write(csv_path, 'old CSV')
     @capybara_saved_file_states_before_example = {
       csv_path => capybara_saved_file_state(csv_path),
@@ -21,18 +15,17 @@ RSpec.describe Features::DownloadHelpers do
 
     File.write(csv_path, 'new,larger CSV')
 
-    expect(downloaded_file_path('*.csv', max_attempts: 1)).to eq(csv_path)
+    expect(downloaded_file_path(relative_glob_pattern, max_attempts: 1)).to eq(csv_path)
   end
 
   it 'ignores an unchanged download from an earlier example' do
-    csv_path = File.join(Capybara.save_path, 'log.csv')
     File.write(csv_path, 'old CSV')
     @capybara_saved_file_states_before_example = {
       csv_path => capybara_saved_file_state(csv_path),
     }
 
     expect {
-      downloaded_file_path('*.csv', max_attempts: 1)
-    }.to raise_error(RuntimeError, /Could not find a file matching '\*\.csv'/)
+      downloaded_file_path(relative_glob_pattern, max_attempts: 1)
+    }.to raise_error(RuntimeError, /Could not find a file matching '.*\*\.csv'/)
   end
 end


### PR DESCRIPTION
LOG-55 added helper specs that temporarily assigned a block-scoped directory to `Capybara.save_path`. The `capybara-screenshot` after hook constructs the shared feature session even when those examples pass, so Cuprite cached that temporary path before `Dir.mktmpdir` removed it. When the helper specs ran before `logs_spec.rb`, every later CSV download in that shard targeted the deleted directory, explaining why both Log examples failed together.

Create isolated subdirectories beneath the stable suite download directory instead. This retains filesystem isolation while leaving `Capybara.save_path` unchanged.

This corrects the helper spec introduced by 75ebb912c (#9131 / LOG-55).