### PR TITLE
[release-tasks] Log retry attempts through Rails logger

### DIFF
--- a/lib/release_tasks/runner.rb
+++ b/lib/release_tasks/runner.rb
@@ -10,7 +10,7 @@ class ReleaseTasks::Runner
     rake_task = Rake::Task[task_name]
 
     (1..attempts).each do |attempt_number|
-      print("attempt ##{attempt_number}... ")
+      Rails.logger.info("attempt ##{attempt_number}... ")
       rake_task.invoke
       break
     rescue => error

--- a/spec/lib/release_tasks/runner_spec.rb
+++ b/spec/lib/release_tasks/runner_spec.rb
@@ -36,7 +36,9 @@ RSpec.describe ReleaseTasks::Runner do
       end
 
       it 'invokes the task once without sleeping' do
-        run_rake_task_with_retries
+        expect(Rails.logger).to receive(:info).with('attempt #1... ').and_call_original
+
+        expect { run_rake_task_with_retries }.not_to output.to_stdout
 
         expect(task_action).to have_received(:call).once
         expect(runner).not_to have_received(:sleep)


### PR DESCRIPTION
Retry progress is operational logging rather than user-facing task output. `Rails.logger.info` is suppressed by the test environment's `:warn` log level, while production's logger writes info messages to stdout, preserving deployment visibility.

The runner spec verifies both the logger call and absence of stdout output.

codex resume 01a02280-309e-7a50-9759-034de330de82