### PR TITLE
[blog specs] Ensure temporary files are cleaned up

### DIFF
--- a/spec/support/blog_spec_helpers.rb
+++ b/spec/support/blog_spec_helpers.rb
@@ -4,8 +4,10 @@ module BlogSpecHelpers
     FileUtils.mkdir_p(file_path.dirname)
     File.write(file_path, content)
 
-    yield
-
-    FileUtils.rm(file_path)
+    begin
+      yield
+    ensure
+      FileUtils.rm_f(file_path)
+    end
   end
 end


### PR DESCRIPTION
Blog specs create files in the ignored `blog/` directory through `BlogSpecHelpers.with_blog_file`. The helper previously removed each file only after the yielded block returned normally, allowing an exception in the scoped wrapper to leave a stale file behind and making cleanup less reliable.

Run cleanup from an `ensure` block and use `FileUtils.rm_f`, so later examples and reruns do not inherit leftover test artifacts.

codex resume 01a022aa-d111-7103-88eb-008fd481e08b