### PR TITLE
[groceries] Allow adding items to spouse stores [GROC-47]

### DIFF
--- a/app/controllers/api/items_controller.rb
+++ b/app/controllers/api/items_controller.rb
@@ -3,12 +3,17 @@ class Api::ItemsController < Api::BaseController
 
   def create
     authorize(Item)
-    store = current_user.stores.find(params.expect(:store_id))
-    @item = store.items.build(item_params)
-    if @item.save
-      render_schema_json(@item, status: :created)
+    store = policy_scope(Store).find_by(id: params.expect(:store_id))
+
+    if store.nil?
+      head(:not_found)
     else
-      render json: { errors: @item.errors.full_messages }, status: :unprocessable_content
+      @item = store.items.build(item_params)
+      if @item.save
+        render_schema_json(@item, status: :created)
+      else
+        render json: { errors: @item.errors.full_messages }, status: :unprocessable_content
+      end
     end
   end
 

--- a/app/javascript/groceries/components/ItemForm.vue
+++ b/app/javascript/groceries/components/ItemForm.vue
@@ -1,8 +1,5 @@
 <template lang="pug">
-form.flex(
-  v-if="store.own_store"
-  @submit.prevent
-)
+form.flex(@submit.prevent)
   ElAutocomplete.item-name-input.max-w-60(
     ref="autocompleteRef"
     v-model="formData.itemName"

--- a/app/policies/store_policy.rb
+++ b/app/policies/store_policy.rb
@@ -1,2 +1,9 @@
 class StorePolicy < ApplicationPolicy
+  class Scope < ::ApplicationPolicy::Scope
+    def resolve
+      @scope.
+        where(user: @user).
+        or(@scope.where(user: @user.spouse, private: false))
+    end
+  end
 end

--- a/spec/controllers/api/items_controller_spec.rb
+++ b/spec/controllers/api/items_controller_spec.rb
@@ -30,6 +30,40 @@ RSpec.describe Api::ItemsController do
             to('cheese puffs')
         end
       end
+
+      context "when creating an item in a spouse's store" do
+        let(:user) { users(:user) }
+
+        context 'when the store is public' do
+          let(:store) do
+            user.spouse.presence!.stores.find_by!(private: false)
+          end
+
+          it 'creates that item for the store' do
+            expect { post_create }.to change { store.reload.items.size }.by(1)
+          end
+
+          it 'returns a 201 status code' do
+            post_create
+            expect(response).to have_http_status(201)
+          end
+        end
+
+        context 'when the store is private' do
+          let(:store) do
+            user.spouse.presence!.stores.find_by!(private: true)
+          end
+
+          it 'does not create an item' do
+            expect { post_create }.not_to change { Item.count }
+          end
+
+          it 'returns a 404 status code' do
+            post_create
+            expect(response).to have_http_status(404)
+          end
+        end
+      end
     end
 
     context 'when the item params are not valid' do

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -107,6 +107,47 @@ RSpec.describe 'Groceries app' do
         # Check that the needed count for the skipped item is still positive.
         expect(needed_item.needed).to be > 0
       end
+
+      context "when viewing the spouse's store" do
+        let(:spouse_store) do
+          user.spouse.presence!.stores.find_by!(private: false)
+        end
+        let(:spouse_item) { spouse_store.items.first! }
+        let(:spouse_new_item_name) { 'Spouse blueberries' }
+
+        it 'searches and adds items' do
+          visit groceries_path
+
+          within('aside') do
+            click_on(spouse_store.name)
+          end
+
+          expect(page).to have_css('h1', text: spouse_store.name)
+
+          item_input = find(:fillable_field, 'Add or search items')
+          item_input.send_keys('banana')
+
+          expect(page).to have_css(
+            '[role="option"]',
+            text: "#{spouse_item.name} (#{spouse_item.needed})",
+            exact_text: true,
+          )
+          item_input.send_keys([:control, 'a'], spouse_new_item_name)
+          expect(page).to have_css(
+            '[role="option"]',
+            text: "Add '#{spouse_new_item_name}'",
+            exact_text: true,
+          )
+
+          find(
+            '[role="option"]',
+            text: "Add '#{spouse_new_item_name}'",
+            exact_text: true,
+          ).click
+
+          expect(page).to have_css('.grocery-item', text: spouse_new_item_name)
+        end
+      end
     end
 
     context 'when the user does not have a spouse' do

--- a/spec/policies/store_policy_spec.rb
+++ b/spec/policies/store_policy_spec.rb
@@ -1,0 +1,32 @@
+RSpec.describe StorePolicy do
+  subject(:policy) { described_class.new(user, store) }
+
+  let(:store) { user.stores.first! }
+
+  describe '#scope' do
+    subject(:scope) { policy.scope }
+
+    context 'when the user has a spouse' do
+      let(:user) { users(:user) }
+      let(:public_spouse_store) do
+        user.spouse.presence!.stores.find_by!(private: false)
+      end
+      let(:private_spouse_store) do
+        user.spouse.presence!.stores.find_by!(private: true)
+      end
+
+      it 'returns the own stores and public spouse stores' do
+        expect(scope).to match_array(user.stores + [public_spouse_store])
+        expect(scope).not_to include(private_spouse_store)
+      end
+    end
+
+    context 'when the user does not have a spouse' do
+      let(:user) { users(:single_user) }
+
+      it 'returns the own stores' do
+        expect(scope).to match_array(user.stores)
+      end
+    end
+  end
+end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -40,6 +40,9 @@ FixtureBuilder.configure do |fbuilder|
     ).first
     name(:item, create(:item, :needed, store:, name: 'olive oil', needed: 2))
     create(:item, :unneeded, store:, name: 'apples')
+    spouse_store = create(:store, user: married_user, name: 'Spouse Store')
+    create(:item, :needed, store: spouse_store, name: 'Spouse bananas')
+    create(:store, user: married_user, name: 'Private Spouse Store', private: true)
 
     # number logs
     number_log = name(:number_log, create(:log, user:, data_type: 'number')).first


### PR DESCRIPTION
The `ItemForm` typeahead is useful for searching a spouse store, but its own-store condition hid the control and left the sticky form container empty.

Render the form for every visible store and allow `Api::ItemsController` to create items in a spouse's public stores. Move the own-store and public-spouse-store access rule into `StorePolicy::Scope`, which the item controller uses when resolving its parent store. Private spouse stores remain unavailable, matching the grocery-store visibility rule.

Cover the store-policy scope, public and private API behavior, and a browser flow that searches a spouse store and adds an item through the typeahead.

Use public and private spouse-store baseline fixtures so specs express their visibility cases without creating or mutating spouse stores locally.

codex resume 01a02d56-3561-7632-9de2-fd2fe35cdb1c