### PR TITLE
[groceries] Blur typeahead after item selection [GROC-44]

### DIFF
--- a/app/javascript/groceries/components/NewItemForm.vue
+++ b/app/javascript/groceries/components/NewItemForm.vue
@@ -4,6 +4,7 @@ form.flex(
   @submit.prevent
 )
   ElAutocomplete.item-name-input.max-w-60(
+    ref="autocompleteRef"
     v-model="formData.newItemName"
     :debounce="0"
     :fetch-suggestions="itemSuggestions"
@@ -25,8 +26,9 @@ import {
   ElAutocomplete,
   type AutocompleteDataItem,
   type AutocompleteFetchSuggestionsCallback,
+  type AutocompleteInstance,
 } from 'element-plus';
-import { reactive } from 'vue';
+import { nextTick, reactive, ref } from 'vue';
 import { object } from 'vue-types';
 
 import { helpers, useGroceriesStore } from '@/groceries/store';
@@ -51,6 +53,7 @@ const props = defineProps({
 });
 
 const groceriesStore = useGroceriesStore();
+const autocompleteRef = ref<AutocompleteInstance>();
 const emit = defineEmits<{
   itemTargeted: [item: Item];
 }>();
@@ -89,6 +92,7 @@ async function selectSuggestion(
 
   if (itemSuggestion.type === 'existing') {
     formData.newItemName = '';
+    await blurAutocomplete();
     emit('itemTargeted', itemSuggestion.item);
     return;
   }
@@ -102,7 +106,13 @@ async function selectSuggestion(
 
   if (item) {
     formData.newItemName = '';
+    await blurAutocomplete();
     emit('itemTargeted', item);
   }
+}
+
+async function blurAutocomplete(): Promise<void> {
+  await nextTick();
+  autocompleteRef.value?.blur();
 }
 </script>

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -224,6 +224,9 @@ RSpec.describe 'Groceries app' do
               "#grocery-item-#{existing_item.id}[data-scrolled-into-view='true']",
             )
             expect(page).to have_css("#grocery-item-#{existing_item.id}.highlighted")
+            expect(page.evaluate_script('document.activeElement?.name')).not_to(
+              eq('newItemName'),
+            )
 
             new_item_input.send_keys(unneeded_item.name)
             expect(page).to have_css(
@@ -244,6 +247,9 @@ RSpec.describe 'Groceries app' do
             new_item = find('.grocery-item', text: unique_new_item_name)
             expect(new_item[:'data-scrolled-into-view']).to eq('true')
             expect(new_item[:class]).to include('highlighted')
+            expect(page.evaluate_script('document.activeElement?.name')).not_to(
+              eq('newItemName'),
+            )
           end
         end
       end


### PR DESCRIPTION
Blur the groceries `ElAutocomplete` after an existing item is selected or a new item is created. Defer the blur until the next Vue tick so Element Plus does not restore focus during its option-click handling.

Extend the groceries feature spec to verify that both selection paths leave the `newItemName` field unfocused, preventing iOS Safari keyboard dismissal from shifting the list later during quantity changes.