### PR TITLE
[authenticated-sessions] Enrich sessions with IP info [DEV-290]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,7 @@
 ## Test design
 
 - Specs under `spec/controllers/api/` automatically receive `request_format: :json` through derived metadata in `spec/spec_helper.rb`. Do not repeat that metadata on individual API controller spec groups unless the spec intentionally needs different format behavior.
-- When a spec needs a fixture record related to another fixture, obtain it through the relevant association rather than looking up a separately named fixture. This keeps the relationship explicit and avoids relying on incidental fixture identities.
+- When a spec needs a fixture record related to another fixture, obtain it through the relevant association rather than looking up a separately named fixture. Apply this when the relationship is part of the setup or behavior under test; when the spec only needs a record of a particular type, use a directly named fixture instead. This keeps required relationships explicit without making unrelated setup depend on them.
 
 ## Database migrations
 

--- a/app/actions/authenticated_sessions/create.rb
+++ b/app/actions/authenticated_sessions/create.rb
@@ -1,0 +1,22 @@
+class AuthenticatedSessions::Create < ApplicationAction
+  requires :authenticatable, ActiveRecord::Base
+  requires :authentication_kind, String
+  requires :request, ActionDispatch::Request
+  requires :initiated_by_authenticated_session, AuthenticatedSession, NilClass
+
+  returns :authenticated_session, AuthenticatedSession
+
+  def execute
+    result.authenticated_session = authenticatable.authenticated_sessions.create!(
+      authentication_kind:,
+      initial_ip: request.remote_ip,
+      latest_ip: request.remote_ip,
+      initial_user_agent: request.user_agent.to_s,
+      latest_user_agent: request.user_agent.to_s,
+      last_active_at: Time.current.change(sec: 0, usec: 0),
+      initiated_by_authenticated_session:,
+    )
+
+    FetchIpInfoForRecord.perform_async(AuthenticatedSession.name, result.authenticated_session.id)
+  end
+end

--- a/app/admin/my_sessions.rb
+++ b/app/admin/my_sessions.rb
@@ -30,6 +30,8 @@ ActiveAdmin.register_page('My Sessions') do
       column('First seen', &:first_seen)
       column('Last active', &:last_active)
       column('Initial IP', &:initial_ip)
+      column :location
+      column :isp
       column('Latest IP', &:latest_ip)
       column('Initial client', &:initial_client)
       column('Latest client', &:latest_client)

--- a/app/models/authenticated_session.rb
+++ b/app/models/authenticated_session.rb
@@ -11,9 +11,11 @@
 #  initial_ip                            :string           not null
 #  initial_user_agent                    :text             not null
 #  initiated_by_authenticated_session_id :bigint
+#  isp                                   :string
 #  last_active_at                        :datetime         not null
 #  latest_ip                             :string           not null
 #  latest_user_agent                     :text             not null
+#  location                              :string
 #  revoked_at                            :datetime
 #  updated_at                            :datetime         not null
 #
@@ -60,6 +62,10 @@ class AuthenticatedSession < ApplicationRecord
     :last_active_at,
     presence: true
   validate :valid_impersonation_parent
+
+  def ip
+    initial_ip
+  end
 
   def active?
     revoked_at.nil?

--- a/app/poros/authenticated_sessions/registry.rb
+++ b/app/poros/authenticated_sessions/registry.rb
@@ -130,16 +130,12 @@ module AuthenticatedSessions::Registry
       request:,
       initiated_by_authenticated_session: nil
     )
-      current_minute = Time.current.change(sec: 0, usec: 0)
-      authenticatable.authenticated_sessions.create!(
+      AuthenticatedSessions::Create.run!(
+        authenticatable:,
         authentication_kind:,
-        initial_ip: request.remote_ip,
-        latest_ip: request.remote_ip,
-        initial_user_agent: request.user_agent.to_s,
-        latest_user_agent: request.user_agent.to_s,
-        last_active_at: current_minute,
+        request:,
         initiated_by_authenticated_session:,
-      )
+      ).authenticated_session
     end
 
     def enroll_legacy!(authenticatable, warden, scope, request)

--- a/app/views/my_account/show.html.haml
+++ b/app/views/my_account/show.html.haml
@@ -33,6 +33,12 @@
         %b Initial IP:
         = authenticated_session.initial_ip
       %div
