### PR TITLE
[vite] Specify 'server.ws.clientPort' to fix reloading and specs

### DIFF
--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -50,6 +50,11 @@ export default defineConfig(({ mode }) => ({
       }),
     },
   },
+  server: {
+    ws: {
+      clientPort: 3036,
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
We were having two problems:

1. `vite-plugin-full-reload` wasn't quite working. I'd usually have to save a file _twice_ before there would be a reload in the browser to reflect my changes.
2. Feature specs were hanging for 60 seconds before eventually exiting with an error about a request to a path like `/vite/?token=5ya5y4O4MvZ2` being unfinished.

The cause of these problems seems to be the same issue and both problems are fixed by the change in this PR, which sets the Vite `server.ws.clientPort` option to `3036` (which is hardcoded elsewhere in our app, such as `config/initializers/content_security_policy.rb`).

I guess that this might now be needed because of some change in Vite at some point (maybe the upgrade from Vite 7 to 8?)?

I tried talking with the following LLMs about this, and they unfortunately didn't really help at all (certainly none proposed this solution or anything like it), but I recorded a decent amount of additional context in those conversations that I don't want to retype here:

1. https://claude.ai/share/d81d4bc1-dfb6-4b0b-b2c4-359003c58207
2. https://x.com/i/grok/share/2ad1b1b8be074cf79a825426deacdf88
3. https://share.gemini.google/9lBqe71SwgOf