### PR TITLE
[fuzzy-typeahead] Handle empty search results

### DIFF
--- a/app/javascript/emoji_picker/EmojiPicker.vue
+++ b/app/javascript/emoji_picker/EmojiPicker.vue
@@ -68,7 +68,9 @@ const googleLoginOrigin = window.location.href;
 function handleKeydown(event: KeyboardEvent) {
   switch (event.key) {
     case 'Enter':
-      selectEmoji(highlightedSearchable.value);
+      if (highlightedSearchable.value) {
+        selectEmoji(highlightedSearchable.value);
+      }
       break;
     case 'ArrowUp':
       onArrowUp();

--- a/app/javascript/lib/composables/useFuzzyTypeahead.ts
+++ b/app/javascript/lib/composables/useFuzzyTypeahead.ts
@@ -40,7 +40,7 @@ export function useFuzzyTypeahead<T extends object>({
     highlightedIndex.value = 0;
   });
 
-  const highlightedSearchable = computed<T>(() => {
+  const highlightedSearchable = computed<T | undefined>(() => {
     return topRankedMatches.value[highlightedIndex.value];
   });
 

--- a/app/javascript/logs/components/LogSelectorModal.vue
+++ b/app/javascript/logs/components/LogSelectorModal.vue
@@ -74,7 +74,10 @@ watch(showingLogSelectorModal, () => {
 });
 
 function selectHighlightedLog() {
-  selectLog(highlightedSearchable.value);
+  const log = highlightedSearchable.value;
+  if (!log) return;
+
+  selectLog(log);
 }
 
 function selectLog(log: Log) {


### PR DESCRIPTION
Searching can produce an empty `topRankedMatches` array, but `highlightedSearchable` was typed as `T` and the Enter handlers passed its undefined value to `selectLog` or `selectEmoji`. This caused a runtime exception when users pressed Enter after a query with no matches.

Expose the computed result as `T | undefined` and guard both handlers before selecting. This preserves keyboard selection for valid matches while making no-match searches harmless.

codex resume 01a02298-0ad6-74e2-8df8-2d570b3e12ab