### PR TITLE
[vite] Suppress deprecated HMR warning [DEV-300]

### DIFF
--- a/app/javascript/vite_config.test.ts
+++ b/app/javascript/vite_config.test.ts
@@ -1,0 +1,11 @@
+import { resolveConfig } from 'vite';
+
+describe('vite.config.mjs', () => {
+  it('sets the WebSocket client port when the Vite CLI supplies server config', async () => {
+    const config = await resolveConfig({ server: {} }, 'serve');
+
+    expect(config.server.ws).toEqual(
+      expect.objectContaining({ clientPort: 3036 }),
+    );
+  });
+});

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -8,6 +8,41 @@ import { defineConfig } from 'vite';
 import FullReload from 'vite-plugin-full-reload';
 import RubyPlugin from 'vite-plugin-ruby';
 
+// Translate the legacy option until vite-plugin-ruby returns `server.ws`.
+function RubyPluginWithWebSocketConfig() {
+  return RubyPlugin().map((plugin) => {
+    if (
+      plugin.name !== 'vite-plugin-ruby' ||
+      typeof plugin.config !== 'function'
+    )
+      return plugin;
+
+    return {
+      ...plugin,
+      config(...args) {
+        const config = plugin.config.apply(this, args);
+        const { hmr, ...server } = config.server;
+        const userWebSocketConfig = args[0]?.server?.ws;
+
+        if (!hmr || server.ws) return config;
+
+        return {
+          ...config,
+          server: {
+            ...server,
+            ws: {
+              ...hmr,
+              ...(userWebSocketConfig &&
+                typeof userWebSocketConfig === 'object' &&
+                userWebSocketConfig),
+            },
+          },
+        };
+      },
+    };
+  });
+}
+
 export default defineConfig(({ mode }) => ({
   // https://github.com/vitejs/vite/issues/ 18164#issuecomment-2365310242
   css: {
@@ -28,7 +63,7 @@ export default defineConfig(({ mode }) => ({
       'app/presenters/**/*',
       'app/views/**/*',
     ]),
-    RubyPlugin(),
+    RubyPluginWithWebSocketConfig(),
     ElementPlus(),
     vue({
       template: {

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -85,6 +85,11 @@ export default defineConfig(({ mode }) => ({
       }),
     },
   },
+  server: {
+    ws: {
+      clientPort: 3036,
+    },
+  },
   test: {
     environment: 'jsdom',
     globals: true,

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -85,11 +85,6 @@ export default defineConfig(({ mode }) => ({
       }),
     },
   },
-  server: {
-    ws: {
-      clientPort: 3036,
-    },
-  },
   test: {
     environment: 'jsdom',
     globals: true,


### PR DESCRIPTION
`vite-plugin-ruby` 5.2.2 still returns `server.hmr.clientPort` from its config hook. Vite 8.2.1 warns when that result is merged, even though this application already configures `server.ws.clientPort`.

Issue here: https://github.com/ElMassimo/vite_ruby/issues/ 614 .

Wrap the plugin config hook so its generated `server.hmr` object is returned as `server.ws`, preserving explicit WebSocket settings from the application. This keeps HMR enabled while avoiding a dependency patch until `vite-plugin-ruby` updates its Vite 8 configuration.

This change addresses the same issue that https://github.com/davidrunger/david_runger/pull/9189 addressed, so, in this change, we now remove what that PR added.

codex resume 01a032a5-742d-7072-8038-778a7b17f4a0