### PR TITLE
[ruby.yml] Save feature spec lists on failure [DEV-283]

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -143,12 +143,16 @@ jobs:
           CODECOV_TOKEN: '${{secrets.CODECOV_TOKEN}}'
 
       - parallel:
-          - name: Save failed feature spec logs
+          - name: Save feature spec artifacts
             uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
             if: failure()
             with:
-              name: failed_feature_spec_logs
-              path: log/failed_feature_specs/
+              name: feature_spec_artifacts
+              path: |
+                log/failed_feature_specs/
+                tmp/feature_specs_a.txt
+                tmp/feature_specs_b.txt
+                tmp/feature_specs_c.txt
               retention-days: 5
 
           - name: Save fixtures artifact


### PR DESCRIPTION
Upload `log/failed_feature_specs/` together with `tmp/feature_specs_a.txt`, `tmp/feature_specs_b.txt`, and `tmp/feature_specs_c.txt` as `feature_spec_artifacts`. The artifact includes both failure logs and randomized shard assignments, so its name describes the complete contents while retaining five-day retention.