### PR TITLE
[ci] Use a dedicated database for RunFeatureTestsB [DEV-294]

### DIFF
--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -5,5 +5,5 @@ spec-commands: |
   export RAILS_ENV=test PALLETS_CONCURRENCY=${PALLETS_CONCURRENCY:-6} DISABLE_SPRING=1
   export POSTGRES_USER=david_runger POSTGRES_HOST=localhost
   set -x
-  redis-cli -n 15 FLUSHDB
+  redis-cli -n 3 FLUSHDB
   bin/run-tests

--- a/app/poros/email/user_generated_delivery_limiter.rb
+++ b/app/poros/email/user_generated_delivery_limiter.rb
@@ -142,7 +142,7 @@ class Email::UserGeneratedDeliveryLimiter
       *applicable_quotas.map { Integer(it.limit.period) },
     ]
 
-    $email_quota_redis_pool.with do |connection|
+    $redis_pool.with do |connection|
       connection.call(
         'EVAL',
         RESERVE_SCRIPT,

--- a/app/poros/redis_options.rb
+++ b/app/poros/redis_options.rb
@@ -1,6 +1,15 @@
 class RedisOptions
   prepend Memoization
 
+  TEST_DB_NUMBERS_BY_SUFFIX = {
+    '_unit' => 4,
+    '_api' => 5,
+    '_html' => 6,
+    '_feature_a' => 7,
+    '_feature_b' => 8,
+    '_feature_c' => 9,
+  }.freeze
+
   def initialize(db: nil, sidekiq: false)
     @db =
       if rails_test?
@@ -28,17 +37,11 @@ class RedisOptions
   memoize \
   def test_db_number(sidekiq:)
     # Piggyback on the Postgres DB_SUFFIX ENV variable to choose a Redis DB number.
+    db_suffix = ENV.fetch('DB_SUFFIX', '_unit')
     base_db_number =
-      case ENV.fetch('DB_SUFFIX', nil)
-      when '_unit', nil then 4
-      when '_api' then 5
-      when '_html' then 6
-      when '_feature_a' then 7
-      when '_feature_c' then 8
-      else raise('Unexpected DB_SUFFIX!')
-      end
+      TEST_DB_NUMBERS_BY_SUFFIX.fetch(db_suffix) { raise('Unexpected DB_SUFFIX!') }
 
-    sidekiq ? base_db_number + 5 : base_db_number
+    sidekiq ? base_db_number + TEST_DB_NUMBERS_BY_SUFFIX.size : base_db_number
   end
 
   memoize \

--- a/app/poros/redis_options.rb
+++ b/app/poros/redis_options.rb
@@ -9,6 +9,8 @@ class RedisOptions
     '_feature_b' => 8,
     '_feature_c' => 9,
   }.freeze
+  SIDEKIQ_REDIS_DATABASE_OFFSET = TEST_DB_NUMBERS_BY_SUFFIX.size
+  PALLETS_REDIS_DATABASE_NUMBER = TEST_DB_NUMBERS_BY_SUFFIX.values.min - 1
 
   def initialize(db: nil, sidekiq: false)
     @db =
@@ -41,7 +43,7 @@ class RedisOptions
     base_db_number =
       TEST_DB_NUMBERS_BY_SUFFIX.fetch(db_suffix) { raise('Unexpected DB_SUFFIX!') }
 
-    sidekiq ? base_db_number + TEST_DB_NUMBERS_BY_SUFFIX.size : base_db_number
+    sidekiq ? base_db_number + SIDEKIQ_REDIS_DATABASE_OFFSET : base_db_number
   end
 
   memoize \

--- a/config/initializers/flipper.rb
+++ b/config/initializers/flipper.rb
@@ -1,8 +1,7 @@
 Flipper.configure do |config|
   config.default do
-    # Use a separate redis DB in test so settings don't mix with development config.
-    db_number = Rails.env.test? ? 3 : 0
-    redis_options = RedisOptions.new(db: db_number)
+    # Use the DB_SUFFIX-specific Redis database in test; use the default in development.
+    redis_options = RedisOptions.new
     adapter = Flipper::Adapters::Redis.new(Redis.new(url: redis_options.url))
     Flipper.new(adapter)
   end

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -5,10 +5,4 @@ unless IS_DOCKER_BUILD
     RedisClient.
       config(url: RedisOptions.new.url).
       new_pool(size: pool_size)
