### PR TITLE
[ci] Reuse prewarmed Cuprite sessions [DEV-284]

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -231,10 +231,17 @@ RSpec.configure do |config|
         puts("Pre-warming #{driver_name} Cuprite browser...")
 
         Capybara.using_driver(driver_name) do
-          session = Capybara::Session.new(driver_name)
+          session = Capybara.current_session
+          warmed = false
           url = 'about:blank'
-          session.visit(url)
-          puts("#{driver_name} Cuprite browser visited #{url} successfully.")
+
+          begin
+            session.visit(url)
+            warmed = true
+            puts("#{driver_name} Cuprite browser visited #{url} successfully.")
+          ensure
+            session.quit if !warmed
+          end
         end
       rescue Ferrum::ProcessTimeoutError => error
         retry_count += 1


### PR DESCRIPTION
Creating a session with `Capybara::Session.new` bypasses Capybara's session pool, leaving its Chrome process tree alive while feature specs start another browser.

Prewarm `Capybara.current_session` under each applicable driver so the feature suite reuses the successfully started browser. If prewarming fails, call `session.quit` before retrying so any partially started browser is terminated and the pooled session can instantiate a fresh driver.