### PR TITLE
[js-routes] Lazy load route generation [DEV-291]

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,7 @@ gem 'haml'
 gem 'haml-rails'
 gem 'hashid-rails'
 gem 'json'
-gem 'js-routes'
+gem 'js-routes', require: false
 gem 'lograge'
 gem 'loofah-activerecord'
 gem 'memo_wise'

--- a/config/initializers/js_routes.rb
+++ b/config/initializers/js_routes.rb
@@ -1,3 +1,0 @@
-JsRoutes.setup do |config|
-  config.include_undefined_query_parameters = false
-end

--- a/lib/tasks/rails_assets.rake
+++ b/lib/tasks/rails_assets.rake
@@ -1,6 +1,9 @@
 desc 'Build named-routes JavaScript helper script'
 task build_js_routes: :environment do
   require 'js-routes'
+  JsRoutes.setup do |config|
+    config.include_undefined_query_parameters = false
+  end
 
   puts 'Clearing Rails tmp cache ...'
   Rake::Task['tmp:cache:clear'].invoke


### PR DESCRIPTION
Mark `js-routes` as `require: false` so ordinary Rails boots do not pay its startup cost.

Move the `include_undefined_query_parameters` setup into `build_js_routes`, immediately after that task requires the gem. This preserves the explicit false behavior and avoids the deprecation warning even when the task runs from a Spring preloader that booted without `JsRoutes`.