### PR TITLE
[lib/test/tasks] Fix test task comment grammar

### DIFF
--- a/lib/test/tasks/run_unit_tests.rb
+++ b/lib/test/tasks/run_unit_tests.rb
@@ -3,7 +3,7 @@ class Test::Tasks::RunUnitTests < Pallets::Task
 
   def run
     # Run all tests in `spec/` _except_ those in
-    # `spec/{controllers,helpers,requests}/` (which will we run by
+    # `spec/{controllers,helpers,requests}/` (which will be run by
     # RunApiControllerTests and RunHtmlControllerTests), `spec/tools/` (which
     # will be run by RunToolsTests), and `spec/features/` (which will be run by
     # RunFeatureTests).


### PR DESCRIPTION
Correct the parenthetical description of the directories excluded from `RunUnitTests`. The sentence now matches the parallel `spec/tools/` and `spec/features/` clauses and clearly states that `RunApiControllerTests` and `RunHtmlControllerTests` execute those specs.

codex resume 01a02292-aa53-7713-9344-202c07ad1cfe