### PR TITLE
[logged-in-header] Use a white fallback background [CSR-17]

### DIFF
--- a/app/views/layouts/_logged_in_header.html.haml
+++ b/app/views/layouts/_logged_in_header.html.haml
@@ -1,4 +1,4 @@
-%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.shrink-0.px-3.max-w-dvw.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,var(--background-color)) leading-[31px]'}
+%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.shrink-0.px-3.max-w-dvw.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,white) leading-[31px]'}
   .flex-1.truncate{title: current_user.email}= current_user.email
   %div.flex.gap-4
     %div= link_to('My account', my_account_path, class: 'text-inherit!')


### PR DESCRIPTION
The shared logged-in header uses `--main-bg-color` for app-specific themes. On pages such as `/ci_step_results`, neither `--main-bg-color` nor the previous `--background-color` fallback is defined, so the `background-color` declaration is invalid and the sticky header remains transparent.

Keep themed pages unchanged while using `white` when no page-level background is supplied.