-
-  # Keep security quota state isolated from general application data in db 0 and Sidekiq in db 1.
-  $email_quota_redis_pool =
-    RedisClient.
-      config(url: RedisOptions.new(db: 2).url).
-      new_pool(size: pool_size)
 end

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -6,12 +6,12 @@ resources, but their keys and `FLUSHDB` operations are separate.
 
 ## Development
 
-| Database | Uses |
-| --- | --- |
-| `0` | Direct application Redis through `$redis_pool`, Flipper, and the email-quota limiter. Action Cable also uses this database when `REDIS_URL` has no database path. |
-| `1` | Sidekiq by default. `SIDEKIQ_REDIS_DATABASE_NUMBER` can override this outside test. |
-| `2` | `Runger::RungerConfig`, through `$runger_redis` in `config/initializers/z.rb` when the application is not running in Docker. |
-| `3` | The Pallets test runner. The gitignored `personal/guardfiles/run_sidekiq.rb` also uses this database. Do not run that Guard runner and Pallets concurrently; the test command and Guard runner flush database `3`. |
+| Database | Uses                                                                                                                                                                                                               |
+| -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `0`      | Direct application Redis through `$redis_pool`, Flipper, and the email-quota limiter. Action Cable also uses this database when `REDIS_URL` has no database path.                                                  |
+| `1`      | Sidekiq by default. `SIDEKIQ_REDIS_DATABASE_NUMBER` can override this outside test.                                                                                                                                |
+| `2`      | `Runger::RungerConfig`, through `$runger_redis` in `config/initializers/z.rb` when the application is not running in Docker.                                                                                       |
+| `3`      | The Pallets test runner. The gitignored `personal/guardfiles/run_sidekiq.rb` also uses this database. Do not run that Guard runner and Pallets concurrently; the test command and Guard runner flush database `3`. |
 
 The Redis cache uses `REDIS_CACHE_URL`, so its database depends on that URL
 and is not part of this fixed mapping.
@@ -22,14 +22,14 @@ and is not part of this fixed mapping.
 databases. The regular application Redis, Flipper, and email-quota state use
 the general test database; Sidekiq uses the corresponding Sidekiq database.
 
-| `DB_SUFFIX` | General test database | Sidekiq database |
-| --- | ---: | ---: |
-| `_unit` | `4` | `10` |
-| `_api` | `5` | `11` |
-| `_html` | `6` | `12` |
-| `_feature_a` | `7` | `13` |
-| `_feature_b` | `8` | `14` |
-| `_feature_c` | `9` | `15` |
+| `DB_SUFFIX`  | General test database | Sidekiq database |
+| ------------ | --------------------: | ---------------: |
+| `_unit`      |                   `4` |             `10` |
+| `_api`       |                   `5` |             `11` |
+| `_html`      |                   `6` |             `12` |
+| `_feature_a` |                   `7` |             `13` |
+| `_feature_b` |                   `8` |             `14` |
+| `_feature_c` |                   `9` |             `15` |
 
 In Rails test, `RedisOptions` derives the database from `DB_SUFFIX`, even if
 the caller passes an explicit `db:` value. Database `3` is reserved for the

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,8 +1,6 @@
 # Redis databases
 
-The application uses Redis logical databases on `REDIS_URL`. Redis provides
-databases `0` through `15`; these databases share the same Redis server and
-resources, but their keys and `FLUSHDB` operations are separate.
+The application uses Redis logical databases on `REDIS_URL`. Redis provides databases `0` through `15`; these databases share the same Redis server and resources, but their keys and `FLUSHDB` operations are separate.
 
 ## Development
 
@@ -13,14 +11,11 @@ resources, but their keys and `FLUSHDB` operations are separate.
 | `2`      | `Runger::RungerConfig`, through `$runger_redis` in `config/initializers/z.rb` when the application is not running in Docker.                                                                                       |
 | `3`      | The Pallets test runner. The gitignored `personal/guardfiles/run_sidekiq.rb` also uses this database. Do not run that Guard runner and Pallets concurrently; the test command and Guard runner flush database `3`. |
 
