### PR TITLE
[spec/helpers] Clarify admin asset URL description

### DIFF
--- a/spec/helpers/assets_helper_spec.rb
+++ b/spec/helpers/assets_helper_spec.rb
@@ -15,9 +15,7 @@ RSpec.describe AssetsHelper do
           end
         end
 
-        # rubocop:disable Lint/InterpolationCheck
-        context 'when a request to "http://localhost:3036/vite-adm_entrypoi nts/#{entrypoint_name}.ts" returns 200' do
-          # rubocop:enable Lint/InterpolationCheck
+        context 'when a request to "http://localhost:3036/vite-admin/admin_entrypoints/<entrypoint_name>.ts" returns 200' do
           before do
             stub_request(
               :get,


### PR DESCRIPTION
The `#admin_ts_tag` example intentionally keeps a generic context rather than interpolating `entrypoint_name`. Use the literal `<entrypoint_name>` placeholder and restore the `vite-admin/admin_entrypoints` path. Removing the `Lint/InterpolationCheck` suppression keeps the description generic without hiding a lint offense.

codex resume 01a02239-85d7-7f42-b2e8-3983bdab4bbc