### PR TITLE
[dependabot] Update Docker Compose images [DEV-302]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,21 @@ updates:
     cooldown:
       default-days: 5
     open-pull-requests-limit: 999
+  - package-ecosystem: docker-compose
+    directory: '/'
+    schedule:
+      interval: cron
+      cronjob: '4 4 * * *'
+      timezone: America/Chicago
+    allow:
+      - dependency-type: all
+    cooldown:
+      default-days: 5
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+    open-pull-requests-limit: 999
   - package-ecosystem: github-actions
     directory: '/'
     schedule:


### PR DESCRIPTION
Configure the `docker-compose` ecosystem at the repository root so versioned, digest-pinned service images receive update pull requests on the same schedule as the existing dependency ecosystems.

Retain the five-day cooldown and effectively unlimited pull request count. Ignore `version-update:semver-major` so migrations and cross-major compatibility work remain deliberate while patch and minor image updates stay automated.

codex resume 01a0369d-20b7-70a0-8681-c58b9dd1be5a