### PR TITLE
[bootstrap] Centralize typed feature bootstrap imports

### DIFF
--- a/app/javascript/check_ins/App.vue
+++ b/app/javascript/check_ins/App.vue
@@ -20,9 +20,9 @@ div(v-else) {{ checkInsStore.partner_ratings_hidden_reason }}
 
 <script setup lang="ts">
 import actionCableConsumer from '@/channels/consumer';
+import { bootstrap } from '@/check_ins/bootstrap';
 import { useCheckInsStore } from '@/check_ins/store';
-import type { Bootstrap, NeedSatisfactionRating } from '@/check_ins/types';
-import { bootstrap } from '@/lib/bootstrap';
+import type { NeedSatisfactionRating } from '@/check_ins/types';
 
 import Ratings from './components/Ratings.vue';
 
@@ -41,8 +41,7 @@ actionCableConsumer.subscriptions.create(
   },
   {
     received: (data: CheckInsCableData) => {
-      if (data.originating_user_id === (bootstrap as Bootstrap).current_user.id)
-        return;
+      if (data.originating_user_id === bootstrap.current_user.id) return;
 
       if (data.event === 'check-in-submitted' && data.ratings) {
         checkInsStore.setPartnerRatingsOfUser({

--- a/app/javascript/check_ins/bootstrap.ts
+++ b/app/javascript/check_ins/bootstrap.ts
@@ -1,0 +1,4 @@
+import type { Bootstrap } from '@/check_ins/types';
+import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
+
+export const bootstrap = untypedBootstrap as Bootstrap;

--- a/app/javascript/check_ins/store.ts
+++ b/app/javascript/check_ins/store.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia';
 
-import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
+import { bootstrap } from '@/check_ins/bootstrap';
 import { assert } from '@/lib/helpers';
 import { http } from '@/lib/http';
 import { getById } from '@/lib/store_helpers';
@@ -9,9 +9,7 @@ import {
   api_need_satisfaction_rating_path,
 } from '@/rails_assets/routes';
 
-import { Bootstrap, NeedSatisfactionRating } from './types';
-
-const bootstrap = untypedBootstrap as Bootstrap;
+import { NeedSatisfactionRating } from './types';
 
 export const useCheckInsStore = defineStore('check-ins', {
   state: () => ({

--- a/app/javascript/emoji_picker/EmojiPicker.vue
+++ b/app/javascript/emoji_picker/EmojiPicker.vue
@@ -32,16 +32,13 @@ import { onBeforeUnmount, onMounted, ref } from 'vue';
 import { POSITION } from 'vue-toastification';
 
 import GoogleLoginButton from '@/components/GoogleLoginButton.vue';
+import { bootstrap } from '@/emoji_picker/bootstrap';
 import BoostsForm from '@/emoji_picker/components/BoostsForm.vue';
 import CopiedEmojiToast from '@/emoji_picker/components/CopiedEmojiToast.vue';
 import { emojiData } from '@/emoji_picker/emoji_data';
-import { type Bootstrap } from '@/emoji_picker/types';
-import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { useFuzzyTypeahead } from '@/lib/composables/useFuzzyTypeahead';
 import { vueToast } from '@/lib/vue_toasts';
 import type { EmojiData } from '@/types';
-
-const bootstrap = untypedBootstrap as Bootstrap;
 
 const query = ref('');
 const queryDebounced = refDebounced(query, 60, { maxWait: 180 });

--- a/app/javascript/emoji_picker/bootstrap.ts
+++ b/app/javascript/emoji_picker/bootstrap.ts
@@ -1,0 +1,4 @@
+import type { Bootstrap } from '@/emoji_picker/types';
+import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
+
+export const bootstrap = untypedBootstrap as Bootstrap;

--- a/app/javascript/emoji_picker/emoji_data.ts
+++ b/app/javascript/emoji_picker/emoji_data.ts
@@ -3,8 +3,7 @@ import EmojiLibData from 'emojilib';
 import { flatMap, isEqual } from 'es-toolkit/compat';
 import { computed, ref } from 'vue';
 
-import { type Bootstrap } from '@/emoji_picker/types';
-import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
+import { bootstrap } from '@/emoji_picker/bootstrap';
 import type { EmojiData, EmojiDataWithBoostedName } from '@/types';
 
 const originalEmojilibData = flatMap(EmojiLibData, (names, symbol) => {
@@ -17,8 +16,6 @@ const originalEmojilibData = flatMap(EmojiLibData, (names, symbol) => {
 });
 
 const emojilibData = ref(originalEmojilibData);
-
-const bootstrap = untypedBootstrap as Bootstrap;
 
 export const boosts = ref<Array<EmojiDataWithBoostedName>>(
   bootstrap.current_user?.emoji_boosts || [],

--- a/app/javascript/groceries/Groceries.vue
+++ b/app/javascript/groceries/Groceries.vue
@@ -14,9 +14,9 @@ import { storeToRefs } from 'pinia';
 import { onBeforeMount } from 'vue';
 
 import actionCableConsumer from '@/channels/consumer';
+import { bootstrap } from '@/groceries/bootstrap';
 import { useGroceriesStore } from '@/groceries/store';
-import type { Bootstrap, ItemBroadcast } from '@/groceries/types';
-import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
+import type { ItemBroadcast } from '@/groceries/types';
 import type { IphoneTouchEvent } from '@/lib/types';
 import { renderBootstrappedToasts } from '@/lib/vue_toasts';
 
@@ -29,8 +29,6 @@ const groceriesStore = useGroceriesStore();
 
 const { currentStore, debouncingOrWaitingOnNetwork } =
   storeToRefs(groceriesStore);
-
-const bootstrap = untypedBootstrap as Bootstrap;
 
 onBeforeMount(() => {
   window.addEventListener('beforeunload', warnIfRequestPending);

--- a/app/javascript/groceries/bootstrap.ts
+++ b/app/javascript/groceries/bootstrap.ts
@@ -1,0 +1,4 @@
+import type { Bootstrap } from '@/groceries/types';
+import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
+
+export const bootstrap = untypedBootstrap as Bootstrap;

--- a/app/javascript/groceries/components/Sidebar.vue
+++ b/app/javascript/groceries/components/Sidebar.vue
@@ -48,9 +48,8 @@ import { storeToRefs } from 'pinia';
 import { computed, reactive, ref } from 'vue';
 import { ArrowBarRightIcon } from 'vue-tabler-icons';
 
+import { bootstrap } from '@/groceries/bootstrap';
 import { useGroceriesStore } from '@/groceries/store';
-import type { Bootstrap } from '@/groceries/types';
-import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { useSubscription } from '@/lib/composables/useSubscription';
 import { isMobileDevice } from '@/lib/is_mobile_device';
 import { new_marriage_path } from '@/rails_assets/routes';
@@ -60,7 +59,6 @@ import StoreListEntry from './StoreListEntry.vue';
 const formData = reactive({
   newStoreName: '',
 });
-const bootstrap = untypedBootstrap as Bootstrap;
 const collapsed = ref(isMobileDevice());
 const groceriesStore = useGroceriesStore();
 const vuelidateRules = {

--- a/app/javascript/groceries/store.ts
+++ b/app/javascript/groceries/store.ts
@@ -2,9 +2,9 @@ import { filter, get, last, pick, sortBy } from 'es-toolkit/compat';
 import { defineStore } from 'pinia';
 import { POSITION } from 'vue-toastification';
 
+import { bootstrap } from '@/groceries/bootstrap';
 import DeletedItemToast from '@/groceries/components/DeletedItemToast.vue';
-import { Bootstrap, CheckInStatus, Item } from '@/groceries/types';
-import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
+import { CheckInStatus, Item } from '@/groceries/types';
 import { emit } from '@/lib/event_bus';
 import { typesafeAssign } from '@/lib/helpers';
 import { http } from '@/lib/http';
@@ -45,8 +45,6 @@ export const helpers = {
     return sortBy(objects, (object) => object.name.toLowerCase());
   },
 };
-
-const bootstrap = untypedBootstrap as Bootstrap;
 
 export const useGroceriesStore = defineStore('groceries', {
   state: (): State => ({

--- a/app/javascript/logs/Logs.vue
+++ b/app/javascript/logs/Logs.vue
@@ -13,18 +13,16 @@
 import { storeToRefs } from 'pinia';
 import { onMounted } from 'vue';
 
-import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { useModalStore } from '@/lib/modal/store';
 import { removeQueryParams } from '@/lib/remove_query_params';
 import { renderBootstrappedToasts } from '@/lib/vue_toasts';
+import { bootstrap } from '@/logs/bootstrap';
 import { useLogsStore } from '@/logs/store';
 
 import LogSelectorModal from './components/LogSelectorModal.vue';
-import type { Bootstrap } from './types';
 
 import 'element-plus/theme-chalk/dark/css-vars.css';
 
-const bootstrap = untypedBootstrap as Bootstrap;
 const logsStore = useLogsStore();
 const modalStore = useModalStore();
 

--- a/app/javascript/logs/bootstrap.ts
+++ b/app/javascript/logs/bootstrap.ts
@@ -1,0 +1,4 @@
+import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
+import type { Bootstrap } from '@/logs/types';
+
+export const bootstrap = untypedBootstrap as Bootstrap;

--- a/app/javascript/logs/components/EditLogSharingSettingsModal.vue
+++ b/app/javascript/logs/components/EditLogSharingSettingsModal.vue
@@ -57,11 +57,10 @@ import {
 import { computed, nextTick, ref } from 'vue';
 
 import Modal from '@/components/Modal.vue';
-import { bootstrap } from '@/lib/bootstrap';
 import { assert } from '@/lib/helpers';
 import { useModalStore } from '@/lib/modal/store';
+import { bootstrap } from '@/logs/bootstrap';
 import { useLogsStore } from '@/logs/store';
-import type { Bootstrap } from '@/logs/types';
 import { user_shared_log_path } from '@/rails_assets/routes';
 import type { LogShare } from '@/types';
 
@@ -83,7 +82,7 @@ const logSharesSortedByLowercasedEmail = computed((): Array<LogShare> => {
 });
 
 const shareableUrl = computed((): string | null => {
-  const currentUser = (bootstrap as Bootstrap).current_user;
+  const currentUser = bootstrap.current_user;
 
   if (currentUser) {
     return (

--- a/app/javascript/logs/components/NewLogForm.vue
+++ b/app/javascript/logs/components/NewLogForm.vue
@@ -46,9 +46,9 @@ import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import { useRouter } from 'vue-router';
 
-import { bootstrap } from '@/lib/bootstrap';
+import { bootstrap } from '@/logs/bootstrap';
 import { useLogsStore } from '@/logs/store';
-import type { Bootstrap, LogInput } from '@/logs/types';
+import type { LogInput } from '@/logs/types';
 
 const router = useRouter();
 const logsStore = useLogsStore();
@@ -57,7 +57,7 @@ const newLog = ref(newLogGenerator());
 const { postingLog } = storeToRefs(logsStore);
 
 const logInputTypes = computed((): Array<LogInput> => {
-  return (bootstrap as Bootstrap).log_input_types;
+  return bootstrap.log_input_types;
 });
 
 async function createLog() {

--- a/app/javascript/logs/store.ts
+++ b/app/javascript/logs/store.ts
@@ -2,11 +2,11 @@ import { last, sortBy } from 'es-toolkit/compat';
 import { defineStore } from 'pinia';
 import { nextTick } from 'vue';
 
-import { bootstrap as untypedBootstrap } from '@/lib/bootstrap';
 import { assert, typesafeAssign } from '@/lib/helpers';
 import { http } from '@/lib/http';
 import { getById } from '@/lib/store_helpers';
 import { toast } from '@/lib/toasts';
+import { bootstrap } from '@/logs/bootstrap';
 import {
   api_log_entries_path,
   api_log_entry_path,
@@ -30,9 +30,7 @@ import { LogRotateEmailSubmissionTokenResponse } from '@/types/responses/LogRota
 import { LogShareCreateResponse } from '@/types/responses/LogShareCreateResponse';
 import { LogUpdateResponse } from '@/types/responses/LogUpdateResponse';
 
-import { Bootstrap, Log } from './types';
-
-const bootstrap = untypedBootstrap as Bootstrap;
+import { Log } from './types';
 
 export const useLogsStore = defineStore('logs', {
   state: () => ({


### PR DESCRIPTION
Each qualifying feature had multiple consumers independently asserting the universal `bootstrap` value as its app-specific `Bootstrap` type. That duplicated typing setup and let the generic module leak into feature consumers.

Add one `bootstrap.ts` module to each multi-consumer area: `check_ins`, `emoji_picker`, `groceries`, and `logs`. Each module performs the existing assertion once and exports the typed `bootstrap`; consumers now import that value and no longer carry redundant aliases, local assertions, or inline assertions. Areas with a single bootstrap consumer remain unchanged.

codex resume 01a02da8-373d-7ac0-91f6-9c19bd3aa9af
codex resume 01a02db0-6466-7b73-ae0b-828b5f404507