### PR TITLE
[runger_style] Update runger_style from 5.18.0 to 5.19.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -676,7 +676,7 @@ GEM
     runger_email_reply_trimmer (0.3.0)
     runger_rails_model_explorer (0.2.2)
       activerecord (>= 8.0.2)
-    runger_style (5.18.0)
+    runger_style (5.19.0)
       prism (>= 0.24.0)
       rubocop (>= 1.72.0)
     safely_block (1.0.0)
@@ -1119,7 +1119,7 @@ CHECKSUMS
   runger_config (5.2.0) sha256=9b76d767a2daa63f6f8f2c52a8183f3f09a877cd35bcaee692d25377f4dd4558
   runger_email_reply_trimmer (0.3.0) sha256=068aa90311da474065f604cf29704785bb36d511a5d5e4031fc87fef8bbd9ac7
   runger_rails_model_explorer (0.2.2) sha256=99adf4e287951996d7a2bc308271abe92065836437719eae0a444894c08e683b
-  runger_style (5.18.0) sha256=a499a7cef6f75621fc1bda5bef677810003737a3c043ae17b9f740440f6329e0
+  runger_style (5.19.0) sha256=373071d00b57b38bedadddd7e8ded7f66c87ef7029524c08782f63de1eb8a35f
   safely_block (1.0.0) sha256=bea80e084e620adeada62fd98cf461bbb9888d40dc0f06d337df9d01e1a658e5
   sanitize (7.0.0) sha256=269d1b9d7326e69307723af5643ec032ff86ad616e72a3b36d301ac75a273984
   securerandom (0.4.1) sha256=cc5193d414a4341b6e225f0cb4446aceca8e50d5e1888743fac16987638ea0b1

--- a/bin/bundle
+++ b/bin/bundle
@@ -92,7 +92,7 @@ m =
     def activate_bundler
       gem_error =
         activation_error_handling do
-          gem 'bundler', bundler_requirement
+          gem('bundler', bundler_requirement)
         end
       unless gem_error.nil?
         require_error =

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -127,10 +127,10 @@ Rails.application.configure do
           begin
             name = nil
             until name.present?
-              print 'What is your name (used by PaperTrail to record who changed records)? '
+              print('What is your name (used by PaperTrail to record who changed records)? ')
               name = gets.chomp
             end
-            puts "Thank you, #{name}! Be safe!"
+            puts("Thank you, #{name}! Be safe!")
             name
           end
       end

--- a/lib/tasks/assets.rake
+++ b/lib/tasks/assets.rake
@@ -5,9 +5,9 @@ namespace :assets do
       with ENV vars #{AmazingPrint::Colors.blue(env_vars.to_s)}...
     LOG
     if system(env_vars, command)
-      puts '... success.'
+      puts('... success.')
     else
-      puts '... failed.'
+      puts('... failed.')
     end
   end
 

--- a/lib/test/diff_helpers.rb
+++ b/lib/test/diff_helpers.rb
@@ -15,7 +15,7 @@ module DiffHelpers
     elsif filename_pattern.is_a?(Regexp)
       files_changed.grep(filename_pattern).present?
     else
-      fail "Unknown match pattern of class #{filename.class}."
+      fail("Unknown match pattern of class #{filename.class}.")
     end
   end
 

--- a/spec/features/external_request_blocking_spec.rb
+++ b/spec/features/external_request_blocking_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe 'Blocking requests to external domains' do
   it 'cannot visit davidrunger.com (when that domain is not allowlisted)' do
-    expect { visit 'https://davidrunger.com/' }.
+    expect { visit('https://davidrunger.com/') }.
       to raise_error(
         Ferrum::StatusError,
         'Request to https://davidrunger.com/ failed (net::ERR_BLOCKED_BY_CLIENT)',

--- a/spec/features/home_spec.rb
+++ b/spec/features/home_spec.rb
@@ -127,7 +127,7 @@ RSpec.describe 'Home page', :prerendering_disabled do
             spec_start_time = Time.current
 
             expect {
-              visit root_path
+              visit(root_path)
             }.to change {
               Request.where('requests.requested_at > ?', spec_start_time).map(&:attributes)
             }.from([]).to([


### PR DESCRIPTION
Update `Gemfile.lock` to `runger_style` 5.19.0 after running `bundle update runger_style --cooldown=0`.

The release enables `Style/MethodCallWithArgsParentheses` for more methods, so apply the autocorrections from `run-rubocop -A` to the eight reported call sites.

codex resume 01a030da-09ec-7e82-8fcf-d772a8574479