### PR TITLE
[groceries] Highlight typeahead targets and pin input

### DIFF
--- a/app/javascript/groceries/components/Item.vue
+++ b/app/javascript/groceries/components/Item.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 li.grocery-item.flex.items-center.w-full(
   :id="`grocery-item-${item.id}`"
-  :class="{ unneeded: item.needed <= 0 }"
+  :class="{ highlighted, unneeded: item.needed <= 0 }"
 )
   .left.whitespace-nowrap
     button.item-button.js-link.text-green-600(
@@ -58,6 +58,7 @@ const ICON_SIZE = 17;
 const props = defineProps({
   item: object<Item>().isRequired,
   ownStore: bool().isRequired,
+  highlighted: bool().isRequired,
 });
 
 const groceriesStore = useGroceriesStore();
@@ -140,6 +141,9 @@ function setNeeded(item: Item, needed: number) {
   margin: 5px 0;
   padding: 6px;
   min-height: 30px;
+  transition:
+    background-color 0.3s ease-in-out,
+    box-shadow 0.3s ease-in-out;
 
   /* stylelint-disable media-feature-name-value-no-unknown */
   &:not(.unneeded):hover {
@@ -163,5 +167,10 @@ function setNeeded(item: Item, needed: number) {
     }
   }
   /* stylelint-enable media-feature-name-value-no-unknown */
+
+  &.highlighted {
+    background: rgb(254, 240, 138, 85%);
+    box-shadow: 0 0 8px rgb(234, 179, 8, 90%);
+  }
 }
 </style>

--- a/app/javascript/groceries/components/NewItemForm.vue
+++ b/app/javascript/groceries/components/NewItemForm.vue
@@ -23,6 +23,7 @@ form.flex(
 <script setup lang="ts">
 import {
   ElAutocomplete,
+  type AutocompleteDataItem,
   type AutocompleteFetchSuggestionsCallback,
 } from 'element-plus';
 import { reactive } from 'vue';
@@ -81,17 +82,21 @@ function itemSuggestions(
   ]);
 }
 
