### PR TITLE
[groceries] Keep item input sticky [GROC-43]

### DIFF
--- a/app/javascript/groceries/Groceries.vue
+++ b/app/javascript/groceries/Groceries.vue
@@ -1,7 +1,7 @@
 <template lang="pug">
 #groceries-app.flex.h-full
   Sidebar
-  main.flex-1.bg-cover
+  main.flex-1.min-h-0.bg-cover
     Store(
       v-if="currentStore"
       :store="currentStore"


### PR DESCRIPTION
Allow the groceries `main` flex item to shrink so the nested `overflow-auto` store pane remains the active scroll container. This keeps the sticky item input in place when selecting a typeahead result scrolls the matching item into view.