-The Redis cache uses `REDIS_CACHE_URL`, so its database depends on that URL
-and is not part of this fixed mapping.
+The Redis cache uses `REDIS_CACHE_URL`, so its database depends on that URL and is not part of this fixed mapping.
 
 ## Test and CI
 
-`RedisOptions` uses `DB_SUFFIX` to keep each test group in its own pair of
-databases. The regular application Redis, Flipper, and email-quota state use
-the general test database; Sidekiq uses the corresponding Sidekiq database.
+`RedisOptions` uses `DB_SUFFIX` to keep each test group in its own pair of databases. The regular application Redis, Flipper, and email-quota state use the general test database; Sidekiq uses the corresponding Sidekiq database.
 
 | `DB_SUFFIX`  | General test database | Sidekiq database |
 | ------------ | --------------------: | ---------------: |
@@ -31,12 +26,8 @@ the general test database; Sidekiq uses the corresponding Sidekiq database.
 | `_feature_b` |                   `8` |             `14` |
 | `_feature_c` |                   `9` |             `15` |
 
-In Rails test, `RedisOptions` derives the database from `DB_SUFFIX`, even if
-the caller passes an explicit `db:` value. Database `3` is reserved for the
-Pallets backend and is outside this per-test-group mapping.
+In Rails test, `RedisOptions` derives the database from `DB_SUFFIX`, even if the caller passes an explicit `db:` value. Database `3` is reserved for the Pallets backend and is outside this per-test-group mapping.
 
-Action Cable uses database `0` in test, but its `channel_prefix` includes
-`DB_SUFFIX`, which keeps channel names separate from the test groups above.
+Action Cable uses database `0` in test, but its `channel_prefix` includes `DB_SUFFIX`, which keeps channel names separate from the test groups above.
 
-The non-Docker `config/initializers/z.rb` still uses database `2` directly
-for `Runger::RungerConfig`; it is not part of the `DB_SUFFIX` mapping.
+The non-Docker `config/initializers/z.rb` still uses database `2` directly for `Runger::RungerConfig`; it is not part of the `DB_SUFFIX` mapping.

--- a/docs/redis.md
+++ b/docs/redis.md
@@ -1,0 +1,42 @@
+# Redis databases
+
+The application uses Redis logical databases on `REDIS_URL`. Redis provides
+databases `0` through `15`; these databases share the same Redis server and
+resources, but their keys and `FLUSHDB` operations are separate.
+
+## Development
+
+| Database | Uses |
+| --- | --- |
+| `0` | Direct application Redis through `$redis_pool`, Flipper, and the email-quota limiter. Action Cable also uses this database when `REDIS_URL` has no database path. |
+| `1` | Sidekiq by default. `SIDEKIQ_REDIS_DATABASE_NUMBER` can override this outside test. |
+| `2` | `Runger::RungerConfig`, through `$runger_redis` in `config/initializers/z.rb` when the application is not running in Docker. |
+| `3` | The Pallets test runner. The gitignored `personal/guardfiles/run_sidekiq.rb` also uses this database. Do not run that Guard runner and Pallets concurrently; the test command and Guard runner flush database `3`. |
+
+The Redis cache uses `REDIS_CACHE_URL`, so its database depends on that URL
+and is not part of this fixed mapping.
+
+## Test and CI
+
+`RedisOptions` uses `DB_SUFFIX` to keep each test group in its own pair of
+databases. The regular application Redis, Flipper, and email-quota state use
+the general test database; Sidekiq uses the corresponding Sidekiq database.
+
+| `DB_SUFFIX` | General test database | Sidekiq database |
+| --- | ---: | ---: |
+| `_unit` | `4` | `10` |
+| `_api` | `5` | `11` |
+| `_html` | `6` | `12` |
+| `_feature_a` | `7` | `13` |
+| `_feature_b` | `8` | `14` |
+| `_feature_c` | `9` | `15` |
+
+In Rails test, `RedisOptions` derives the database from `DB_SUFFIX`, even if
+the caller passes an explicit `db:` value. Database `3` is reserved for the
+Pallets backend and is outside this per-test-group mapping.
+
+Action Cable uses database `0` in test, but its `channel_prefix` includes
+`DB_SUFFIX`, which keeps channel names separate from the test groups above.
+
+The non-Docker `config/initializers/z.rb` still uses database `2` directly
+for `Runger::RungerConfig`; it is not part of the `DB_SUFFIX` mapping.