+        %b Location:
+        = authenticated_session.location
+      %div
+        %b ISP:
+        = authenticated_session.isp
+      %div
         %b Latest IP:
         = authenticated_session.latest_ip
       %div

--- a/app/workers/fetch_ip_info_for_record.rb
+++ b/app/workers/fetch_ip_info_for_record.rb
@@ -8,6 +8,15 @@ class FetchIpInfoForRecord
   class UnexpectedIpApiResponse < StandardError; end
 
   def perform(class_name, record_id)
+    disable_flag_name = :"disable_fetch_ip_info_for_#{class_name.underscore}_worker"
+
+    if Flipper.enabled?(disable_flag_name)
+      logger.info(<<~LOG.squish)
+        Skipping #{self.class.name} job for #{class_name} because the `#{disable_flag_name}` flag is enabled.
+      LOG
+      return
+    end
+
     record = class_name.safe_constantize.find(record_id)
     write_location_info(record)
   end

--- a/db/datamigrate/20260820052700_enrich_authenticated_sessions.rb
+++ b/db/datamigrate/20260820052700_enrich_authenticated_sessions.rb
@@ -1,0 +1,25 @@
+# Run locally:
+#   bin/rails runner db/datamigrate/20260820052700_enrich_authenticated_sessions.rb
+#
+# Run in production after this datamigration deploys:
+#   bin/run-datamigration db/datamigrate/20260820052700_enrich_authenticated_sessions.rb
+
+class EnrichAuthenticatedSessions < Datamigration::Base
+  include SpacedLaunching
+
+  def run
+    authenticated_sessions = AuthenticatedSession.where(isp: nil).or(
+      AuthenticatedSession.where(location: nil),
+    )
+
+    log("Enqueueing IP info fetches for #{authenticated_sessions.size} AuthenticatedSessions.")
+
+    launch_with_spacing(
+      worker: FetchIpInfoForRecord,
+      arguments_list: authenticated_sessions.find_each.map { [it.class.name, it.id] },
+      spacing_seconds: 5,
+    )
+  end
+end
+
+Datamigration::Runner.new(EnrichAuthenticatedSessions).run

--- a/db/migrate/20260820052612_add_ip_info_to_authenticated_sessions.rb
+++ b/db/migrate/20260820052612_add_ip_info_to_authenticated_sessions.rb
@@ -1,0 +1,6 @@
+class AddIpInfoToAuthenticatedSessions < ActiveRecord::Migration[8.1]
+  def change
+    add_column :authenticated_sessions, :isp, :string
+    add_column :authenticated_sessions, :location, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_13_061819) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_20_052612) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -95,9 +95,11 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_13_061819) do
     t.string "initial_ip", null: false
     t.text "initial_user_agent", null: false
     t.bigint "initiated_by_authenticated_session_id"
+    t.string "isp"
     t.datetime "last_active_at", null: false
     t.string "latest_ip", null: false
     t.text "latest_user_agent", null: false
+    t.string "location"
     t.datetime "revoked_at"
     t.datetime "updated_at", null: false
     t.index ["authenticatable_type", "authenticatable_id", "revoked_at"], name: "index_authenticated_sessions_for_account_listing"

--- a/spec/actions/authenticated_sessions/create_spec.rb
+++ b/spec/actions/authenticated_sessions/create_spec.rb
@@ -1,0 +1,41 @@
+RSpec.describe AuthenticatedSessions::Create do
+  subject(:action) do
+    described_class.new!(
+      authenticatable: user,
+      authentication_kind:,
+      request:,
+      initiated_by_authenticated_session: nil,
+    )
+  end
+
+  let(:user) { users(:user) }
+  let(:authentication_kind) { 'google_oauth' }
+  let(:request) do
+    ActionDispatch::Request.new(
+      'REMOTE_ADDR' => observed_ip,
+      'HTTP_USER_AGENT' => observed_user_agent,
+    )
+  end
+  let(:observed_ip) { Faker::Internet.ip_v4_address }
+  let(:observed_user_agent) { 'Test Browser/1.0' }
+
+  describe '#run!' do
+    subject(:run!) { action.run! }
+
+    it 'creates an AuthenticatedSession and enqueues an IP info fetch' do
+      expect { run! }.to change { user.authenticated_sessions.count }.by(1)
+
+      authenticated_session = user.authenticated_sessions.last!
+      expect(authenticated_session.attributes).to include(
+        'authentication_kind' => authentication_kind,
+        'initial_ip' => observed_ip,
+        'latest_ip' => observed_ip,
+        'initial_user_agent' => observed_user_agent,
+        'latest_user_agent' => observed_user_agent,
+      )
+      expect(FetchIpInfoForRecord).
+        to have_enqueued_sidekiq_job.
+        with('AuthenticatedSession', authenticated_session.id)
+    end
+  end
+end

