### PR TITLE
[spec/features/groceries] Remove negative 'Add item' button checks

### DIFF
--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'Groceries app' do
 
         expect(page).not_to have_spinner
         expect(find(:fillable_field, 'newItemName').value).to eq('')
-        expect(page).not_to have_button('Add item')
 
         # Verify that the item is listed only once.
         expect(page.text.scan(new_item_name).size).to eq(1)
@@ -212,7 +211,6 @@ RSpec.describe 'Groceries app' do
               text: "Add '#{substring_of_existing_item_name}'",
               exact_text: true,
             )
-            expect(page).not_to have_button('Add item')
 
             page.execute_script(<<~JS)
               HTMLElement.prototype.scrollIntoView = function() {


### PR DESCRIPTION
There are infinitely many things that we can check not to be there (and which never are / will be there). I don't think that having previously had an 'Add item' button is a good reason to indefinitely retain a spec checking that it's not there currently or going forward. So, this change removes two expectations checking for the absence of an 'Add item' button.