### PR TITLE
[.rubocop.yml] Exclude old datamigrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ AllCops:
   CacheRootDirectory: tmp
   Exclude:
     - !ruby/regexp /db\/migrate\/(201|202[0-4])/
+    - !ruby/regexp /db\/datamigrate\/(?!(?:202[6-9]|20[3-9]\d|2[1-9]\d{2}|[3-9]\d{3})\d{10}_)/
   StringLiteralsFrozenByDefault: true
 
 CustomCops/DontRollBackDatamigration:


### PR DESCRIPTION
RuboCop currently excludes older files under `db/migrate/`, but that rule does not apply to `db/datamigrate/`.

Datamigrations are historical records of the code as it was written when each migration ran. Excluding historical datamigrations from current RuboCop linting preserves that record by avoiding autocorrections and the need to suppress violations in old files. Newly added datamigrations remain subject to current RuboCop rules because only files with 2026 or later timestamps are linted.

codex resume 01a030cc-3155-7b43-96de-ca59de3442b5