-async function selectSuggestion(suggestion: ItemSuggestion): Promise<void> {
-  if (suggestion.type === 'existing') {
+async function selectSuggestion(
+  suggestion: AutocompleteDataItem,
+): Promise<void> {
+  const itemSuggestion = suggestion as ItemSuggestion;
+
+  if (itemSuggestion.type === 'existing') {
     formData.newItemName = '';
-    emit('itemTargeted', suggestion.item);
+    emit('itemTargeted', itemSuggestion.item);
     return;
   }
 
   const item = await groceriesStore.createItem({
     store: props.store,
     itemAttributes: {
-      name: suggestion.value,
+      name: itemSuggestion.value,
     },
   });
 

--- a/app/javascript/groceries/components/NewItemForm.vue
+++ b/app/javascript/groceries/components/NewItemForm.vue
@@ -25,7 +25,7 @@ import {
   ElAutocomplete,
   type AutocompleteFetchSuggestionsCallback,
 } from 'element-plus';
-import { nextTick, reactive } from 'vue';
+import { reactive } from 'vue';
 import { object } from 'vue-types';
 
 import { helpers, useGroceriesStore } from '@/groceries/store';
@@ -50,6 +50,9 @@ const props = defineProps({
 });
 
 const groceriesStore = useGroceriesStore();
+const emit = defineEmits<{
+  itemTargeted: [item: Item];
+}>();
 
 const formData = reactive({
   newItemName: '',
@@ -81,25 +84,20 @@ function itemSuggestions(
 async function selectSuggestion(suggestion: ItemSuggestion): Promise<void> {
   if (suggestion.type === 'existing') {
     formData.newItemName = '';
-    await nextTick();
-    document
-      .getElementById(`grocery-item-${suggestion.item.id}`)
-      ?.scrollIntoView({
-        behavior: 'smooth',
-        block: 'center',
-      });
+    emit('itemTargeted', suggestion.item);
     return;
   }
 
-  const success = await groceriesStore.createItem({
+  const item = await groceriesStore.createItem({
     store: props.store,
     itemAttributes: {
       name: suggestion.value,
     },
   });
 
-  if (success) {
+  if (item) {
     formData.newItemName = '';
+    emit('itemTargeted', item);
   }
 }
 </script>

--- a/app/javascript/groceries/components/Store.vue
+++ b/app/javascript/groceries/components/Store.vue
@@ -9,7 +9,11 @@
 
   StoreNotes(:store="store")
 
-  NewItemForm(:store="store")
+  .new-item-form-container.sticky.top-0.z-10.py-2
+    NewItemForm(
+      :store="store"
+      @item-targeted="scrollToAndHighlightItem"
+    )
 
   TransitionGroup.items-list.relative.mt-0.mb-8(
     name="appear-and-disappear-vertically-list"
@@ -20,6 +24,7 @@
       :item="item"
       :key="item.id"
       :ownStore="store.own_store"
+      :highlighted="item.id === highlightedItemId"
     )
 
   CheckInModal
@@ -30,7 +35,7 @@
 <script setup lang="ts">
 import { useTitle } from '@vueuse/core';
 import { ElButton } from 'element-plus';
-import { computed } from 'vue';
+import { computed, nextTick, onBeforeUnmount, ref } from 'vue';
 import { object } from 'vue-types';
 
 import { helpers, useGroceriesStore } from '@/groceries/store';
@@ -54,6 +59,8 @@ useTitle(() => `${props.store.name} - Groceries - David Runger`);
 
 const groceriesStore = useGroceriesStore();
 const modalStore = useModalStore();
+const highlightedItemId = ref<number>();
+let clearHighlightTimeout: ReturnType<typeof setTimeout> | undefined;
 
 const sortedItems = computed((): ItemType[] => {
   return helpers.sortByName(props.store.items);
@@ -65,4 +72,27 @@ function initializeTripCheckIn() {
   });
   modalStore.showModal({ modalName: 'check-in-shopping-trip' });
 }
+
+async function scrollToAndHighlightItem(item: ItemType): Promise<void> {
+  highlightedItemId.value = item.id;
+  clearTimeout(clearHighlightTimeout);
+
+  await nextTick();
+  document.getElementById(`grocery-item-${item.id}`)?.scrollIntoView({
+    behavior: 'smooth',
+    block: 'center',
+  });
+
+  clearHighlightTimeout = setTimeout(() => {
+    highlightedItemId.value = undefined;
+  }, 2_000);
+}
+
+onBeforeUnmount(() => clearTimeout(clearHighlightTimeout));
 </script>
+
+<style lang="scss" scoped>
+.new-item-form-container {
+  background: rgb(255 255 255 / 80%);
+}
+</style>

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -95,7 +95,7 @@ export const useGroceriesStore = defineStore('groceries', {
         toastErrors(itemData.errors);
       } else if (itemData) {
         this.addItem({ store, itemData });
-        return true;
+        return itemData;
       }
     },
 

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe 'Groceries app' do
             expect(page).not_to have_button('Add item')
 
             page.execute_script(<<~JS)
-              document.getElementById('grocery-item-#{existing_item.id}').scrollIntoView = function() {
+              HTMLElement.prototype.scrollIntoView = function() {
                 this.dataset.scrolledIntoView = 'true';
               };
             JS
@@ -223,6 +223,7 @@ RSpec.describe 'Groceries app' do
             expect(page).to have_css(
               "#grocery-item-#{existing_item.id}[data-scrolled-into-view='true']",
             )
+            expect(page).to have_css("#grocery-item-#{existing_item.id}.highlighted")
 
             new_item_input.send_keys(unneeded_item.name)
             expect(page).to have_css(
@@ -240,7 +241,9 @@ RSpec.describe 'Groceries app' do
               exact_text: true,
             ).click
 
-            expect(page).to have_css('li', text: unique_new_item_name)
+            new_item = find('.grocery-item', text: unique_new_item_name)
+            expect(new_item[:'data-scrolled-into-view']).to eq('true')
+            expect(new_item[:class]).to include('highlighted')
           end
         end
       end


### PR DESCRIPTION
Scroll each selected typeahead target into view and apply a temporary highlight. Return the created item data so the same feedback applies after adding an item.

Keep the add-item field sticky within the store list for long shopping lists. Extend feature coverage for existing and newly created typeahead targets.

Follow-up to #9177.