### PR TITLE
[check-links] Manage status exceptions in ActiveAdmin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@
 
 ## Tests and coverage
 
-- When adding a new model class, consider adding realistic baseline records for the primary fixtures to the FixtureBuilder setup when the domain naturally calls for them. This lets specs reuse those records for faster setup and gives feature specs a more representative database state, increasing the chance that relevant data-shape bugs surface.
+- When adding a new model class, add at least one realistic baseline record to the FixtureBuilder setup unless fixtures are unsuitable for that model. Define a factory as needed to create the fixture. This lets specs reuse those records for faster setup and gives feature specs a more representative database state, increasing the chance that relevant data-shape bugs surface.
 - Before running feature specs that exercise changed frontend assets, start the live Vite server with `./node_modules/.bin/vite --force` in a separate terminal and leave it running while iterating. This ensures that each feature-spec run uses the current source without rebuilding assets after every edit. When a task runner starts Vite as a managed background process instead, confirm that the server is ready before running specs and stop it when testing is complete.
 - When investigating a flaky feature spec through repeated runs or otherwise planning to run one or more feature specs multiple times, first determine whether frontend assets will change. If they will not, compile the assets once before the first run and run the repetitions against the compiled output instead of starting the live Vite server. This avoids dev-server startup or optimization traffic interfering with timing-sensitive specs and generally makes repeated runs faster. Rebuild before any subsequent run after changing frontend assets.
 - When running a live Vite server is impractical, run `RAILS_ENV=test bin/vite build` immediately before the relevant feature specs. Repeat the build after every frontend change; otherwise feature specs can silently exercise stale compiled assets.
@@ -61,6 +61,8 @@
   bin/rails generate datamigration NAME
   ```
 
+- Prefer testing one-time datamigrations locally against the development database with `rollback: true` rather than committing specs that will run indefinitely after the migration is complete. Remove `rollback: true` before committing the datamigration. Add lasting specs only when the datamigration contains behavior that warrants ongoing coverage.
+- Run datamigrations through their standard `Datamigration::Runner` when testing them in development. A reasonable, limited number of resulting development `DatamigrationRun` records is acceptable. The runner's `AdminMailer.datamigration_run` notification cannot send external email in development because delivery uses `letter_opener`; it is safe if the resulting Sidekiq job remains queued.
 - Apply branch migrations to both development and test databases with:
 
   ```sh

--- a/app/admin/link_status_expectations.rb
+++ b/app/admin/link_status_expectations.rb
@@ -1,0 +1,27 @@
+ActiveAdmin.register(LinkStatusExpectation) do
+  permit_params :status, :url
+
+  filter :url
+  filter :created_at
+  filter :updated_at
+
+  index do
+    id_column
+    column :url
+    column :status
+    column :created_at
+    column :updated_at
+    actions
+  end
+
+  show do
+    attributes_table do
+      row :url
+      row :status
+      row :created_at
+      row :updated_at
+    end
+
+    active_admin_comments_for(resource)
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -92,6 +92,10 @@ class ApplicationController < ActionController::Base
     Current.browser_uuid = cookies[:browser_uuid]
   end
 
+  def set_admin_user_for_paper_trail
+    PaperTrail.request.whodunnit = current_admin_user&.class_id_string
+  end
+
   def _render_with_renderer_json(resource, options)
     super(resource_for_json_rendering(resource), options)
   end

--- a/app/models/link_status_expectation.rb
+++ b/app/models/link_status_expectation.rb
@@ -1,0 +1,39 @@
+# == Schema Information
+#
+# Table name: link_status_expectations
+#
+#  created_at :datetime         not null
+#  id         :bigint           not null, primary key
+#  status     :integer          not null
+#  updated_at :datetime         not null
+#  url        :text             not null
+#
+# Indexes
+#
+#  index_link_status_expectations_on_url_and_status  (url,status) UNIQUE
+#
+class LinkStatusExpectation < ApplicationRecord
+  HTTP_URL_REGEX = /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/
+
+  has_paper_trail_for_all_events
+
+  validates(
+    :status,
+    presence: true,
+    numericality: {
+      greater_than_or_equal_to: 100,
+      less_than_or_equal_to: 999,
+      only_integer: true,
+    },
+    uniqueness: { scope: :url },
+  )
+  validates(
+    :url,
+    presence: true,
+    format: { with: HTTP_URL_REGEX },
+  )
+
+  def self.ransackable_attributes(_auth_object = nil)
+    %w[created_at id status updated_at url]
+  end
+end

