### PR TITLE
[groceries] Add item typeahead

### DIFF
--- a/app/javascript/groceries/components/Item.vue
+++ b/app/javascript/groceries/components/Item.vue
@@ -1,5 +1,6 @@
 <template lang="pug">
 li.grocery-item.flex.items-center.w-full(
+  :id="`grocery-item-${item.id}`"
   :class="{ unneeded: item.needed <= 0 }"
 )
   .left.whitespace-nowrap

--- a/app/javascript/groceries/components/NewItemForm.vue
+++ b/app/javascript/groceries/components/NewItemForm.vue
@@ -1,32 +1,49 @@
 <template lang="pug">
 form.flex(
   v-if="store.own_store"
-  @submit.prevent="postNewItem"
+  @submit.prevent
 )
-  .float-left
-    ElInput.item-name-input.max-w-60(
-      placeholder="Add an item"
-      type="text"
-      v-model="formData.newItemName"
-      name="newItemName"
-    )
-  .ml-2
-    ElButton.button.button-outline(
-      native-type="submit"
-      aria-label="Add item"
-      :disabled="v$.$invalid"
-    ) Add
+  ElAutocomplete.item-name-input.max-w-60(
+    v-model="formData.newItemName"
+    :debounce="0"
+    :fetch-suggestions="itemSuggestions"
+    :trigger-on-focus="false"
+    fit-input-width
+    name="newItemName"
+    placeholder="Add an item"
+    @select="selectSuggestion"
+  )
+    template(#default="slotProps")
+      template(v-if="slotProps.item.type === 'existing'")
+        span {{ slotProps.item.value }}
+        span.ml-2.text-neutral-500(v-if="slotProps.item.item.needed > 0") &nbsp;({{ slotProps.item.item.needed }})
+      span(v-else) Add '{{ slotProps.item.value }}'
 </template>
 
 <script setup lang="ts">
-import { useVuelidate } from '@vuelidate/core';
-import { required } from '@vuelidate/validators';
-import { ElButton, ElInput } from 'element-plus';
-import { reactive } from 'vue';
+import {
+  ElAutocomplete,
+  type AutocompleteFetchSuggestionsCallback,
+} from 'element-plus';
+import { nextTick, reactive } from 'vue';
 import { object } from 'vue-types';
 
-import { useGroceriesStore } from '@/groceries/store';
+import { helpers, useGroceriesStore } from '@/groceries/store';
+import type { Item } from '@/groceries/types';
 import type { Store } from '@/types';
+
+interface ExistingItemSuggestion {
+  item: Item;
+  type: 'existing';
+  value: string;
+}
+
+interface AddItemSuggestion {
+  type: 'add';
+  value: string;
+}
+
+type ItemSuggestion = AddItemSuggestion | ExistingItemSuggestion;
 
 const props = defineProps({
   store: object<Store>().isRequired,
@@ -34,19 +51,50 @@ const props = defineProps({
 
 const groceriesStore = useGroceriesStore();
 
-const vuelidateRules = {
-  newItemName: { required },
-};
 const formData = reactive({
   newItemName: '',
 });
-const v$ = useVuelidate(vuelidateRules, formData);
 
-async function postNewItem() {
+function itemSuggestions(
+  queryString: string,
+  callback: AutocompleteFetchSuggestionsCallback<ItemSuggestion>,
+): void {
+  const normalizedQuery = queryString.toLowerCase();
+  const existingSuggestions: ExistingItemSuggestion[] = helpers
+    .sortByName(props.store.items)
+    .filter((item) => item.name.toLowerCase().includes(normalizedQuery))
+    .map((item) => ({
+      item,
+      type: 'existing',
+      value: item.name,
+    }));
+
+  callback([
+    ...existingSuggestions,
+    {
+      type: 'add',
+      value: queryString,
+    },
+  ]);
+}
+
+async function selectSuggestion(suggestion: ItemSuggestion): Promise<void> {
+  if (suggestion.type === 'existing') {
+    formData.newItemName = '';
+    await nextTick();
+    document
+      .getElementById(`grocery-item-${suggestion.item.id}`)
+      ?.scrollIntoView({
+        behavior: 'smooth',
+        block: 'center',
+      });
+    return;
+  }
+
   const success = await groceriesStore.createItem({
     store: props.store,
     itemAttributes: {
-      name: formData.newItemName,
+      name: suggestion.value,
     },
   });
 

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -22,19 +22,12 @@ RSpec.describe 'Groceries app' do
         unneeded_item = store.items.unneeded.first!
         expect(page).to have_text(/#{needed_item.name} +\(#{needed_item.needed}\)/)
 
-        # NOTE: When running specs with the development vite server, the
-        # following line triggers two warnings, which I'm pretty sure are caused
-        # by a bug in cuprite (namely that focus and blur events are of type
-        # Event rather than FocusEvent). github.com/rubycdp/cuprite/pull/ 272
-        fill_in('newItemName', with: new_item_name)
-        find(:button, 'Add item').click
+        find(:fillable_field, 'newItemName').send_keys(new_item_name)
+        find('[role="option"]', text: "Add '#{new_item_name}'", exact_text: true).click
 
         expect(page).not_to have_spinner
         expect(find(:fillable_field, 'newItemName').value).to eq('')
-        # The add-new-item button should be disabled, now that it has no value (so it's not valid).
-        within(find('.item-name-input').ancestor('form')) do
-          expect(find(:link_or_button, 'Add', disabled: true)).to be_disabled
-        end
+        expect(page).not_to have_button('Add item')
 
         # Verify that the item is listed only once.
         expect(page.text.scan(new_item_name).size).to eq(1)
@@ -184,10 +177,11 @@ RSpec.describe 'Groceries app' do
 
       context 'when the store has an item' do
         let(:existing_store) { user.stores.joins(:items).first! }
-        let(:existing_item) { existing_store.items.first! }
+        let(:existing_item) { existing_store.items.needed.first! }
+        let(:unneeded_item) { existing_store.items.unneeded.first! }
 
-        context 'when the user attempts to add a duplicate item' do
-          it 'displays a toast message and allows (re)submitting with a unique item name' do
+        context 'when the user searches for an item' do
+          it 'offers matching items and a new item option, and handles both selections' do
             visit(groceries_path)
 
             within('aside') do
@@ -196,15 +190,55 @@ RSpec.describe 'Groceries app' do
 
             expect(page).to have_css('h1', text: existing_store.name)
 
-            fill_in('Add an item', with: existing_item.name)
-            click_on('Add item')
+            new_item_input = find(:fillable_field, 'Add an item')
+            substring_of_existing_item_name = existing_item.name[1..4]
+            new_item_input.send_keys(substring_of_existing_item_name)
 
-            expect(page).to have_vue_toast('Name has already been taken', type: :error)
+            existing_item_option_text = "#{existing_item.name} (#{existing_item.needed})"
+            expect(page).to have_css(
+              '[role="option"]',
+              text: existing_item_option_text,
+              exact_text: true,
+            )
+            expect(page).to have_css(
+              '[role="option"]',
+              text: "Add '#{substring_of_existing_item_name}'",
+              exact_text: true,
+            )
+            expect(page).not_to have_button('Add item')
+
+            page.execute_script(<<~JS)
+              document.getElementById('grocery-item-#{existing_item.id}').scrollIntoView = function() {
+                this.dataset.scrolledIntoView = 'true';
+              };
+            JS
+
+            find(
+              '[role="option"]',
+              text: existing_item_option_text,
+              exact_text: true,
+            ).click
+
+            expect(page).not_to have_spinner
+            expect(page).to have_css(
+              "#grocery-item-#{existing_item.id}[data-scrolled-into-view='true']",
+            )
+
+            new_item_input.send_keys(unneeded_item.name)
+            expect(page).to have_css(
+              '[role="option"]',
+              text: unneeded_item.name,
+              exact_text: true,
+            )
 
             unique_new_item_name = "#{existing_item.name} #{SecureRandom.alphanumeric(5)}"
 
-            fill_in('Add an item', with: unique_new_item_name)
-            click_on('Add item')
+            new_item_input.send_keys([:control, 'a'], unique_new_item_name)
+            find(
+              '[role="option"]',
+              text: "Add '#{unique_new_item_name}'",
+              exact_text: true,
+            ).click
 
             expect(page).to have_css('li', text: unique_new_item_name)
           end


### PR DESCRIPTION
Replace the separate `ElInput` and submit button with `ElAutocomplete`. Suggestions filter current-store items by a case-insensitive substring, show positive needed counts, and append a dedicated "Add" action for the entered text.

Selecting an existing item targets its stable `grocery-item-<id>` element with `scrollIntoView()`. Feature coverage exercises existing needed and unneeded suggestions, scrolling, and new-item creation.