### PR TITLE
[question-uploads] Remove stale Turbo comment

### DIFF
--- a/app/views/question_uploads/new.html.haml
+++ b/app/views/question_uploads/new.html.haml
@@ -4,8 +4,6 @@
 %h1 Upload questions for #{@quiz.name}
 
 %section
-  -# `turbo: false` here because otherwise we don't get the necessary bootstrap data
-  -# in the quiz show view after submitting this form (Turbo bug?)
   = form_with(url: quiz_question_uploads_path) do |form|
     - if @error_message
       .my-8


### PR DESCRIPTION
The question-upload form no longer passes `data: { turbo: false }`, but the adjacent comment still described that old workaround.

Commit f04787820 removed the `data: { turbo: false }` option while adding validation-failure rendering and preserving submitted questions. The comment remained behind and became misleading, so remove it.

codex resume 01a022a6-ab72-7932-a748-84d146cf7c8c