### PR TITLE
[aws-sdk-s3] Lazy load the S3 SDK [DEV-292]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ source 'https://rubygems.org', cooldown: 5
 gem 'activeadmin', '>= 4.0.0.beta15'
 gem 'addressable'
 gem 'alba'
-gem 'aws-sdk-s3'
+gem 'aws-sdk-s3', require: false
 gem 'benchmark'
 gem 'blazer'
 gem 'bootsnap', require: false

--- a/app/poros/prerender_utils.rb
+++ b/app/poros/prerender_utils.rb
@@ -5,9 +5,11 @@ module PrerenderUtils
     end
 
     def transformed_s3_content(git_rev:, filename:)
+      require 'aws-sdk-s3'
+
       object_key = "prerenders/#{git_rev}/#{filename}"
       get_response =
-        Aws::S3::Resource.new(region: 'us-east-1').
+        Aws::S3::Resource.new(region: 'us-east-1', credentials: aws_credentials).
           bucket('david-runger-test-uploads').
           object(object_key).
           get
@@ -36,6 +38,14 @@ module PrerenderUtils
     end
 
     private
+
+    def aws_credentials
+      Aws.config[:credentials] ||
+        Aws::Credentials.new(
+          ENV['AWS_ACCESS_KEY_ID'].presence,
+          ENV['AWS_SECRET_ACCESS_KEY'].presence,
+        )
+    end
 
     def content_signing_public_key
       ContentSignature.key_from_base64(ENV.fetch('CONTENT_SIGNING_PUBLIC_KEY'))

--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -1,6 +1,0 @@
-Aws.config.update(
-  credentials: Aws::Credentials.new(
-    ENV['AWS_ACCESS_KEY_ID'].presence,
-    ENV['AWS_SECRET_ACCESS_KEY'].presence,
-  ),
-)

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -28,6 +28,8 @@ namespace :assets do
   end
 
   def upload_s3_bucket
+    require 'aws-sdk-s3'
+
     @upload_s3_bucket ||=
       Aws::S3::Resource.new(region: 'us-east-1').bucket('david-runger-test-uploads')
   end
@@ -97,6 +99,8 @@ Rake::Task['assets:precompile'].enhance(%w[build_js_routes]) do
   end
 
   def s3_bucket
+    require 'aws-sdk-s3'
+
     @s3_bucket ||=
       Aws::S3::Resource.new(
         region: 'us-east-1',

--- a/spec/lib/vite_asset_archive_spec.rb
+++ b/spec/lib/vite_asset_archive_spec.rb
@@ -1,3 +1,5 @@
+require 'aws-sdk-s3'
+
 RSpec.describe ViteAssetArchive do
   let(:private_key) { OpenSSL::PKey.generate_key('ED25519') }
   let(:public_key) { OpenSSL::PKey.read(private_key.public_to_pem) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -440,6 +440,8 @@ RSpec.configure do |config|
   end
 
   config.around(:each, :fake_aws_credentials) do |spec|
+    require 'aws-sdk-s3'
+
     original_credentials = Aws.config[:credentials]
 
     Aws.config.update(


### PR DESCRIPTION
Mark `aws-sdk-s3` as `require: false` so Bundler does not load the AWS SDK during every application boot.

Load the SDK only when prerendering, asset transfer tasks, Active Storage S3 service code, or S3-specific specs need it. Move prerender credentials from the global initializer to the S3 resource so development retains its explicit missing-credential behavior without requiring the SDK globally.