### PR TITLE
[check-links] Send custom user agent [DEV-304]

### DIFF
--- a/app/poros/safe_external_http_fetcher.rb
+++ b/app/poros/safe_external_http_fetcher.rb
@@ -44,7 +44,7 @@ class SafeExternalHttpFetcher
     ff00::/8
   ].map { IPAddr.new(it) }.freeze
 
-  def get(url, timeout:)
+  def get(url, timeout:, user_agent:)
     uri = http_uri(url)
     pinned_address = resolved_address(uri.hostname)
 
@@ -56,6 +56,7 @@ class SafeExternalHttpFetcher
       end
     end.get do |request|
       request.url(uri)
+      request.headers['User-Agent'] = user_agent
       request.options.timeout = timeout
     end
   end

--- a/app/workers/check_links/checker.rb
+++ b/app/workers/check_links/checker.rb
@@ -3,6 +3,7 @@ class CheckLinks::Checker
   prepend ApplicationWorker
 
   LINK_CHECK_CACHE_KEY_PREFIX = 'link-check'
+  USER_AGENT = "DavidRungerLinkChecker/1.0 (+#{DavidRunger::CANONICAL_URL})".freeze
   LOGGED_IN_DAVID_RUNGER_DOT_COM_REGEX = %r{
     \A
     https://davidrunger.com/
@@ -79,7 +80,7 @@ class CheckLinks::Checker
   def response(url)
     Rails.cache.fetch(cache_key(url), expires_in: 6.hours, skip_nil: true) do
       Rails.error.handle(severity: :info, context: { url: }) do
-        SafeExternalHttpFetcher.new.get(url, timeout: 5)
+        SafeExternalHttpFetcher.new.get(url, timeout: 5, user_agent: USER_AGENT)
       end
     end
   end

--- a/spec/poros/safe_external_http_fetcher_spec.rb
+++ b/spec/poros/safe_external_http_fetcher_spec.rb
@@ -3,11 +3,12 @@ RSpec.describe SafeExternalHttpFetcher do
   subject(:fetcher) { described_class.new }
 
   describe '#get' do
-    subject(:get) { fetcher.get(url, timeout: 5) }
+    subject(:get) { fetcher.get(url, timeout: 5, user_agent:) }
 
     let(:url) { 'https://public.example.test/path?query=value' }
     let(:hostname) { 'public.example.test' }
     let(:resolved_addresses) { [] }
+    let(:user_agent) { 'ExampleFetcher/1.0' }
 
     before do
       allow(Resolv).to receive(:getaddresses).with(hostname).and_return(resolved_addresses)
@@ -19,6 +20,13 @@ RSpec.describe SafeExternalHttpFetcher do
 
       it 'connects to the address' do
         expect(get.status).to eq(200)
+      end
+
+      it 'sends the specified user agent' do
+        get
+
+        expect(a_request(:get, url).with(headers: { 'User-Agent' => user_agent })).
+          to have_been_made
       end
 
       it 'pins the connection while preserving the hostname for HTTP and TLS' do

--- a/spec/workers/check_links/checker_spec.rb
+++ b/spec/workers/check_links/checker_spec.rb
@@ -20,6 +20,18 @@ RSpec.describe CheckLinks::Checker do
       # rubocop:enable Style/IpAddresses
     end
 
+    it 'identifies the request as the davidrunger.com link checker' do
+      perform
+
+      expect(
+        a_request(:get, url).with(
+          headers: {
+            'User-Agent' => 'DavidRungerLinkChecker/1.0 (+https://davidrunger.com/)',
+          },
+        ),
+      ).to have_been_made
+    end
+
     context 'when a previous failure is marked in Redis' do
       before { $redis_pool.with { it.call('set', redis_failure_key, '1') } }
 


### PR DESCRIPTION
Send `DavidRungerLinkChecker/1.0` as the product token for outbound link checks, with `DavidRunger::CANONICAL_URL` in a comment. This gives site operators useful context when the daily requests appear in their logs, keeps the attribution URL aligned with the application host, and avoids exposing the underlying Faraday version.

Require callers of `SafeExternalHttpFetcher#get` to provide the user agent explicitly so the request identity remains an application-level choice.

codex resume 01a03afe-41e1-72a2-b084-0b0869b3171c