### PR TITLE
[active_admin] Fix logout path comment grammar

### DIFF
--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -87,7 +87,7 @@ ActiveAdmin.setup do |config|
   # settings configure the location and method used for the link.
   #
   # This setting changes the path where the link points to. If it's
-  # a string, the strings is used as the path. If it's a Symbol, we
+  # a string, the string is used as the path. If it's a Symbol, we
   # will call the method to return the path.
   #
   # Default:


### PR DESCRIPTION
Correct the Active Admin initializer comment describing `config.logout_link_path`. The comment used the plural "strings" while describing a singular value, making the configuration guidance grammatically incorrect.

This is a documentation-only correction and does not alter Active Admin behavior.

codex resume 01a0228f-e945-7611-a7eb-005f4ebc83a1