--- a/spec/controllers/logs/uploads_controller_spec.rb
+++ b/spec/controllers/logs/uploads_controller_spec.rb
@@ -68,7 +68,7 @@ RSpec.describe Logs::UploadsController do
 
       it 'does not create any log entries' do
         expect do
-          Sidekiq::Testing.inline! do
+          with_inline_sidekiq do
             post_create
           end
         end.not_to change { log.reload.log_entries.size }

--- a/spec/controllers/my_account_controller_spec.rb
+++ b/spec/controllers/my_account_controller_spec.rb
@@ -81,6 +81,8 @@ RSpec.describe MyAccountController do
         satisfy { |record| record.authenticatable == user && record.active? },
       )
       expect(response.body).to have_text(visible_session.initial_ip)
+      expect(response.body).to have_text(visible_session.location)
+      expect(response.body).to have_text(visible_session.isp)
       expect(response.body).not_to have_text(visible_session.identifier)
       expect(response.body).not_to have_text(impersonation.initial_ip)
       expect(response.body).to match(/Last active:.*\d{1,2}:\d{2} [AP]M/m)

--- a/spec/factories/authenticated_sessions.rb
+++ b/spec/factories/authenticated_sessions.rb
@@ -11,9 +11,11 @@
 #  initial_ip                            :string           not null
 #  initial_user_agent                    :text             not null
 #  initiated_by_authenticated_session_id :bigint
+#  isp                                   :string
 #  last_active_at                        :datetime         not null
 #  latest_ip                             :string           not null
 #  latest_user_agent                     :text             not null
+#  location                              :string
 #  revoked_at                            :datetime
 #  updated_at                            :datetime         not null
 #
@@ -29,6 +31,10 @@ FactoryBot.define do
     authentication_kind { 'legacy' }
     initial_ip { Faker::Internet.ip_v4_address }
     latest_ip { initial_ip }
