### PR TITLE
[home] Retry navbar anchor scrolling [HOME-24]

### DIFF
--- a/app/javascript/home/Home.vue
+++ b/app/javascript/home/Home.vue
@@ -46,34 +46,17 @@ import ParallaxImage from './components/ParallaxImage.vue';
 import Projects from './components/Projects.vue';
 import Resume from './components/Resume.vue';
 import Skills from './components/Skills.vue';
+import { setScrollToFragmentTimeouts } from './scroll_to_fragment';
+import { useManualScrollTracking } from './useManualScrollTracking';
 
 renderBootstrappedToasts();
 useExternalLinkTracking();
 useScrollTracking();
+useManualScrollTracking();
 
 onMounted(() => {
   setScrollToFragmentTimeouts();
 });
-
-function setScrollToFragmentTimeouts() {
-  if (window.location.hash) {
-    const fragmentTarget = document.getElementById(
-      window.location.hash.slice(1),
-    );
-    if (fragmentTarget) {
-      // retarget scrolling to the element several times. earlier timeouts are so that we
-      // scroll there as quickly as possible. later timeouts are because adjustments to the DOM
-      // might be changing the scroll position of the target element as the page renders. stop
-      // after 850 ms because at that point the user has a reasonable expectation to have full
-      // control over their scroll position.
-      for (const timeoutMilliseconds of [0, 150, 320, 500, 850]) {
-        setTimeout(() => {
-          fragmentTarget.scrollIntoView();
-        }, timeoutMilliseconds);
-      }
-    }
-  }
-}
 </script>
 
 <style lang="scss">

--- a/app/javascript/home/components/NavLink.vue
+++ b/app/javascript/home/components/NavLink.vue
@@ -2,7 +2,7 @@
 a.nav-link(
   :href="`#${section}`"
   :class="{ active }"
-  @click="homeStore.registerClickedSection(section)"
+  @click="scrollToSection"
 )
   span {{ linkText || prettyName }}
 </template>
@@ -13,6 +13,8 @@ import { computed } from 'vue';
 import { string } from 'vue-types';
 
 import { useHomeStore } from '@/home/store';
+
+import { setScrollToFragmentTimeouts } from '../scroll_to_fragment';
 
 const props = defineProps({
   linkText: string().def(''),
@@ -28,6 +30,11 @@ const active = computed((): boolean => {
 const prettyName = computed((): string => {
   return capitalize(props.section);
 });
+
+function scrollToSection() {
+  homeStore.registerClickedSection(props.section);
+  setScrollToFragmentTimeouts(props.section);
+}
 </script>
 
 <style lang="scss" scoped>

--- a/app/javascript/home/scroll_to_fragment.test.ts
+++ b/app/javascript/home/scroll_to_fragment.test.ts
@@ -1,0 +1,45 @@
+import { setScrollToFragmentTimeouts } from './scroll_to_fragment';
+
+describe('setScrollToFragmentTimeouts', () => {
+  let fragmentTarget: HTMLElement;
+  let scrollIntoView: ReturnType<
+    typeof vi.fn<(arg?: boolean | ScrollIntoViewOptions) => void>
+  >;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+
+    fragmentTarget = document.createElement('div');
+    fragmentTarget.id = 'links';
+    scrollIntoView = vi.fn<(arg?: boolean | ScrollIntoViewOptions) => void>();
+    fragmentTarget.scrollIntoView = scrollIntoView;
+    document.body.append(fragmentTarget);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.replaceChildren();
+    window.history.replaceState({}, '', '/');
+  });
+
+  it('repeatedly scrolls to the fragment from the URL', () => {
+    window.history.replaceState({}, '', '/#links');
+
+    setScrollToFragmentTimeouts();
+
+    expect(scrollIntoView).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(850);
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(5);
+  });
+
+  it('uses the provided fragment rather than the URL fragment', () => {
+    window.history.replaceState({}, '', '/#not-in-the-dom');
+
+    setScrollToFragmentTimeouts('links');
+    vi.runAllTimers();
+
+    expect(scrollIntoView).toHaveBeenCalledTimes(5);
+  });
+});

--- a/app/javascript/home/scroll_to_fragment.ts
+++ b/app/javascript/home/scroll_to_fragment.ts
@@ -1,0 +1,21 @@
+const FRAGMENT_SCROLL_TIMEOUTS = [0, 150, 320, 500, 850];
+
+export function setScrollToFragmentTimeouts(
+  fragment = window.location.hash.slice(1),
+) {
+  if (!fragment) return;
+
+  const fragmentTarget = document.getElementById(fragment);
+  if (!fragmentTarget) return;
+
+  // retarget scrolling to the element several times. earlier timeouts are so that we
+  // scroll there as quickly as possible. later timeouts are because adjustments to the DOM
+  // might be changing the scroll position of the target element as the page renders. stop
+  // after 850 ms because at that point the user has a reasonable expectation to have full
+  // control over their scroll position.
+  for (const timeoutMilliseconds of FRAGMENT_SCROLL_TIMEOUTS) {
+    setTimeout(() => {
+      fragmentTarget.scrollIntoView();
+    }, timeoutMilliseconds);
+  }
+}

--- a/app/javascript/home/store.test.ts
+++ b/app/javascript/home/store.test.ts
@@ -1,0 +1,37 @@
+import { createPinia, setActivePinia } from 'pinia';
+
+import { useHomeStore } from './store';
+
+describe('useHomeStore', () => {
+  let homeStore: ReturnType<typeof useHomeStore>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    homeStore = useHomeStore();
+  });
+
+  it('orders the links section after the resume section', () => {
+    homeStore.addSectionShowing('resume');
+    homeStore.addSectionShowing('links');
+
+    expect(homeStore.activeSection).toBe('links');
+  });
+
+  it('keeps a clicked section active through automated observer changes', () => {
+    homeStore.registerClickedSection('links');
+    homeStore.removeSectionShowing('links');
+    homeStore.addSectionShowing('resume');
+
+    expect(homeStore.activeSection).toBe('links');
+  });
+
+  it('releases a clicked section after the user scrolls it out of view', () => {
+    homeStore.addSectionShowing('links');
+    homeStore.registerClickedSection('links');
+    homeStore.registerUserScroll();
+    homeStore.removeSectionShowing('links');
+    homeStore.addSectionShowing('resume');
+
+    expect(homeStore.activeSection).toBe('resume');
+  });
+});

