### PR TITLE
[home] Clarify workout description

### DIFF
--- a/app/javascript/home/components/Projects.vue
+++ b/app/javascript/home/components/Projects.vue
@@ -18,7 +18,7 @@ HomeSection(
 
         li #[a(:href="groceries_path()") Groceries]* - Simplify and streamline your family's grocery shopping with a collaborative, mobile-friendly, real-time (WebSockets-enabled) list.
 
-        li #[a(:href="workouts_path()") Workouts]* - An app for tracking workouts over time, and to stay on-pace within a workout.
+        li #[a(:href="workouts_path()") Workouts]* - An app for tracking workouts over time and staying on pace within a workout.
 
         li #[a(:href="logs_path()") Logs]* - Track anything you like using various log types: text, number, duration, or counter.
 


### PR DESCRIPTION
The homepage Workouts project description mixed the gerund "tracking" with the infinitive "to stay" and hyphenated the phrase "on-pace". Rewrite the sentence with parallel gerunds and the standard "on pace" phrasing so this public-facing copy reads naturally in `app/javascript/home/components/Projects.vue`.

codex resume 01a02260-00e4-7960-b1f1-5f5136ebdcdf