### PR TITLE
[groceries] Use marriage status for invite prompt [GROC-48]

### DIFF
--- a/app/javascript/groceries/components/Sidebar.vue
+++ b/app/javascript/groceries/components/Sidebar.vue
@@ -37,9 +37,7 @@ aside.border-r.border-neutral-400.max-h-full.overflow-auto.hidden-scrollbars(
               :key="store.id"
               :store="store"
             )
-    .mt-auto.text-center.p-3(
-      v-if="!groceriesStore.sortedSpouseStores.length && !collapsed"
-    ) Tip: You and your partner can automatically view each other's lists. #[a(:href="invitePartnerHref") Invite them to join.]
+    .mt-auto.text-center.p-3(v-if="!bootstrap.spouse && !collapsed") Tip: You and your partner can automatically view each other's lists. #[a(:href="invitePartnerHref") Invite them to join.]
 </template>
 
 <script setup lang="ts">
@@ -51,6 +49,8 @@ import { computed, reactive, ref } from 'vue';
 import { ArrowBarRightIcon } from 'vue-tabler-icons';
 
 import { useGroceriesStore } from '@/groceries/store';
+import type { Bootstrap } from '@/groceries/types';
+import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { useSubscription } from '@/lib/composables/useSubscription';
 import { isMobileDevice } from '@/lib/is_mobile_device';
 import { new_marriage_path } from '@/rails_assets/routes';
@@ -60,6 +60,7 @@ import StoreListEntry from './StoreListEntry.vue';
 const formData = reactive({
   newStoreName: '',
 });
+const bootstrap = untypedBootstrap as Bootstrap;
 const collapsed = ref(isMobileDevice());
 const groceriesStore = useGroceriesStore();
 const vuelidateRules = {

--- a/spec/features/groceries_spec.rb
+++ b/spec/features/groceries_spec.rb
@@ -5,6 +5,10 @@ RSpec.describe 'Groceries app' do
   context 'when a user is signed in' do
     before { sign_in(user) }
 
+    let(:invite_prompt) do
+      "Tip: You and your partner can automatically view each other's lists."
+    end
+
     context 'when the user has a spouse' do
       before { expect(user.spouse).to be_present }
 
@@ -148,6 +152,19 @@ RSpec.describe 'Groceries app' do
           expect(page).to have_css('.grocery-item', text: spouse_new_item_name)
         end
       end
+
+      context 'when the spouse has no stores' do
+        before do
+          user.spouse.presence!.stores.includes(:items).find_each(&:destroy!)
+        end
+
+        it 'does not show a prompt to invite the spouse' do
+          visit groceries_path
+
+          expect(page).to have_css('aside')
+          expect(page).not_to have_text(invite_prompt)
+        end
+      end
     end
 
     context 'when the user does not have a spouse' do
@@ -158,9 +175,7 @@ RSpec.describe 'Groceries app' do
       it 'has a link to invite a partner' do
         visit groceries_path
 
-        expect(page).to have_text(
-          "Tip: You and your partner can automatically view each other's lists.",
-        )
+        expect(page).to have_text(invite_prompt)
 
         click_on('Invite them to join.')
 


### PR DESCRIPTION
The invite tip was previously keyed off `sortedSpouseStores`, which is empty when a joined spouse has not created a store. Use bootstrapped `spouse` presence so the tip is shown only to users who have no spouse.

Add a groceries feature regression covering a married user whose spouse has no stores.

codex resume 01a02d90-212a-7c01-a092-c9461d181965