### PR TITLE
[capybara] Log actions [DEV-287]

### DIFF
--- a/spec/config/capybara/action_logger_spec.rb
+++ b/spec/config/capybara/action_logger_spec.rb
@@ -19,5 +19,16 @@ RSpec.describe Capybara::ActionLogger do
 
       capybara_dsl.find('.navigation', visible: false)
     end
+
+    it 'logs Capybara nodes without inspecting them' do
+      node = Capybara::Node::Element.allocate
+
+      expect(Rails.logger).to receive(:info).with(
+        '[Capybara] within args=[#<Capybara::Node::Element>] kwargs={}',
+      )
+      expect(session).to receive(:within).with(node)
+
+      capybara_dsl.within(node)
+    end
   end
 end

--- a/spec/config/capybara/action_logger_spec.rb
+++ b/spec/config/capybara/action_logger_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe Capybara::ActionLogger do
+  let(:session) { instance_double(Capybara::Session) }
+
+  let(:capybara_dsl) do
+    page = session
+    Class.new do
+      include Capybara::DSL
+
+      define_method(:page) { page }
+    end.new
+  end
+
+  describe 'Capybara DSL methods' do
+    it 'logs their names and arguments before forwarding them to the current session' do
+      expect(Rails.logger).to receive(:info).with(
+        '[Capybara] find args=[".navigation"] kwargs={visible: false}',
+      )
+      expect(session).to receive(:find).with('.navigation', visible: false)
+
+      capybara_dsl.find('.navigation', visible: false)
+    end
+  end
+end

--- a/spec/support/capybara/action_logger.rb
+++ b/spec/support/capybara/action_logger.rb
@@ -1,10 +1,37 @@
 module Capybara::ActionLogger
   Capybara::Session::DSL_METHODS.each do |method|
     define_method(method) do |*args, **kwargs, &block|
-      Rails.logger.info("[Capybara] #{method} args=#{args.inspect} kwargs=#{kwargs.inspect}")
+      arguments = capybara_log_value(args)
+      keyword_arguments = capybara_log_value(kwargs)
+      Rails.logger.info("[Capybara] #{method} args=#{arguments} kwargs=#{keyword_arguments}")
 
       super(*args, **kwargs, &block)
     end
+  end
+
+  private
+
+  def capybara_log_value(value)
+    case value
+    when Capybara::Node::Base
+      "#<#{value.class}>"
+    when Array
+      "[#{value.map { capybara_log_value(it) }.join(', ')}]"
+    when Hash
+      log_entries =
+        value.map do |key, nested_value|
+          "#{capybara_log_key(key)} #{capybara_log_value(nested_value)}"
+        end
+      "{#{log_entries.join(', ')}}"
+    else
+      value.inspect
+    end
+  end
+
+  def capybara_log_key(key)
+    return "#{key.name}:" if key.is_a?(Symbol) && key.name.match?(/\A[A-Za-z_]\w*[!?=]?\z/)
+
+    "#{capybara_log_value(key)} =>"
   end
 end
 

--- a/spec/support/capybara/action_logger.rb
+++ b/spec/support/capybara/action_logger.rb
@@ -1,0 +1,11 @@
+module Capybara::ActionLogger
+  Capybara::Session::DSL_METHODS.each do |method|
+    define_method(method) do |*args, **kwargs, &block|
+      Rails.logger.info("[Capybara] #{method} args=#{args.inspect} kwargs=#{kwargs.inspect}")
+
+      super(*args, **kwargs, &block)
+    end
+  end
+end
+
+Capybara::DSL.prepend(Capybara::ActionLogger)


### PR DESCRIPTION
Feature-spec failure logs capture Rails logging in an in-memory logger, but they did not identify the Capybara DSL calls (nor the timing thereof) that led to a failure.

Prepend a test-support module to `Capybara::DSL` after Capybara loads. It logs every `Session` DSL method name, positional arguments, and keyword arguments through `Rails.logger` before forwarding the call, without writing to `stdout`.

Cover the logged message and normal forwarding behavior with a focused spec.