--- a/app/javascript/home/store.ts
+++ b/app/javascript/home/store.ts
@@ -3,13 +3,14 @@ import { defineStore } from 'pinia';
 
 import { assert } from '@/lib/helpers';
 
-const SECTION_ORDER = ['about', 'skills', 'projects', 'resume', 'contact'];
+const SECTION_ORDER = ['about', 'skills', 'projects', 'resume', 'links'];
 
 export const useHomeStore = defineStore('home', {
   state: () => ({
     clickedSection: null as null | string,
     homeIsVisible: true,
     menuOpen: false,
+    userHasScrolled: false,
     visibleSections: [] as Array<string>,
   }),
 
@@ -25,10 +26,24 @@ export const useHomeStore = defineStore('home', {
 
     registerClickedSection(section: string) {
       this.clickedSection = section;
+      this.userHasScrolled = false;
+    },
+
+    registerUserScroll() {
+      this.userHasScrolled = true;
+
+      if (
+        this.clickedSection &&
+        !this.visibleSections.includes(this.clickedSection)
+      ) {
+        this.clickedSection = null;
+      }
     },
 
     removeSectionShowing(section: string) {
-      if (this.clickedSection === section) this.clickedSection = null;
+      if (this.clickedSection === section && this.userHasScrolled) {
+        this.clickedSection = null;
+      }
       pull(this.visibleSections, [section]);
     },
   },

--- a/app/javascript/home/useManualScrollTracking.ts
+++ b/app/javascript/home/useManualScrollTracking.ts
@@ -1,0 +1,42 @@
+import { onMounted, onUnmounted } from 'vue';
+
+import { useHomeStore } from './store';
+
+const MANUAL_SCROLL_KEYS = new Set([
+  ' ',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+  'ArrowUp',
+  'End',
+  'Home',
+  'PageDown',
+  'PageUp',
+]);
+
+export function useManualScrollTracking() {
+  const homeStore = useHomeStore();
+
+  const registerUserScroll = () => homeStore.registerUserScroll();
+  const registerKeyboardScroll = (event: KeyboardEvent) => {
+    if (MANUAL_SCROLL_KEYS.has(event.key)) registerUserScroll();
+  };
+
+  onMounted(() => {
+    window.addEventListener('pointerdown', registerUserScroll, {
+      passive: true,
+    });
+    window.addEventListener('touchmove', registerUserScroll, {
+      passive: true,
+    });
+    window.addEventListener('wheel', registerUserScroll, { passive: true });
+    window.addEventListener('keydown', registerKeyboardScroll);
+  });
+
+  onUnmounted(() => {
+    window.removeEventListener('pointerdown', registerUserScroll);
+    window.removeEventListener('touchmove', registerUserScroll);
+    window.removeEventListener('wheel', registerUserScroll);
+    window.removeEventListener('keydown', registerKeyboardScroll);
+  });
+}


### PR DESCRIPTION
Native anchor navigation can become stale when lazy-loaded project images add height above the target section. The home page already retries URL-fragment scrolling during initial rendering, but navbar clicks previously relied on the browser one-time anchor jump.

Extract the retry schedule into `setScrollToFragmentTimeouts` and reuse it from `NavLink`. Pass the clicked section explicitly because the click handler runs before the browser updates `window.location.hash`, while retaining the existing URL-based behavior for initial page loads.

Keep the clicked section authoritative while automated scroll and layout changes temporarily alter intersection-observer results. Release that override only after user scroll input moves the section out of view, and keep `links` last in `SECTION_ORDER` so normal visibility tracking also chooses Contact/Links when lower sections overlap.

codex resume 01a0326d-2e13-7fc3-bf13-b8e6744bf565