### PR TITLE
[StartPercy] Defer readiness to snapshots [DEV-295]

### DIFF
--- a/lib/test/tasks/start_percy.rb
+++ b/lib/test/tasks/start_percy.rb
@@ -1,68 +1,11 @@
-require 'net/http'
-
 class Test::Tasks::StartPercy < Pallets::Task
   include Test::TaskHelpers
-
-  PERCY_HEALTHCHECK_PATH = '/percy/healthcheck'
-  PERCY_SERVER_PORT = 5338
-  PERCY_STARTUP_TIMEOUT = 45
 
   def run
     if ENV['PERCY_TOKEN'].present?
       execute_detached_system_command('./node_modules/.bin/percy exec:start')
-
-      # Avoid starting another Percy CLI process for each check. Loading the CLI can take
-      # several seconds and compete with the Percy process that is still starting.
-      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-      num_checks = 0
-      sleep(6)
-
-      loop do
-        num_checks += 1
-
-        if percy_running?
-          record_success_and_log_message(<<~LOG.squish)
-            Percy is running after #{num_checks} check(s)
-            and #{elapsed_time(started_at)} seconds.
-          LOG
-
-          break
-        elsif elapsed_time(started_at) >= PERCY_STARTUP_TIMEOUT
-          record_failure_and_log_message(<<~LOG.squish)
-            Percy is still not running after #{num_checks} attempt(s)
-            and #{elapsed_time(started_at)} seconds.
-          LOG
-
-          break
-        end
-
-        sleep(0.1)
-      end
     else
       record_success_and_log_message('Percy token was not present; skipping percy exec:start.')
     end
-  end
-
-  private
-
-  def percy_running?
-    response =
-      Net::HTTP.start(
-        '127.0.0.1',
-        PERCY_SERVER_PORT,
-        nil,
-        open_timeout: 0.1,
-        read_timeout: 0.1,
-      ) do |http|
-        http.get(PERCY_HEALTHCHECK_PATH)
-      end
-
-    response.is_a?(Net::HTTPSuccess)
-  rescue SystemCallError, Timeout::Error
-    false
-  end
-
-  def elapsed_time(started_at)
-    (Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at).round(3)
   end
 end

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Groceries app' do
         # Verify that the URL in the item name is automatically linkified.
         expect(page).to have_link(url_in_item_name, href: url_in_item_name)
 
-        page.percy_snapshot('Groceries')
+        take_percy_snapshot('Groceries')
 
         # Confirm expected item is in list.
         expect(page).to have_css('.grocery-item', text: unneeded_item.name)

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Home page', :prerendering_disabled do
       end.to eq(true)
     end
 
-    page.percy_snapshot('Homepage')
+    take_percy_snapshot('Homepage')
 
     # Scroll tracking >>>
     event_count_before = Event.count