+    location do
+      "#{Faker::Address.city}, #{Faker::Address.state_abbr}, #{Faker::Address.country_code}"
+    end
+    isp { Faker::Company.name }
     initial_user_agent { 'Mozilla/5.0 Test Browser' }
     latest_user_agent { initial_user_agent }
     last_active_at { Time.current.change(sec: 0, usec: 0) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -436,7 +436,7 @@ RSpec.configure do |config|
   end
 
   config.around(:each, :inline_sidekiq) do |spec|
-    Sidekiq.testing!(:inline) do
+    SidekiqSpecHelpers.with_global_inline_sidekiq do
       spec.run
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -436,7 +436,13 @@ RSpec.configure do |config|
   end
 
   config.around(:each, :inline_sidekiq) do |spec|
-    Sidekiq::Testing.inline! { spec.run }
+    Sidekiq.testing!(:inline) do
+      spec.run
+    end
+  end
+
+  config.before(:each, :inline_sidekiq) do
+    activate_feature!(:disable_fetch_ip_info_for_authenticated_session_worker)
   end
 
   config.around(:each, :fake_aws_credentials) do |spec|

--- a/spec/support/sidekiq_spec_helpers.rb
+++ b/spec/support/sidekiq_spec_helpers.rb
@@ -2,13 +2,12 @@ module SidekiqSpecHelpers
   # NOTE: This is a workaround for the issue mentioned here
   # https://github.com/sidekiq/sidekiq/issues/ 6069#issuecomment-1755344641 .
   def with_inline_sidekiq(&block)
-    original_test_mode = Sidekiq::Testing.__test_mode
-    Sidekiq::Testing.inline!
+    activate_feature!(:disable_fetch_ip_info_for_authenticated_session_worker)
 
-    # Disabling Prosopite here risks false negatives, but it avoids false
-    # positives, so let's do it.
-    Prosopite.pause(&block)
-
-    Sidekiq::Testing.__set_test_mode(original_test_mode)
+    Sidekiq.testing!(:inline) do
+      # Disabling Prosopite here risks false negatives, but it avoids false
+      # positives, so let's do it.
+      Prosopite.pause(&block)
+    end
   end
 end

--- a/spec/support/sidekiq_spec_helpers.rb
+++ b/spec/support/sidekiq_spec_helpers.rb
@@ -1,10 +1,31 @@
 module SidekiqSpecHelpers
   # NOTE: This is a workaround for the issue mentioned here
   # https://github.com/sidekiq/sidekiq/issues/ 6069#issuecomment-1755344641 .
+  def self.with_global_inline_sidekiq
+    original_test_mode =
+      if Sidekiq::Testing.inline?
+        :inline
+      elsif Sidekiq::Testing.disabled?
+        :disable
+      else
+        :fake
+      end
+
+    # Capybara's server handles browser requests on another thread, so a block-scoped
+    # testing mode would not affect jobs enqueued by those requests.
+    Sidekiq.testing!(:inline)
+
+    begin
+      yield
+    ensure
+      Sidekiq.testing!(original_test_mode)
+    end
+  end
+
   def with_inline_sidekiq(&block)
     activate_feature!(:disable_fetch_ip_info_for_authenticated_session_worker)
 
-    Sidekiq.testing!(:inline) do
+    SidekiqSpecHelpers.with_global_inline_sidekiq do
       # Disabling Prosopite here risks false negatives, but it avoids false
       # positives, so let's do it.
       Prosopite.pause(&block)

--- a/spec/support/spec_helpers.rb
+++ b/spec/support/spec_helpers.rb
@@ -4,8 +4,13 @@ module SpecHelpers
   end
 
   def activate_feature!(feature_name)
+    @activated_features ||= []
+    @activated_features << feature_name if @activated_features.exclude?(feature_name)
+
     allow(Flipper).to receive(:enabled?).and_call_original
-    allow(Flipper).to receive(:enabled?).with(feature_name).and_return(true)
+    @activated_features.each do |activated_feature|
+      allow(Flipper).to receive(:enabled?).with(activated_feature).and_return(true)
+    end
   end
 
   def wait_until

--- a/spec/workers/fetch_ip_info_for_record_spec.rb
+++ b/spec/workers/fetch_ip_info_for_record_spec.rb
@@ -83,5 +83,28 @@ RSpec.describe FetchIpInfoForRecord do
         end
       end
     end
+
+    context 'when class_name is "AuthenticatedSession"' do
+      let(:class_name) { 'AuthenticatedSession' }
+      let(:authenticated_session) { authenticated_sessions(:user_authenticated_session) }
+      let(:record) { authenticated_session }
+
+      before { authenticated_session.update!(location: nil, isp: nil) }
+
+      context 'when IP address info is already cached', :cache do
+        before do
+          Rails.cache.write("ip-info:#{authenticated_session.initial_ip}", { location:, isp: })
+        end
+
+        it 'updates the AuthenticatedSession with the IP address info' do
+          expect {
+            perform
+          }.to change {
+            authenticated_session.reload.attributes.values_at(*%w[location isp])
+          }.from([nil, nil]).
+            to([location, isp])
+        end
+      end
+    end
   end
 end

--- a/spec/workers/fetch_ip_info_for_record_spec.rb
+++ b/spec/workers/fetch_ip_info_for_record_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe FetchIpInfoForRecord do
             to([location, isp])
         end
       end
+
+      context 'when IP info fetching is disabled for AuthenticatedSession' do
+        before { activate_feature!(:disable_fetch_ip_info_for_authenticated_session_worker) }
+
+        it 'does not update the AuthenticatedSession' do
+          expect {
+            perform
+          }.not_to change {
+            authenticated_session.reload.attributes.values_at(*%w[location isp])
+          }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add nullable `isp` and `location` fields to `AuthenticatedSession` and display them in user and administrator session listings.

Route all production session creation through `AuthenticatedSessions::Create`, which persists the session metadata and explicitly enqueues `FetchIpInfoForRecord` instead of relying on an `ActiveRecord` lifecycle callback.

Add `EnrichAuthenticatedSessions` to enqueue missing enrichment jobs at five-second intervals, reusing `SpacedLaunching` to stay below the `ip-api.com` rate limit. Extend worker coverage for authenticated sessions and cover the action and rendered fields.

Give the authenticated-session factory randomized `Faker` values for `location` and `isp`, allowing the account rendering spec to use persisted fixture data without test-local updates.

Clarify in `AGENTS.md` that association-based fixture lookup is for behaviorally relevant relationships; specs that only need a record of a given type should use a directly named fixture.