--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -26,26 +26,12 @@ class CheckLinks::Checker
   URL_STATUS_EXPECTATIONS = [
     [LOGGED_IN_DAVID_RUNGER_DOT_COM_REGEX, 302],
     [REDIRECTING_URL_REGEX, 302],
-    [%r{\Ahttps://www.appacademy.io/\z}, [200, 403]],
     [%r{\Ahttps://github\.com/.+/blob/.+}, [200, 429]],
   ].freeze
-  # rubocop:disable Style/MutableConstant
-  STATUS_EXPECTATIONS = {
-    'https://www.commonlit.org/' => [200, 403],
-    'https://www.linkedin.com/in/davidrunger' => [200, 429, 999],
-    'https://www.termsfeed.com/privacy-policy-generator/' => [200, 403],
-    'https://www.termsfeed.com/blog/cookies/#What_Are_Cookies' => [200, 403],
-  }
-  STATUS_EXPECTATIONS.default_proc =
-    proc do |_hash, url|
-      URL_STATUS_EXPECTATIONS.find { url.match?(it.first) }&.last || 200
-    end
-  STATUS_EXPECTATIONS.freeze
-  # rubocop:enable Style/MutableConstant
 
   def perform(url, page_source_url)
     status = response(url)&.status
-    expected_statuses = Array(STATUS_EXPECTATIONS[url])
+    expected_statuses = expected_statuses(url, status)
 
     Rails.logger.info(<<~LOG.squish)
       [#{self.class.name}] #{url} returned #{status.inspect}
@@ -71,6 +57,19 @@ class CheckLinks::Checker
   end
 
   private
+
+  def expected_statuses(url, status)
+    code_expected_statuses =
+      Array(URL_STATUS_EXPECTATIONS.find { url.match?(it.first) }&.last || 200).dup
+
+    if status.in?(code_expected_statuses)
+      code_expected_statuses
+    else
+      code_expected_statuses.concat(
+        LinkStatusExpectation.where(url:).order(:status).pluck(:status),
+      )
+    end
+  end
 
   def redis_failure_key(url)
     "link_check:#{url}:failed"

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -132,7 +132,7 @@ ActiveAdmin.setup do |config|
   # You can add before, after and around filters to all of your
   # Active Admin resources and pages from here.
   #
-  # config.before_action :do_something_awesome
+  config.before_action(:set_admin_user_for_paper_trail)
 
   # == Attribute Filters
   #

--- a/db/datamigrate/20260824145414_populate_link_status_expectations.rb
+++ b/db/datamigrate/20260824145414_populate_link_status_expectations.rb
@@ -1,0 +1,26 @@
+# Run locally:
+#   bin/rails runner db/datamigrate/20260824145414_populate_link_status_expectations.rb
+#
+# Run in production after this datamigration deploys:
+#   bin/run-datamigration db/datamigrate/20260824145414_populate_link_status_expectations.rb
+
+class PopulateLinkStatusExpectations < Datamigration::Base
+  EXPECTATIONS = {
+    'https://crystal-lang.org/reference/latest/' => [301],
+    'https://www.appacademy.io/' => [403],
+    'https://www.commonlit.org/' => [403],
+    'https://www.linkedin.com/in/davidrunger' => [429, 999],
+    'https://www.termsfeed.com/blog/cookies/#What_Are_Cookies' => [403],
+    'https://www.termsfeed.com/privacy-policy-generator/' => [403],
+  }.freeze
+
+  def run
+    within_transaction do
+      EXPECTATIONS.each do |url, statuses|
+        statuses.each { |status| LinkStatusExpectation.create!(url:, status:) }
+      end
+    end
+  end
+end
+
+Datamigration::Runner.new(PopulateLinkStatusExpectations).run

--- a/db/migrate/20260824145414_create_link_status_expectations.rb
+++ b/db/migrate/20260824145414_create_link_status_expectations.rb
@@ -1,0 +1,17 @@
+class CreateLinkStatusExpectations < ActiveRecord::Migration[8.1]
+  def change
+    create_table :link_status_expectations do |t|
+      t.text :url, null: false
+      t.integer :status, null: false
+
+      t.timestamps
+    end
+
+    add_index :link_status_expectations, %i[url status], unique: true
+    add_check_constraint(
+      :link_status_expectations,
+      'status BETWEEN 100 AND 999',
+      name: 'link_status_expectations_status_range',
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_21_034707) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_145414) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_stat_statements"
@@ -296,6 +296,15 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_21_034707) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["user_id", "preference_type"], name: "index_json_preferences_on_user_id_and_preference_type", unique: true
+  end
+
+  create_table "link_status_expectations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "status", null: false
+    t.datetime "updated_at", null: false
+    t.text "url", null: false
+    t.index ["url", "status"], name: "index_link_status_expectations_on_url_and_status", unique: true
+    t.check_constraint "status >= 100 AND status <= 999", name: "link_status_expectations_status_range"
   end
 
   create_table "log_entries", force: :cascade do |t|

--- a/spec/controllers/admin/link_status_expectations_controller_spec.rb
+++ b/spec/controllers/admin/link_status_expectations_controller_spec.rb
@@ -1,0 +1,40 @@
+RSpec.describe Admin::LinkStatusExpectationsController do
+  context 'when logged in as an AdminUser' do
+    let(:admin_user) { admin_users(:admin_user) }
+    let(:link_status_expectation) { link_status_expectations(:app_academy) }
+
+    before { sign_in(admin_user) }
+
+    describe '#update' do
+      subject(:put_update) do
+        put(
+          :update,
+          params: {
+            id: link_status_expectation.id,
+            link_status_expectation: { status: 302 },
+          },
+        )
+      end
+
+      it "records the AdminUser's class ID string as the PaperTrail whodunnit", :versioning do
+        expect { put_update }.to change { link_status_expectation.versions.count }.by(1)
+
+        expect(link_status_expectation.versions.last!.whodunnit).
+          to eq(admin_user.class_id_string)
+      end
+    end
+
+    describe '#destroy' do
+      subject(:delete_destroy) do
+        delete(:destroy, params: { id: link_status_expectation.id })
+      end
+
+      it "records the AdminUser's class ID string as the PaperTrail whodunnit", :versioning do
+        expect { delete_destroy }.to change { link_status_expectation.versions.count }.by(1)
+
+        expect(link_status_expectation.versions.last!.whodunnit).
+          to eq(admin_user.class_id_string)
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/link_status_expectations_controller_spec.rb
+++ b/spec/controllers/admin/link_status_expectations_controller_spec.rb
@@ -5,6 +5,26 @@ RSpec.describe Admin::LinkStatusExpectationsController do
 
     before { sign_in(admin_user) }
 
+    describe '#index' do
+      subject(:get_index) { get(:index) }
+
+      it 'responds with 200' do
+        get_index
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe '#show' do
+      subject(:get_show) { get(:show, params: { id: link_status_expectation.id }) }
+
+      it 'responds with 200' do
+        get_show
+
+        expect(response).to have_http_status(200)
+      end
+    end
+
     describe '#update' do
       subject(:put_update) do
         put(

--- a/spec/factories/link_status_expectations.rb
+++ b/spec/factories/link_status_expectations.rb
@@ -1,0 +1,20 @@
+# == Schema Information
+#
+# Table name: link_status_expectations
+#
+#  created_at :datetime         not null
+#  id         :bigint           not null, primary key
+#  status     :integer          not null
+#  updated_at :datetime         not null
+#  url        :text             not null
+#
+# Indexes
+#
+#  index_link_status_expectations_on_url_and_status  (url,status) UNIQUE
+#
+FactoryBot.define do
+  factory :link_status_expectation do
+    sequence(:url) { |index| "https://example.com/redirects/#{index}" }
+    status { 301 }
+  end
+end

--- a/spec/models/link_status_expectation_spec.rb
+++ b/spec/models/link_status_expectation_spec.rb
@@ -1,0 +1,19 @@
+RSpec.describe LinkStatusExpectation do
+  subject(:link_status_expectation) { build(:link_status_expectation) }
+
+  it { is_expected.to validate_presence_of(:status) }
+  it { is_expected.to validate_numericality_of(:status).only_integer }
+  it { is_expected.to validate_uniqueness_of(:status).scoped_to(:url) }
+  it { is_expected.to validate_presence_of(:url) }
+  it { is_expected.to allow_value('http://example.com').for(:url) }
+  it { is_expected.to allow_value('https://example.com').for(:url) }
+  it { is_expected.not_to allow_value('example.com').for(:url) }
+  it { is_expected.not_to allow_value('prefix https://example.com').for(:url) }
+
+  it 'tracks create events', :versioning do
+    expect { link_status_expectation.save! }.
+      to change { link_status_expectation.versions.creates.count }.
+      from(0).
+      to(1)
+  end
+end

--- a/spec/support/fixture_builder.rb
+++ b/spec/support/fixture_builder.rb
@@ -93,6 +93,16 @@ FixtureBuilder.configure do |fbuilder|
     create(:banned_path_fragment, value: 'wp')
     create(:banned_path_fragment, value: 'wordpress')
 
+    # link status expectations
+    name(
+      :app_academy,
+      create(
+        :link_status_expectation,
+        status: 403,
+        url: 'https://www.appacademy.io/',
+      ),
+    )
+
     # quizzes
     quiz = create(:quiz, owner: married_user)
 

--- a/spec/workers/check_links/checker_spec.rb
+++ b/spec/workers/check_links/checker_spec.rb
@@ -41,8 +41,25 @@ RSpec.describe CheckLinks::Checker do
         context 'when the URL returns 302' do
           let(:status) { 302 }
 
-          it 'does not send an email', queue_adapter: :test do
+          it 'does not query for an exception or send an email', queue_adapter: :test do
+            expect(LinkStatusExpectation).not_to receive(:where)
+
             expect { perform }.not_to enqueue_mail
+          end
+        end
+
+        context 'when the URL returns 200' do
+          let(:status) { 200 }
+
+          it 'queries for an exception and sends an email', queue_adapter: :test do
+            expect(LinkStatusExpectation).
+              to receive(:where).
+              with(url:).
+              and_call_original
+
+            expect { perform }.
+              to enqueue_mail(AdminMailer, :broken_link).
+              with(url, page_source_url, status, [302])
           end
         end
       end
@@ -168,7 +185,7 @@ RSpec.describe CheckLinks::Checker do
     end
 
     context 'when requesting appacademy.io' do
-      let(:url) { 'https://www.appacademy.io/' }
+      let(:url) { link_status_expectations(:app_academy).url }
 
       context 'when the link returns 200' do
         let(:status) { 200 }
@@ -184,6 +201,11 @@ RSpec.describe CheckLinks::Checker do
         let(:status) { 403 }
 
         it 'does not mark the failure in Redis' do
+          expect(LinkStatusExpectation).
+            to receive(:where).
+            with(url:).
+            and_call_original
+
           expect { perform }.not_to change {
             $redis_pool.with { it.call('get', redis_failure_key) }
           }.from(nil)


### PR DESCRIPTION
Store each exact URL and exceptional response status in a `LinkStatusExpectation` record. Preserve pattern-based expectations in `CheckLinks::Checker`, and consult PostgreSQL only when a response misses those code-defined statuses.

Expose the records through ActiveAdmin and retain all PaperTrail events for them. Attribute ActiveAdmin mutations to the acting `AdminUser` with its class ID string so creation and subsequent edits or deletions remain auditable.

Populate the exact exceptions previously held in `STATUS_EXPECTATIONS`, move the App Academy exact match, and add the Crystal reference redirect. Add a representative `app_academy` FixtureBuilder record and reuse it in focused specs.

Document the local `Datamigration::Runner`, `rollback: true`, and `letter_opener` workflow, as well as the baseline fixture convention for new models.

Motivation: don't require a code change to add new link status expectations.

codex resume 01a03433-1e40-7a33-a9c8-965736e9d55b