### PR TITLE
[Dockerfile] Update Ruby base image digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG RUBY_VERSION
 # Update this digest when `.ruby-version` changes.
-FROM ruby:$RUBY_VERSION-slim-bookworm@sha256:c5650da02325ecb3e7dd96e7074772c3ae2ecd093a9acf2cdbcf1a2fdc680726 AS base
+FROM ruby:$RUBY_VERSION-slim-bookworm@sha256:a2a5fba951ab65cfae20320aaeb9481278a1ac000ba33a51df71b20117b04244 AS base
 
 RUN test -n "$RUBY_VERSION"
 


### PR DESCRIPTION
Docker Hub now resolves `ruby:4.0.6-slim-bookworm` to `sha256:a2a5fba951ab65cfae20320aaeb9481278a1ac000ba33a51df71b20117b04244` instead of the digest pinned in `Dockerfile`, causing `bin/check-ruby-image-digest` to fail.

The old and new OCI indexes contain the same five Linux platforms. Their amd64 manifests use the same official Ruby source revision `887da016bf8e524ac6f1a96f079d1ba9628189f2`, retain `RUBY_VERSION=4.0.6` and the same `RUBY_DOWNLOAD_SHA256`, and differ in the refreshed `debian:bookworm-slim` base snapshot. Keep the image pinned to the current official index while preserving reproducible builds.

Official image metadata: https://hub.docker.com/_/ruby

Official source revision: https://github.com/docker-library/ruby/commit/887da016bf8e524ac6f1a96f079d1ba9628189f2

codex resume 01a03870-9cdd-7de3-a483-08b9c97208ab