### PR TITLE
[ruby.yml] Verify Ruby image digest only on version changes

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -165,7 +165,8 @@ jobs:
             if: ${{ !cancelled() }}
             run: |
               if git diff --quiet main...HEAD -- .ruby-version; then
-                echo "Skipping Ruby base image digest verification because .ruby-version is unchanged relative to main."
+                echo "Skipping Ruby base image digest verification because" \
+                  ".ruby-version is unchanged relative to main."
                 exit 0
               fi
 

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -69,7 +69,13 @@ jobs:
               echo "PERCY_BROWSER_EXECUTABLE=$CHROME_PATH" >> $GITHUB_ENV
 
           - name: Verify Ruby base image digest
-            run: bin/check-ruby-image-digest
+            run: |
+              if git diff --quiet main...HEAD -- .ruby-version; then
+                echo "Skipping Ruby base image digest verification because .ruby-version is unchanged relative to main."
+                exit 0
+              fi
+
+              bin/check-ruby-image-digest
 
           - name: Set up Ruby
             uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -139,16 +139,16 @@ jobs:
           PERCY_TOKEN: '${{secrets.PERCY_TOKEN}}'
           CODECOV_TOKEN: '${{secrets.CODECOV_TOKEN}}'
 
-      - name: Verify Ruby base image digest
-        run: |
-          if git diff --quiet main...HEAD -- .ruby-version; then
-            echo "Skipping Ruby base image digest verification because .ruby-version is unchanged relative to main."
-            exit 0
-          fi
-
-          bin/check-ruby-image-digest
-
       - parallel:
+          - name: Verify Ruby base image digest
+            run: |
+              if git diff --quiet main...HEAD -- .ruby-version; then
+                echo "Skipping Ruby base image digest verification because .ruby-version is unchanged relative to main."
+                exit 0
+              fi
+
+              bin/check-ruby-image-digest
+
           - name: Save feature spec artifacts
             uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
             if: failure()

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -68,15 +68,6 @@ jobs:
               CHROME_PATH=$(which google-chrome)
               echo "PERCY_BROWSER_EXECUTABLE=$CHROME_PATH" >> $GITHUB_ENV
 
-          - name: Verify Ruby base image digest
-            run: |
-              if git diff --quiet main...HEAD -- .ruby-version; then
-                echo "Skipping Ruby base image digest verification because .ruby-version is unchanged relative to main."
-                exit 0
-              fi
-
-              bin/check-ruby-image-digest
-
           - name: Set up Ruby
             uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
             with:
@@ -147,6 +138,15 @@ jobs:
           CI_STEP_RESULTS_AUTH_TOKEN: '${{secrets.CI_STEP_RESULTS_AUTH_TOKEN}}'
           PERCY_TOKEN: '${{secrets.PERCY_TOKEN}}'
           CODECOV_TOKEN: '${{secrets.CODECOV_TOKEN}}'
+
+      - name: Verify Ruby base image digest
+        run: |
+          if git diff --quiet main...HEAD -- .ruby-version; then
+            echo "Skipping Ruby base image digest verification because .ruby-version is unchanged relative to main."
+            exit 0
+          fi
+
+          bin/check-ruby-image-digest
 
       - parallel:
           - name: Save feature spec artifacts

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -140,15 +140,6 @@ jobs:
           CODECOV_TOKEN: '${{secrets.CODECOV_TOKEN}}'
 
       - parallel:
-          - name: Verify Ruby base image digest
-            run: |
-              if git diff --quiet main...HEAD -- .ruby-version; then
-                echo "Skipping Ruby base image digest verification because .ruby-version is unchanged relative to main."
-                exit 0
-              fi
-
-              bin/check-ruby-image-digest
-
           - name: Save feature spec artifacts
             uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
             if: failure()
@@ -169,6 +160,16 @@ jobs:
               name: fixtures
               path: spec/fixtures/
               retention-days: 5
+
+          - name: Verify Ruby base image digest
+            if: ${{ !cancelled() }}
+            run: |
+              if git diff --quiet main...HEAD -- .ruby-version; then
+                echo "Skipping Ruby base image digest verification because .ruby-version is unchanged relative to main."
+                exit 0
+              fi
+
+              bin/check-ruby-image-digest
 
           - name: Upload Code Coverage
             uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0


### PR DESCRIPTION
The digest lookup in `bin/check-ruby-image-digest` is sensitive to Docker Hub retagging even when a pull request does not change Ruby. Compare the checked-out tree with `main` before running the check.

This keeps unrelated pull requests from failing on a changed image digest while preserving the existing mismatch failure whenever `.ruby-version` is updated.

codex resume 01a03895-ef05-7d00-b9d5-b93c68cd690f