--- a/lib/test/requirements_resolver.rb
+++ b/lib/test/requirements_resolver.rb
@@ -75,7 +75,6 @@ class Test::RequirementsResolver
           Test::Tasks::CompileAdminJavaScript,
           Test::Tasks::CompileUserJavaScript,
           Test::Tasks::StartPercy,
-          Test::Tasks::RunApiControllerTests,
         ],
         Test::Tasks::RunFeatureTestsC => [
           Test::Tasks::DivideFeatureSpecs,

--- a/lib/test/run_pallets_tests.rb
+++ b/lib/test/run_pallets_tests.rb
@@ -9,7 +9,9 @@ Pallets.configure do |c|
 
   c.concurrency = concurrency
   c.max_failures = 0
-  c.backend_args = { url: 'redis://127.0.0.1:6379/15' } # Use redis db 15 (to avoid conflicts).
+  c.backend_args = {
+    url: "redis://127.0.0.1:6379/#{RedisOptions::PALLETS_REDIS_DATABASE_NUMBER}",
+  }
   c.middleware << Test::Middleware::ExitOnFailureMiddleware
   c.middleware << Test::Middleware::TaskResultTrackingMiddleware
 end

--- a/lib/test/run_pallets_tests.rb
+++ b/lib/test/run_pallets_tests.rb
@@ -2,6 +2,7 @@ require_relative '../../config/initializers/monkeypatches/faraday.rb'
 require_relative 'middleware/exit_on_failure_middleware.rb'
 require_relative 'middleware/task_result_tracking_middleware.rb'
 require_relative 'runner.rb'
+require Rails.root.join('app/poros/redis_options.rb')
 
 Pallets.configure do |c|
   concurrency = Integer(ENV.fetch('PALLETS_CONCURRENCY'))

--- a/lib/test/tasks/create_db_copies.rb
+++ b/lib/test/tasks/create_db_copies.rb
@@ -10,7 +10,7 @@ class Test::Tasks::CreateDbCopies < Pallets::Task
     postgres_host = ENV.fetch('POSTGRES_HOST', 'localhost')
     postgres_user = ENV.fetch('POSTGRES_USER', 'david_runger')
 
-    %w[unit api html feature_a feature_c].each do |db_suffix|
+    %w[unit api html feature_a feature_b feature_c].each do |db_suffix|
       db_name = "david_runger_test_#{db_suffix}"
 
       # in CI, we know that the database doesn't exist, so don't waste any time dropping it

--- a/lib/test/tasks/run_feature_tests_b.rb
+++ b/lib/test/tasks/run_feature_tests_b.rb
@@ -3,7 +3,7 @@ class Test::Tasks::RunFeatureTestsB < Pallets::Task
 
   def run
     execute_rspec_command(<<~COMMAND)
-      DB_SUFFIX=_api CAPYBARA_SERVER_PORT=3002
+      DB_SUFFIX=_feature_b CAPYBARA_SERVER_PORT=3002
       COVERAGE_RESULTSET_NAME=feature_b
       bin/rspec $(cat tmp/feature_specs_b.txt)
       #{rspec_output_options}

--- a/spec/poros/email/user_generated_delivery_limiter_spec.rb
+++ b/spec/poros/email/user_generated_delivery_limiter_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe Email::UserGeneratedDeliveryLimiter, queue_adapter: :test do
       )
 
       keys =
-        $email_quota_redis_pool.with do |connection|
+        $redis_pool.with do |connection|
           connection.call('KEYS', "#{described_class::REDIS_KEY_PREFIX}:*")
         end
 
@@ -118,7 +118,7 @@ RSpec.describe Email::UserGeneratedDeliveryLimiter, queue_adapter: :test do
           recipient_email,
         ].join(':')
       alert_key = "#{quota_key}:alerted"
-      $email_quota_redis_pool.with do |connection|
+      $redis_pool.with do |connection|
         connection.call('PEXPIRE', quota_key, 2_500)
       end
 