--- a/spec/lib/features/percy_helpers_spec.rb
+++ b/spec/lib/features/percy_helpers_spec.rb
@@ -1,0 +1,75 @@
+RSpec.describe(Features::PercyHelpers) do
+  subject(:helper) do
+    Class.new do
+      include RSpec::Matchers
+      include RSpec::Wait
+      include Features::PercyHelpers
+
+      attr_accessor :page
+    end.new.tap { it.page = page }
+  end
+
+  let(:page) do
+    Class.new do
+      attr_reader :snapshot_name
+
+      def percy_snapshot(snapshot_name)
+        @snapshot_name = snapshot_name
+      end
+    end.new
+  end
+
+  let(:healthcheck_url) { 'http://127.0.0.1:5338/percy/healthcheck' }
+
+  describe '#take_percy_snapshot' do
+    context 'when Percy is enabled' do
+      around do |spec|
+        ClimateControl.modify(PERCY_TOKEN: 'token') { spec.run }
+      end
+
+      context 'when Percy starts before the timeout' do
+        before do
+          stub_request(:get, healthcheck_url).to_return(status: 200)
+        end
+
+        it 'waits for Percy before taking the snapshot' do
+          helper.take_percy_snapshot('Snapshot name')
+
+          expect(page.snapshot_name).to eq('Snapshot name')
+          expect(a_request(:get, healthcheck_url)).to have_been_made.once
+        end
+      end
+
+      context 'when Percy does not start before the timeout' do
+        before do
+          stub_const('Features::PercyHelpers::PERCY_WAIT_TIMEOUT', 0)
+          stub_request(:get, healthcheck_url).to_return(status: 503)
+        end
+
+        it 'raises an expectation failure before taking the snapshot' do
+          expect do
+            helper.take_percy_snapshot('Snapshot name')
+          end.to raise_error(
+            RSpec::Expectations::ExpectationNotMetError,
+            'Percy did not start before the snapshot',
+          )
+
+          expect(page.snapshot_name).to be_nil
+        end
+      end
+    end
+
+    context 'when Percy is disabled' do
+      around do |spec|
+        ClimateControl.modify(PERCY_TOKEN: nil) { spec.run }
+      end
+
+      it 'takes the snapshot without checking Percy health' do
+        helper.take_percy_snapshot('Snapshot name')
+
+        expect(page.snapshot_name).to eq('Snapshot name')
+        expect(a_request(:get, healthcheck_url)).not_to have_been_made
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -150,6 +150,7 @@ RSpec.configure do |config|
   config.include(Devise::Test::ControllerHelpers, type: :controller)
   config.include(Devise::Test::IntegrationHelpers, type: :feature)
   config.include(Features::DownloadHelpers, type: :feature)
+  config.include(Features::PercyHelpers, type: :feature)
   config.include(Features::SignInHelpers, type: :feature)
   config.include(Monkeypatches::MakeAllRequestsAsJson, request_format: :json)
   config.include(ActionCable::TestHelper, :action_cable_test_adapter)

--- a/spec/support/features/percy_helpers.rb
+++ b/spec/support/features/percy_helpers.rb
@@ -1,0 +1,46 @@
+require 'net/http'
+
+module Features::PercyHelpers
+  PERCY_HEALTHCHECK_PATH = '/percy/healthcheck'
+  PERCY_SERVER_PORT = 5338
+  PERCY_WAIT_TIMEOUT = 45
+
+  def take_percy_snapshot(snapshot_name)
+    wait_for_percy(snapshot_name) if ENV['PERCY_TOKEN'].present?
+
+    page.percy_snapshot(snapshot_name)
+  end
+
+  private
+
+  def wait_for_percy(snapshot_name)
+    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+
+    with_wait(timeout: PERCY_WAIT_TIMEOUT) do
+      wait_for { percy_running? }.to be(true), 'Percy did not start before the snapshot'
+    end
+
+    elapsed_time = Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at
+    RSpec.configuration.reporter.message(<<~LOG.squish)
+      Waited #{elapsed_time.round(3)} seconds for Percy before taking the
+      "#{snapshot_name}" snapshot.
+    LOG
+  end
+
+  def percy_running?
+    response =
+      Net::HTTP.start(
+        '127.0.0.1',
+        PERCY_SERVER_PORT,
+        nil,
+        open_timeout: 0.1,
+        read_timeout: 0.1,
+      ) do |http|
+        http.get(PERCY_HEALTHCHECK_PATH)
+      end
+
+    response.is_a?(Net::HTTPSuccess)
+  rescue SystemCallError, Timeout::Error
+    false
+  end
+end


### PR DESCRIPTION
The prior readiness optimization in ae0226406 reduced one `main` run to 8.6 seconds, compared with the historical 17.846-second median. Even that faster startup can overlap useful feature-spec work instead of remaining a global prerequisite.

Make `StartPercy` return after spawning the detached Percy process. Feature tasks retain their dependency on `StartPercy`, guaranteeing that Percy has been launched without holding every feature shard until its server and browser are ready.

Wrap the two Percy snapshots with `take_percy_snapshot`. When `PERCY_TOKEN` is present, the helper polls the direct health endpoint for up to 45 seconds immediately before calling the Percy SDK and reports how long that snapshot waited. Specs without Percy enabled continue without a readiness check.