### PR TITLE
[need_satisfaction_rating] Correct validation description typo

### DIFF
--- a/spec/models/need_satisfaction_rating_spec.rb
+++ b/spec/models/need_satisfaction_rating_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe NeedSatisfactionRating do
       end
     end
 
-    context 'when the score is grater than 3' do
+    context 'when the score is greater than 3' do
       before { need_satisfaction_rating.score = 4 }
 
       it 'is not valid' do


### PR DESCRIPTION
Correct the misspelled `greater` in the context description for the invalid `score` case. This keeps RSpec output aligned with the validation intent.

codex resume 01a02289-d246-7141-a8f2-54a9c4974176