### PR TITLE
[groceries] Rename item form for search support [GROC-46]

### DIFF
--- a/app/javascript/groceries/components/ItemForm.vue
+++ b/app/javascript/groceries/components/ItemForm.vue
@@ -5,13 +5,13 @@ form.flex(
 )
   ElAutocomplete.item-name-input.max-w-60(
     ref="autocompleteRef"
-    v-model="formData.newItemName"
+    v-model="formData.itemName"
     :debounce="0"
     :fetch-suggestions="itemSuggestions"
     :trigger-on-focus="false"
     fit-input-width
-    name="newItemName"
-    placeholder="Add an item"
+    name="itemName"
+    placeholder="Add or search items"
     @select="selectSuggestion"
   )
     template(#default="slotProps")
@@ -59,7 +59,7 @@ const emit = defineEmits<{
 }>();
 
 const formData = reactive({
-  newItemName: '',
+  itemName: '',
 });
 
 function itemSuggestions(
@@ -91,7 +91,7 @@ async function selectSuggestion(
   const itemSuggestion = suggestion as ItemSuggestion;
 
   if (itemSuggestion.type === 'existing') {
-    formData.newItemName = '';
+    formData.itemName = '';
     await blurAutocomplete();
     emit('itemTargeted', itemSuggestion.item);
     return;
@@ -105,7 +105,7 @@ async function selectSuggestion(
   });
 
   if (item) {
-    formData.newItemName = '';
+    formData.itemName = '';
     await blurAutocomplete();
     emit('itemTargeted', item);
   }

--- a/app/javascript/groceries/components/Store.vue
+++ b/app/javascript/groceries/components/Store.vue
@@ -9,8 +9,8 @@
 
   StoreNotes(:store="store")
 
-  .new-item-form-container.sticky.top-0.z-10.py-2
-    NewItemForm(
+  .item-form-container.sticky.top-0.z-10.py-2
+    ItemForm(
       :store="store"
       @item-targeted="scrollToAndHighlightItem"
     )
@@ -46,8 +46,8 @@ import type { Store } from '@/types';
 
 import CheckInModal from './CheckInModal.vue';
 import Item from './Item.vue';
+import ItemForm from './ItemForm.vue';
 import ManageCheckInStoresModal from './ManageCheckInStoresModal.vue';
-import NewItemForm from './NewItemForm.vue';
 import StoreHeader from './StoreHeader.vue';
 import StoreNotes from './StoreNotes.vue';
 
@@ -92,7 +92,7 @@ onBeforeUnmount(() => clearTimeout(clearHighlightTimeout));
 </script>
 
 <style lang="scss" scoped>
-.new-item-form-container {
+.item-form-container {
   background: rgb(255 255 255 / 80%);
 }
 </style>

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe 'Groceries app' do
         unneeded_item = store.items.unneeded.first!
         expect(page).to have_text(/#{needed_item.name} +\(#{needed_item.needed}\)/)
 
-        find(:fillable_field, 'newItemName').send_keys(new_item_name)
+        find(:fillable_field, 'itemName').send_keys(new_item_name)
         find('[role="option"]', text: "Add '#{new_item_name}'", exact_text: true).click
 
         expect(page).not_to have_spinner
-        expect(find(:fillable_field, 'newItemName').value).to eq('')
+        expect(find(:fillable_field, 'itemName').value).to eq('')
 
         # Verify that the item is listed only once.
         expect(page.text.scan(new_item_name).size).to eq(1)
@@ -180,7 +180,7 @@ RSpec.describe 'Groceries app' do
         let(:unneeded_item) { existing_store.items.unneeded.first! }
 
         context 'when the user searches for an item' do
-          let(:new_item_input_name) { 'newItemName' }
+          let(:item_input_name) { 'itemName' }
 
           it 'offers matching items and a new item option, and handles both selections' do
             visit(groceries_path)
@@ -191,14 +191,14 @@ RSpec.describe 'Groceries app' do
 
             expect(page).to have_css('h1', text: existing_store.name)
 
-            new_item_input = find(:fillable_field, 'Add an item')
-            new_item_input.click
+            item_input = find(:fillable_field, 'Add or search items')
+            item_input.click
             expect(page.evaluate_script('document.activeElement?.name')).to(
-              eq(new_item_input_name),
+              eq(item_input_name),
             )
 
             substring_of_existing_item_name = existing_item.name[1..4]
-            new_item_input.send_keys(substring_of_existing_item_name)
+            item_input.send_keys(substring_of_existing_item_name)
 
             existing_item_option_text = "#{existing_item.name} (#{existing_item.needed})"
             expect(page).to have_css(
@@ -230,10 +230,10 @@ RSpec.describe 'Groceries app' do
             )
             expect(page).to have_css("#grocery-item-#{existing_item.id}.highlighted")
             expect(page.evaluate_script('document.activeElement?.name')).not_to(
-              eq(new_item_input_name),
+              eq(item_input_name),
             )
 
-            new_item_input.send_keys(unneeded_item.name)
+            item_input.send_keys(unneeded_item.name)
             expect(page).to have_css(
               '[role="option"]',
               text: unneeded_item.name,
@@ -242,7 +242,7 @@ RSpec.describe 'Groceries app' do
 
             unique_new_item_name = "#{existing_item.name} #{SecureRandom.alphanumeric(5)}"
 
-            new_item_input.send_keys([:control, 'a'], unique_new_item_name)
+            item_input.send_keys([:control, 'a'], unique_new_item_name)
             find(
               '[role="option"]',
               text: "Add '#{unique_new_item_name}'",
@@ -253,7 +253,7 @@ RSpec.describe 'Groceries app' do
             expect(new_item[:'data-scrolled-into-view']).to eq('true')
             expect(new_item[:class]).to include('highlighted')
             expect(page.evaluate_script('document.activeElement?.name')).not_to(
-              eq(new_item_input_name),
+              eq(item_input_name),
             )
           end
         end


### PR DESCRIPTION
The autocomplete behavior added in #9177 broadened `NewItemForm.vue` from an add-only form to a control that also searches existing items. Its remaining `new` naming obscured that shared responsibility.

Rename the component to `ItemForm.vue`, update the `Store.vue` import and wrapper class, and rename the form state and DOM field from `newItemName` to `itemName`. Change the placeholder from "Add an item" to "Add or search items" so the control communicates both supported actions.

Update feature-spec selectors and local input variables to use the shared item terminology. Keep names such as `new_item_name` and `unique_new_item_name` where they describe items that the test intentionally creates, and retain the visible "new item" option because it verifies the actual add-new-item behavior.