### PR TITLE
[spec/features] Scope pending sign-ins to browser sessions [CHK-7]

### DIFF
--- a/spec/features/check_ins_spec.rb
+++ b/spec/features/check_ins_spec.rb
@@ -46,10 +46,9 @@ RSpec.describe 'Check-Ins app' do
 
         # log in proposee and accept the proposal
         Capybara.using_session('proposee') do
-          wait_for do
-            sign_in(proposee)
-            sign_in_confirmed_via_my_account?(proposee)
-          end.to eq(true)
+          sign_in(proposee)
+          visit(my_account_path)
+          expect(page).to have_text(proposee.email)
 
           open_email(proposee.email)
           # rubocop:disable RungerStyle/ClickAmbiguously
@@ -105,11 +104,9 @@ RSpec.describe 'Check-Ins app' do
 
           # other partner fills in ratings
           Capybara.using_session('spouse') do
-            wait_for do
-              sign_in(spouse)
-              visit(check_in_path(check_in))
-              page.has_text?('Their answers [hidden until you submit your answers]')
-            end.to eq(true)
+            sign_in(spouse)
+            visit(check_in_path(check_in))
+            expect(page).to have_text('Their answers [hidden until you submit your answers]')
             fill_in_emotional_needs_ratings(rating: -2)
             wait_for do
               CheckIn.order(:created_at).last!.

--- a/spec/features/sign_in_helpers_spec.rb
+++ b/spec/features/sign_in_helpers_spec.rb
@@ -1,0 +1,22 @@
+RSpec.describe 'Feature sign-in helpers' do
+  it 'applies a pending sign-in only to the Capybara session that requested it' do
+    user = users(:user)
+    other_user = User.where.not(id: user).first!
+
+    sign_in(user)
+    visit(my_account_path)
+    expect(page).to have_text(user.email)
+
+    Capybara.using_session('other user') do
+      sign_in(other_user)
+
+      Capybara.using_session(:default) do
+        visit(my_account_path)
+        expect(page).to have_text(user.email)
+      end
+
+      visit(my_account_path)
+      expect(page).to have_text(other_user.email)
+    end
+  end
+end

--- a/spec/support/features/sign_in_helpers.rb
+++ b/spec/support/features/sign_in_helpers.rb
@@ -1,11 +1,45 @@
 module Features::SignInHelpers
+  SIGN_IN_TOKEN_HEADER = 'X-Capybara-Sign-In-Token'
+  SIGN_IN_TOKEN_ENV_KEY = 'HTTP_X_CAPYBARA_SIGN_IN_TOKEN'
+
+  class << self
+    def register_sign_in(resource:, scope:)
+      SecureRandom.uuid.tap do |token|
+        pending_sign_ins_mutex.synchronize do
+          pending_sign_ins[token] = { resource:, scope: }
+        end
+      end
+    end
+
+    def consume_sign_in(token)
+      return unless token
+
+      pending_sign_ins_mutex.synchronize { pending_sign_ins.delete(token) }
+    end
+
+    def reset!
+      pending_sign_ins_mutex.synchronize { pending_sign_ins.clear }
+    end
+
+    private
+
+    def pending_sign_ins
+      @pending_sign_ins ||= {}
+    end
+
+    def pending_sign_ins_mutex
+      @pending_sign_ins_mutex ||= Mutex.new
+    end
+  end
+
   def sign_in(resource, scope: nil)
     scope ||= Devise::Mapping.find_scope!(resource)
+    token = Features::SignInHelpers.register_sign_in(resource:, scope:)
 
-    Warden.on_next_request do |proxy|
-      proxy.env['HTTP_USER_AGENT'] = 'Feature spec browser' if proxy.env['HTTP_USER_AGENT'].blank?
-      proxy.env["authenticated_session.authentication_kind.#{scope}"] = 'legacy'
-      proxy.set_user(resource, scope:, event: :authentication)
+    if page.driver.respond_to?(:add_header)
+      page.driver.add_header(SIGN_IN_TOKEN_HEADER, token)
+    else
+      page.driver.header(SIGN_IN_TOKEN_HEADER, token)
     end
   end
 
@@ -22,4 +56,22 @@ module Features::SignInHelpers
       page.has_text?(user.email)
     end
   end
+end
+
+# `Warden.on_next_request` is process-global, so an Action Cable request from a different
+# Capybara session can consume a pending sign-in. Match the sign-in to a per-session header.
+Warden::Manager.on_request do |proxy|
+  sign_in = Features::SignInHelpers.consume_sign_in(
+    proxy.env[Features::SignInHelpers::SIGN_IN_TOKEN_ENV_KEY],
+  )
+  next unless sign_in
+
+  resource, scope = sign_in.values_at(:resource, :scope)
+  proxy.env['HTTP_USER_AGENT'] = 'Feature spec browser' if proxy.env['HTTP_USER_AGENT'].blank?
+  proxy.env["authenticated_session.authentication_kind.#{scope}"] = 'legacy'
+  proxy.set_user(resource, scope:, event: :authentication)
+end
+
+RSpec.configure do |config|
+  config.after(:each, type: :feature) { Features::SignInHelpers.reset! }
 end


### PR DESCRIPTION
The feature helper previously delegated to `Warden.on_next_request`. That queue is process-global, so an Action Cable reconnect from another `Capybara` session could consume the spouse login, revoke the original user session (`AuthenticatedSession`), and leave the default browser unauthorized.

Associate each pending login with a unique `X-Capybara-Sign-In-Token` header and consume it only on the matching request. Clear pending entries after every feature example and cover a competing-session request deterministically.

Keep sign-in and navigation outside `wait_for` blocks so retries only repeat observations instead of creating additional `AuthenticatedSession` records.