### PR TITLE
[home] Correct model explorer image alt text

### DIFF
--- a/app/javascript/home/components/Projects.vue
+++ b/app/javascript/home/components/Projects.vue
@@ -100,7 +100,7 @@ HomeSection(
       img.box-shadow(
         loading="lazy"
         src="https://david-runger-public-uploads.s3.us-east-1.amazonaws.com/vue-rails-model-explorer.png"
-        alt="Serpent Game"
+        alt="Vue Rails Model Explorer"
       )
     template(#overview)
       p When working on a feature that involves multiple different ActiveRecord models, keeping the relevant details about those models in one's head can be challenging, especially in an app one is not yet very familiar with. I built the #[b Vue Rails Model Explorer] so that I don't #[i need] to keep so much information in my head (or search through #[code db/schema.rb] and look at association declarations in #[code app/models/]). This interactive tool makes it fast and easy to explore the columns and associations of a Rails application's models.


### PR DESCRIPTION
The Vue Rails Model Explorer project card displayed the unrelated "Serpent Game" value in its image `alt` attribute. Replace it with the project name so assistive technology receives an accurate description of the image.

codex resume 01a02239-85d7-7f42-b2e8-3983bdab4bbc