### PR TITLE
[CI] Decrease pallets concurrency from 6 to 4

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -122,7 +122,7 @@ jobs:
         run: bin/run-tests
         env:
           CI: true
-          PALLETS_CONCURRENCY: 6
+          PALLETS_CONCURRENCY: 4
           AWS_EC2_METADATA_DISABLED: true
           RAILS_ENV: test
           DISABLE_SPRING: 1

--- a/.runger-config.yml
+++ b/.runger-config.yml
@@ -2,7 +2,7 @@ expected-num-github-checks:
   at-least: 2
 javascript-watch-command: ./node_modules/.bin/vite --force
 spec-commands: |
-  export RAILS_ENV=test PALLETS_CONCURRENCY=${PALLETS_CONCURRENCY:-6} DISABLE_SPRING=1
+  export RAILS_ENV=test PALLETS_CONCURRENCY=${PALLETS_CONCURRENCY:-4} DISABLE_SPRING=1
   export POSTGRES_USER=david_runger POSTGRES_HOST=localhost
   set -x
   redis-cli -n 3 FLUSHDB


### PR DESCRIPTION
As of #9215, I think that feature specs might be able to start running too early in CI, causing too much concurrent CPU load. I wonder if we might get faster CI runs by decreasing the concurrency enough to at least slow the starting of one of the feature spec batches until both unit specs and API controller specs have finished. This change implements that, at least as an experiment on this branch, and probably as an experiment on `main`, too.