### PR TITLE
[logged-in-header] Respect blog background fallback [DEV-297]

### DIFF
--- a/app/views/layouts/_logged_in_header.html.haml
+++ b/app/views/layouts/_logged_in_header.html.haml
@@ -1,4 +1,5 @@
-%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.shrink-0.px-3.max-w-dvw.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,white) leading-[31px]'}
+-# Blog pages set `--background-color` for the system color scheme, so use it before white to keep this header's `--text-color` legible.
+%header.sticky.top-0.left-0.right-0.flex.justify-between.items-center.shrink-0.px-3.max-w-dvw.z-100.border-b-1.border-neutral-800.text-base{class: 'text-(--main-text-color,var(--text-color)) bg-(--main-bg-color,var(--background-color,white)) leading-[31px]'}
   .flex-1.truncate{title: current_user.email}= current_user.email
   %div.flex.gap-4
     %div= link_to('My account', my_account_path, class: 'text-inherit!')

--- a/spec/controllers/blog_controller_spec.rb
+++ b/spec/controllers/blog_controller_spec.rb
@@ -56,6 +56,19 @@ RSpec.describe(BlogController) do
             expect(response.body).to match(/\bstyles\b/)
             expect(response.body).to end_with(show_content)
           end
+
+          context 'when the user is signed in' do
+            before { sign_in(users(:user)) }
+
+            let(:show_content) { '<html><head></head><body></body></html>' }
+
+            it 'uses the page background color before white as the logged-in header background fallback' do
+              get_show
+
+              expect(response.body).
+                to include('bg-(--main-bg-color,var(--background-color,white))')
+            end
+          end
         end
 
         context 'when the requested file does not exist in the blog/ directory' do


### PR DESCRIPTION
The blog stylesheet defines a dark `--background-color` and a light `--text-color` when the system color scheme is dark. ac2f6af1ae9aa2e4a72db96c0431db14fcadbce1 changed the shared header to fall back directly to `white`, which made the signed-in blog header unreadable.

Use the blog-aware background variable before the final `white` fallback, retaining the fix for pages that define neither background variable. Document this intentionally non-obvious ordering beside the header and cover the injected signed-in blog header response.

codex resume 01a0281e-f343-71a1-94b4-9dadccc3afcc