### PR TITLE
[config/environments] Clarify test CSRF setting

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -30,7 +30,7 @@ Rails.application.configure do
 
   config.action_dispatch.show_exceptions = :none
 
-  # Disable request forgery protection in test environment.
+  # Enable request forgery protection in the test environment.
   config.action_controller.allow_forgery_protection = true
 
   # Store uploaded files on the local file system in a temporary directory.


### PR DESCRIPTION
The `config.action_controller.allow_forgery_protection` setting is enabled in the test environment, but its adjacent comment incorrectly described request forgery protection as disabled. Update the comment to match the configured behavior.

codex resume 01a02285-0d5e-7a12-b40b-42cdaef9e210