### PR TITLE
[AGENTS.md] Clarify test-only coverage expectations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@
 - Do not routinely run Vitest or TypeScript checks locally. Run them when the task particularly benefits from them; otherwise rely on CI.
 - Do not run `bin/run-tests` locally by default. It is primarily a CI command, and CI may catch issues through checks that are intentionally not run during local development.
 - When an expected asset-size change requires updating `Test::Tasks::RunFileSizeChecks::CONSTRAINTS`, round the reported size to the nearest whole KiB and set the constraint to a 10 KiB range centered on that value (rounded size minus 5 through rounded size plus 5).
-- Maintain 100% line coverage for Ruby code included in coverage, apart from lines that are explicitly ignored. Coverage may come from any combination of spec types; it does not need to come entirely from unit specs.
+- Maintain 100% line coverage for application Ruby code included in coverage, apart from lines that are explicitly ignored. Coverage may come from any combination of spec types; it does not need to come entirely from unit specs. Test-only Ruby code, including specs, support code, and CI/test-runner code under `lib/test/`, does not need 100% line coverage. Do not add or expand specs solely to cover test-only code.
 - Do not run the entire test suite locally solely to confirm total coverage. CI performs the authoritative full-suite coverage check; Codecov also reports full-suite coverage.
 
 ## Test design


### PR DESCRIPTION
Limit the 100% line-coverage expectation to application Ruby code. Test-only code such as specs, support helpers, and CI/test-runner code under `lib/test/` can still be tested where behavior warrants it, but agents should not add or expand specs solely to raise its coverage.