### PR TITLE
[logs] Use native link for CSV downloads [LOG-60]

### DIFF
--- a/app/javascript/logs/components/Log.vue
+++ b/app/javascript/logs/components/Log.vue
@@ -27,16 +27,23 @@ div
         template(#reference)
           ElButton Delete last entry
     .mt-2
-      ElDropdown(
-        split-button
-        trigger="click"
-        @click="downloadCsv"
-        @command="confirmExactCsvDownload"
-      )
-        | Download CSV
-        template(#dropdown)
-          ElDropdownMenu
-            ElDropdownItem(command="preserve") Download exact CSV
+      ElButtonGroup.csv-download-buttons
+        ElButton(
+          tag="a"
+          :href="download_log_path(log.slug)"
+          download
+        ) Download CSV
+        ElDropdown(
+          trigger="click"
+          @command="confirmExactCsvDownload"
+        )
+          ElButton.el-dropdown__caret-button(
+            :icon="ArrowDown"
+            aria-label="Toggle Dropdown"
+          )
+          template(#dropdown)
+            ElDropdownMenu
+              ElDropdownItem(command="preserve") Download exact CSV
     .mt-2
       ElButton.multi-line(
         @click="modalStore.showModal({ modalName: 'edit-log-sharing-settings' })"
@@ -67,9 +74,11 @@ div
 </template>
 
 <script setup lang="ts">
+import { ArrowDown } from '@element-plus/icons-vue';
 import { useTitle } from '@vueuse/core';
 import {
   ElButton,
+  ElButtonGroup,
   ElDropdown,
   ElDropdownItem,
   ElDropdownMenu,
@@ -138,10 +147,6 @@ const emailSubmissionTokenLastRotatedAt = computed((): string => {
 
 function destroyLastEntry() {
   logsStore.deleteLastLogEntry({ log });
-}
-
-function downloadCsv() {
-  window.location.assign(download_log_path(log.slug));
 }
 
 async function confirmExactCsvDownload(formulaHandling: string) {
@@ -243,6 +248,10 @@ subscribeToLogEntriesChannel();
 <style scoped>
 .description {
   font-weight: 200;
+}
+
+.csv-download-buttons :deep(.el-dropdown__caret-button) {
+  border-left: none;
 }
 
 .el-button {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@activeadmin/activeadmin": "4.0.0-beta22",
     "@davidrunger/vue-model-explorer": "^0.3.3",
+    "@element-plus/icons-vue": "^2.3.2",
     "@rails/actioncable": "^8.1.301",
     "@rails/ujs": "^7.1.600",
     "@tailwindcss/vite": "^4.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@davidrunger/vue-model-explorer':
         specifier: ^0.3.3
         version: 0.3.3(vue@3.5.41(typescript@6.0.3))
+      '@element-plus/icons-vue':
+        specifier: ^2.3.2
+        version: 2.3.2(vue@3.5.41(typescript@6.0.3))
       '@rails/actioncable':
         specifier: ^8.1.301
         version: 8.1.301

--- a/spec/features/logs_spec.rb
+++ b/spec/features/logs_spec.rb
@@ -210,7 +210,10 @@ RSpec.describe 'Logs app' do
         it 'allows the user to download a CSV with the log data' do
           visit(log_path(slug: log.slug))
 
-          wait_for { page }.to have_button('Download CSV')
+          wait_for { page }.to have_link(
+            'Download CSV',
+            href: download_log_path(log.slug),
+          )
 
           csv_path = downloaded_file_path('*.csv') { click_on('Download CSV') }
           csv = CSV.read(csv_path, headers: true)


### PR DESCRIPTION
The LOG-60 artifact records Capybara clicking "Download CSV", but no `GET /logs/:slug/download` reaches `LogsController#download`. This matches the earlier event-binding failure that LOG-52 mitigated with a fixed delay.

Commit fcefd55b8 removed that delay while addressing a different downstream download-completion failure, allowing the click race to recur even though `Ferrum::Downloads#wait` correctly handles completed transfers.

Render the standard export as an `ElButton`-styled native `<a download>` inside an `ElButtonGroup`, with an independent `ElDropdown` caret for exact exports. Native navigation no longer depends on `ElDropdown` emitting `click`; the exact workflow remains JavaScript-driven because confirmation is required.

Declare `@element-plus/icons-vue` directly so the composed caret can reuse the `ArrowDown` component and caret styling from Element Plus rather than duplicate its SVG or diverge visually from the original split button.

Update the feature expectation to require the standard action `href`, guarding the native navigation that prevents this flake.

codex resume 01a038fc-f157-7d53-95ef-40810ec2ad52