### PR TITLE
[auth-tokens] Correct permitted action example

### DIFF
--- a/app/views/my_account/edit.html.haml
+++ b/app/views/my_account/edit.html.haml
@@ -24,7 +24,7 @@
       .my-2
         %div
           = form.label :permitted_actions_list, 'Permitted actions (optional). ', class: 'block'
-          %small A comma- and/or whitespace-separated list of controller actions (in the form `api/csp_results#create`) for which this auth token may be used as an authorization mechanism. Note: A blank list means that the auth token is valid for all controller actions.
+          %small A comma- and/or whitespace-separated list of controller actions (in the form `api/csp_reports#create`) for which this auth token may be used as an authorization mechanism. Note: A blank list means that the auth token is valid for all controller actions.
         = form.textarea :permitted_actions_list, rows: 2, class: 'w-full'
 
       .my-2

--- a/db/migrate/20260821034707_correct_permitted_actions_list_comment.rb
+++ b/db/migrate/20260821034707_correct_permitted_actions_list_comment.rb
@@ -1,0 +1,24 @@
+class CorrectPermittedActionsListComment < ActiveRecord::Migration[8.1]
+  def change
+    old_comment = <<~COMMENT.squish
+      A comma- and/or whitespace-separated list of controller actions (in the
+      form `api/csp_results#create`) for which the auth token may be used as an
+      authorization mechanism. Note: A blank list means that the AuthToken is
+      valid for all controller actions.
+    COMMENT
+
+    new_comment = <<~COMMENT.squish
+      A comma- and/or whitespace-separated list of controller actions (in the
+      form `api/csp_reports#create`) for which the auth token may be used as an
+      authorization mechanism. Note: A blank list means that the AuthToken is
+      valid for all controller actions.
+    COMMENT
+
+    change_column_comment(
+      :auth_tokens,
+      :permitted_actions_list,
+      from: old_comment,
+      to: new_comment,
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_20_052612) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_21_034707) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -78,7 +78,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_20_052612) do
     t.datetime "created_at", null: false
     t.datetime "last_used_at", precision: nil
     t.text "name"
-    t.text "permitted_actions_list", comment: "A comma- and/or whitespace-separated list of controller actions (in the form `api/csp_results#create`) for which the auth token may be used as an authorization mechanism. Note: A blank list means that the AuthToken is valid for all controller actions."
+    t.text "permitted_actions_list", comment: "A comma- and/or whitespace-separated list of controller actions (in the form `api/csp_reports#create`) for which the auth token may be used as an authorization mechanism. Note: A blank list means that the AuthToken is valid for all controller actions."
     t.text "secret", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false

--- a/spec/controllers/concerns/token_authenticatable_spec.rb
+++ b/spec/controllers/concerns/token_authenticatable_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
 
         context 'when the AuthToken has a permitted_actions_list that includes the requested action' do
           before do
-            auth_token.update!(permitted_actions_list: 'anonymous#index, api/csp_results#create')
+            auth_token.update!(permitted_actions_list: 'anonymous#index, api/csp_reports#create')
           end
 
           it "is the AuthToken's user" do
@@ -78,7 +78,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
 
         context 'when the AuthToken has a permitted_actions_list that does not include the requested action' do
           before do
-            auth_token.update!(permitted_actions_list: 'anonymous#show, api/csp_results#create')
+            auth_token.update!(permitted_actions_list: 'anonymous#show, api/csp_reports#create')
           end
 
           it 'is nil' do
@@ -104,7 +104,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
 
         context 'when the AuthToken has a permitted_actions_list that includes the requested action' do
           before do
-            auth_token.update!(permitted_actions_list: 'anonymous#index, api/csp_results#create')
+            auth_token.update!(permitted_actions_list: 'anonymous#index, api/csp_reports#create')
           end
 
           it "is the AuthToken's user" do
@@ -116,7 +116,7 @@ RSpec.describe TokenAuthenticatable, :without_verifying_authorization do
 
         context 'when the AuthToken has a permitted_actions_list that does not include the requested action' do
           before do
-            auth_token.update!(permitted_actions_list: 'anonymous#show, api/csp_results#create')
+            auth_token.update!(permitted_actions_list: 'anonymous#show, api/csp_reports#create')
           end
 
           it 'is nil' do


### PR DESCRIPTION
The auth-token settings page showed `api/csp_results#create`, but the endpoint is `api/csp_reports#create`. Align the page copy and the permitted-action examples in `spec/controllers/concerns/token_authenticatable_spec.rb` with the actual route.

Add `CorrectPermittedActionsListComment` to update the PostgreSQL column comment without editing the historical `20250325233233_add_permitted_actions_list_to_auth_tokens.rb` migration. Regenerate `db/schema.rb` from the applied migration so new deployments and checked-in schema metadata agree.

codex resume 01a02263-4700-7ba3-96de-d6b7865e2363