@@ -126,7 +126,7 @@ RSpec.describe Email::UserGeneratedDeliveryLimiter, queue_adapter: :test do
       reserve_delivery.call(actor_id:, recipient_email:, category:)
 
       quota_expires_at_ms, alert_expires_at_ms =
-        $email_quota_redis_pool.with do |connection|
+        $redis_pool.with do |connection|
           [
             connection.call('PEXPIRETIME', quota_key),
             connection.call('PEXPIRETIME', alert_key),
@@ -269,7 +269,7 @@ RSpec.describe Email::UserGeneratedDeliveryLimiter, queue_adapter: :test do
     context 'when Redis is unavailable' do
       it 'fails open and reports the Redis error' do
         redis_error = RedisClient::CannotConnectError.new('Redis unavailable')
-        allow($email_quota_redis_pool).to receive(:with).and_raise(redis_error)
+        allow($redis_pool).to receive(:with).and_raise(redis_error)
         allow(Rails.error).to receive(:report).and_call_original
 
         result = reserve_delivery.call(actor_id:, recipient_email:, category:)

--- a/spec/poros/redis_options_spec.rb
+++ b/spec/poros/redis_options_spec.rb
@@ -59,40 +59,48 @@ RSpec.describe RedisOptions do
         context 'when DB_SUFFIX is _unit' do
           around { |spec| ClimateControl.modify(DB_SUFFIX: '_unit') { spec.run } }
 
-          it 'returns 9' do
-            expect(test_db_number).to eq(9)
+          it 'returns 10' do
+            expect(test_db_number).to eq(10)
           end
         end
 
         context 'when DB_SUFFIX is _api' do
           around { |spec| ClimateControl.modify(DB_SUFFIX: '_api') { spec.run } }
 
-          it 'returns 10' do
-            expect(test_db_number).to eq(10)
+          it 'returns 11' do
+            expect(test_db_number).to eq(11)
           end
         end
 
         context 'when DB_SUFFIX is _html' do
           around { |spec| ClimateControl.modify(DB_SUFFIX: '_html') { spec.run } }
 
-          it 'returns 11' do
-            expect(test_db_number).to eq(11)
+          it 'returns 12' do
+            expect(test_db_number).to eq(12)
           end
         end
 
         context 'when DB_SUFFIX is _feature_a' do
           around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_a') { spec.run } }
 
-          it 'returns 12' do
-            expect(test_db_number).to eq(12)
+          it 'returns 13' do
+            expect(test_db_number).to eq(13)
+          end
+        end
+
+        context 'when DB_SUFFIX is _feature_b' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_b') { spec.run } }
+
+          it 'returns 14' do
+            expect(test_db_number).to eq(14)
           end
         end
 
         context 'when DB_SUFFIX is _feature_c' do
           around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_c') { spec.run } }
 
-          it 'returns 13' do
-            expect(test_db_number).to eq(13)
+          it 'returns 15' do
+            expect(test_db_number).to eq(15)
           end
         end
 
@@ -144,11 +152,19 @@ RSpec.describe RedisOptions do
           end
         end
 
-        context 'when DB_SUFFIX is _feature_c' do
-          around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_c') { spec.run } }
+        context 'when DB_SUFFIX is _feature_b' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_b') { spec.run } }
 
           it 'returns 8' do
             expect(test_db_number).to eq(8)
+          end
+        end
+
+        context 'when DB_SUFFIX is _feature_c' do
+          around { |spec| ClimateControl.modify(DB_SUFFIX: '_feature_c') { spec.run } }
+
+          it 'returns 9' do
+            expect(test_db_number).to eq(9)
           end
         end
 


### PR DESCRIPTION
Provision `david_runger_test_feature_b` in `CreateDbCopies` and run `RunFeatureTestsB` with `DB_SUFFIX=_feature_b`.

Give the new suffix its own `RedisOptions` database and remove the dependency on `RunApiControllerTests`, allowing FeatureTestsB to start as soon as its other prerequisites are complete.

Keep the Postgres suffix-to-Redis mapping in `TEST_DB_NUMBERS_BY_SUFFIX` and derive the Sidekiq offset from its size. This prevents Redis database collisions when the number of parallel spec databases changes, including the collision that would otherwise occur between `_unit` Sidekiq Redis and FeatureTestsC Redis.