### PR TITLE
[groceries] Restore request state after failures

### DIFF
--- a/app/javascript/groceries/store.test.ts
+++ b/app/javascript/groceries/store.test.ts
@@ -1,0 +1,91 @@
+import { createPinia, setActivePinia } from 'pinia';
+
+import type { Item } from '@/groceries/types';
+import { http } from '@/lib/http';
+import type { Store } from '@/types';
+
+vi.mock('@/lib/http', () => ({
+  http: {
+    delete: vi.fn(),
+    get: vi.fn(),
+    patch: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+const storeData: Store = {
+  id: 1,
+  items: [],
+  name: 'Groceries',
+  notes: null,
+  own_store: true,
+  private: false,
+  viewed_at: null,
+};
+
+const itemData: Item = {
+  id: 1,
+  name: 'Apples',
+  needed: 1,
+  store_id: storeData.id,
+};
+
+describe('useGroceriesStore', () => {
+  let useGroceriesStore: typeof import('./store').useGroceriesStore;
+  let groceriesStore: ReturnType<typeof useGroceriesStore>;
+  let item: Item;
+
+  beforeAll(async () => {
+    window.davidrunger = { bootstrap: {}, env: 'test' };
+    ({ useGroceriesStore } = await import('./store'));
+  });
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    setActivePinia(createPinia());
+    groceriesStore = useGroceriesStore();
+    item = { ...itemData };
+    groceriesStore.own_stores = [{ ...storeData, items: [item] }];
+    groceriesStore.spouse_stores = [];
+  });
+
+  it('clears the posting state when creating a store fails', async () => {
+    const error = new Error('Network failure');
+    vi.mocked(http.post).mockRejectedValueOnce(error);
+
+    await expect(groceriesStore.createStore('New store')).rejects.toThrow(
+      error,
+    );
+
+    expect(groceriesStore.postingStore).toBe(false);
+  });
+
+  it.each([
+    [
+      'creating an item',
+      () =>
+        groceriesStore.createItem({
+          store: groceriesStore.own_stores[0],
+          itemAttributes: { name: 'Bananas' },
+        }),
+    ],
+    ['deleting an item', () => groceriesStore.destroyItem({ item })],
+    [
+      'updating an item',
+      () =>
+        groceriesStore.updateItem({
+          item,
+          attributes: { name: 'Pears' },
+        }),
+    ],
+  ])('clears pending request state when %s fails', async (_action, action) => {
+    const error = new Error('Network failure');
+    vi.mocked(http.delete).mockRejectedValueOnce(error);
+    vi.mocked(http.patch).mockRejectedValueOnce(error);
+    vi.mocked(http.post).mockRejectedValueOnce(error);
+
+    await expect(action()).rejects.toThrow(error);
+
+    expect(groceriesStore.pendingRequests).toBe(0);
+  });
+});

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -83,13 +83,12 @@ export const useGroceriesStore = defineStore('groceries', {
       store: Store;
       itemAttributes: { name: string };
     }) {
-      this.incrementPendingRequests();
-
-      const itemData = await http.post<
-        Intersection<Item, ItemCreateResponse> | ObjectWithErrors
-      >(api_store_items_path(store.id), { item: itemAttributes });
-
-      this.decrementPendingRequests();
+      const itemData = await this.withPendingRequest(() =>
+        http.post<Intersection<Item, ItemCreateResponse> | ObjectWithErrors>(
+          api_store_items_path(store.id),
+          { item: itemAttributes },
+        ),
+      );
 
       if (isObjectWithErrors(itemData)) {
         toastErrors(itemData.errors);
@@ -107,17 +106,29 @@ export const useGroceriesStore = defineStore('groceries', {
         },
       };
 
-      const newStoreData = await http.post<
-        Intersection<Store, StoreCreateResponse> | ObjectWithErrors
-      >(api_stores_path(), payload);
+      try {
+        const newStoreData = await http.post<
+          Intersection<Store, StoreCreateResponse> | ObjectWithErrors
+        >(api_stores_path(), payload);
 
-      this.postingStore = false;
+        if (isObjectWithErrors(newStoreData)) {
+          toastErrors(newStoreData.errors);
+        } else if (newStoreData) {
+          this.own_stores.unshift(newStoreData);
+          return true;
+        }
+      } finally {
+        this.postingStore = false;
+      }
+    },
 
-      if (isObjectWithErrors(newStoreData)) {
-        toastErrors(newStoreData.errors);
-      } else if (newStoreData) {
-        this.own_stores.unshift(newStoreData);
-        return true;
+    async withPendingRequest<T>(request: () => Promise<T>): Promise<T> {
+      this.incrementPendingRequests();
+
+      try {
+        return await request();
+      } finally {
+        this.decrementPendingRequests();
       }
     },
 
@@ -133,10 +144,10 @@ export const useGroceriesStore = defineStore('groceries', {
     async destroyItem({ item }: { item: Item }) {
       item.deleted = true;
 
-      this.incrementPendingRequests();
-
       const { restore_item_path: restoreItemPath } =
-        await http.delete<ItemDestroyResponse>(api_item_path(item.id));
+        await this.withPendingRequest(() =>
+          http.delete<ItemDestroyResponse>(api_item_path(item.id)),
+        );
 
       vueToast(
         {
@@ -151,7 +162,6 @@ export const useGroceriesStore = defineStore('groceries', {
         },
       );
 
-      this.decrementPendingRequests();
       this.deleteItem({ item });
     },
 
@@ -260,13 +270,12 @@ export const useGroceriesStore = defineStore('groceries', {
       item: Item;
       attributes: { name: string };
     }) {
-      this.incrementPendingRequests();
-
-      const updatedItemData = await http.patch<
-        Intersection<Item, ItemUpdateResponse>
-      >(api_item_path(item.id), { item: attributes });
-
-      this.decrementPendingRequests();
+      const updatedItemData = await this.withPendingRequest(() =>
+        http.patch<Intersection<Item, ItemUpdateResponse>>(
+          api_item_path(item.id),
+          { item: attributes },
+        ),
+      );
 
       if (!this.debouncingOrWaitingOnNetwork) {
         this.modifyItem({ item, attributes: updatedItemData });


### PR DESCRIPTION
Groceries actions increment `pendingRequests` or set `postingStore` before awaiting HTTP requests, but previously cleared those flags only on success. A rejected network request could leave the item spinner and unload warning active or permanently disable the store-creation button.

Route item creation, deletion, and updates through a shared `withPendingRequest` action that decrements in `finally`, and reset `postingStore` in a `finally` block around store creation. Add `Vitest` coverage for rejected requests to preserve retryable UI state.

codex resume 01a0224b-dc87-7f72-b32f-021f74b94dba